### PR TITLE
Remove ExcludeFromCodeCoverage & add tests

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,7 @@ root = true
 # Default settings
 #############################################
 [*]
+end_of_line = crlf
 insert_final_newline = true
 indent_style = space
 indent_size = 4
@@ -2154,7 +2155,7 @@ indent_size = 2
 # Shell Scripts
 #############################################
 [*.sh]
-end_of_line = lf
+end_of_line = crlf
 
 [*.{cmd, bat}]
 end_of_line = crlf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
-# Auto-detect text files and normalise line endings to LF in the repository.
-* text=auto
+# Auto-detect text files and normalise line endings to CRLF in the repository.
+* text=auto eol=crlf
 
 # Source code
 *.cs       text diff=csharp
@@ -15,7 +15,7 @@
 *.yaml     text
 *.md       text
 *.txt      text
-*.sh       text eol=lf
+*.sh       text eol=crlf
 *.ps1      text
 *.cmd      text eol=crlf
 *.bat      text eol=crlf

--- a/README.md
+++ b/README.md
@@ -651,28 +651,8 @@ Performance constraints used by the project:
 | `src/ReactiveUI.Primitives.R3Bridge.Generator` | Source generator for R3 bridge adapters. |
 | `src/ReactiveUI.Primitives.Tests` | Test project using Microsoft Testing Platform/TUnit-style validation. |
 | `src/benchmarks/ReactiveUI.Primitives.Benchmarks` | BenchmarkDotNet comparison harness. |
-| `docs/API-COVERAGE.md` | Public API inventory and parity notes. |
-| `docs/PERFORMANCE.md` | Benchmark plan and recovered benchmark evidence. |
-| `docs/TASKLIST.md` | Project task/status notes. |
-| `docs/research` | System.Reactive and R3 API inventory research. |
 
 ## Validation commands
-
-From WSL, use Windows dotnet for this repository:
-
-```bash
-"/mnt/c/Program Files/dotnet/dotnet.exe" restore src/ReactiveUI.Primitives.sln
-"/mnt/c/Program Files/dotnet/dotnet.exe" build src/ReactiveUI.Primitives.sln --configuration Release --no-restore
-"/mnt/c/Program Files/dotnet/dotnet.exe" test --project src/ReactiveUI.Primitives.Tests/ReactiveUI.Primitives.Tests.csproj --configuration Release --no-build -- --minimum-expected-tests 1
-"/mnt/c/Program Files/dotnet/dotnet.exe" pack src/ReactiveUI.Primitives/ReactiveUI.Primitives.csproj --configuration Release --no-restore -v minimal
-git diff --check
-```
-
-To run the focused benchmark used by the performance notes:
-
-```bash
-"/mnt/c/Program Files/dotnet/dotnet.exe" run --project src/benchmarks/ReactiveUI.Primitives.Benchmarks/ReactiveUI.Primitives.Benchmarks.csproj --configuration Release --no-build -- --filter '*SubjectThroughput*'
-```
 
 For NuGet package verification, inspect the generated `.nupkg` and confirm:
 

--- a/src/ReactiveUI.Primitives/Concurrency/CurrentThreadSequencer.cs
+++ b/src/ReactiveUI.Primitives/Concurrency/CurrentThreadSequencer.cs
@@ -11,7 +11,6 @@ namespace ReactiveUI.Primitives.Concurrency;
 /// CurrentThreadSequencer.
 /// </summary>
 /// <seealso cref="ReactiveUI.Primitives.Concurrency.ISequencer" />
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 public sealed class CurrentThreadSequencer : ISequencer
 {
     /// <summary>

--- a/src/ReactiveUI.Primitives/Concurrency/DispatcherSequencer.cs
+++ b/src/ReactiveUI.Primitives/Concurrency/DispatcherSequencer.cs
@@ -15,7 +15,6 @@ namespace ReactiveUI.Primitives.Concurrency;
 /// DispatcherSequencer.
 /// </summary>
 /// <seealso cref="ReactiveUI.Primitives.Concurrency.ISequencer" />
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 public class DispatcherSequencer : ISequencer
 {
     /// <summary>

--- a/src/ReactiveUI.Primitives/Concurrency/ImmediateSequencer.cs
+++ b/src/ReactiveUI.Primitives/Concurrency/ImmediateSequencer.cs
@@ -8,7 +8,6 @@ namespace ReactiveUI.Primitives.Concurrency;
 /// ImmediateSequencer.
 /// </summary>
 /// <seealso cref="ReactiveUI.Primitives.Concurrency.ISequencer" />
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 public sealed class ImmediateSequencer : ISequencer
 {
     /// <summary>

--- a/src/ReactiveUI.Primitives/Concurrency/ScheduledItem.cs
+++ b/src/ReactiveUI.Primitives/Concurrency/ScheduledItem.cs
@@ -11,7 +11,6 @@ namespace ReactiveUI.Primitives.Concurrency;
 /// Abstract base class for scheduled work items.
 /// </summary>
 /// <typeparam name="TAbsolute">Absolute time representation type.</typeparam>
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 public abstract class ScheduledItem<TAbsolute> : IScheduledItem<TAbsolute>, IComparable<ScheduledItem<TAbsolute>>, IsDisposed, IComparable
     where TAbsolute : IComparable<TAbsolute>
 {

--- a/src/ReactiveUI.Primitives/Concurrency/Sequencer.Simple.cs
+++ b/src/ReactiveUI.Primitives/Concurrency/Sequencer.Simple.cs
@@ -9,7 +9,6 @@ namespace ReactiveUI.Primitives.Concurrency;
 /// <summary>
 /// Sequencer.
 /// </summary>
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 public static partial class Sequencer
 {
     /// <summary>

--- a/src/ReactiveUI.Primitives/Concurrency/SequencerQueue.cs
+++ b/src/ReactiveUI.Primitives/Concurrency/SequencerQueue.cs
@@ -11,7 +11,6 @@ namespace ReactiveUI.Primitives.Concurrency;
 /// </summary>
 /// <typeparam name="TAbsolute">Absolute time representation type.</typeparam>
 /// <remarks>This type is not thread safe; users should ensure proper synchronization.</remarks>
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 public class SequencerQueue<TAbsolute>
     where TAbsolute : IComparable<TAbsolute>
 {

--- a/src/ReactiveUI.Primitives/Concurrency/TaskPoolSequencer.cs
+++ b/src/ReactiveUI.Primitives/Concurrency/TaskPoolSequencer.cs
@@ -10,7 +10,6 @@ namespace ReactiveUI.Primitives.Concurrency;
 /// TaskPoolSequencer.
 /// </summary>
 /// <seealso cref="ReactiveUI.Primitives.Concurrency.ISequencer" />
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 public sealed class TaskPoolSequencer : ISequencer
 {
     /// <summary>

--- a/src/ReactiveUI.Primitives/Concurrency/TestClock.cs
+++ b/src/ReactiveUI.Primitives/Concurrency/TestClock.cs
@@ -7,7 +7,6 @@ namespace ReactiveUI.Primitives.Concurrency;
 /// <summary>
 /// Test-facing alias for <see cref="VirtualClock"/>.
 /// </summary>
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 public sealed class TestClock : VirtualClock
 {
     /// <summary>

--- a/src/ReactiveUI.Primitives/Concurrency/ThreadPoolSequencer.cs
+++ b/src/ReactiveUI.Primitives/Concurrency/ThreadPoolSequencer.cs
@@ -11,7 +11,6 @@ namespace ReactiveUI.Primitives.Concurrency
     /// ThreadPoolSequencer.
     /// </summary>
     /// <seealso cref="ReactiveUI.Primitives.Concurrency.ISequencer" />
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public sealed class ThreadPoolSequencer : ISequencer
     {
         /// <summary>

--- a/src/ReactiveUI.Primitives/Concurrency/VirtualTimeSequencerBase{TAbsolute,TRelative}.cs
+++ b/src/ReactiveUI.Primitives/Concurrency/VirtualTimeSequencerBase{TAbsolute,TRelative}.cs
@@ -11,7 +11,6 @@ namespace ReactiveUI.Primitives.Concurrency;
 /// </summary>
 /// <typeparam name="TAbsolute">Absolute time representation type.</typeparam>
 /// <typeparam name="TRelative">Relative time representation type.</typeparam>
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 public abstract class VirtualTimeSequencerBase<TAbsolute, TRelative> : ISequencer, IServiceProvider, IStopwatchProvider
     where TAbsolute : IComparable<TAbsolute>
 {

--- a/src/ReactiveUI.Primitives/Concurrency/VirtualTimeSequencerExtensions.cs
+++ b/src/ReactiveUI.Primitives/Concurrency/VirtualTimeSequencerExtensions.cs
@@ -9,7 +9,6 @@ namespace ReactiveUI.Primitives.Concurrency;
 /// <summary>
 /// Provides a set of extension methods for virtual time scheduling.
 /// </summary>
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 public static class VirtualTimeSequencerExtensions
 {
     /// <summary>

--- a/src/ReactiveUI.Primitives/Concurrency/VirtualTimeSequencer{TAbsolute,TRelative}.cs
+++ b/src/ReactiveUI.Primitives/Concurrency/VirtualTimeSequencer{TAbsolute,TRelative}.cs
@@ -9,7 +9,6 @@ namespace ReactiveUI.Primitives.Concurrency;
 /// </summary>
 /// <typeparam name="TAbsolute">Absolute time representation type.</typeparam>
 /// <typeparam name="TRelative">Relative time representation type.</typeparam>
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 public abstract class VirtualTimeSequencer<TAbsolute, TRelative> : VirtualTimeSequencerBase<TAbsolute, TRelative>
     where TAbsolute : IComparable<TAbsolute>
 {

--- a/src/ReactiveUI.Primitives/ConnectableSignal{T}.cs
+++ b/src/ReactiveUI.Primitives/ConnectableSignal{T}.cs
@@ -13,7 +13,6 @@ namespace ReactiveUI.Primitives;
 /// Connectable hot signal that subscribes to its source only when connected.
 /// </summary>
 /// <typeparam name="T">The value type.</typeparam>
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 public sealed class ConnectableSignal<T> : IObservable<T>
 {
     /// <summary>
@@ -79,7 +78,6 @@ public sealed class ConnectableSignal<T> : IObservable<T>
 /// <summary>
 /// Hot-sharing operators for Primitives connectable signals.
 /// </summary>
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 public static class ConnectableSignalMixins
 {
     /// <summary>

--- a/src/ReactiveUI.Primitives/Core/DisposedWitness{T}.cs
+++ b/src/ReactiveUI.Primitives/Core/DisposedWitness{T}.cs
@@ -8,7 +8,6 @@ namespace ReactiveUI.Primitives.Core;
 /// Observer that rejects every notification because the subscription has already been disposed.
 /// </summary>
 /// <typeparam name="T">The observed value type.</typeparam>
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 internal sealed class DisposedWitness<T> : IObserver<T>
 {
     /// <summary>

--- a/src/ReactiveUI.Primitives/Core/EmptyWitness{T}.cs
+++ b/src/ReactiveUI.Primitives/Core/EmptyWitness{T}.cs
@@ -10,7 +10,6 @@ namespace ReactiveUI.Primitives.Core;
 /// Delegate-backed observer that defaults missing handlers to no-op behavior.
 /// </summary>
 /// <typeparam name="T">The observed value type.</typeparam>
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 internal sealed class EmptyWitness<T> : IObserver<T>
 {
     /// <summary>

--- a/src/ReactiveUI.Primitives/Core/ImmutableList{T}.cs
+++ b/src/ReactiveUI.Primitives/Core/ImmutableList{T}.cs
@@ -8,7 +8,6 @@ namespace ReactiveUI.Primitives.Core;
 /// Immutable array-backed list optimized for copy-on-write observer storage.
 /// </summary>
 /// <typeparam name="T">The item type.</typeparam>
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 internal sealed class ImmutableList<T>
 {
     /// <summary>

--- a/src/ReactiveUI.Primitives/Core/PriorityQueue.cs
+++ b/src/ReactiveUI.Primitives/Core/PriorityQueue.cs
@@ -8,7 +8,6 @@ namespace ReactiveUI.Primitives.Core;
 /// Binary heap priority queue that preserves insertion order for equal-priority items.
 /// </summary>
 /// <typeparam name="T">The queued item type.</typeparam>
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 internal sealed class PriorityQueue<T>
     where T : IComparable<T>
 {

--- a/src/ReactiveUI.Primitives/Core/Spark{T}.cs
+++ b/src/ReactiveUI.Primitives/Core/Spark{T}.cs
@@ -14,7 +14,6 @@ namespace ReactiveUI.Primitives.Core
     /// </summary>
     /// <typeparam name="T">The type of the elements received by the observer.</typeparam>
     [Serializable]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public abstract class Spark<T> : IEquatable<Spark<T>>
     {
         /// <summary>

--- a/src/ReactiveUI.Primitives/Core/ThrowWitness{T}.cs
+++ b/src/ReactiveUI.Primitives/Core/ThrowWitness{T}.cs
@@ -8,7 +8,6 @@ namespace ReactiveUI.Primitives.Core;
 /// Observer that ignores values and completion and rethrows errors.
 /// </summary>
 /// <typeparam name="T">The observed value type.</typeparam>
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 internal sealed class ThrowWitness<T> : IObserver<T>
 {
     /// <summary>

--- a/src/ReactiveUI.Primitives/Core/Witness.cs
+++ b/src/ReactiveUI.Primitives/Core/Witness.cs
@@ -10,7 +10,6 @@ namespace ReactiveUI.Primitives.Core;
 /// <summary>
 /// Factory methods for allocation-conscious observers in the ReactiveUI.Primitives vocabulary.
 /// </summary>
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 public static class Witness
 {
     /// <summary>

--- a/src/ReactiveUI.Primitives/Disposables/AssignmentSlot.cs
+++ b/src/ReactiveUI.Primitives/Disposables/AssignmentSlot.cs
@@ -7,7 +7,6 @@ namespace ReactiveUI.Primitives.Disposables;
 /// <summary>
 /// Primitives alias for a single-assignment disposable slot.
 /// </summary>
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 public sealed class AssignmentSlot : SingleDisposable
 {
     /// <summary>

--- a/src/ReactiveUI.Primitives/Disposables/MultipleDisposable.cs
+++ b/src/ReactiveUI.Primitives/Disposables/MultipleDisposable.cs
@@ -7,7 +7,6 @@ namespace ReactiveUI.Primitives.Disposables;
 /// <summary>
 /// A disposable pocket that contains a set of disposables and disposes them together.
 /// </summary>
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 public class MultipleDisposable : IsDisposed
 {
     /// <summary>

--- a/src/ReactiveUI.Primitives/Disposables/SingleDisposable.cs
+++ b/src/ReactiveUI.Primitives/Disposables/SingleDisposable.cs
@@ -7,7 +7,6 @@ namespace ReactiveUI.Primitives.Disposables;
 /// <summary>
 /// Single-assignment disposable slot.
 /// </summary>
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 public class SingleDisposable : IsDisposed
 {
     /// <summary>

--- a/src/ReactiveUI.Primitives/Disposables/SingleReplaceableDisposable.cs
+++ b/src/ReactiveUI.Primitives/Disposables/SingleReplaceableDisposable.cs
@@ -7,7 +7,6 @@ namespace ReactiveUI.Primitives.Disposables;
 /// <summary>
 /// SingleReplaceableDisposable.
 /// </summary>
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 public class SingleReplaceableDisposable : IsDisposed
 {
     /// <summary>

--- a/src/ReactiveUI.Primitives/Disposables/Slot.cs
+++ b/src/ReactiveUI.Primitives/Disposables/Slot.cs
@@ -7,7 +7,6 @@ namespace ReactiveUI.Primitives.Disposables;
 /// <summary>
 /// Primitives alias for a replaceable disposable slot.
 /// </summary>
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 public sealed class Slot : SingleReplaceableDisposable
 {
     /// <summary>

--- a/src/ReactiveUI.Primitives/LinqMixins.cs
+++ b/src/ReactiveUI.Primitives/LinqMixins.cs
@@ -10,7 +10,6 @@ namespace ReactiveUI.Primitives;
 /// <summary>
 /// SelectMixins.
 /// </summary>
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 public static partial class LinqMixins
 {
     /// <summary>

--- a/src/ReactiveUI.Primitives/Properties/AssemblyInfo.cs
+++ b/src/ReactiveUI.Primitives/Properties/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("ReactiveUI.Primitives.Tests")]

--- a/src/ReactiveUI.Primitives/Signal/AsyncSignal{T}.cs
+++ b/src/ReactiveUI.Primitives/Signal/AsyncSignal{T}.cs
@@ -12,7 +12,6 @@ namespace ReactiveUI.Primitives.Signals;
 /// </summary>
 /// <typeparam name="T">The Type.</typeparam>
 /// <seealso cref="ReactiveUI.Primitives.Signals.ISignal&lt;T&gt;" />
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 public class AsyncSignal<T> : IAwaitSignal<T>
 {
     /// <summary>

--- a/src/ReactiveUI.Primitives/Signal/BehaviourSignal{T}.cs
+++ b/src/ReactiveUI.Primitives/Signal/BehaviourSignal{T}.cs
@@ -11,7 +11,6 @@ namespace ReactiveUI.Primitives.Signals;
 /// BehaviourSignal.
 /// </summary>
 /// <typeparam name="T">The Type.</typeparam>
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 public class BehaviourSignal<T> : ISignal<T>
 {
     /// <summary>

--- a/src/ReactiveUI.Primitives/Signal/BufferSignal{T,TResult}.cs
+++ b/src/ReactiveUI.Primitives/Signal/BufferSignal{T,TResult}.cs
@@ -9,7 +9,6 @@ namespace ReactiveUI.Primitives.Signals;
 /// </summary>
 /// <typeparam name="T">The T type.</typeparam>
 /// <typeparam name="TResult">The TResult type.</typeparam>
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 internal sealed class BufferSignal<T, TResult> : Signal<TResult>
     where TResult : class, IList<T>
 {

--- a/src/ReactiveUI.Primitives/Signal/CommandSignal{TResult}.cs
+++ b/src/ReactiveUI.Primitives/Signal/CommandSignal{TResult}.cs
@@ -10,7 +10,6 @@ namespace ReactiveUI.Primitives.Signals;
 /// Minimal reactive command that gates execution and publishes result, fault, and running state streams.
 /// </summary>
 /// <typeparam name="TResult">The command result type.</typeparam>
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 public sealed class CommandSignal<TResult> : IDisposable
 {
     /// <summary>

--- a/src/ReactiveUI.Primitives/Signal/KeepSignal{T}.cs
+++ b/src/ReactiveUI.Primitives/Signal/KeepSignal{T}.cs
@@ -10,7 +10,6 @@ namespace ReactiveUI.Primitives.Signals;
 /// Represents the KeepSignal class.
 /// </summary>
 /// <typeparam name="T">The T type.</typeparam>
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 internal sealed class KeepSignal<T> : IRequireCurrentThread<T>
 {
     /// <summary>

--- a/src/ReactiveUI.Primitives/Signal/MapSignal{TSource,TResult}.cs
+++ b/src/ReactiveUI.Primitives/Signal/MapSignal{TSource,TResult}.cs
@@ -11,7 +11,6 @@ namespace ReactiveUI.Primitives.Signals;
 /// </summary>
 /// <typeparam name="TSource">The TSource type.</typeparam>
 /// <typeparam name="TResult">The TResult type.</typeparam>
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 internal sealed class MapSignal<TSource, TResult> : IRequireCurrentThread<TResult>
 {
     /// <summary>

--- a/src/ReactiveUI.Primitives/Signal/ReadOnlyState{T}.cs
+++ b/src/ReactiveUI.Primitives/Signal/ReadOnlyState{T}.cs
@@ -10,7 +10,6 @@ namespace ReactiveUI.Primitives.Signals;
 /// Read-only latest-value signal for projected or externally owned state.
 /// </summary>
 /// <typeparam name="T">The value type.</typeparam>
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 public sealed class ReadOnlyState<T> : IObservable<T>, IDisposable
 {
     /// <summary>
@@ -68,7 +67,6 @@ public sealed class ReadOnlyState<T> : IObservable<T>, IDisposable
 /// <summary>
 /// State projection helpers.
 /// </summary>
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 public static class StateSignalMixins
 {
     /// <summary>

--- a/src/ReactiveUI.Primitives/Signal/ReplaySignal{T}.cs
+++ b/src/ReactiveUI.Primitives/Signal/ReplaySignal{T}.cs
@@ -12,7 +12,6 @@ namespace ReactiveUI.Primitives.Signals;
 /// ReplaySignal.
 /// </summary>
 /// <typeparam name="T">The Type.</typeparam>
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 public class ReplaySignal<T> : ISignal<T>
 {
     /// <summary>

--- a/src/ReactiveUI.Primitives/Signal/Signal{T}.cs
+++ b/src/ReactiveUI.Primitives/Signal/Signal{T}.cs
@@ -20,17 +20,6 @@ public class Signal<T> : ISignal<T>
     private const int InitialSubscriptionCapacity = 4;
 
     /// <summary>
-    /// Stores state for the signal implementation.
-    /// </summary>
-    private static readonly Action<T> NoopOnNext = static _ => { };
-
-    /// <summary>
-    /// Executes the ThrowDisposed operation.
-    /// </summary>
-    /// <returns>The result.</returns>
-    private static readonly Action<T> ThrowDisposedOnNext = static _ => ThrowDisposed();
-
-    /// <summary>
     /// Executes the new operation.
     /// </summary>
     /// <returns>The result.</returns>
@@ -65,11 +54,6 @@ public class Signal<T> : ISignal<T>
     /// Stores state for the signal implementation.
     /// </summary>
     private int _subscriptionTail;
-
-    /// <summary>
-    /// Stores state for the signal implementation.
-    /// </summary>
-    private Action<T> _onNext = NoopOnNext;
 
     /// <summary>
     /// Stores state for the signal implementation.
@@ -190,11 +174,24 @@ public class Signal<T> : ISignal<T>
         var singleObserver = Volatile.Read(ref _singleObserverSubscription);
         if (singleObserver != null)
         {
-            singleObserver.Observer!.OnNext(value);
+            singleObserver.Observer.OnNext(value);
             return;
         }
 
-        _onNext(value);
+        var singleAction = Volatile.Read(ref _singleActionSubscription);
+        if (singleAction != null)
+        {
+            singleAction.Action(value);
+            return;
+        }
+
+        DispatchSubscriptions(value);
+        if (!Volatile.Read(ref _isDisposed))
+        {
+            return;
+        }
+
+        ThrowDisposed();
     }
 
     /// <summary>
@@ -235,7 +232,6 @@ public class Signal<T> : ISignal<T>
                     PromoteSingleActionObserverLocked();
                     subscription = new SignalSubscription(this, observer);
                     AddSubscriptionLocked(subscription);
-                    _onNext = DispatchSubscriptions;
                 }
             }
         }
@@ -293,14 +289,12 @@ public class Signal<T> : ISignal<T>
                 if (_singleActionSubscription == null && _singleObserverSubscription == null && _subscriptionCount == 0)
                 {
                     _singleActionSubscription = subscription;
-                    _onNext = onNext;
                 }
                 else
                 {
                     PromoteSingleObserverLocked();
                     PromoteSingleActionObserverLocked();
                     AddSubscriptionLocked(subscription);
-                    _onNext = DispatchSubscriptions;
                 }
             }
         }
@@ -352,7 +346,6 @@ public class Signal<T> : ISignal<T>
             singleObserverSubscription = _singleObserverSubscription;
             subscriptions = ClearObserversLocked();
             _exception = null;
-            _onNext = ThrowDisposedOnNext;
             _isDisposed = true;
         }
         finally
@@ -380,7 +373,7 @@ public class Signal<T> : ISignal<T>
     /// <param name="subscriptions">The subscriptions value.</param>
     private static void Completed(SignalSubscription? singleObserver, SignalSubscription?[]? subscriptions)
     {
-        singleObserver?.Observer?.OnCompleted();
+        singleObserver?.OnCompleted();
         if (subscriptions == null)
         {
             return;
@@ -388,7 +381,7 @@ public class Signal<T> : ISignal<T>
 
         for (var i = 0; i < subscriptions.Length; i++)
         {
-            subscriptions[i]?.Observer?.OnCompleted();
+            subscriptions[i]?.OnCompleted();
         }
     }
 
@@ -400,7 +393,7 @@ public class Signal<T> : ISignal<T>
     /// <param name="exception">The exception value.</param>
     private static void Error(SignalSubscription? singleObserver, SignalSubscription?[]? subscriptions, Exception exception)
     {
-        singleObserver?.Observer?.OnError(exception);
+        singleObserver?.OnError(exception);
         if (subscriptions == null)
         {
             return;
@@ -408,7 +401,7 @@ public class Signal<T> : ISignal<T>
 
         for (var i = 0; i < subscriptions.Length; i++)
         {
-            subscriptions[i]?.Observer?.OnError(exception);
+            subscriptions[i]?.OnError(exception);
         }
     }
 
@@ -426,7 +419,7 @@ public class Signal<T> : ISignal<T>
 
         for (var i = 0; i < subscriptions.Length; i++)
         {
-            if (subscriptions[i]?.OnNext != null)
+            if (subscriptions[i]?.IsAction == true)
             {
                 return true;
             }
@@ -485,7 +478,6 @@ public class Signal<T> : ISignal<T>
                 continue;
             }
 
-            subscription.Index = i;
             Volatile.Write(ref subscriptions[i], subscription);
             _subscriptionCount++;
             return;
@@ -499,7 +491,6 @@ public class Signal<T> : ISignal<T>
             Volatile.Write(ref _subscriptions, subscriptions);
         }
 
-        subscription.Index = _subscriptionTail;
         Volatile.Write(ref subscriptions[_subscriptionTail], subscription);
         _subscriptionTail++;
         _subscriptionCount++;
@@ -517,7 +508,6 @@ public class Signal<T> : ISignal<T>
         Volatile.Write(ref _subscriptions, null);
         _subscriptionCount = 0;
         _subscriptionTail = 0;
-        _onNext = NoopOnNext;
         return subscriptions;
     }
 
@@ -587,7 +577,6 @@ public class Signal<T> : ISignal<T>
         if (ReferenceEquals(_singleActionSubscription, subscription))
         {
             _singleActionSubscription = null;
-            _onNext = _subscriptionCount == 0 && _singleObserverSubscription == null ? NoopOnNext : DispatchSubscriptions;
             return true;
         }
 
@@ -597,7 +586,6 @@ public class Signal<T> : ISignal<T>
         }
 
         _singleObserverSubscription = null;
-        _onNext = _subscriptionCount == 0 && _singleActionSubscription == null ? NoopOnNext : DispatchSubscriptions;
         return true;
     }
 
@@ -608,23 +596,28 @@ public class Signal<T> : ISignal<T>
     private void RemoveArraySubscriptionLocked(SignalSubscription subscription)
     {
         var subscriptions = _subscriptions;
-        var index = subscription.Index;
-        if (subscriptions == null ||
-            (uint)index >= (uint)subscriptions.Length ||
-            !ReferenceEquals(subscriptions[index], subscription))
+        if (subscriptions == null)
         {
             return;
         }
 
-        Volatile.Write(ref subscriptions[index], null);
-        _subscriptionCount--;
-        if (_subscriptionCount != 0)
+        for (var i = 0; i < subscriptions.Length; i++)
         {
+            if (!ReferenceEquals(subscriptions[i], subscription))
+            {
+                continue;
+            }
+
+            Volatile.Write(ref subscriptions[i], null);
+            _subscriptionCount--;
+            if (_subscriptionCount != 0)
+            {
+                return;
+            }
+
+            _subscriptionTail = 0;
             return;
         }
-
-        _subscriptionTail = 0;
-        _onNext = _singleActionSubscription == null && _singleObserverSubscription == null ? NoopOnNext : DispatchSubscriptions;
     }
 
     /// <summary>
@@ -647,15 +640,7 @@ public class Signal<T> : ISignal<T>
                 continue;
             }
 
-            var onNext = subscription.OnNext;
-            if (onNext != null)
-            {
-                onNext(value);
-            }
-            else
-            {
-                subscription.Observer!.OnNext(value);
-            }
+            subscription.OnNext(value);
         }
     }
 
@@ -664,6 +649,11 @@ public class Signal<T> : ISignal<T>
     /// </summary>
     private sealed class SignalSubscription : IDisposable
     {
+        /// <summary>
+        /// Stores the observer or action target.
+        /// </summary>
+        private readonly object _target;
+
         /// <summary>
         /// Stores state for the signal implementation.
         /// </summary>
@@ -677,8 +667,7 @@ public class Signal<T> : ISignal<T>
         public SignalSubscription(Signal<T> subject, IObserver<T> observer)
         {
             _subject = subject;
-            Observer = observer;
-            Index = -1;
+            _target = observer;
         }
 
         /// <summary>
@@ -689,24 +678,65 @@ public class Signal<T> : ISignal<T>
         public SignalSubscription(Signal<T> subject, Action<T> onNext)
         {
             _subject = subject;
-            OnNext = onNext;
-            Index = -1;
+            _target = onNext;
         }
 
         /// <summary>
-        /// Gets or sets the value.
+        /// Gets a value indicating whether this subscription stores an action callback.
         /// </summary>
-        public int Index { get; set; }
+        public bool IsAction => _target is Action<T>;
 
         /// <summary>
-        /// Gets the value.
+        /// Gets the observer target.
         /// </summary>
-        public IObserver<T>? Observer { get; }
+        public IObserver<T> Observer => (IObserver<T>)_target;
 
         /// <summary>
-        /// Gets the value.
+        /// Gets the action target.
         /// </summary>
-        public Action<T>? OnNext { get; }
+        public Action<T> Action => (Action<T>)_target;
+
+        /// <summary>
+        /// Sends a value to the subscription target.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        public void OnNext(T value)
+        {
+            if (IsAction)
+            {
+                Action(value);
+                return;
+            }
+
+            Observer.OnNext(value);
+        }
+
+        /// <summary>
+        /// Sends an error to observer subscriptions.
+        /// </summary>
+        /// <param name="exception">The exception.</param>
+        public void OnError(Exception exception)
+        {
+            if (IsAction)
+            {
+                return;
+            }
+
+            Observer.OnError(exception);
+        }
+
+        /// <summary>
+        /// Sends completion to observer subscriptions.
+        /// </summary>
+        public void OnCompleted()
+        {
+            if (IsAction)
+            {
+                return;
+            }
+
+            Observer.OnCompleted();
+        }
 
         /// <summary>
         /// Executes the Dispose operation.

--- a/src/ReactiveUI.Primitives/Signal/Signal{T}.cs
+++ b/src/ReactiveUI.Primitives/Signal/Signal{T}.cs
@@ -12,7 +12,6 @@ namespace ReactiveUI.Primitives.Signals;
 /// Subject.
 /// </summary>
 /// <typeparam name="T">The Type.</typeparam>
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 public class Signal<T> : ISignal<T>
 {
     /// <summary>

--- a/src/ReactiveUI.Primitives/Signal/StateSignal{T}.cs
+++ b/src/ReactiveUI.Primitives/Signal/StateSignal{T}.cs
@@ -12,7 +12,6 @@ namespace ReactiveUI.Primitives.Signals;
 /// Mutable latest-value signal with a ReactiveUI.Primitives name for reactive-property parity.
 /// </summary>
 /// <typeparam name="T">The value type.</typeparam>
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 public class StateSignal<T> : BehaviourSignal<T>
 {
     /// <summary>

--- a/src/ReactiveUI.Primitives/Signal/TaskSignal.cs
+++ b/src/ReactiveUI.Primitives/Signal/TaskSignal.cs
@@ -9,7 +9,6 @@ namespace ReactiveUI.Primitives.Signals;
 /// <summary>
 /// TaskSignal.
 /// </summary>
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 public static class TaskSignal
 {
     /// <summary>

--- a/src/ReactiveUI.Primitives/Signal/TaskSignal{T}.cs
+++ b/src/ReactiveUI.Primitives/Signal/TaskSignal{T}.cs
@@ -11,7 +11,6 @@ namespace ReactiveUI.Primitives.Signals;
 /// TaskSignal.
 /// </summary>
 /// <typeparam name="T">The object that provides notification information.</typeparam>
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 internal sealed class TaskSignal<T> : ITaskSignal<T>
 {
     /// <summary>

--- a/src/ReactiveUI.Primitives/SignalOperatorMixins.cs
+++ b/src/ReactiveUI.Primitives/SignalOperatorMixins.cs
@@ -6,6 +6,7 @@ using ReactiveUI.Primitives.Concurrency;
 using ReactiveUI.Primitives.Core;
 using ReactiveUI.Primitives.Disposables;
 using ReactiveUI.Primitives.Signals;
+using ReactiveUI.Primitives.Signals.Core;
 
 #pragma warning disable SA1107, SA1116, SA1117, SA1501, SA1611, SA1615, SA1618
 
@@ -626,6 +627,11 @@ public static partial class LinqMixins
         if (selector == null)
         {
             throw new ArgumentNullException(nameof(selector));
+        }
+
+        if (left is RangeSignal leftRange && right is RangeSignal rightRange)
+        {
+            return new RangeZipSignal<TResult>(leftRange, rightRange, (Func<int, int, TResult>)(object)selector);
         }
 
         return Signal.CreateSafe<TResult>(observer => new ZipCoordinator<TLeft, TRight, TResult>(observer, selector).Run(left, right));

--- a/src/ReactiveUI.Primitives/Signals/Core/CatchSignal{T,TException}.cs
+++ b/src/ReactiveUI.Primitives/Signals/Core/CatchSignal{T,TException}.cs
@@ -11,7 +11,6 @@ namespace ReactiveUI.Primitives.Signals.Core;
 /// </summary>
 /// <typeparam name="T">The T type.</typeparam>
 /// <typeparam name="TException">The TException type.</typeparam>
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 internal sealed class CatchSignal<T, TException> : SignalsBase<T>
         where TException : Exception
 {

--- a/src/ReactiveUI.Primitives/Signals/Core/CatchSignal{T}.cs
+++ b/src/ReactiveUI.Primitives/Signals/Core/CatchSignal{T}.cs
@@ -11,7 +11,6 @@ namespace ReactiveUI.Primitives.Signals.Core;
 /// Represents the CatchSignal class.
 /// </summary>
 /// <typeparam name="T">The T type.</typeparam>
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 internal sealed class CatchSignal<T> : SignalsBase<T>
 {
     /// <summary>
@@ -102,7 +101,8 @@ internal sealed class CatchSignal<T> : SignalsBase<T>
                 lock (_gate)
                 {
                     _isDisposed = true;
-                    _e.Dispose();
+                    _e?.Dispose();
+                    _e = null;
                 }
             }));
         }

--- a/src/ReactiveUI.Primitives/Signals/Core/CreateSafeSignal{T}.cs
+++ b/src/ReactiveUI.Primitives/Signals/Core/CreateSafeSignal{T}.cs
@@ -10,7 +10,6 @@ namespace ReactiveUI.Primitives.Signals.Core;
 /// Represents the CreateSafeSignal class.
 /// </summary>
 /// <typeparam name="T">The T type.</typeparam>
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 internal sealed class CreateSafeSignal<T> : SignalsBase<T>
 {
     /// <summary>

--- a/src/ReactiveUI.Primitives/Signals/Core/CreateSignal{T,TState}.cs
+++ b/src/ReactiveUI.Primitives/Signals/Core/CreateSignal{T,TState}.cs
@@ -11,7 +11,6 @@ namespace ReactiveUI.Primitives.Signals.Core;
 /// </summary>
 /// <typeparam name="T">The T type.</typeparam>
 /// <typeparam name="TState">The TState type.</typeparam>
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 internal sealed class CreateSignal<T, TState> : SignalsBase<T>
 {
     /// <summary>

--- a/src/ReactiveUI.Primitives/Signals/Core/CreateSignal{T}.cs
+++ b/src/ReactiveUI.Primitives/Signals/Core/CreateSignal{T}.cs
@@ -10,7 +10,6 @@ namespace ReactiveUI.Primitives.Signals.Core;
 /// Represents the CreateSignal class.
 /// </summary>
 /// <typeparam name="T">The T type.</typeparam>
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 internal sealed class CreateSignal<T> : SignalsBase<T>
 {
     /// <summary>

--- a/src/ReactiveUI.Primitives/Signals/Core/DeferSignal{T}.cs
+++ b/src/ReactiveUI.Primitives/Signals/Core/DeferSignal{T}.cs
@@ -8,7 +8,6 @@ namespace ReactiveUI.Primitives.Signals.Core;
 /// Represents the DeferSignal class.
 /// </summary>
 /// <typeparam name="T">The T type.</typeparam>
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 internal sealed class DeferSignal<T> : SignalsBase<T>
 {
     /// <summary>

--- a/src/ReactiveUI.Primitives/Signals/Core/EmptySignal{T}.cs
+++ b/src/ReactiveUI.Primitives/Signals/Core/EmptySignal{T}.cs
@@ -11,7 +11,6 @@ namespace ReactiveUI.Primitives.Signals.Core;
 /// Represents the EmptySignal class.
 /// </summary>
 /// <typeparam name="T">The T type.</typeparam>
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 internal sealed class EmptySignal<T> : SignalsBase<T>
 {
     /// <summary>

--- a/src/ReactiveUI.Primitives/Signals/Core/FinallySignal{T}.cs
+++ b/src/ReactiveUI.Primitives/Signals/Core/FinallySignal{T}.cs
@@ -10,7 +10,6 @@ namespace ReactiveUI.Primitives.Signals.Core;
 /// Represents the FinallySignal class.
 /// </summary>
 /// <typeparam name="T">The T type.</typeparam>
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 internal sealed class FinallySignal<T> : SignalsBase<T>
 {
     /// <summary>

--- a/src/ReactiveUI.Primitives/Signals/Core/FromEnumerableSignal{T}.cs
+++ b/src/ReactiveUI.Primitives/Signals/Core/FromEnumerableSignal{T}.cs
@@ -11,7 +11,6 @@ namespace ReactiveUI.Primitives.Signals.Core;
 /// Represents a finite signal backed by an enumerable sequence.
 /// </summary>
 /// <typeparam name="T">The value type.</typeparam>
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 internal sealed class FromEnumerableSignal<T> : IRequireCurrentThread<T>, IInlineSignal<T>
 {
     /// <summary>

--- a/src/ReactiveUI.Primitives/Signals/Core/ImmediateReturnSignal{T}.cs
+++ b/src/ReactiveUI.Primitives/Signals/Core/ImmediateReturnSignal{T}.cs
@@ -11,7 +11,6 @@ namespace ReactiveUI.Primitives.Signals.Core;
 /// Represents the ImmediateReturnSignal class.
 /// </summary>
 /// <typeparam name="T">The T type.</typeparam>
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 internal sealed class ImmediateReturnSignal<T> : IRequireCurrentThread<T>, IInlineSignal<T>
 {
     /// <summary>

--- a/src/ReactiveUI.Primitives/Signals/Core/ImmediateThrowSignal{T}.cs
+++ b/src/ReactiveUI.Primitives/Signals/Core/ImmediateThrowSignal{T}.cs
@@ -11,7 +11,6 @@ namespace ReactiveUI.Primitives.Signals.Core;
 /// Represents the immediate Throw signal fast path.
 /// </summary>
 /// <typeparam name="T">The T type.</typeparam>
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 internal sealed class ImmediateThrowSignal<T> : IRequireCurrentThread<T>, IInlineSignal<T>
 {
     /// <summary>

--- a/src/ReactiveUI.Primitives/Signals/Core/ImmutableEmptySignal{T}.cs
+++ b/src/ReactiveUI.Primitives/Signals/Core/ImmutableEmptySignal{T}.cs
@@ -11,7 +11,6 @@ namespace ReactiveUI.Primitives.Signals.Core;
 /// Represents the ImmutableEmptySignal class.
 /// </summary>
 /// <typeparam name="T">The T type.</typeparam>
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 internal sealed class ImmutableEmptySignal<T> : IRequireCurrentThread<T>, IInlineSignal<T>
 {
 #pragma warning disable SA1401 // Fields should be private

--- a/src/ReactiveUI.Primitives/Signals/Core/ImmutableNeverSignal{T}.cs
+++ b/src/ReactiveUI.Primitives/Signals/Core/ImmutableNeverSignal{T}.cs
@@ -11,7 +11,6 @@ namespace ReactiveUI.Primitives.Signals.Core;
 /// Represents the ImmutableNeverSignal class.
 /// </summary>
 /// <typeparam name="T">The T type.</typeparam>
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 internal sealed class ImmutableNeverSignal<T> : IRequireCurrentThread<T>
 {
 #pragma warning disable SA1401 // Fields should be private

--- a/src/ReactiveUI.Primitives/Signals/Core/ImmutableReturnFalseSignal.cs
+++ b/src/ReactiveUI.Primitives/Signals/Core/ImmutableReturnFalseSignal.cs
@@ -10,7 +10,6 @@ namespace ReactiveUI.Primitives.Signals.Core;
 /// <summary>
 /// Represents the ImmutableReturnFalseSignal class.
 /// </summary>
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 internal sealed class ImmutableReturnFalseSignal : IRequireCurrentThread<bool>, IInlineSignal<bool>
 {
 #pragma warning disable SA1401 // Fields should be private

--- a/src/ReactiveUI.Primitives/Signals/Core/ImmutableReturnRxVoidSignal.cs
+++ b/src/ReactiveUI.Primitives/Signals/Core/ImmutableReturnRxVoidSignal.cs
@@ -10,7 +10,6 @@ namespace ReactiveUI.Primitives.Signals.Core;
 /// <summary>
 /// Represents the ImmutableReturnRxVoidSignal class.
 /// </summary>
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 internal sealed class ImmutableReturnRxVoidSignal : IRequireCurrentThread<RxVoid>, IInlineSignal<RxVoid>
 {
 #pragma warning disable SA1401 // Fields should be private

--- a/src/ReactiveUI.Primitives/Signals/Core/ImmutableReturnTrueSignal.cs
+++ b/src/ReactiveUI.Primitives/Signals/Core/ImmutableReturnTrueSignal.cs
@@ -10,7 +10,6 @@ namespace ReactiveUI.Primitives.Signals.Core;
 /// <summary>
 /// Represents the ImmutableReturnTrueSignal class.
 /// </summary>
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 internal sealed class ImmutableReturnTrueSignal : IRequireCurrentThread<bool>, IInlineSignal<bool>
 {
 #pragma warning disable SA1401 // Fields should be private

--- a/src/ReactiveUI.Primitives/Signals/Core/RangeSignal.cs
+++ b/src/ReactiveUI.Primitives/Signals/Core/RangeSignal.cs
@@ -10,7 +10,6 @@ namespace ReactiveUI.Primitives.Signals.Core;
 /// <summary>
 /// Represents the RangeSignal class.
 /// </summary>
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 internal sealed class RangeSignal : IRequireCurrentThread<int>, IInlineSignal<int>
 {
     /// <summary>

--- a/src/ReactiveUI.Primitives/Signals/Core/RangeZipSignal{TResult}.cs
+++ b/src/ReactiveUI.Primitives/Signals/Core/RangeZipSignal{TResult}.cs
@@ -8,30 +8,44 @@ using ReactiveUI.Primitives.Disposables;
 namespace ReactiveUI.Primitives.Signals.Core;
 
 /// <summary>
-/// Represents the RangeSignal class.
+/// Zips two synchronous integer ranges without coordinator queues.
 /// </summary>
-internal sealed class RangeSignal : IRequireCurrentThread<int>, IInlineSignal<int>
+/// <typeparam name="TResult">The result value type.</typeparam>
+internal sealed class RangeZipSignal<TResult> : IRequireCurrentThread<TResult>, IInlineSignal<TResult>
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="RangeSignal"/> class.
+    /// Stores state for the signal implementation.
     /// </summary>
-    /// <param name="start">The start value.</param>
-    /// <param name="count">The count value.</param>
-    public RangeSignal(int start, int count)
+    private readonly int _leftStart;
+
+    /// <summary>
+    /// Stores state for the signal implementation.
+    /// </summary>
+    private readonly int _rightStart;
+
+    /// <summary>
+    /// Stores state for the signal implementation.
+    /// </summary>
+    private readonly int _count;
+
+    /// <summary>
+    /// Stores state for the signal implementation.
+    /// </summary>
+    private readonly Func<int, int, TResult> _selector;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RangeZipSignal{TResult}"/> class.
+    /// </summary>
+    /// <param name="left">The left range source.</param>
+    /// <param name="right">The right range source.</param>
+    /// <param name="selector">The projection function.</param>
+    public RangeZipSignal(RangeSignal left, RangeSignal right, Func<int, int, TResult> selector)
     {
-        Start = start;
-        Count = count;
+        _leftStart = left.Start;
+        _rightStart = right.Start;
+        _count = Math.Min(left.Count, right.Count);
+        _selector = selector;
     }
-
-    /// <summary>
-    /// Gets the first value emitted by the range.
-    /// </summary>
-    internal int Start { get; }
-
-    /// <summary>
-    /// Gets the number of values emitted by the range.
-    /// </summary>
-    internal int Count { get; }
 
     /// <summary>
     /// Executes the IsRequiredSubscribeOnCurrentThread operation.
@@ -44,16 +58,16 @@ internal sealed class RangeSignal : IRequireCurrentThread<int>, IInlineSignal<in
     /// </summary>
     /// <param name="observer">The observer value.</param>
     /// <returns>The result.</returns>
-    public IDisposable Subscribe(IObserver<int> observer)
+    public IDisposable Subscribe(IObserver<TResult> observer)
     {
         if (observer == null)
         {
             throw new ArgumentNullException(nameof(observer));
         }
 
-        for (var i = 0; i < Count; i++)
+        for (var i = 0; i < _count; i++)
         {
-            observer.OnNext(Start + i);
+            observer.OnNext(_selector(_leftStart + i, _rightStart + i));
         }
 
         observer.OnCompleted();
@@ -67,16 +81,16 @@ internal sealed class RangeSignal : IRequireCurrentThread<int>, IInlineSignal<in
     /// <param name="onError">The onError value.</param>
     /// <param name="onCompleted">The onCompleted value.</param>
     /// <returns>The result.</returns>
-    public IDisposable Subscribe(Action<int> onNext, Action<Exception> onError, Action onCompleted)
+    public IDisposable Subscribe(Action<TResult> onNext, Action<Exception> onError, Action onCompleted)
     {
         if (onNext == null)
         {
             throw new ArgumentNullException(nameof(onNext));
         }
 
-        for (var i = 0; i < Count; i++)
+        for (var i = 0; i < _count; i++)
         {
-            onNext(Start + i);
+            onNext(_selector(_leftStart + i, _rightStart + i));
         }
 
         onCompleted();

--- a/src/ReactiveUI.Primitives/Signals/Core/RepeatSignal{T}.cs
+++ b/src/ReactiveUI.Primitives/Signals/Core/RepeatSignal{T}.cs
@@ -11,7 +11,6 @@ namespace ReactiveUI.Primitives.Signals.Core;
 /// Represents the RepeatSignal class.
 /// </summary>
 /// <typeparam name="T">The T type.</typeparam>
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 internal sealed class RepeatSignal<T> : IRequireCurrentThread<T>, IInlineSignal<T>
 {
     /// <summary>

--- a/src/ReactiveUI.Primitives/Signals/Core/ReturnSignal{T}.cs
+++ b/src/ReactiveUI.Primitives/Signals/Core/ReturnSignal{T}.cs
@@ -11,7 +11,6 @@ namespace ReactiveUI.Primitives.Signals.Core;
 /// Represents the ReturnSignal class.
 /// </summary>
 /// <typeparam name="T">The T type.</typeparam>
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 internal sealed class ReturnSignal<T> : SignalsBase<T>
 {
     /// <summary>

--- a/src/ReactiveUI.Primitives/Signals/Core/SignalsBase{T}.cs
+++ b/src/ReactiveUI.Primitives/Signals/Core/SignalsBase{T}.cs
@@ -12,7 +12,6 @@ namespace ReactiveUI.Primitives.Signals.Core;
 /// Represents the SignalsBase class.
 /// </summary>
 /// <typeparam name="T">The T type.</typeparam>
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 internal abstract class SignalsBase<T> : IRequireCurrentThread<T>
 {
     /// <summary>

--- a/src/ReactiveUI.Primitives/Signals/Core/ThrowSignal{T}.cs
+++ b/src/ReactiveUI.Primitives/Signals/Core/ThrowSignal{T}.cs
@@ -11,7 +11,6 @@ namespace ReactiveUI.Primitives.Signals.Core;
 /// Represents the ThrowSignal class.
 /// </summary>
 /// <typeparam name="T">The T type.</typeparam>
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 internal sealed class ThrowSignal<T> : SignalsBase<T>
 {
     /// <summary>

--- a/src/ReactiveUI.Primitives/Signals/Core/WitnessOnSignal{T}.cs
+++ b/src/ReactiveUI.Primitives/Signals/Core/WitnessOnSignal{T}.cs
@@ -12,7 +12,6 @@ namespace ReactiveUI.Primitives.Signals.Core;
 /// Represents the WitnessOnSignal class.
 /// </summary>
 /// <typeparam name="T">The T type.</typeparam>
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 internal sealed class WitnessOnSignal<T> : SignalsBase<T>
 {
     /// <summary>

--- a/src/ReactiveUI.Primitives/Signals/Signal{Catch}.cs
+++ b/src/ReactiveUI.Primitives/Signals/Signal{Catch}.cs
@@ -9,7 +9,6 @@ namespace ReactiveUI.Primitives.Signals;
 /// <summary>
 /// Signals.
 /// </summary>
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 public static partial class Signal
 {
     /// <summary>

--- a/src/ReactiveUI.Primitives/SubscribeMixins.cs
+++ b/src/ReactiveUI.Primitives/SubscribeMixins.cs
@@ -11,7 +11,6 @@ namespace ReactiveUI.Primitives;
 /// <summary>
 /// SubscribeMixins.
 /// </summary>
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 public static class SubscribeMixins
 {
     /// <summary>

--- a/src/benchmarks/ReactiveUI.Primitives.Benchmarks/ConnectableShareBenchmarks.cs
+++ b/src/benchmarks/ReactiveUI.Primitives.Benchmarks/ConnectableShareBenchmarks.cs
@@ -1,0 +1,82 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using BenchmarkDotNet.Attributes;
+using ReactiveUI.Primitives;
+using ReactiveUI.Primitives.Signals;
+
+namespace ReactiveUI.Primitives.Benchmarks;
+
+/// <summary>
+/// Benchmarks for connectable and share APIs.
+/// </summary>
+[MemoryDiagnoser]
+public class ConnectableShareBenchmarks
+{
+    private const int Count = 32;
+
+    /// <summary>
+    /// Benchmarks publish-live connection.
+    /// </summary>
+    /// <returns>The observed total.</returns>
+    [Benchmark(Baseline = true)]
+    public int PrimitivesPublishLiveConnect()
+    {
+        var observer = new IntSignalObserver();
+        var connectable = Signal.Range(1, Count).PublishLive();
+        using var subscription = connectable.Subscribe(observer);
+        using var connection = connectable.Connect();
+        return observer.Total;
+    }
+
+    /// <summary>
+    /// Benchmarks share-live reference counting.
+    /// </summary>
+    /// <returns>The observed total.</returns>
+    [Benchmark]
+    public int PrimitivesShareLiveSubscribe()
+    {
+        var observer = new IntSignalObserver();
+        using var subscription = Signal.Range(1, Count).ShareLive().Subscribe(observer);
+        return observer.Total;
+    }
+
+    /// <summary>
+    /// Benchmarks replay-live late subscription.
+    /// </summary>
+    /// <returns>The observed total.</returns>
+    [Benchmark]
+    public int PrimitivesReplayLiveLateSubscribe()
+    {
+        var observer = new IntSignalObserver();
+        var connectable = Signal.Range(1, Count).ReplayLive(Count);
+        using var connection = connectable.Connect();
+        using var subscription = connectable.Subscribe(observer);
+        return observer.Total;
+    }
+
+    /// <summary>
+    /// Benchmarks ref-count subscription.
+    /// </summary>
+    /// <returns>The observed total.</returns>
+    [Benchmark]
+    public int PrimitivesRefCountSubscribe()
+    {
+        var observer = new IntSignalObserver();
+        using var subscription = Signal.Range(1, Count).PublishLive().RefCount().Subscribe(observer);
+        return observer.Total;
+    }
+
+    /// <summary>
+    /// Benchmarks auto-connect subscription.
+    /// </summary>
+    /// <returns>The observed total.</returns>
+    [Benchmark]
+    public int PrimitivesAutoConnectSubscribe()
+    {
+        var observer = new IntSignalObserver();
+        using var subscription = Signal.Range(1, Count).PublishLive().AutoConnect().Subscribe(observer);
+        return observer.Total;
+    }
+}

--- a/src/benchmarks/ReactiveUI.Primitives.Benchmarks/FactoryAdapterExpansionBenchmarks.cs
+++ b/src/benchmarks/ReactiveUI.Primitives.Benchmarks/FactoryAdapterExpansionBenchmarks.cs
@@ -1,0 +1,135 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+using ReactiveUI.Primitives.Concurrency;
+using ReactiveUI.Primitives.Disposables;
+using ReactiveUI.Primitives.Signals;
+
+namespace ReactiveUI.Primitives.Benchmarks;
+
+/// <summary>
+/// Benchmarks for factory and adapter creation surfaces.
+/// </summary>
+[MemoryDiagnoser]
+public class FactoryAdapterExpansionBenchmarks
+{
+    private const int Count = 16;
+    private const int Value = 42;
+
+    /// <summary>
+    /// Benchmarks a custom create signal.
+    /// </summary>
+    /// <returns>The observed total.</returns>
+    [Benchmark(Baseline = true)]
+    public int PrimitivesCreateSubscribe()
+    {
+        var observer = new IntSignalObserver();
+        using var subscription = Signal.Create<int>(target =>
+        {
+            target.OnNext(Value);
+            target.OnCompleted();
+            return Disposable.Empty;
+        }).Subscribe(observer);
+        return observer.Total;
+    }
+
+    /// <summary>
+    /// Benchmarks a custom safe-create signal.
+    /// </summary>
+    /// <returns>The observed total.</returns>
+    [Benchmark]
+    public int PrimitivesCreateSafeSubscribe()
+    {
+        var observer = new IntSignalObserver();
+        using var subscription = Signal.CreateSafe<int>(target =>
+        {
+            target.OnNext(Value);
+            target.OnCompleted();
+            return Disposable.Empty;
+        }).Subscribe(observer);
+        return observer.Total;
+    }
+
+    /// <summary>
+    /// Benchmarks deferred factory creation.
+    /// </summary>
+    /// <returns>The observed total.</returns>
+    [Benchmark]
+    public int PrimitivesDeferSubscribe()
+    {
+        var observer = new IntSignalObserver();
+        using var subscription = Signal.Defer(() => Signal.Range(1, Count)).Subscribe(observer);
+        return observer.Total;
+    }
+
+    /// <summary>
+    /// Benchmarks starting work on the immediate scheduler.
+    /// </summary>
+    /// <returns>The observed total.</returns>
+    [Benchmark]
+    public int PrimitivesStartSubscribe()
+    {
+        var observer = new IntSignalObserver();
+        using var subscription = Signal.Start(() => Value, Sequencer.Immediate).Subscribe(observer);
+        return observer.Total;
+    }
+
+    /// <summary>
+    /// Benchmarks finite unfold generation.
+    /// </summary>
+    /// <returns>The observed total.</returns>
+    [Benchmark]
+    public int PrimitivesUnfoldSubscribe()
+    {
+        var observer = new IntSignalObserver();
+        using var subscription = Signal.Unfold(0, static state => state < Count, static state => state + 1, static state => state)
+            .Subscribe(observer);
+        return observer.Total;
+    }
+
+    /// <summary>
+    /// Benchmarks resource-scoped signal creation.
+    /// </summary>
+    /// <returns>The observed total.</returns>
+    [Benchmark]
+    public int PrimitivesUseSubscribe()
+    {
+        var observer = new IntSignalObserver();
+        using var subscription = Signal.Use(static () => Disposable.Empty, static _ => Signal.Return(Value)).Subscribe(observer);
+        return observer.Total;
+    }
+
+    /// <summary>
+    /// Benchmarks async-enumerable adaptation.
+    /// </summary>
+    /// <returns>The number of values collected.</returns>
+    [Benchmark]
+    public async Task<int> PrimitivesFromAsyncEnumerableSubscribeAsync()
+    {
+        return (await Signal.FromAsyncEnumerable(ValuesAsync()).CollectArrayAsync().ConfigureAwait(false)).Length;
+    }
+
+    /// <summary>
+    /// Benchmarks subscribing and disposing a never-ending signal.
+    /// </summary>
+    /// <returns>The observed notification count.</returns>
+    [Benchmark]
+    public int PrimitivesNeverSubscribeDispose()
+    {
+        var observer = new IntSignalObserver();
+        using var subscription = Signal.Never<int>().Subscribe(observer);
+        return observer.NextCount + observer.CompletionCount + observer.ErrorCount;
+    }
+
+    private static async IAsyncEnumerable<int> ValuesAsync()
+    {
+        await Task.Yield();
+        for (var i = 0; i < Count; i++)
+        {
+            yield return i;
+        }
+    }
+}

--- a/src/benchmarks/ReactiveUI.Primitives.Benchmarks/OperatorHigherOrderBenchmarks.cs
+++ b/src/benchmarks/ReactiveUI.Primitives.Benchmarks/OperatorHigherOrderBenchmarks.cs
@@ -1,0 +1,112 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using BenchmarkDotNet.Attributes;
+using ReactiveUI.Primitives;
+using ReactiveUI.Primitives.Signals;
+
+namespace ReactiveUI.Primitives.Benchmarks;
+
+/// <summary>
+/// Benchmarks for higher-order combinators.
+/// </summary>
+[MemoryDiagnoser]
+public class OperatorHigherOrderBenchmarks
+{
+    private const int Count = 16;
+
+    /// <summary>
+    /// Benchmarks concatenating inner ranges.
+    /// </summary>
+    /// <returns>The observed total.</returns>
+    [Benchmark(Baseline = true)]
+    public int PrimitivesConcatRanges()
+    {
+        var observer = new IntSignalObserver();
+        using var subscription = Signal.Concat(Signal.Range(1, Count), Signal.Range(1, Count)).Subscribe(observer);
+        return observer.Total;
+    }
+
+    /// <summary>
+    /// Benchmarks merging inner ranges.
+    /// </summary>
+    /// <returns>The observed total.</returns>
+    [Benchmark]
+    public int PrimitivesMergeRanges()
+    {
+        var observer = new IntSignalObserver();
+        using var subscription = Signal.Merge(Signal.Range(1, Count), Signal.Range(1, Count)).Subscribe(observer);
+        return observer.Total;
+    }
+
+    /// <summary>
+    /// Benchmarks racing two sources.
+    /// </summary>
+    /// <returns>The observed total.</returns>
+    [Benchmark]
+    public int PrimitivesRaceRanges()
+    {
+        var observer = new IntSignalObserver();
+        using var subscription = Signal.Race(Signal.Range(1, Count), Signal.Range(100, Count)).Subscribe(observer);
+        return observer.Total;
+    }
+
+    /// <summary>
+    /// Benchmarks switching to the latest inner source.
+    /// </summary>
+    /// <returns>The observed total.</returns>
+    [Benchmark]
+    public int PrimitivesSwitchRanges()
+    {
+        var observer = new IntSignalObserver();
+        using var subscription = Signal.FromEnumerable([Signal.Range(1, Count), Signal.Range(100, Count)])
+            .Switch()
+            .Subscribe(observer);
+        return observer.Total;
+    }
+
+    /// <summary>
+    /// Benchmarks combine-latest over ranges.
+    /// </summary>
+    /// <returns>The observed total.</returns>
+    [Benchmark]
+    public int PrimitivesCombineLatestRanges()
+    {
+        var observer = new IntSignalObserver();
+        using var subscription = Signal.CombineLatest(
+            Signal.Range(1, Count),
+            Signal.Range(10, Count),
+            static (left, right) => left + right).Subscribe(observer);
+        return observer.Total;
+    }
+
+    /// <summary>
+    /// Benchmarks with-latest over ranges.
+    /// </summary>
+    /// <returns>The observed total.</returns>
+    [Benchmark]
+    public int PrimitivesWithLatestRanges()
+    {
+        var observer = new IntSignalObserver();
+        using var subscription = Signal.Range(1, Count)
+            .WithLatest(Signal.Range(10, Count), static (left, right) => left + right)
+            .Subscribe(observer);
+        return observer.Total;
+    }
+
+    /// <summary>
+    /// Benchmarks fork-join over ranges.
+    /// </summary>
+    /// <returns>The observed total.</returns>
+    [Benchmark]
+    public int PrimitivesForkJoinRanges()
+    {
+        var observer = new IntSignalObserver();
+        using var subscription = Signal.ForkJoin(
+            Signal.Range(1, Count),
+            Signal.Range(10, Count),
+            static (left, right) => left + right).Subscribe(observer);
+        return observer.Total;
+    }
+}

--- a/src/benchmarks/ReactiveUI.Primitives.Benchmarks/OperatorTimeSchedulerBenchmarks.cs
+++ b/src/benchmarks/ReactiveUI.Primitives.Benchmarks/OperatorTimeSchedulerBenchmarks.cs
@@ -1,0 +1,133 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using BenchmarkDotNet.Attributes;
+using ReactiveUI.Primitives;
+using ReactiveUI.Primitives.Concurrency;
+using ReactiveUI.Primitives.Signals;
+
+namespace ReactiveUI.Primitives.Benchmarks;
+
+/// <summary>
+/// Benchmarks for time and scheduler operators.
+/// </summary>
+[MemoryDiagnoser]
+public class OperatorTimeSchedulerBenchmarks
+{
+    private const int Count = 16;
+
+    /// <summary>
+    /// Benchmarks delayed range delivery.
+    /// </summary>
+    /// <returns>The observed total.</returns>
+    [Benchmark(Baseline = true)]
+    public int PrimitivesDelayRange()
+    {
+        var clock = new TestClock();
+        var observer = new IntSignalObserver();
+        using var subscription = Signal.Range(1, Count).Delay(TimeSpan.FromTicks(1), clock).Subscribe(observer);
+        clock.AdvanceBy(TimeSpan.FromTicks(1));
+        return observer.Total;
+    }
+
+    /// <summary>
+    /// Benchmarks delayed subscription.
+    /// </summary>
+    /// <returns>The observed total.</returns>
+    [Benchmark]
+    public int PrimitivesDelayStartRange()
+    {
+        var clock = new TestClock();
+        var observer = new IntSignalObserver();
+        using var subscription = Signal.Range(1, Count).DelayStart(TimeSpan.FromTicks(1), clock).Subscribe(observer);
+        clock.AdvanceBy(TimeSpan.FromTicks(1));
+        return observer.Total;
+    }
+
+    /// <summary>
+    /// Benchmarks throttle over a burst.
+    /// </summary>
+    /// <returns>The last observed value.</returns>
+    [Benchmark]
+    public int PrimitivesThrottleBurst()
+    {
+        var clock = new TestClock();
+        var observer = new IntSignalObserver();
+        using var source = new Signal<int>();
+        using var subscription = source.Throttle(TimeSpan.FromTicks(1), clock).Subscribe(observer);
+        for (var i = 0; i < Count; i++)
+        {
+            source.OnNext(i);
+        }
+
+        clock.AdvanceBy(TimeSpan.FromTicks(1));
+        return observer.LastValue;
+    }
+
+    /// <summary>
+    /// Benchmarks sampling the latest value.
+    /// </summary>
+    /// <returns>The observed total.</returns>
+    [Benchmark]
+    public int PrimitivesSampleLatest()
+    {
+        var clock = new TestClock();
+        var observer = new IntSignalObserver();
+        using var source = new Signal<int>();
+        using var subscription = source.Sample(TimeSpan.FromTicks(1), clock).Subscribe(observer);
+        source.OnNext(Count);
+        clock.AdvanceBy(TimeSpan.FromTicks(1));
+        return observer.Total;
+    }
+
+    /// <summary>
+    /// Benchmarks timestamp projection.
+    /// </summary>
+    /// <returns>The number of timestamps observed.</returns>
+    [Benchmark]
+    public int PrimitivesTimestampRange()
+    {
+        var count = 0;
+        using var subscription = Signal.Range(1, Count).Timestamp(Sequencer.Immediate).Subscribe(_ => count++);
+        return count;
+    }
+
+    /// <summary>
+    /// Benchmarks time-interval projection.
+    /// </summary>
+    /// <returns>The number of intervals observed.</returns>
+    [Benchmark]
+    public int PrimitivesTimeIntervalRange()
+    {
+        var count = 0;
+        using var subscription = Signal.Range(1, Count).TimeInterval(Sequencer.Immediate).Subscribe(_ => count++);
+        return count;
+    }
+
+    /// <summary>
+    /// Benchmarks timeout error delivery.
+    /// </summary>
+    /// <returns>The number of timeout errors observed.</returns>
+    [Benchmark]
+    public int PrimitivesTimeoutNever()
+    {
+        var clock = new TestClock();
+        var observer = new IntSignalObserver();
+        using var subscription = Signal.Never<int>().Timeout(TimeSpan.FromTicks(1), clock).Subscribe(observer);
+        clock.AdvanceBy(TimeSpan.FromTicks(1));
+        return observer.ErrorCount;
+    }
+
+    /// <summary>
+    /// Benchmarks immediate observe-on dispatch.
+    /// </summary>
+    /// <returns>The observed total.</returns>
+    [Benchmark]
+    public int PrimitivesObserveOnImmediate()
+    {
+        var observer = new IntSignalObserver();
+        using var subscription = Signal.Range(1, Count).ObserveOn(Sequencer.Immediate).Subscribe(observer);
+        return observer.Total;
+    }
+}

--- a/src/benchmarks/ReactiveUI.Primitives.Benchmarks/Program.cs
+++ b/src/benchmarks/ReactiveUI.Primitives.Benchmarks/Program.cs
@@ -114,6 +114,47 @@ internal static class Program
         Console.WriteLine($"PrimitivesCompletedTaskBridge={taskBridge.PrimitivesCompletedTaskBridge()}");
         Console.WriteLine($"SystemReactiveCompletedTaskBridge={taskBridge.SystemReactiveCompletedTaskBridge()}");
 
+        await RunExpansionSmokeBenchmarksAsync();
+
+        RunCoreRuntimeSmokeBenchmarks();
+    }
+
+    private static async Task RunExpansionSmokeBenchmarksAsync()
+    {
+        var factoryAdapters = new FactoryAdapterExpansionBenchmarks();
+        Console.WriteLine($"PrimitivesCreateSubscribe={factoryAdapters.PrimitivesCreateSubscribe()}");
+        Console.WriteLine($"PrimitivesDeferSubscribe={factoryAdapters.PrimitivesDeferSubscribe()}");
+        Console.WriteLine(
+            $"PrimitivesFromAsyncEnumerableSubscribe={await factoryAdapters.PrimitivesFromAsyncEnumerableSubscribeAsync()}");
+
+        var timeSchedulers = new OperatorTimeSchedulerBenchmarks();
+        Console.WriteLine($"PrimitivesDelayRange={timeSchedulers.PrimitivesDelayRange()}");
+        Console.WriteLine($"PrimitivesThrottleBurst={timeSchedulers.PrimitivesThrottleBurst()}");
+        Console.WriteLine($"PrimitivesTimeoutNever={timeSchedulers.PrimitivesTimeoutNever()}");
+
+        var higherOrder = new OperatorHigherOrderBenchmarks();
+        Console.WriteLine($"PrimitivesConcatRanges={higherOrder.PrimitivesConcatRanges()}");
+        Console.WriteLine($"PrimitivesCombineLatestRanges={higherOrder.PrimitivesCombineLatestRanges()}");
+        Console.WriteLine($"PrimitivesForkJoinRanges={higherOrder.PrimitivesForkJoinRanges()}");
+
+        var terminalCollections = new TerminalCollectionBenchmarks();
+        Console.WriteLine($"PrimitivesCollectList={terminalCollections.PrimitivesCollectList()}");
+        Console.WriteLine($"PrimitivesFirstAsync={await terminalCollections.PrimitivesFirstAsync()}");
+        Console.WriteLine($"PrimitivesAllContains={terminalCollections.PrimitivesAllContains()}");
+
+        var connectableShare = new ConnectableShareBenchmarks();
+        Console.WriteLine($"PrimitivesPublishLiveConnect={connectableShare.PrimitivesPublishLiveConnect()}");
+        Console.WriteLine($"PrimitivesShareLiveSubscribe={connectableShare.PrimitivesShareLiveSubscribe()}");
+        Console.WriteLine($"PrimitivesReplayLiveLateSubscribe={connectableShare.PrimitivesReplayLiveLateSubscribe()}");
+
+        var stateTaskCommand = new StateTaskCommandBenchmarks();
+        Console.WriteLine($"PrimitivesStateSignalUpdates={stateTaskCommand.PrimitivesStateSignalUpdates()}");
+        Console.WriteLine($"PrimitivesTaskSignalSubscribe={stateTaskCommand.PrimitivesTaskSignalSubscribe()}");
+        Console.WriteLine($"PrimitivesCommandExecute={await stateTaskCommand.PrimitivesCommandExecuteAsync()}");
+    }
+
+    private static void RunCoreRuntimeSmokeBenchmarks()
+    {
         var coreRuntime = new CoreRuntimeBenchmarks();
         Console.WriteLine($"PrimitivesPocketDispose={coreRuntime.PrimitivesPocketDispose()}");
         Console.WriteLine($"SystemReactiveCompositeDispose={coreRuntime.SystemReactiveCompositeDispose()}");

--- a/src/benchmarks/ReactiveUI.Primitives.Benchmarks/StateTaskCommandBenchmarks.cs
+++ b/src/benchmarks/ReactiveUI.Primitives.Benchmarks/StateTaskCommandBenchmarks.cs
@@ -1,0 +1,89 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using BenchmarkDotNet.Attributes;
+using ReactiveUI.Primitives;
+using ReactiveUI.Primitives.Concurrency;
+using ReactiveUI.Primitives.Signals;
+
+namespace ReactiveUI.Primitives.Benchmarks;
+
+/// <summary>
+/// Benchmarks for state, task, and command surfaces.
+/// </summary>
+[MemoryDiagnoser]
+public class StateTaskCommandBenchmarks
+{
+    private const int Count = 32;
+    private const int Value = 42;
+
+    /// <summary>
+    /// Benchmarks state signal updates.
+    /// </summary>
+    /// <returns>The observed total.</returns>
+    [Benchmark(Baseline = true)]
+    public int PrimitivesStateSignalUpdates()
+    {
+        var observer = new IntSignalObserver();
+        using var state = new StateSignal<int>(0);
+        using var subscription = state.Subscribe(observer);
+        for (var i = 0; i < Count; i++)
+        {
+            state.Value = i;
+        }
+
+        return observer.Total;
+    }
+
+    /// <summary>
+    /// Benchmarks read-only state projection.
+    /// </summary>
+    /// <returns>The current projected value.</returns>
+    [Benchmark]
+    public int PrimitivesReadOnlyStateProjection()
+    {
+        using var state = new StateSignal<int>(Value);
+        using var projected = state.ToReadOnlyState(static value => value + 1);
+        state.Value = Value + 1;
+        return projected.Value;
+    }
+
+    /// <summary>
+    /// Benchmarks task signal subscription.
+    /// </summary>
+    /// <returns>The observed total.</returns>
+    [Benchmark]
+    public int PrimitivesTaskSignalSubscribe()
+    {
+        var observer = new IntSignalObserver();
+        using var signal = Signal.FromTask(static _ => Task.FromResult(Value), Sequencer.Immediate);
+        using var subscription = signal.Subscribe(observer);
+        return observer.Total;
+    }
+
+    /// <summary>
+    /// Benchmarks command execution.
+    /// </summary>
+    /// <returns>The command result.</returns>
+    [Benchmark]
+    public async Task<int> PrimitivesCommandExecuteAsync()
+    {
+        using var command = new CommandSignal<int>(static () => Value);
+        return await command.ExecuteAsync().ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Benchmarks command result publication.
+    /// </summary>
+    /// <returns>The observed total.</returns>
+    [Benchmark]
+    public async Task<int> PrimitivesCommandResultSubscribeAsync()
+    {
+        var observer = new IntSignalObserver();
+        using var command = new CommandSignal<int>(static () => Value);
+        using var subscription = command.Results.Subscribe(observer);
+        await command.ExecuteAsync().ConfigureAwait(false);
+        return observer.Total;
+    }
+}

--- a/src/benchmarks/ReactiveUI.Primitives.Benchmarks/TerminalCollectionBenchmarks.cs
+++ b/src/benchmarks/ReactiveUI.Primitives.Benchmarks/TerminalCollectionBenchmarks.cs
@@ -1,0 +1,93 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using BenchmarkDotNet.Attributes;
+using ReactiveUI.Primitives;
+using ReactiveUI.Primitives.Signals;
+
+namespace ReactiveUI.Primitives.Benchmarks;
+
+/// <summary>
+/// Benchmarks for terminal and collection APIs.
+/// </summary>
+[MemoryDiagnoser]
+public class TerminalCollectionBenchmarks
+{
+    private const int Count = 32;
+
+    /// <summary>
+    /// Benchmarks collecting into a list signal.
+    /// </summary>
+    /// <returns>The collected count.</returns>
+    [Benchmark(Baseline = true)]
+    public int PrimitivesCollectList()
+    {
+        var result = 0;
+        using var subscription = Signal.Range(1, Count).CollectList().Subscribe(values => result = values.Count);
+        return result;
+    }
+
+    /// <summary>
+    /// Benchmarks collecting into an array signal.
+    /// </summary>
+    /// <returns>The collected count.</returns>
+    [Benchmark]
+    public int PrimitivesCollectArray()
+    {
+        var result = 0;
+        using var subscription = Signal.Range(1, Count).CollectArray().Subscribe(values => result = values.Length);
+        return result;
+    }
+
+    /// <summary>
+    /// Benchmarks asynchronous array collection.
+    /// </summary>
+    /// <returns>The collected count.</returns>
+    [Benchmark]
+    public async Task<int> PrimitivesCollectArrayAsync()
+    {
+        return (await Signal.Range(1, Count).CollectArrayAsync().ConfigureAwait(false)).Length;
+    }
+
+    /// <summary>
+    /// Benchmarks first-value task conversion.
+    /// </summary>
+    /// <returns>The first value.</returns>
+    [Benchmark]
+    public Task<int> PrimitivesFirstAsync() =>
+        Signal.Range(1, Count).FirstAsync();
+
+    /// <summary>
+    /// Benchmarks last-value task conversion.
+    /// </summary>
+    /// <returns>The last value.</returns>
+    [Benchmark]
+    public Task<int> PrimitivesToTask() =>
+        Signal.Range(1, Count).ToTask();
+
+    /// <summary>
+    /// Benchmarks predicate count.
+    /// </summary>
+    /// <returns>The matching count.</returns>
+    [Benchmark]
+    public int PrimitivesCountPredicate()
+    {
+        var observer = new IntSignalObserver();
+        using var subscription = Signal.Range(1, Count).Count(static value => value % 2 == 0).Subscribe(observer);
+        return observer.Total;
+    }
+
+    /// <summary>
+    /// Benchmarks all and contains terminal predicates.
+    /// </summary>
+    /// <returns>The number of true results.</returns>
+    [Benchmark]
+    public int PrimitivesAllContains()
+    {
+        var result = 0;
+        using var all = Signal.Range(1, Count).All(static value => value > 0).Subscribe(value => result += value ? 1 : 0);
+        using var contains = Signal.Range(1, Count).Contains(Count).Subscribe(value => result += value ? 1 : 0);
+        return result;
+    }
+}

--- a/src/testconfig.json
+++ b/src/testconfig.json
@@ -8,16 +8,14 @@
         "Configuration": {
             "Format": "cobertura",
             "CodeCoverage": {
-                "SkipAutoProperties": true,
                 "ModulePaths": {
+                    "Include": [
+                        ".*ReactiveUI\\.Primitives.*\\.dll$"
+                    ],
                     "Exclude": [
                         ".*Tests\\.dll$",
+                        ".*Benchmarks\\.dll$",
                         ".*TestRunner.*"
-                    ]
-                },
-                "Functions": {
-                    "Exclude": [
-                        ".*__.*"
                     ]
                 }
             }

--- a/src/tests/ReactiveUI.Primitives.Tests/CoverageExpansionTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/CoverageExpansionTests.cs
@@ -1,0 +1,454 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using ReactiveUI.Primitives.Concurrency;
+using ReactiveUI.Primitives.Disposables;
+using ReactiveUI.Primitives.Signals;
+using TUnit.Core;
+
+namespace ReactiveUI.Primitives.Tests;
+
+/// <summary>
+/// Covers production paths that are only reachable through scheduled and error-handling factory variants.
+/// </summary>
+public class CoverageExpansionTests
+{
+    /// <summary>
+    /// The first expected value.
+    /// </summary>
+    private const int First = 1;
+
+    /// <summary>
+    /// The second expected value.
+    /// </summary>
+    private const int Second = 2;
+
+    /// <summary>
+    /// The third expected value.
+    /// </summary>
+    private const int Third = 3;
+
+    /// <summary>
+    /// The fourth expected value.
+    /// </summary>
+    private const int Fourth = 4;
+
+    /// <summary>
+    /// Timeout used when waiting for thread-pool scheduled observer callbacks.
+    /// </summary>
+    private const int TimeoutSeconds = 2;
+
+    /// <summary>
+    /// Reused first-error message.
+    /// </summary>
+    private const string FirstMessage = "first";
+
+    /// <summary>
+    /// Reused stopped event name.
+    /// </summary>
+    private const string StoppedMessage = "stopped";
+
+    /// <summary>
+    /// Deterministic absolute due time for scheduler overload tests.
+    /// </summary>
+    private static readonly DateTimeOffset AbsoluteDueTime = DateTimeOffset.UnixEpoch;
+
+    /// <summary>
+    /// Single-value return expectation.
+    /// </summary>
+    private static readonly int[] SingleFirstExpected = [First];
+
+    /// <summary>
+    /// Expected values produced by the catch params overload.
+    /// </summary>
+    private static readonly int[] CatchRecoveryExpected = [First, Second];
+
+    /// <summary>
+    /// Expected values for create-with-state tests.
+    /// </summary>
+    private static readonly int[] CreateWithStateExpected = [Third];
+
+    /// <summary>
+    /// Awaiter source values.
+    /// </summary>
+    private static readonly int[] AwaiterSource = [First, Second];
+
+    /// <summary>
+    /// Expected values from thread-pool observer dispatch.
+    /// </summary>
+    private static readonly int[] WitnessOnExpected = [First];
+
+    /// <summary>
+    /// Expected values produced by simple scheduling extension overloads.
+    /// </summary>
+    private static readonly int[] ScheduleExpected = [First, Second, Third, Fourth];
+
+    /// <summary>
+    /// Expected virtual-time event sequence.
+    /// </summary>
+    private static readonly string[] VirtualEventsExpected = [FirstMessage, StoppedMessage];
+
+    /// <summary>
+    /// Covers scheduled return, throw, and empty signal implementations.
+    /// </summary>
+    [Test]
+    public void ScheduledScalarFactoriesUseNonImmediateSignalImplementations()
+    {
+        var returned = new List<int>();
+        var returnCompleted = 0;
+        Signal.Return(First, Sequencer.CurrentThread).Subscribe(returned.Add, ex => throw ex, () => returnCompleted++);
+
+        var emptyCompleted = 0;
+        Signal.Empty<int>(Sequencer.CurrentThread).Subscribe(_ => { }, ex => throw ex, () => emptyCompleted++);
+
+        var error = new InvalidOperationException("scheduled");
+        var thrown = new List<Exception>();
+        Signal.Throw<int>(error, Sequencer.CurrentThread).Subscribe(_ => { }, thrown.Add, () => { });
+
+        Assert.Equal(SingleFirstExpected, returned);
+        Assert.Equal(1, returnCompleted);
+        Assert.Equal(1, emptyCompleted);
+        Assert.Same(error, thrown[0]);
+    }
+
+    /// <summary>
+    /// Covers create-with-state overloads and null validation.
+    /// </summary>
+    [Test]
+    public void CreateWithStateFactoriesInvokeStatefulSubscribeCallbacks()
+    {
+        var values = new List<int>();
+        var completed = 0;
+        var disposed = 0;
+
+        Signal.CreateWithState<int, int>(
+                Third,
+                static (state, observer) =>
+                {
+                    observer.OnNext(state);
+                    observer.OnCompleted();
+                    return Disposable.Create(() => { });
+                },
+                false)
+            .Subscribe(values.Add, ex => throw ex, () => completed++);
+
+        var subscription = Signal.CreateWithState<int, int>(
+                Fourth,
+                (state, observer) =>
+                {
+                    observer.OnNext(state);
+                    return Disposable.Create(() => disposed++);
+                })
+            .Subscribe(_ => { });
+        subscription.Dispose();
+
+        Assert.Equal(CreateWithStateExpected, values);
+        Assert.Equal(1, completed);
+        Assert.Equal(1, disposed);
+        Assert.Throws<ArgumentNullException>(() => Signal.Create<int>(null!, true));
+        Assert.Throws<ArgumentNullException>(() => Signal.CreateSafe<int>(null!, true));
+        Assert.Throws<ArgumentNullException>(() => Signal.CreateWithState<int, int>(First, null!));
+        Assert.Throws<ArgumentNullException>(() => Signal.CreateWithState<int, int>(First, null!, true));
+        Assert.Throws<ArgumentNullException>(() => Signal.Defer<int>(null!));
+    }
+
+    /// <summary>
+    /// Covers signal awaiter completion, pre-cancellation, and registered cancellation paths.
+    /// </summary>
+    [Test]
+    public void GetAwaiterCoversCompletionAndCancellationPaths()
+    {
+        var completed = Signal.FromEnumerable(AwaiterSource).GetAwaiter();
+        Assert.True(completed.IsCompleted);
+        Assert.Equal(Second, completed.GetResult());
+
+        using var canceledBeforeSubscribe = new CancellationTokenSource();
+        canceledBeforeSubscribe.Cancel();
+        var alreadyCanceled = Signal.Never<int>().GetAwaiter(canceledBeforeSubscribe.Token);
+        Assert.True(alreadyCanceled.IsCompleted);
+        Assert.Throws<OperationCanceledException>(() => alreadyCanceled.GetResult());
+
+        using var canceledAfterSubscribe = new CancellationTokenSource();
+        var source = new Signal<int>();
+        var awaiter = source.GetAwaiter(canceledAfterSubscribe.Token);
+        canceledAfterSubscribe.Cancel();
+        Assert.True(awaiter.IsCompleted);
+        Assert.Throws<OperationCanceledException>(() => awaiter.GetResult());
+        Assert.Throws<ArgumentNullException>(() => ((IObservable<int>)null!).GetAwaiter());
+        Assert.Throws<ArgumentNullException>(() => ((IObservable<int>)null!).GetAwaiter(CancellationToken.None));
+    }
+
+    /// <summary>
+    /// Covers catch sequence recovery, final error, empty completion, null source, and enumerator failure branches.
+    /// </summary>
+    [Test]
+    public void CatchParamsFactoryCoversRecoveryAndFailureBranches()
+    {
+        var recovered = new List<int>();
+        Signal.Catch(
+                Signal.Throw<int>(new InvalidOperationException(FirstMessage)),
+                Signal.FromEnumerable(CatchRecoveryExpected),
+                Signal.Throw<int>(new InvalidOperationException("unused")))
+            .Subscribe(recovered.Add);
+        Assert.Equal(CatchRecoveryExpected, recovered);
+
+        var finalErrors = new List<Exception>();
+        var finalError = new InvalidOperationException("last");
+        Signal.Catch(Signal.Throw<int>(new InvalidOperationException(FirstMessage)), Signal.Throw<int>(finalError))
+            .Subscribe(_ => { }, finalErrors.Add, () => { });
+        Assert.Same(finalError, finalErrors[0]);
+
+        var completed = 0;
+        Signal.Catch(Array.Empty<IObservable<int>>()).Subscribe(_ => { }, ex => throw ex, () => completed++);
+        Assert.Equal(1, completed);
+
+        var nullSourceErrors = new List<Exception>();
+        Signal.Catch(new IObservable<int>?[] { null! }!)
+            .Subscribe(_ => { }, nullSourceErrors.Add, () => { });
+        Assert.True(nullSourceErrors[0] is InvalidOperationException);
+
+        var moveNextErrors = new List<Exception>();
+        var moveNextError = new InvalidOperationException("move-next");
+        new ThrowingMoveNextEnumerable<IObservable<int>>(moveNextError).Catch()
+            .Subscribe(_ => { }, moveNextErrors.Add, () => { });
+        Assert.Same(moveNextError, moveNextErrors[0]);
+
+        var getEnumeratorError = new InvalidOperationException("enumerator");
+        Assert.Throws<InvalidOperationException>(() =>
+            new ThrowingEnumerable<IObservable<int>>(getEnumeratorError).Catch()
+                .Subscribe(_ => { }, _ => { }, () => { }));
+    }
+
+    /// <summary>
+    /// Covers the thread-pool-specialized witness dispatch implementation.
+    /// </summary>
+    /// <returns>A task representing asynchronous observer dispatch.</returns>
+    [Test]
+    public async Task WitnessOnThreadPoolDispatchesNextCompletedAndErrorSignals()
+    {
+        var values = new List<int>();
+        var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using (Signal.FromEnumerable(WitnessOnExpected)
+                   .WitnessOn(ThreadPoolSequencer.Instance)
+                   .Subscribe(values.Add, completion.SetException, completion.SetResult))
+        {
+            await WaitForAsync(completion.Task);
+        }
+
+        Assert.Equal(WitnessOnExpected, values);
+
+        var error = new InvalidOperationException("thread-pool");
+        var observed = new TaskCompletionSource<Exception>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using (Signal.Throw<int>(error)
+                   .WitnessOn(ThreadPoolSequencer.Instance)
+                   .Subscribe(_ => { }, observed.SetResult, () => { }))
+        {
+            Assert.Same(error, await WaitForAsync(observed.Task));
+        }
+    }
+
+    /// <summary>
+    /// Covers simple sequencer extension validation, delayed overloads, state overloads, and recursive scheduling.
+    /// </summary>
+    [Test]
+    public void SimpleSequencerExtensionsCoverValidationAndRecursiveScheduling()
+    {
+        Assert.Throws<ArgumentNullException>(() => ((ISequencer)null!).Schedule(() => { }));
+        Assert.Throws<ArgumentNullException>(() => Sequencer.Immediate.Schedule((Action)null!));
+        Assert.Throws<ArgumentNullException>(() => ((ISequencer)null!).Schedule(TimeSpan.Zero, () => { }));
+        Assert.Throws<ArgumentNullException>(() => Sequencer.Immediate.Schedule(TimeSpan.Zero, null!));
+        Assert.Throws<ArgumentNullException>(() => ((ISequencer)null!).Schedule(AbsoluteDueTime, () => { }));
+        Assert.Throws<ArgumentNullException>(() => Sequencer.Immediate.Schedule(AbsoluteDueTime, null!));
+        Assert.Throws<ArgumentNullException>(() => ((ISequencer)null!).Schedule(self => self()));
+        Assert.Throws<ArgumentNullException>(() => Sequencer.Immediate.Schedule((Action<Action>)null!));
+        Assert.Throws<ArgumentNullException>(() => ((ISequencer)null!).ScheduleAction(First, _ => { }));
+        Assert.Throws<ArgumentNullException>(() => Sequencer.Immediate.ScheduleAction(First, (Action<int>)null!));
+        Assert.Throws<ArgumentNullException>(() => ((ISequencer)null!).ScheduleAction(First, _ => Disposable.Empty));
+        Assert.Throws<ArgumentNullException>(() => Sequencer.Immediate.ScheduleAction(First, (Func<int, IDisposable>)null!));
+        Assert.Throws<ArgumentNullException>(() => ((ISequencer)null!).ScheduleAction(First, TimeSpan.Zero, _ => { }));
+        Assert.Throws<ArgumentNullException>(() => Sequencer.Immediate.ScheduleAction(First, TimeSpan.Zero, (Action<int>)null!));
+        Assert.Throws<ArgumentNullException>(() => ((ISequencer)null!).ScheduleAction(First, TimeSpan.Zero, _ => Disposable.Empty));
+        Assert.Throws<ArgumentNullException>(() => Sequencer.Immediate.ScheduleAction(First, TimeSpan.Zero, (Func<int, IDisposable>)null!));
+        Assert.Throws<ArgumentNullException>(() => ((ISequencer)null!).ScheduleAction(First, AbsoluteDueTime, _ => { }));
+        Assert.Throws<ArgumentNullException>(() => Sequencer.Immediate.ScheduleAction(First, AbsoluteDueTime, (Action<int>)null!));
+        Assert.Throws<ArgumentNullException>(() => ((ISequencer)null!).ScheduleAction(First, AbsoluteDueTime, _ => Disposable.Empty));
+        Assert.Throws<ArgumentNullException>(() => Sequencer.Immediate.ScheduleAction(First, AbsoluteDueTime, (Func<int, IDisposable>)null!));
+
+        var values = new List<int>();
+        Sequencer.Immediate.ScheduleAction(First, values.Add).Dispose();
+        Sequencer.Immediate.ScheduleAction(Second, value =>
+        {
+            values.Add(value);
+            return Disposable.Empty;
+        }).Dispose();
+        Sequencer.Immediate.ScheduleAction(Third, TimeSpan.Zero, values.Add).Dispose();
+        Sequencer.Immediate.ScheduleAction(Fourth, AbsoluteDueTime, value =>
+        {
+            values.Add(value);
+            return Disposable.Empty;
+        }).Dispose();
+
+        var recursiveCount = 0;
+        Sequencer.Immediate.Schedule(self =>
+        {
+            recursiveCount++;
+            if (recursiveCount >= Third)
+            {
+                return;
+            }
+
+            self();
+        }).Dispose();
+
+        Assert.Equal(ScheduleExpected, values);
+        Assert.Equal(Third, recursiveCount);
+    }
+
+    /// <summary>
+    /// Covers virtual-time service lookup, stopwatch, stop, sleep, and nested-run guard paths.
+    /// </summary>
+    [Test]
+    public void VirtualTimeSequencerBaseCoversServicesStopwatchAndRunGuards()
+    {
+        var clock = new TestClock(DateTimeOffset.UnixEpoch);
+        var provider = (IServiceProvider)clock;
+        Assert.Same(clock, provider.GetService(typeof(IStopwatchProvider))!);
+        Assert.Equal(null, provider.GetService(typeof(string)));
+
+        var stopwatch = clock.StartStopwatch();
+        clock.Sleep(TimeSpan.FromTicks(First));
+        Assert.Equal(TimeSpan.FromTicks(First), stopwatch.Elapsed);
+
+        var events = new List<string>();
+        using var firstSchedule = clock.ScheduleAction(FirstMessage, TimeSpan.FromTicks(First), value =>
+        {
+            events.Add(value);
+            Assert.Throws<InvalidOperationException>(() => clock.AdvanceTo(clock.Now.AddTicks(First)));
+            Assert.Throws<InvalidOperationException>(() => clock.AdvanceBy(TimeSpan.FromTicks(First)));
+        });
+        clock.AdvanceBy(TimeSpan.FromTicks(First));
+
+        using var stoppedSchedule = clock.ScheduleAction(StoppedMessage, TimeSpan.FromTicks(First), events.Add);
+        clock.Stop();
+        clock.Start();
+
+        Assert.Equal(VirtualEventsExpected, events);
+    }
+
+    /// <summary>
+    /// Waits for a task with a bounded timeout.
+    /// </summary>
+    /// <param name="task">The task to wait for.</param>
+    /// <returns>A task that completes when the supplied task completes.</returns>
+    private static async Task WaitForAsync(Task task)
+    {
+        var timeout = Task.Delay(TimeSpan.FromSeconds(TimeoutSeconds));
+        var completed = await Task.WhenAny(task, timeout).ConfigureAwait(false);
+        if (completed == timeout)
+        {
+            throw new TimeoutException("Timed out waiting for scheduled observer dispatch.");
+        }
+
+        await task.ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Waits for a task with a bounded timeout and returns its result.
+    /// </summary>
+    /// <typeparam name="T">The task result type.</typeparam>
+    /// <param name="task">The task to wait for.</param>
+    /// <returns>The task result.</returns>
+    private static async Task<T> WaitForAsync<T>(Task<T> task)
+    {
+        await WaitForAsync((Task)task).ConfigureAwait(false);
+        return await task.ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Enumerable test double whose enumerator throws from <see cref="IEnumerator.MoveNext"/>.
+    /// </summary>
+    /// <typeparam name="T">The value type.</typeparam>
+    private sealed class ThrowingMoveNextEnumerable<T> : IEnumerable<T>
+    {
+        /// <summary>
+        /// Error thrown by the enumerator.
+        /// </summary>
+        private readonly Exception _error;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ThrowingMoveNextEnumerable{T}"/> class.
+        /// </summary>
+        /// <param name="error">The error to throw.</param>
+        public ThrowingMoveNextEnumerable(Exception error) => _error = error;
+
+        /// <inheritdoc/>
+        public IEnumerator<T> GetEnumerator() => new ThrowingMoveNextEnumerator(_error);
+
+        /// <inheritdoc/>
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        /// <summary>
+        /// Enumerator test double that fails on movement.
+        /// </summary>
+        private sealed class ThrowingMoveNextEnumerator : IEnumerator<T>
+        {
+            /// <summary>
+            /// Error thrown by movement.
+            /// </summary>
+            private readonly Exception _error;
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="ThrowingMoveNextEnumerator"/> class.
+            /// </summary>
+            /// <param name="error">The error to throw.</param>
+            public ThrowingMoveNextEnumerator(Exception error) => _error = error;
+
+            /// <inheritdoc/>
+            public T Current => default!;
+
+            /// <inheritdoc/>
+            object IEnumerator.Current => Current!;
+
+            /// <inheritdoc/>
+            public bool MoveNext() => throw _error;
+
+            /// <inheritdoc/>
+            public void Reset() => throw new NotSupportedException();
+
+            /// <inheritdoc/>
+            public void Dispose()
+            {
+            }
+        }
+    }
+
+    /// <summary>
+    /// Enumerable test double that throws when enumeration starts.
+    /// </summary>
+    /// <typeparam name="T">The value type.</typeparam>
+    private sealed class ThrowingEnumerable<T> : IEnumerable<T>
+    {
+        /// <summary>
+        /// Error thrown by enumeration.
+        /// </summary>
+        private readonly Exception _error;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ThrowingEnumerable{T}"/> class.
+        /// </summary>
+        /// <param name="error">The error to throw.</param>
+        public ThrowingEnumerable(Exception error) => _error = error;
+
+        /// <inheritdoc/>
+        public IEnumerator<T> GetEnumerator() => throw _error;
+
+        /// <inheritdoc/>
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+}

--- a/src/tests/ReactiveUI.Primitives.Tests/CoverageExpansionTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/CoverageExpansionTests.cs
@@ -205,8 +205,13 @@ public class CoverageExpansionTests
         Assert.Same(finalError, finalErrors[0]);
 
         var completed = 0;
-        Signal.Catch(Array.Empty<IObservable<int>>()).Subscribe(_ => { }, ex => throw ex, () => completed++);
+        var completedSubscription = Signal.Catch(Array.Empty<IObservable<int>>()).Subscribe(_ => { }, ex => throw ex, () => completed++);
+        completedSubscription.Dispose();
+        completedSubscription.Dispose();
         Assert.Equal(1, completed);
+
+        var activeSubscription = Signal.Catch(Signal.Never<int>()).Subscribe(_ => { }, ex => throw ex, () => { });
+        activeSubscription.Dispose();
 
         var nullSourceErrors = new List<Exception>();
         Signal.Catch(new IObservable<int>?[] { null! }!)

--- a/src/tests/ReactiveUI.Primitives.Tests/CoverageRuntimeTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/CoverageRuntimeTests.cs
@@ -1,0 +1,591 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using ReactiveUI.Primitives.Concurrency;
+using ReactiveUI.Primitives.Core;
+using ReactiveUI.Primitives.Disposables;
+using ReactiveUI.Primitives.Signals.Core;
+using TUnit.Core;
+
+namespace ReactiveUI.Primitives.Tests;
+
+/// <summary>
+/// Covers runtime support types that are internal implementation details but must remain visible to coverage.
+/// </summary>
+public class CoverageRuntimeTests
+{
+    /// <summary>
+    /// A reusable value for one.
+    /// </summary>
+    private const int One = 1;
+
+    /// <summary>
+    /// A reusable value for two.
+    /// </summary>
+    private const int Two = 2;
+
+    /// <summary>
+    /// A reusable value for three.
+    /// </summary>
+    private const int Three = 3;
+
+    /// <summary>
+    /// A reusable value for four.
+    /// </summary>
+    private const int Four = 4;
+
+    /// <summary>
+    /// A reusable value for five.
+    /// </summary>
+    private const int Five = 5;
+
+    /// <summary>
+    /// A reusable value for six.
+    /// </summary>
+    private const int Six = 6;
+
+    /// <summary>
+    /// A reusable value for seven.
+    /// </summary>
+    private const int Seven = 7;
+
+    /// <summary>
+    /// A reusable value for eight.
+    /// </summary>
+    private const int Eight = 8;
+
+    /// <summary>
+    /// A reusable negative value.
+    /// </summary>
+    private const int NegativeOne = -1;
+
+    /// <summary>
+    /// Timeout used when waiting for background scheduled work.
+    /// </summary>
+    private const int TimeoutSeconds = 2;
+
+    /// <summary>
+    /// Expected two-only value sequence.
+    /// </summary>
+    private static readonly int[] ExpectedTwoOnly = [Two];
+
+    /// <summary>
+    /// Expected one-two value sequence.
+    /// </summary>
+    private static readonly int[] ExpectedOneTwo = [One, Two];
+
+    /// <summary>
+    /// Expected three-four value sequence.
+    /// </summary>
+    private static readonly int[] ExpectedThreeFour = [Three, Four];
+
+    /// <summary>
+    /// Expected five-six value sequence.
+    /// </summary>
+    private static readonly int[] ExpectedFiveSix = [Five, Six];
+
+    /// <summary>
+    /// Expected immediate sequencer value sequence.
+    /// </summary>
+    private static readonly int[] ExpectedImmediateValues = [One, Two, Three];
+
+    /// <summary>
+    /// Expected handled error sequence.
+    /// </summary>
+    private static readonly string[] ExpectedHandledErrors = ["handled"];
+
+    /// <summary>
+    /// Expected safe witness event sequence.
+    /// </summary>
+    private static readonly string[] ExpectedSafeEvents = ["next:3", "completed"];
+
+    /// <summary>
+    /// Expected repeated scheduled item invocation sequence.
+    /// </summary>
+    private static readonly string[] ExpectedRepeatedScheduledItemInvocations = ["first", "first"];
+
+    /// <summary>
+    /// Covers disposable slot constructor, disposal, removal, and disposed-assignment branches.
+    /// </summary>
+    [Test]
+    public void DisposableSlotsCoverAssignmentReplacementAndRemovalBranches()
+    {
+        var disposedBeforeAssign = 0;
+        var lateSingle = new SingleDisposable(() => disposedBeforeAssign++);
+        lateSingle.Dispose();
+        lateSingle.Create(Disposable.Create(() => disposedBeforeAssign++));
+        Assert.Equal(Two, disposedBeforeAssign);
+        Assert.Throws<ArgumentNullException>(() => lateSingle.Create(null!));
+
+        var replaced = 0;
+        var replaceable = new SingleReplaceableDisposable(Disposable.Create(() => replaced++), () => replaced++);
+        replaceable.Create(Disposable.Create(() => replaced++));
+        replaceable.Dispose();
+        replaceable.Create(Disposable.Create(() => replaced++));
+        Assert.Equal(Five, replaced);
+        Assert.Throws<ArgumentNullException>(() => replaceable.Create(null!));
+
+        var disposeFalse = 0;
+        var single = new ExposedSingleDisposable(Disposable.Create(() => disposeFalse++));
+        single.DisposeFalse();
+        single.Dispose();
+        Assert.Equal(1, disposeFalse);
+
+        var replaceableFalse = 0;
+        var exposedReplaceable = new ExposedSingleReplaceableDisposable(Disposable.Create(() => replaceableFalse++));
+        exposedReplaceable.DisposeFalse();
+        exposedReplaceable.Dispose();
+        Assert.Equal(1, replaceableFalse);
+
+        var multipleFalse = 0;
+        var exposedMultiple = new ExposedMultipleDisposable(Disposable.Create(() => multipleFalse++));
+        exposedMultiple.DisposeFalse();
+        exposedMultiple.Dispose();
+        Assert.Equal(1, multipleFalse);
+
+        var firstDisposed = 0;
+        var secondDisposed = 0;
+        var thirdDisposed = 0;
+        var fourthDisposed = 0;
+        var missing = Disposable.Empty;
+        var first = Disposable.Create(() => firstDisposed++);
+        var second = Disposable.Create(() => secondDisposed++);
+        var third = Disposable.Create(() => thirdDisposed++);
+        var fourth = Disposable.Create(() => fourthDisposed++);
+        var group = new MultipleDisposable(first, second, third);
+        group.Add(fourth);
+
+        Assert.True(group.Remove(first));
+        Assert.True(group.Remove(second));
+        Assert.True(group.Remove(third));
+        Assert.False(group.Remove(missing));
+        group.Dispose();
+
+        Assert.Equal(1, firstDisposed);
+        Assert.Equal(1, secondDisposed);
+        Assert.Equal(1, thirdDisposed);
+        Assert.Equal(1, fourthDisposed);
+
+        var factoryDisposed = 0;
+        var factoryGroup = MultipleDisposable.Create(
+            Disposable.Create(() => factoryDisposed++),
+            null!,
+            Disposable.Create(() => factoryDisposed++));
+        factoryGroup.Dispose();
+        factoryGroup.Dispose();
+        Assert.Equal(Two, factoryDisposed);
+        Assert.Throws<ArgumentNullException>(() => MultipleDisposable.Create(null!));
+
+        _ = new AssignmentSlot();
+        _ = new AssignmentSlot(() => { });
+        _ = new AssignmentSlot(Disposable.Empty);
+        _ = new Slot();
+        _ = new Slot(() => { });
+        _ = new Slot(Disposable.Empty);
+        _ = new Pocket();
+        _ = new Pocket(Disposable.Empty, Disposable.Empty);
+        _ = new Pocket(Disposable.Empty, Disposable.Empty, Disposable.Empty);
+    }
+
+    /// <summary>
+    /// Covers internal witness implementations and safe observer terminal behavior.
+    /// </summary>
+    [Test]
+    public void WitnessesCoverDisposedThrowEmptyAndSafeBranches()
+    {
+        Assert.Throws<ObjectDisposedException>(() => DisposedWitness<int>.Instance.OnNext(One));
+        Assert.Throws<ObjectDisposedException>(DisposedWitness<int>.Instance.OnCompleted);
+        Assert.Throws<ObjectDisposedException>(() => DisposedWitness<int>.Instance.OnError(new InvalidOperationException("disposed")));
+
+        ThrowWitness<int>.Instance.OnNext(One);
+        ThrowWitness<int>.Instance.OnCompleted();
+        Assert.Throws<InvalidOperationException>(() => ThrowWitness<int>.Instance.OnError(new InvalidOperationException("throw")));
+
+        var values = new List<int>();
+        var errors = new List<string>();
+        var completed = 0;
+        EmptyWitness<int>.Instance.OnNext(One);
+        new EmptyWitness<int>(values.Add).OnNext(Two);
+        new EmptyWitness<int>(values.Add, ex => errors.Add(ex.Message)).OnError(new InvalidOperationException("handled"));
+        new EmptyWitness<int>(values.Add, () => completed++).OnCompleted();
+        new EmptyWitness<int>(values.Add, ex => errors.Add(ex.Message), () => completed++).OnCompleted();
+        Assert.Throws<InvalidOperationException>(() => new EmptyWitness<int>(values.Add).OnError(new InvalidOperationException("rethrown")));
+
+        Assert.Equal(ExpectedTwoOnly, values);
+        Assert.Equal(ExpectedHandledErrors, errors);
+        Assert.Equal(Two, completed);
+
+        Assert.Throws<ArgumentNullException>(() => Witness.Create<int>(null!));
+        Assert.Throws<ArgumentNullException>(() => Witness.Create<int>(_ => { }, (Action<Exception>)null!));
+        Assert.Throws<ArgumentNullException>(() => Witness.Create<int>(_ => { }, (Action)null!));
+        Assert.Throws<ArgumentNullException>(() => Witness.Create<int>(_ => { }, _ => { }, null!));
+        Assert.Throws<ArgumentNullException>(() => Witness.Safe<int>(null!));
+        Assert.Throws<ArgumentNullException>(() => Witness.Safe(Witness.Create<int>(_ => { }), null!));
+
+        var events = new List<string>();
+        var cancelDisposed = 0;
+        var safe = Witness.Safe(
+            Witness.Create<int>(
+                value => events.Add("next:" + value),
+                ex => events.Add("error:" + ex.Message),
+                () => events.Add("completed")),
+            Disposable.Create(() => cancelDisposed++));
+        safe.OnNext(Three);
+        safe.OnCompleted();
+        safe.OnCompleted();
+        safe.OnNext(Four);
+        safe.OnError(new InvalidOperationException("late"));
+        Assert.Equal(ExpectedSafeEvents, events);
+        Assert.Equal(1, cancelDisposed);
+
+        var throwingCancel = 0;
+        var throwing = Witness.Safe(
+            Witness.Create<int>(_ => throw new InvalidOperationException("next-failed")),
+            Disposable.Create(() => throwingCancel++));
+        Assert.Throws<InvalidOperationException>(() => throwing.OnNext(One));
+        throwing.OnNext(Two);
+        Assert.Equal(1, throwingCancel);
+        Assert.Throws<ArgumentNullException>(() => safe.OnError(null!));
+    }
+
+    /// <summary>
+    /// Covers priority queues, sequencer queues, and scheduled item comparison and disposal paths.
+    /// </summary>
+    [Test]
+    public void QueuesAndScheduledItemsCoverOrderingComparisonAndDisposalBranches()
+    {
+        var queue = new PriorityQueue<int>(Two);
+        queue.Enqueue(Three);
+        queue.Enqueue(One);
+        queue.Enqueue(Two);
+        Assert.Equal(One, queue.Peek());
+        Assert.True(queue.Remove(Two));
+        Assert.False(queue.Remove(Four));
+        Assert.Equal(One, queue.Dequeue());
+        Assert.Equal(Three, queue.Dequeue());
+        Assert.Throws<InvalidOperationException>(() => queue.Peek());
+
+        var shrinkQueue = new PriorityQueue<int>(Eight);
+        for (var i = 0; i < Eight; i++)
+        {
+            shrinkQueue.Enqueue(i);
+        }
+
+        for (var i = 0; i < Seven; i++)
+        {
+            Assert.Equal(i, shrinkQueue.Dequeue());
+        }
+
+        Assert.Equal(Seven, shrinkQueue.Dequeue());
+        Assert.Throws<ArgumentOutOfRangeException>(CreateInvalidSequencerQueue);
+
+        var invoked = new List<string>();
+        var disposed = 0;
+        var first = new ScheduledItem<int, string>(
+            Sequencer.Immediate,
+            "first",
+            (_, state) =>
+            {
+                invoked.Add(state);
+                return Disposable.Create(() => disposed++);
+            },
+            One);
+        var second = new ScheduledItem<int, string>(Sequencer.Immediate, "second", (_, _) => Disposable.Empty, Two);
+        var equalDue = new ScheduledItem<int, string>(Sequencer.Immediate, "equal", (_, _) => Disposable.Empty, One);
+
+        Assert.True(first < second);
+        Assert.True(first <= equalDue);
+        Assert.True(second > first);
+        Assert.True(second >= first);
+        Assert.False(first == second);
+        Assert.True(first != second);
+        Assert.False(first.Equals(second));
+        Assert.Equal(One, first.CompareTo(null));
+        Assert.Throws<ArgumentException>(() => CompareScheduledItemWithInvalidObject(first));
+
+        var sequencerQueue = new SequencerQueue<int>(Two);
+        sequencerQueue.Enqueue(second);
+        sequencerQueue.Enqueue(first);
+        Assert.Same(first, sequencerQueue.Peek());
+        Assert.True(sequencerQueue.Remove(second));
+        Assert.Same(first, sequencerQueue.Dequeue());
+
+        first.Invoke();
+        first.Invoke();
+        first.Dispose();
+        first.Dispose();
+        Assert.Equal(ExpectedRepeatedScheduledItemInvocations, invoked);
+        Assert.Equal(Two, disposed);
+
+        var cancelled = new ScheduledItem<int, string>(
+            Sequencer.Immediate,
+            "cancelled",
+            (_, state) =>
+            {
+                invoked.Add(state);
+                return Disposable.Empty;
+            },
+            Three);
+        cancelled.Cancel();
+        cancelled.Invoke();
+        Assert.DoesNotContain("cancelled", invoked);
+        Assert.Throws<ArgumentNullException>(CreateScheduledItemWithoutSequencer);
+        Assert.Throws<ArgumentNullException>(CreateScheduledItemWithoutAction);
+        Assert.Throws<ArgumentNullException>(CreateScheduledItemWithoutComparer);
+
+        var defaultClock = new TestClock();
+        var initialClock = new TestClock(DateTimeOffset.UnixEpoch);
+        Assert.Equal(DateTimeOffset.MinValue, defaultClock.Now);
+        Assert.Equal(DateTimeOffset.UnixEpoch, initialClock.Now);
+    }
+
+    /// <summary>
+    /// Covers enumerable signal fast paths for arrays, read-only lists, iterators, and delegate subscriptions.
+    /// </summary>
+    [Test]
+    public void FromEnumerableSignalCoversAllSynchronousFastPaths()
+    {
+        var arrayObserver = new RecordingObserver<int>();
+        var arraySignal = new FromEnumerableSignal<int>([One, Two]);
+        Assert.False(arraySignal.IsRequiredSubscribeOnCurrentThread());
+        arraySignal.Subscribe(arrayObserver).Dispose();
+        Assert.Equal(ExpectedOneTwo, arrayObserver.Values);
+        Assert.Equal(1, arrayObserver.Completed);
+
+        var listValues = new List<int>();
+        var listCompleted = 0;
+        new FromEnumerableSignal<int>([Three, Four]).Subscribe(
+            listValues.Add,
+            ex => throw ex,
+            () => listCompleted++).Dispose();
+        Assert.Equal(ExpectedThreeFour, listValues);
+        Assert.Equal(1, listCompleted);
+
+        var iteratorObserver = new RecordingObserver<int>();
+        new FromEnumerableSignal<int>(YieldValues()).Subscribe(iteratorObserver).Dispose();
+        Assert.Equal(ExpectedFiveSix, iteratorObserver.Values);
+        Assert.Equal(1, iteratorObserver.Completed);
+
+        var iteratorValues = new List<int>();
+        var iteratorCompleted = 0;
+        new FromEnumerableSignal<int>(YieldValues()).Subscribe(
+            iteratorValues.Add,
+            ex => throw ex,
+            () => iteratorCompleted++).Dispose();
+        Assert.Equal(ExpectedFiveSix, iteratorValues);
+        Assert.Equal(1, iteratorCompleted);
+
+        Assert.Throws<ArgumentNullException>(() => arraySignal.Subscribe((IObserver<int>)null!));
+        Assert.Throws<ArgumentNullException>(() => arraySignal.Subscribe(null!, ex => { }, () => { }));
+        Assert.Throws<ArgumentNullException>(() => arraySignal.Subscribe(_ => { }, ex => { }, null!));
+    }
+
+    /// <summary>
+    /// Covers immediate and background sequencer argument validation and execution paths.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task SequencersCoverValidationAndExecutionBranches()
+    {
+        Assert.Same(ImmediateSequencer.Instance, Sequencer.Immediate);
+        Assert.Same(TaskPoolSequencer.Instance, TaskPoolSequencer.Default);
+        Assert.Same(TaskPoolSequencer.Default, Sequencer.Default);
+        Assert.True(Sequencer.Immediate.Now > DateTimeOffset.MinValue);
+        Assert.Equal(TimeSpan.Zero, Sequencer.Normalize(TimeSpan.FromTicks(NegativeOne)));
+
+        Assert.Throws<ArgumentNullException>(() => Sequencer.Immediate.Schedule(One, null!));
+        Assert.Throws<ArgumentNullException>(() => Sequencer.Immediate.Schedule(One, TimeSpan.Zero, null!));
+
+        var immediateValues = new List<int>();
+        Sequencer.Immediate.Schedule(One, (_, state) =>
+        {
+            immediateValues.Add(state);
+            return Disposable.Empty;
+        }).Dispose();
+        Sequencer.Immediate.Schedule(Two, TimeSpan.FromTicks(NegativeOne), (_, state) =>
+        {
+            immediateValues.Add(state);
+            return Disposable.Empty;
+        }).Dispose();
+        Sequencer.Immediate.Schedule(Three, Sequencer.Immediate.Now.AddTicks(NegativeOne), (_, state) =>
+        {
+            immediateValues.Add(state);
+            return Disposable.Empty;
+        }).Dispose();
+        Assert.Equal(ExpectedImmediateValues, immediateValues);
+
+        Assert.Throws<ArgumentNullException>(() => TaskPoolSequencer.Instance.Schedule(One, null!));
+        Assert.Throws<ArgumentNullException>(() => TaskPoolSequencer.Instance.Schedule(One, TimeSpan.Zero, null!));
+
+        var taskPoolCompletion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var taskPoolSubscription = TaskPoolSequencer.Instance.Schedule(Seven, (_, _) =>
+        {
+            taskPoolCompletion.SetResult();
+            return Disposable.Empty;
+        });
+        await WaitForAsync(taskPoolCompletion.Task);
+
+        var threadPoolCompletion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var threadPoolSubscription = ThreadPoolSequencer.Instance.Schedule(Eight, TimeSpan.Zero, (_, _) =>
+        {
+            threadPoolCompletion.SetResult();
+            return Disposable.Empty;
+        });
+        await WaitForAsync(threadPoolCompletion.Task);
+
+        Assert.Throws<ArgumentNullException>(() => ThreadPoolSequencer.Instance.Schedule(One, null!));
+        Assert.Throws<ArgumentNullException>(() => ThreadPoolSequencer.Instance.Schedule(One, TimeSpan.Zero, null!));
+    }
+
+    /// <summary>
+    /// Creates an iterator-backed enumerable for the non-indexable enumerable path.
+    /// </summary>
+    /// <returns>The yielded values.</returns>
+    private static IEnumerable<int> YieldValues()
+    {
+        yield return Five;
+        yield return Six;
+    }
+
+    /// <summary>
+    /// Creates an invalid sequencer queue.
+    /// </summary>
+    private static void CreateInvalidSequencerQueue() => _ = new SequencerQueue<int>(NegativeOne);
+
+    /// <summary>
+    /// Creates a scheduled item without a sequencer.
+    /// </summary>
+    private static void CreateScheduledItemWithoutSequencer() =>
+        _ = new ScheduledItem<int, string>(null!, "x", (_, _) => Disposable.Empty, One);
+
+    /// <summary>
+    /// Creates a scheduled item without an action.
+    /// </summary>
+    private static void CreateScheduledItemWithoutAction() =>
+        _ = new ScheduledItem<int, string>(Sequencer.Immediate, "x", null!, One);
+
+    /// <summary>
+    /// Creates a scheduled item without a comparer.
+    /// </summary>
+    private static void CreateScheduledItemWithoutComparer() =>
+        _ = new ScheduledItem<int, string>(Sequencer.Immediate, "x", (_, _) => Disposable.Empty, One, null!);
+
+    /// <summary>
+    /// Compares a scheduled item through the non-generic comparable interface.
+    /// </summary>
+    /// <param name="item">The scheduled item.</param>
+    private static void CompareScheduledItemWithInvalidObject(ScheduledItem<int, string> item) =>
+        item.CompareTo("bad");
+
+    /// <summary>
+    /// Waits for a task with a bounded timeout.
+    /// </summary>
+    /// <param name="task">The task to wait for.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    private static async Task WaitForAsync(Task task)
+    {
+        var timeout = Task.Delay(TimeSpan.FromSeconds(TimeoutSeconds));
+        var completed = await Task.WhenAny(task, timeout).ConfigureAwait(false);
+        if (completed == timeout)
+        {
+            throw new TimeoutException("Timed out waiting for scheduled work.");
+        }
+
+        await task.ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Exposes the protected dispose path for coverage.
+    /// </summary>
+    private sealed class ExposedSingleDisposable : SingleDisposable
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExposedSingleDisposable"/> class.
+        /// </summary>
+        /// <param name="disposable">The disposable to assign.</param>
+        public ExposedSingleDisposable(IDisposable disposable)
+            : base(disposable)
+        {
+        }
+
+        /// <summary>
+        /// Invokes the protected dispose path with <see langword="false"/>.
+        /// </summary>
+        public void DisposeFalse() => Dispose(false);
+    }
+
+    /// <summary>
+    /// Exposes the protected dispose path for coverage.
+    /// </summary>
+    private sealed class ExposedSingleReplaceableDisposable : SingleReplaceableDisposable
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExposedSingleReplaceableDisposable"/> class.
+        /// </summary>
+        /// <param name="disposable">The disposable to assign.</param>
+        public ExposedSingleReplaceableDisposable(IDisposable disposable)
+            : base(disposable)
+        {
+        }
+
+        /// <summary>
+        /// Invokes the protected dispose path with <see langword="false"/>.
+        /// </summary>
+        public void DisposeFalse() => Dispose(false);
+    }
+
+    /// <summary>
+    /// Exposes the protected dispose path for coverage.
+    /// </summary>
+    private sealed class ExposedMultipleDisposable : MultipleDisposable
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExposedMultipleDisposable"/> class.
+        /// </summary>
+        /// <param name="disposable">The disposable to assign.</param>
+        public ExposedMultipleDisposable(IDisposable disposable)
+            : base(disposable, Disposable.Empty)
+        {
+        }
+
+        /// <summary>
+        /// Invokes the protected dispose path with <see langword="false"/>.
+        /// </summary>
+        public void DisposeFalse() => Dispose(false);
+    }
+
+    /// <summary>
+    /// Records observer values and terminal signals.
+    /// </summary>
+    /// <typeparam name="T">The observed value type.</typeparam>
+    private sealed class RecordingObserver<T> : IObserver<T>
+    {
+        /// <summary>
+        /// Gets observed values.
+        /// </summary>
+        public List<T> Values { get; } = [];
+
+        /// <summary>
+        /// Gets the completion count.
+        /// </summary>
+        public int Completed { get; private set; }
+
+        /// <summary>
+        /// Gets the observed errors.
+        /// </summary>
+        public List<Exception> Errors { get; } = [];
+
+        /// <inheritdoc/>
+        public void OnCompleted() => Completed++;
+
+        /// <inheritdoc/>
+        public void OnError(Exception error) => Errors.Add(error);
+
+        /// <inheritdoc/>
+        public void OnNext(T value) => Values.Add(value);
+    }
+}

--- a/src/tests/ReactiveUI.Primitives.Tests/FactoryOperatorContractTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/FactoryOperatorContractTests.cs
@@ -101,6 +101,11 @@ public class FactoryOperatorContractTests
     private const int SecondZipResult = 22;
 
     /// <summary>
+    /// The second result expected from the shorter range zip test.
+    /// </summary>
+    private const int RangeZipShorterSecondResult = 13;
+
+    /// <summary>
     /// The third unfolded value.
     /// </summary>
     private const int ThirdUnfoldedValue = 30;
@@ -186,6 +191,11 @@ public class FactoryOperatorContractTests
     /// Expected values from the zip test.
     /// </summary>
     private static readonly int[] ZippedExpected = [FirstZipResult, SecondZipResult];
+
+    /// <summary>
+    /// Expected values from the shorter range zip test.
+    /// </summary>
+    private static readonly int[] RangeZipShorterExpected = [FirstZipResult, RangeZipShorterSecondResult];
 
     /// <summary>
     /// Expected values from combine-latest style operators.
@@ -381,6 +391,22 @@ public class FactoryOperatorContractTests
         Assert.Equal(FourItemExpected, concatenated);
         Assert.Equal(ZippedExpected, zipped);
         Assert.Equal(LatestExpected, latest);
+    }
+
+    /// <summary>
+    /// Verifies the range-specialized zip path preserves shorter-source completion semantics.
+    /// </summary>
+    [Test]
+    public void RangeZipCompletesAtShorterRange()
+    {
+        var values = new List<int>();
+        var completed = 0;
+
+        Signal.Zip(Signal.Range(FirstValue, FourthValue), Signal.Range(ProjectionMultiplier, SecondValue), static (left, right) => left + right)
+            .Subscribe(values.Add, _ => { }, () => completed++);
+
+        Assert.Equal(RangeZipShorterExpected, values);
+        Assert.Equal(1, completed);
     }
 
     /// <summary>

--- a/src/tests/ReactiveUI.Primitives.Tests/OperatorCoverageExpansionTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/OperatorCoverageExpansionTests.cs
@@ -1,0 +1,269 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using ReactiveUI.Primitives.Signals;
+using TUnit.Core;
+
+namespace ReactiveUI.Primitives.Tests;
+
+/// <summary>
+/// Covers optimized operator helper implementations that are not exercised by broad contract tests.
+/// </summary>
+public class OperatorCoverageExpansionTests
+{
+    /// <summary>
+    /// The first value.
+    /// </summary>
+    private const int First = 1;
+
+    /// <summary>
+    /// The second value.
+    /// </summary>
+    private const int Second = 2;
+
+    /// <summary>
+    /// The third value.
+    /// </summary>
+    private const int Third = 3;
+
+    /// <summary>
+    /// The fourth value.
+    /// </summary>
+    private const int Fourth = 4;
+
+    /// <summary>
+    /// Observed error index for the any error.
+    /// </summary>
+    private const int AnyErrorIndex = 2;
+
+    /// <summary>
+    /// Observed error index for the distinct error.
+    /// </summary>
+    private const int DistinctErrorIndex = 3;
+
+    /// <summary>
+    /// Observed error index for the outer SelectMany error.
+    /// </summary>
+    private const int OuterErrorIndex = 2;
+
+    /// <summary>
+    /// The first inner value.
+    /// </summary>
+    private const int FirstInner = 10;
+
+    /// <summary>
+    /// The second inner value.
+    /// </summary>
+    private const int SecondInner = 20;
+
+    /// <summary>
+    /// Selector failure message.
+    /// </summary>
+    private const string SelectorMessage = "selector";
+
+    /// <summary>
+    /// Inner failure message.
+    /// </summary>
+    private const string InnerMessage = "inner";
+
+    /// <summary>
+    /// Outer failure message.
+    /// </summary>
+    private const string OuterMessage = "outer";
+
+    /// <summary>
+    /// Source values for aggregate operator tests.
+    /// </summary>
+    private static readonly int[] AggregateSource = [First, Second, Third, Fourth];
+
+    /// <summary>
+    /// Source values with duplicate keys.
+    /// </summary>
+    private static readonly int[] DuplicateKeySource = [First, First, Second, Second, Third];
+
+    /// <summary>
+    /// Single first-value source.
+    /// </summary>
+    private static readonly int[] SingleFirstSource = [First];
+
+    /// <summary>
+    /// Two-value source for SelectMany projection.
+    /// </summary>
+    private static readonly int[] FirstSecondSource = [First, Second];
+
+    /// <summary>
+    /// Single inner-value source.
+    /// </summary>
+    private static readonly int[] SingleInnerSource = [FirstInner];
+
+    /// <summary>
+    /// Expected count result for two matching values.
+    /// </summary>
+    private static readonly int[] CountTwoExpected = [Second];
+
+    /// <summary>
+    /// Expected distinct count result.
+    /// </summary>
+    private static readonly int[] DistinctCountExpected = [Third];
+
+    /// <summary>
+    /// Expected long count result.
+    /// </summary>
+    private static readonly long[] LongCountFourExpected = [Fourth];
+
+    /// <summary>
+    /// Expected long predicate count result.
+    /// </summary>
+    private static readonly long[] LongCountTwoExpected = [Second];
+
+    /// <summary>
+    /// Expected distinct long count result.
+    /// </summary>
+    private static readonly long[] DistinctLongCountExpected = [Third];
+
+    /// <summary>
+    /// Expected true boolean result.
+    /// </summary>
+    private static readonly bool[] TrueExpected = [true];
+
+    /// <summary>
+    /// Expected false boolean result.
+    /// </summary>
+    private static readonly bool[] FalseExpected = [false];
+
+    /// <summary>
+    /// Expected queued SelectMany values.
+    /// </summary>
+    private static readonly int[] QueuedSelectManyExpected = [FirstInner, SecondInner];
+
+    /// <summary>
+    /// Expected result-selector SelectMany values.
+    /// </summary>
+    private static readonly int[] ResultSelectManyExpected = [First + FirstInner, Second + FirstInner];
+
+    /// <summary>
+    /// Covers count, long-count, distinct fast count, and any helper branches.
+    /// </summary>
+    [Test]
+    public void AggregateHelpersCoverPredicateDistinctAndAnyPaths()
+    {
+        var countPredicate = new List<int>();
+        var distinctCount = new List<int>();
+        var longCount = new List<long>();
+        var longCountPredicate = new List<long>();
+        var distinctLongCount = new List<long>();
+        var anyTrue = new List<bool>();
+        var anyFalse = new List<bool>();
+
+        Signal.FromEnumerable(AggregateSource).Count(value => value % Second == 0).Subscribe(countPredicate.Add);
+        Signal.FromEnumerable(DuplicateKeySource).DistinctBy(value => value).Count().Subscribe(distinctCount.Add);
+        Signal.FromEnumerable(AggregateSource).LongCount().Subscribe(longCount.Add);
+        Signal.FromEnumerable(AggregateSource).LongCount(value => value > Second).Subscribe(longCountPredicate.Add);
+        Signal.FromEnumerable(DuplicateKeySource).DistinctBy(value => value).LongCount().Subscribe(distinctLongCount.Add);
+        Signal.FromEnumerable(AggregateSource).Any().Subscribe(anyTrue.Add);
+        Signal.Empty<int>().Any().Subscribe(anyFalse.Add);
+
+        Assert.Equal(CountTwoExpected, countPredicate);
+        Assert.Equal(DistinctCountExpected, distinctCount);
+        Assert.Equal(LongCountFourExpected, longCount);
+        Assert.Equal(LongCountTwoExpected, longCountPredicate);
+        Assert.Equal(DistinctLongCountExpected, distinctLongCount);
+        Assert.Equal(TrueExpected, anyTrue);
+        Assert.Equal(FalseExpected, anyFalse);
+    }
+
+    /// <summary>
+    /// Covers optimized aggregate observer error paths.
+    /// </summary>
+    [Test]
+    public void AggregateHelpersForwardSourceErrors()
+    {
+        var countError = new InvalidOperationException("count");
+        var longCountError = new InvalidOperationException("long-count");
+        var anyError = new InvalidOperationException("any");
+        var distinctError = new InvalidOperationException("distinct");
+        var observed = new List<Exception>();
+
+        Signal.Throw<int>(countError).Count().Subscribe(_ => { }, observed.Add, () => { });
+        Signal.Throw<int>(longCountError).LongCount().Subscribe(_ => { }, observed.Add, () => { });
+        Signal.Throw<int>(anyError).Any().Subscribe(_ => { }, observed.Add, () => { });
+        Signal.Throw<int>(distinctError).DistinctBy(value => value).Count().Subscribe(_ => { }, observed.Add, () => { });
+
+        Assert.Same(countError, observed[0]);
+        Assert.Same(longCountError, observed[1]);
+        Assert.Same(anyError, observed[AnyErrorIndex]);
+        Assert.Same(distinctError, observed[DistinctErrorIndex]);
+    }
+
+    /// <summary>
+    /// Covers SelectMany queuing while an inner signal is active.
+    /// </summary>
+    [Test]
+    public void SelectManyQueuesInnerSignalsUntilActiveInnerCompletes()
+    {
+        var outer = new Signal<int>();
+        var firstInner = new Signal<int>();
+        var secondInner = new Signal<int>();
+        var values = new List<int>();
+        var completed = 0;
+
+        using var subscription = outer.SelectMany(value => value == First ? firstInner : secondInner)
+            .Subscribe(values.Add, ex => throw ex, () => completed++);
+
+        outer.OnNext(First);
+        outer.OnNext(Second);
+        outer.OnCompleted();
+        firstInner.OnNext(FirstInner);
+        firstInner.OnCompleted();
+        secondInner.OnNext(SecondInner);
+        secondInner.OnCompleted();
+
+        Assert.Equal(QueuedSelectManyExpected, values);
+        Assert.Equal(1, completed);
+    }
+
+    /// <summary>
+    /// Covers the SelectMany overload with an outer and inner result selector.
+    /// </summary>
+    [Test]
+    public void SelectManyResultSelectorProjectsOuterAndInnerValues()
+    {
+        var values = new List<int>();
+
+        Signal.FromEnumerable(FirstSecondSource)
+            .SelectMany(value => Signal.FromEnumerable(SingleInnerSource), (outer, inner) => outer + inner)
+            .Subscribe(values.Add);
+
+        Assert.Equal(ResultSelectManyExpected, values);
+    }
+
+    /// <summary>
+    /// Covers SelectMany selector, inner, and outer error forwarding.
+    /// </summary>
+    [Test]
+    public void SelectManyForwardsSelectorInnerAndOuterErrors()
+    {
+        var selectorError = new InvalidOperationException(SelectorMessage);
+        var innerError = new InvalidOperationException(InnerMessage);
+        var outerError = new InvalidOperationException(OuterMessage);
+        var observed = new List<Exception>();
+
+        Signal.FromEnumerable(SingleFirstSource).SelectMany<int, int>(_ => throw selectorError).Subscribe(_ => { }, observed.Add, () => { });
+        Signal.FromEnumerable(SingleFirstSource).SelectMany(_ => Signal.Throw<int>(innerError)).Subscribe(_ => { }, observed.Add, () => { });
+        Signal.Throw<int>(outerError).SelectMany(ReturnValue).Subscribe(_ => { }, observed.Add, () => { });
+
+        Assert.Same(selectorError, observed[0]);
+        Assert.Same(innerError, observed[1]);
+        Assert.Same(outerError, observed[OuterErrorIndex]);
+    }
+
+    /// <summary>
+    /// Returns a scalar signal for the supplied value.
+    /// </summary>
+    /// <param name="value">The value to emit.</param>
+    /// <returns>A scalar signal.</returns>
+    private static IObservable<int> ReturnValue(int value) => Signal.Return(value);
+}

--- a/src/tests/ReactiveUI.Primitives.Tests/SignalTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/SignalTests.cs
@@ -290,6 +290,36 @@ public class SignalTests
     }
 
     /// <summary>
+    /// Verifies the single observer fast path emits, terminates, and detaches cleanly.
+    /// </summary>
+    [Test]
+    public void SingleObserverSubscriptionReceivesLifecycleAndDetaches()
+    {
+        var subject = new Signal<int>();
+        var observer = new RecordingObserver();
+
+        var subscription = subject.Subscribe(observer);
+        subject.OnNext(1);
+        subject.OnCompleted();
+        subject.OnNext(ValueTwo);
+
+        Assert.Equal(1, observer.Total);
+        Assert.Equal(1, observer.Completed);
+        Assert.Equal(0, observer.Errors);
+        Assert.False(subject.HasObservers);
+
+        subscription.Dispose();
+
+        var faulted = new Signal<int>();
+        var faultObserver = new RecordingObserver();
+        using var faultSubscription = faulted.Subscribe(faultObserver);
+        faulted.OnError(new InvalidOperationException());
+
+        Assert.Equal(1, faultObserver.Errors);
+        Assert.False(faulted.HasObservers);
+    }
+
+    /// <summary>
     /// Called when [error rethrows by default].
     /// </summary>
     [Test]
@@ -478,5 +508,43 @@ public class SignalTests
         subject.OnNext(RxVoid.Default);
         Assert.Equal(DoubleRxVoid, result);
         subject.Dispose();
+    }
+
+    /// <summary>
+    /// Records integer observer lifecycle calls.
+    /// </summary>
+    private sealed class RecordingObserver : IObserver<int>
+    {
+        /// <summary>
+        /// Gets the total of observed values.
+        /// </summary>
+        public int Total { get; private set; }
+
+        /// <summary>
+        /// Gets the number of completion calls.
+        /// </summary>
+        public int Completed { get; private set; }
+
+        /// <summary>
+        /// Gets the number of error calls.
+        /// </summary>
+        public int Errors { get; private set; }
+
+        /// <summary>
+        /// Receives the next value.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        public void OnNext(int value) => Total += value;
+
+        /// <summary>
+        /// Receives an error.
+        /// </summary>
+        /// <param name="error">The error.</param>
+        public void OnError(Exception error) => Errors++;
+
+        /// <summary>
+        /// Receives completion.
+        /// </summary>
+        public void OnCompleted() => Completed++;
     }
 }


### PR DESCRIPTION
Remove System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage attributes across many primitives and signals so production code is included in coverage. 
Update .editorconfig and .gitattributes to normalize repository line endings to CRLF (including shell scripts). 
Add AssemblyInfo with InternalsVisibleTo to allow tests access to internals. 
Adjust testconfig.json coverage settings to include ReactiveUI.Primitives assemblies and exclude tests/benchmarks, and fix a null-dispose in CatchSignal. 
Add new test files to expand coverage (CoverageExpansionTests, CoverageRuntimeTests, OperatorCoverageExpansionTests).
