### PR TITLE
Rename primitive Signal APIs, add Final/History

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,14 +165,14 @@ Creation APIs live on `ReactiveUI.Primitives.Signals.Signal`.
 | `Signal.Create<T>(Func<IObserver<T>, IDisposable>)` | Build a custom observable. |
 | `Signal.CreateSafe<T>(Func<IObserver<T>, IDisposable>)` | Build a custom observable with safety wrapping. |
 | `Signal.CreateWithState<T,TState>(...)` | Build a custom observable while passing state explicitly. |
-| `Signal.Defer<T>(Func<IObservable<T>>)` | Create the source per subscription. |
-| `Signal.Return<T>(T)` | Emit one value and complete. Specialized fast paths exist for `bool`, `int`, and `RxVoid`. |
-| `Signal.Empty<T>()` | Complete without values. |
-| `Signal.Never<T>()` / `Signal.Never<T>(T witness)` | Never emit and never complete. |
-| `Signal.Throw<T>(Exception)` | Terminate with an error. |
-| `Signal.Range(int start, int count)` | Emit an integer range and complete. |
-| `Signal.Repeat<T>(T value)` / `Repeat<T>(T value, int count)` | Repeat indefinitely or a fixed number of times. |
-| `Signal.Unfold<TState,TResult>(...)` / `Signal.Generate<TState,TResult>(...)` | Generate a finite sequence from state. |
+| `Signal.Lazy<T>(Func<IObservable<T>>)` | Create the source per subscription. |
+| `Signal.Emit<T>(T)` | Emit one value and complete. Specialized fast paths exist for `bool`, `int`, and `RxVoid`. |
+| `Signal.None<T>()` | Complete without values. |
+| `Signal.Silent<T>()` / `Signal.Silent<T>(T witness)` | Never emit and never complete. |
+| `Signal.Fail<T>(Exception)` | Terminate with an error. |
+| `Signal.Sequence(int start, int count)` | Emit an integer range and complete. |
+| `Signal.Loop<T>(T value)` / `Signal.Loop<T>(T value, int count)` | Repeat indefinitely or a fixed number of times. |
+| `Signal.Unfold<TState,TResult>(...)` / `Signal.Iterate<TState,TResult>(...)` | Generate a finite sequence from state. |
 | `Signal.Use<TResource,T>(...)` | Tie a resource lifetime to a subscription. |
 | `Signal.FromEventPattern(...)` | Convert .NET events to `EventPattern<TEventArgs>` values. |
 | `Signal.FromEnumerable<T>(IEnumerable<T>)` | Convert an enumerable. |
@@ -183,10 +183,9 @@ Creation APIs live on `ReactiveUI.Primitives.Signals.Signal`.
 | `Signal.After(TimeSpan, ISequencer?)` | Emit one `long` tick after a delay. |
 | `Signal.Every(TimeSpan, ISequencer?)` | Emit increasing `long` ticks repeatedly. |
 | `Signal.Pulse(...)` | Alias of `Every`. |
-| `Signal.Interval(...)` | Alias of `Every`. |
-| `Signal.Timer(...)` | Alias/overload for one-shot and periodic timers. |
-| `Signal.Concat(...)`, `Signal.Merge(...)`, `Signal.Race(...)` | Compose multiple sources. |
-| `Signal.Zip(...)`, `Signal.CombineLatest(...)`, `Signal.ZipLatest(...)`, `Signal.ForkJoin(...)` | Pairwise combination helpers. |
+| `Signal.After(...)` | One-shot and periodic timer overloads. |
+| `Signal.Chain(...)`, `Signal.Blend(...)`, `Signal.Race(...)` | Compose multiple sources. |
+| `Signal.Pair(...)`, `Signal.SyncLatest(...)`, `Signal.PairLatest(...)`, `Signal.ForkJoin(...)` | Pairwise combination helpers. |
 
 Example:
 
@@ -194,7 +193,7 @@ Example:
 using ReactiveUI.Primitives;
 using ReactiveUI.Primitives.Signals;
 
-IObservable<int> values = Signal.Range(1, 5);
+IObservable<int> values = Signal.Sequence(1, 5);
 
 using var subscription = values.Subscribe(
     value => Console.WriteLine(value),
@@ -218,7 +217,7 @@ IObservable<string> source = Signal.CreateSafe<string>(observer =>
 
 ## Operators
 
-Operators are extension methods over `IObservable<T>`. ReactiveUI.Primitives intentionally includes both canonical LINQ/Rx names where useful and Primitives names where the library wants a distinct surface.
+Operators are extension methods over `IObservable<T>`. ReactiveUI.Primitives uses a distinct vocabulary for operators that would otherwise collide with System.Reactive or R3.
 
 ### Transformation and filtering
 
@@ -226,16 +225,16 @@ Operators are extension methods over `IObservable<T>`. ReactiveUI.Primitives int
 |---|---|
 | `Select` | `Map` | Prefer `Map` for the distinct Primitives style. |
 | stateful `Select` without closure | `MapWith` |
-| `Where` | `Keep`; `Where` delegates to `Keep`. |
+| `Where` | `Keep` |
 | stateful `Where` without closure | `KeepWith` |
 | non-null filtering | `KeepNotNull` |
-| `OfType` / `Cast` | `OfType<TResult>` / `Cast<TResult>` |
+| `OfType` / `Cast` | `KeepType<TResult>` / `CastTo<TResult>` |
 | side effects | `Tap`, `TapWith` |
-| `Scan` | `Scan` |
-| `Aggregate` | `Fold` |
+| `Scan` | `Fold` |
+| `Aggregate` | `Reduce` |
 | `Distinct` | `Distinct` |
-| `DistinctUntilChanged` | `DistinctUntilChanged` |
-| key-based distinct | `DistinctBy`, `DistinctUntilChangedBy` |
+| `DistinctUntilChanged` | `Unique` |
+| key-based distinct | `DistinctBy`, `UniqueBy` |
 | `Take` / `Skip` | `Take`, `Skip` |
 | `TakeWhile` / `SkipWhile` | `TakeWhile`, `SkipWhile` |
 | `IgnoreElements` | `IgnoreValues` |
@@ -247,7 +246,7 @@ Example:
 using ReactiveUI.Primitives;
 using ReactiveUI.Primitives.Signals;
 
-IObservable<string> labels = Signal.Range(1, 10)
+IObservable<string> labels = Signal.Sequence(1, 10)
     .Keep(value => value % 2 == 0)
     .Map(value => $"even:{value}")
     .Tap(label => Console.WriteLine($"observed {label}"));
@@ -259,33 +258,33 @@ using var subscription = labels.Subscribe(Console.WriteLine);
 
 | Concept | API |
 |---|---|
-| sequential concatenation | `Concat` |
-| concurrent merge | `Merge` |
+| sequential concatenation | `Chain` |
+| concurrent merge | `Blend` |
 | first source wins | `Race` |
-| latest inner source wins | `Switch` |
-| pairwise zip | `Zip` |
-| latest-value combination | `CombineLatest` |
-| combine left emission with latest right value | `WithLatest` |
-| latest-fusion alias | `ZipLatest`, `FuseLatest` |
+| latest inner source wins | `SwitchTo` |
+| pairwise zip | `Pair` |
+| latest-value combination | `SyncLatest` |
+| combine left emission with latest right value | `Latch` |
+| latest-fusion alias | `PairLatest`, `FuseLatest` |
 | last values after both complete | `ForkJoin` |
-| retry | `Retry` |
-| catch/rescue | `Rescue`, `Resume`, `Signal.Catch` |
-| final action | `Signal.Finally` |
+| retry | `Reattempt` |
+| catch/rescue | `Recover`, `Rescue`, `Resume`, `Signal.Recover` |
+| final action | `Signal.OnCleanup` |
 
-Merge example:
+Blend example:
 
 ```csharp
 using ReactiveUI.Primitives;
 using ReactiveUI.Primitives.Signals;
 
-IObservable<int> low = Signal.Range(1, 3);
-IObservable<int> high = Signal.Range(100, 3);
+IObservable<int> low = Signal.Sequence(1, 3);
+IObservable<int> high = Signal.Sequence(100, 3);
 
-using var merged = Signal.Merge(low, high)
+using var merged = Signal.Blend(low, high)
     .Subscribe(value => Console.WriteLine(value));
 ```
 
-CombineLatest example:
+SyncLatest example:
 
 ```csharp
 using ReactiveUI.Primitives;
@@ -294,7 +293,7 @@ using ReactiveUI.Primitives.Signals;
 var width = new StateSignal<int>(640);
 var height = new StateSignal<int>(480);
 
-using var area = Signal.CombineLatest(width, height, (w, h) => w * h)
+using var area = Signal.SyncLatest(width, height, (w, h) => w * h)
     .Subscribe(value => Console.WriteLine($"area={value}"));
 
 width.Value = 800;
@@ -306,10 +305,10 @@ height.Value = 600;
 | Concept | API |
 |---|---|
 | delayed subscription | `DelayStart` |
-| delayed values | `Delay` |
-| quiet-period sampling | `Throttle` |
-| periodic sampling | `Sample` |
-| timeout | `Timeout` |
+| delayed values | `Shift` |
+| quiet-period sampling | `Calm` / `Stabilize` |
+| periodic sampling | `Probe` |
+| timeout | `Expire` |
 | schedule subscription | `SubscribeOn` |
 | timestamp values | `Timestamp` |
 | measure intervals | `TimeInterval` |
@@ -318,14 +317,14 @@ height.Value = 600;
 | collect asynchronously | `CollectListAsync`, `CollectArrayAsync`, `ToListAsync`, `ToArrayAsync` |
 | first/last value task | `FirstAsync`, `FirstOrDefaultAsync`, `LastAsync`, `LastOrDefaultAsync` |
 
-Timer example:
+After example:
 
 ```csharp
 using ReactiveUI.Primitives;
 using ReactiveUI.Primitives.Concurrency;
 using ReactiveUI.Primitives.Signals;
 
-using var subscription = Signal.Timer(
+using var subscription = Signal.After(
         dueTime: TimeSpan.FromMilliseconds(250),
         period: TimeSpan.FromSeconds(1),
         scheduler: ThreadPoolSequencer.Instance)
@@ -338,14 +337,14 @@ using var subscription = Signal.Timer(
 
 ### Spark materialization
 
-`Spark<T>` represents value/error/completion notifications. Use `Sparkify` to convert stream events into values and `Unspark` to turn them back into observer notifications.
+`Spark<T>` represents value/error/completion notifications. Use `Spark` to convert stream events into values and `Unspark` to turn them back into observer notifications.
 
 ```csharp
 using ReactiveUI.Primitives;
 using ReactiveUI.Primitives.Core;
 using ReactiveUI.Primitives.Signals;
 
-IObservable<Spark<int>> sparks = Signal.Range(1, 3).Sparkify();
+IObservable<Spark<int>> sparks = Signal.Sequence(1, 3).Spark();
 IObservable<int> values = sparks.Unspark();
 ```
 
@@ -356,9 +355,9 @@ ReactiveUI.Primitives uses explicit names instead of cloning every System.Reacti
 | System.Reactive type | ReactiveUI.Primitives equivalent | Notes |
 |---|---|---|
 | `Subject<T>` | `Signal<T>` | Push values, errors, and completion to subscribers. |
-| `BehaviorSubject<T>` | `BehaviorSignal<T>`, or `StateSignal<T>` | Stores the latest value and emits it to new subscribers. `StateSignal<T>` adds a mutable `Value` setter and `Changed`. |
-| `ReplaySubject<T>` | `ReplaySignal<T>` | Replays buffered values by size and/or time window. |
-| `AsyncSubject<T>` | `AsyncSignal<T>` | Awaitable subject-like signal; also implements `IAwaitSignal<T>`. |
+| `BehaviorSubject<T>` | `StateSignal<T>` | Stores the latest value, exposes a mutable `Value`, and emits changes through `Changed`. |
+| `ReplaySubject<T>` | `HistorySignal<T>` | Replays buffered values by size and/or time window. |
+| `AsyncSubject<T>` | `FinalSignal<T>` | Awaitable subject-like signal; also implements `IAwaitSignal<T>`. |
 | `ReactiveProperty<T>` / state holder | `StateSignal<T>` plus `ReadOnlyState<T>` | Mutable state and read-only projected state. |
 
 State example:
@@ -377,18 +376,18 @@ temperature.Value = 26.2;
 temperature.Refresh();
 ```
 
-Replay example:
+History example:
 
 ```csharp
 using ReactiveUI.Primitives;
 using ReactiveUI.Primitives.Signals;
 
-var replay = new ReplaySignal<string>(bufferSize: 2);
-replay.OnNext("A");
-replay.OnNext("B");
-replay.OnNext("C");
+var history = new HistorySignal<string>(bufferSize: 2);
+history.OnNext("A");
+history.OnNext("B");
+history.OnNext("C");
 
-using var subscription = replay.Subscribe(Console.WriteLine); // replays B, C
+using var subscription = history.Subscribe(Console.WriteLine); // replays B, C
 ```
 
 Error and completion example:
@@ -397,7 +396,7 @@ Error and completion example:
 using ReactiveUI.Primitives;
 using ReactiveUI.Primitives.Signals;
 
-IObservable<int> failed = Signal.Throw<int>(new InvalidOperationException("not available"));
+IObservable<int> failed = Signal.Fail<int>(new InvalidOperationException("not available"));
 
 using var subscription = failed.Subscribe(
     value => Console.WriteLine(value),
@@ -442,7 +441,7 @@ ReactiveUI.Primitives follows the BCL observer contract and keeps ownership expl
 - Time-based factories and operators use `ISequencer` overloads where deterministic or UI-thread dispatch matters. Use `TestClock`/`VirtualClock` for tests; avoid sleeping real threads.
 - A subscription is an `IDisposable`. Disposing a subscription removes that observer and prevents later notifications to that subscription. Disposing a composite (`MultipleDisposable`, `Pocket`, `Slot`, etc.) cascades to contained disposables according to the container contract.
 - Terminal notifications are single-assignment: `OnCompleted` and `OnError` end a signal, and later values are ignored by terminated sources.
-- `OnError(Exception)` requires a non-null exception and propagates the terminal error to current subscribers. Operators such as `Rescue`, `Resume`, `Retry`, and `Signal.Catch` are the explicit recovery points.
+- `OnError(Exception)` requires a non-null exception and propagates the terminal error to current subscribers. Operators such as `Recover`, `Rescue`, `Resume`, `Reattempt`, and `Signal.Recover` are the explicit recovery points.
 - Observer callback exceptions are guarded by the operator/source that owns the callback. Prefer `CreateSafe` for custom sources unless you are deliberately implementing lower-level observer semantics.
 - The production package has no runtime dependency on System.Reactive or R3; bridge generators only emit boundary adapters when a consuming project already references those packages.
 
@@ -488,7 +487,7 @@ using var subscription = PrimitivesSource
     .Map(value => value * 10)
     .Subscribe(Console.WriteLine);
 
-IObservable<int> systemObservable = Signal.Range(1, 3).AsSystemObservable();
+IObservable<int> systemObservable = Signal.Sequence(1, 3).AsSystemObservable();
 ```
 
 R3 bridge example, when the consuming project already references R3:
@@ -500,7 +499,7 @@ using ReactiveUI.Primitives.Signals;
 
 // R3.Observable<int> r3Source = ...;
 // IObservable<int> PrimitivesSource = r3Source.AsPrimitivesSignal();
-// R3.Observable<int> r3Again = Signal.Range(1, 3).AsR3Observable();
+// R3.Observable<int> r3Again = Signal.Sequence(1, 3).AsR3Observable();
 ```
 
 The R3 snippet is intentionally shown as a migration shape because it requires the consuming application to reference R3. ReactiveUI.Primitives itself remains free of an R3 runtime dependency.
@@ -513,20 +512,20 @@ ReactiveUI.Primitives is not a byte-for-byte clone of System.Reactive. It keeps 
 
 | System.Reactive | ReactiveUI.Primitives | Notes |
 |---|---|---|
-| `Observable.Return(value)` | `Signal.Return(value)` | Emits one value and completes. |
-| `Observable.Empty<T>()` | `Signal.Empty<T>()` | Completes immediately. |
-| `Observable.Never<T>()` | `Signal.Never<T>()` or `Signal.Never<T>(witness)` | Non-terminating signal; witness overload helps type inference. |
-| `Observable.Throw<T>(ex)` | `Signal.Throw<T>(ex)` | Emits terminal error. |
-| `Observable.Range(start, count)` | `Signal.Range(start, count)` | Optional scheduler overload exists. |
-| `Observable.Repeat(value)` | `Signal.Repeat(value)` | Indefinite repeat. |
-| `Observable.Repeat(value, count)` | `Signal.Repeat(value, count)` | Fixed repeat. |
-| `Observable.Defer(factory)` | `Signal.Defer(factory)` | Create source per subscription. |
+| `Observable.Return(value)` | `Signal.Emit(value)` | Emits one value and completes. |
+| `Observable.Empty<T>()` | `Signal.None<T>()` | Completes immediately. |
+| `Observable.Never<T>()` | `Signal.Silent<T>()` or `Signal.Silent<T>(witness)` | Non-terminating signal; witness overload helps type inference. |
+| `Observable.Throw<T>(ex)` | `Signal.Fail<T>(ex)` | Emits terminal error. |
+| `Observable.Range(start, count)` | `Signal.Sequence(start, count)` | Optional scheduler overload exists. |
+| `Observable.Repeat(value)` | `Signal.Loop(value)` | Indefinite repeat. |
+| `Observable.Repeat(value, count)` | `Signal.Loop(value, count)` | Fixed repeat. |
+| `Observable.Defer(factory)` | `Signal.Lazy(factory)` | Create source per subscription. |
 | `Observable.FromAsync(...)` | `Signal.FromAsync(...)` | Invoke a task factory per subscription. |
 | `Observable.Create<T>(...)` | `Signal.Create<T>(...)` or `Signal.CreateSafe<T>(...)` | Prefer `CreateSafe` for general custom sources. |
 | `Observable.Using(...)` | `Signal.Use(...)` | Resource scoped to subscription. |
-| `Observable.Timer(dueTime)` | `Signal.Timer(dueTime)` or `Signal.After(dueTime)` | Emits `long` tick `0`. |
-| `Observable.Timer(dueTime, period)` | `Signal.Timer(dueTime, period)` | Periodic `long` ticks. |
-| `Observable.Interval(period)` | `Signal.Interval(period)` or `Signal.Every(period)` | Repeating ticks. |
+| `Observable.Timer(dueTime)` | `Signal.After(dueTime)` | Emits `long` tick `0`. |
+| `Observable.Timer(dueTime, period)` | `Signal.After(dueTime, period)` | Periodic `long` ticks. |
+| `Observable.Interval(period)` | `Signal.Pulse(period)` or `Signal.Every(period)` | Repeating ticks. |
 | `ToObservable()` from enumerable | `Signal.FromEnumerable(values)`, `values.ToSignal()`, or `values.ToObservable()` | Cancellation-token overloads are available. |
 | task conversion | `Signal.FromTask(task)` | Function-based task signals also exist. |
 
@@ -535,43 +534,43 @@ ReactiveUI.Primitives is not a byte-for-byte clone of System.Reactive. It keeps 
 | System.Reactive | ReactiveUI.Primitives | Migration detail |
 |---|---|---|
 | `new Subject<T>()` | `new Signal<T>()` | Use `OnNext`, `OnError`, `OnCompleted`, and `Subscribe`. |
-| `new BehaviorSubject<T>(initial)` | `new BehaviorSignal<T>(initial)` | Keeps `Value` getter and emits latest value to subscribers. |
+| `new BehaviorSubject<T>(initial)` | `new StateSignal<T>(initial)` | Keeps `Value` getter/setter and emits changes through `Changed`. |
 | mutable reactive property | `new StateSignal<T>(initial)` | Set `Value` to emit. Use `Changed` for observable state stream. |
-| `new ReplaySubject<T>()` | `new ReplaySignal<T>()` | Unbounded replay. |
-| `new ReplaySubject<T>(bufferSize)` | `new ReplaySignal<T>(bufferSize)` | Size-limited replay. |
-| `new ReplaySubject<T>(window)` | `new ReplaySignal<T>(window)` | Time-window replay. |
-| `new AsyncSubject<T>()` | `new AsyncSignal<T>()` | Awaitable signal shape. |
+| `new ReplaySubject<T>()` | `new HistorySignal<T>()` | Unbounded replay. |
+| `new ReplaySubject<T>(bufferSize)` | `new HistorySignal<T>(bufferSize)` | Size-limited replay. |
+| `new ReplaySubject<T>(window)` | `new HistorySignal<T>(window)` | Time-window replay. |
+| `new AsyncSubject<T>()` | `new FinalSignal<T>()` | Awaitable final-value signal shape. |
 
 ### Operator mapping
 
 | System.Reactive | ReactiveUI.Primitives | Notes |
 |---|---|---|
 | `Select` | `Map` | Prefer `Map` for distinct Primitives style. |
-| `Where` | `Keep` or `Where` | `Where` delegates to `Keep`. |
-| `SelectMany` | `SelectMany` or `Bind` | `Bind` is the Primitives alias. |
-| `Aggregate` | `Fold` | Emits final accumulated value on completion. |
-| `Scan` | `Scan` | Emits every accumulated value. |
+| `Where` | `Keep` | Predicate filtering. |
+| `SelectMany` | `FlatMap` or `Bind` | `Bind` is a Primitives alias for flat mapping. |
+| `Aggregate` | `Reduce` | Emits final accumulated value on completion. |
+| `Scan` | `Fold` | Emits every accumulated value. |
 | `Do` | `Tap` | Side effect while preserving values. |
 | `Take` / `Skip` | `Take` / `Skip` | Count-based overloads. |
 | `TakeWhile` / `SkipWhile` | `TakeWhile` / `SkipWhile` | Predicate-based. |
 | `Distinct` | `Distinct` | Full seen-set distinct. |
-| `DistinctUntilChanged` | `DistinctUntilChanged` | Adjacent dedupe. |
-| `OfType` / `Cast` | `OfType` / `Cast` | Object-source projections. |
-| `Materialize` | `Sparkify` | Converts notifications into `Spark<T>`. |
+| `DistinctUntilChanged` | `Unique` | Adjacent dedupe. |
+| `OfType` / `Cast` | `KeepType` / `CastTo` | Object-source projections. |
+| `Materialize` | `Spark` | Converts notifications into `Spark<T>`. |
 | `Dematerialize` | `Unspark` | Converts `Spark<T>` values back into notifications. |
-| `Merge` | `Merge` or `Signal.Merge` | Works over source-of-sources and params factories. |
-| `Concat` | `Concat` or `Signal.Concat` | Sequential composition. |
+| `Merge` | `Blend` or `Signal.Blend` | Works over source-of-sources and params factories. |
+| `Concat` | `Chain` or `Signal.Chain` | Sequential composition. |
 | `Amb` | `Race` | First source to produce a value or terminal signal wins. |
-| `Switch` | `Switch` | Latest inner observable wins. |
-| `Zip` | `Zip` or `Signal.Zip` | Pair values by index. |
-| `CombineLatest` | `CombineLatest` or `Signal.CombineLatest` | Latest values after both sources have emitted. |
-| `WithLatestFrom` | `WithLatest` | Left emission paired with latest right value. |
+| `Switch` | `SwitchTo` | Latest inner observable wins. |
+| `Zip` | `Pair` or `Signal.Pair` | Pair values by index. |
+| `CombineLatest` | `SyncLatest` or `Signal.SyncLatest` | Latest values after both sources have emitted. |
+| `WithLatestFrom` | `Latch` | Left emission paired with latest right value. |
 | `ForkJoin` | `ForkJoin` | Last values after completion. |
-| `Throttle` | `Throttle` | Quiet-period emission. |
-| `Sample` | `Sample` | Periodic latest-value sampling. |
-| `Delay` | `Delay` | Delay emitted values. |
+| `Throttle` | `Calm` / `Stabilize` | Quiet-period emission. |
+| `Sample` | `Probe` | Periodic latest-value sampling. |
+| `Delay` | `Shift` | Delay emitted values. |
 | `DelaySubscription` | `DelayStart` | Delay source subscription. |
-| `Timeout` | `Timeout` | Error on missing value before due time. |
+| `Timeout` | `Expire` | Error on missing value before due time. |
 | `Buffer(count)` | `Buffer(count)` | Fixed-size buffers. |
 | `SubscribeOn` | `SubscribeOn` | Schedule source subscription. |
 | `ToList` / `ToArray` | `ToList` / `ToArray` or `CollectList` / `CollectArray` | Signal results. |
@@ -620,9 +619,9 @@ R3 uses its own `Observable<T>` type and observer model. ReactiveUI.Primitives s
 | R3 concept | ReactiveUI.Primitives equivalent |
 |---|---|
 | `R3.Observable<T>` | BCL `IObservable<T>` from ReactiveUI.Primitives factories/operators. |
-| R3 subject | `Signal<T>` / `StateSignal<T>` / `ReplaySignal<T>` depending on state/replay needs. |
+| R3 subject | `Signal<T>` / `StateSignal<T>` / `HistorySignal<T>` depending on state/replay needs. |
 | R3 `Select` / `Where` | `Map` / `Keep`. |
-| R3 time operators | `Signal.Timer`, `Signal.Interval`, `Throttle`, `Sample`, `Delay`, scheduler overloads. |
+| R3 time operators | `Signal.After`, `Signal.Pulse`, `Calm`, `Probe`, `Shift`, scheduler overloads. |
 | R3 bridge | Generated `AsPrimitivesSignal` / `AsR3Observable` when R3 is referenced by the consumer. |
 
 Use the generated bridge only at boundaries. Prefer native ReactiveUI.Primitives operators inside new code.
@@ -656,53 +655,53 @@ The table below is generated from the joined BenchmarkDotNet CSV and uses `Mean 
 
 | Scenario | ReactiveUI.Primitives | System.Reactive | R3 |
 |---|---:|---:|---:|
-| Return subscribe | 0.2186 ns / 0 B | 53.2379 ns / 120 B | 30.0486 ns / 80 B |
-| Empty subscribe | 3.0541 ns / 40 B | 44.6828 ns / 96 B | 26.8593 ns / 56 B |
-| Range subscribe | 49.8325 ns / 96 B | 2,459.2019 ns / 2,472 B | 74.6073 ns / 80 B |
-| Repeat subscribe | 7.0823 ns / 0 B | 2,324.1525 ns / 2,408 B | 75.9459 ns / 80 B |
-| Throw subscribe | 55.2666 ns / 120 B | 107.4731 ns / 240 B | 88.8770 ns / 200 B |
+| Emit subscribe | 0.2186 ns / 0 B | 53.2379 ns / 120 B | 30.0486 ns / 80 B |
+| None subscribe | 3.0541 ns / 40 B | 44.6828 ns / 96 B | 26.8593 ns / 56 B |
+| Sequence subscribe | 49.8325 ns / 96 B | 2,459.2019 ns / 2,472 B | 74.6073 ns / 80 B |
+| Loop subscribe | 7.0823 ns / 0 B | 2,324.1525 ns / 2,408 B | 75.9459 ns / 80 B |
+| Fail subscribe | 55.2666 ns / 120 B | 107.4731 ns / 240 B | 88.8770 ns / 200 B |
 | FromEnumerable subscribe | 50.5124 ns / 40 B | 2,369.0857 ns / 2,504 B | 78.1008 ns / 88 B |
 | Completed task bridge | 9.1928 ns / 88 B | 822.4185 ns / 793 B | 38.3042 ns / 88 B |
 | Create subscribe | 47.2199 ns / 248 B | 45.7875 ns / 168 B | 54.1915 ns / 128 B |
 | CreateSafe subscribe | 47.3391 ns / 248 B | 45.6351 ns / 168 B | 54.6268 ns / 128 B |
-| Defer subscribe | 73.2374 ns / 240 B | 1,345.5338 ns / 1,512 B | 117.8853 ns / 152 B |
+| Lazy subscribe | 73.2374 ns / 240 B | 1,345.5338 ns / 1,512 B | 117.8853 ns / 152 B |
 | Start subscribe | 60.3452 ns / 376 B | 816.3317 ns / 751 B | 56.4896 ns / 160 B |
 | Unfold subscribe | 190.6104 ns / 736 B | 2,223.5963 ns / 2,768 B | 93.6088 ns / 128 B |
 | Use subscribe | 72.3636 ns / 432 B | 86.6686 ns / 168 B | 55.2117 ns / 128 B |
 | FromAsyncEnumerable subscribe | 1,881.6833 ns / 2,062 B | 1,532.8305 ns / 2,448 B | 1,060.5681 ns / 1,023 B |
-| Never subscribe/dispose | 0.2485 ns / 0 B | 6.0823 ns / 40 B | 16.9295 ns / 56 B |
+| Silent subscribe/dispose | 0.2485 ns / 0 B | 6.0823 ns / 40 B | 16.9295 ns / 56 B |
 | Map + Keep over range | 131.9449 ns / 208 B | 2,512.4803 ns / 2,616 B | 297.4630 ns / 272 B |
-| Aggregate + Any + Count | 191.4086 ns / 824 B | 5,298.7536 ns / 5,896 B | 635.6714 ns / 1,280 B |
-| StartWith + Append + DefaultIfEmpty | 31.6353 ns / 168 B | 937.0711 ns / 1,257 B | 137.8890 ns / 288 B |
+| Reduce + Any + Count | 191.4086 ns / 824 B | 5,298.7536 ns / 5,896 B | 635.6714 ns / 1,280 B |
+| Prepend + Append + DefaultIfEmpty | 31.6353 ns / 168 B | 937.0711 ns / 1,257 B | 137.8890 ns / 288 B |
 | DefaultIfEmpty(empty) | 5.5567 ns / 64 B | 66.3831 ns / 144 B | 60.2487 ns / 136 B |
-| SelectMany over ranges | 906.9976 ns / 712 B | 3,489.8946 ns / 3,872 B | 973.1711 ns / 1,040 B |
-| Zip over ranges | 45.5839 ns / 232 B | 3,139.5301 ns / 2,976 B | 693.6180 ns / 656 B |
-| Concat ranges | 67.5521 ns / 256 B | 2,677.6141 ns / 2,856 B | 258.3191 ns / 360 B |
-| Merge ranges | 70.9983 ns / 256 B | 3,770.6044 ns / 3,953 B | 661.3140 ns / 352 B |
+| FlatMap over ranges | 906.9976 ns / 712 B | 3,489.8946 ns / 3,872 B | 973.1711 ns / 1,040 B |
+| Pair over ranges | 45.5839 ns / 232 B | 3,139.5301 ns / 2,976 B | 693.6180 ns / 656 B |
+| Chain ranges | 67.5521 ns / 256 B | 2,677.6141 ns / 2,856 B | 258.3191 ns / 360 B |
+| Blend ranges | 70.9983 ns / 256 B | 3,770.6044 ns / 3,953 B | 661.3140 ns / 352 B |
 | Race ranges | 39.1824 ns / 192 B | 1,442.9846 ns / 1,760 B | 254.1584 ns / 360 B |
-| Switch ranges | 755.5194 ns / 1,376 B | 2,089.1303 ns / 2,336 B | 688.3416 ns / 392 B |
-| CombineLatest ranges | 98.9031 ns / 504 B | 3,028.5990 ns / 2,824 B | 611.6543 ns / 344 B |
-| WithLatest ranges | 100.5133 ns / 504 B | 3,193.1360 ns / 2,824 B | 377.9174 ns / 248 B |
+| SwitchTo ranges | 755.5194 ns / 1,376 B | 2,089.1303 ns / 2,336 B | 688.3416 ns / 392 B |
+| SyncLatest ranges | 98.9031 ns / 504 B | 3,028.5990 ns / 2,824 B | 611.6543 ns / 344 B |
+| Latch ranges | 100.5133 ns / 504 B | 3,193.1360 ns / 2,824 B | 377.9174 ns / 248 B |
 | ForkJoin ranges | 75.6980 ns / 480 B | 3,391.6289 ns / 3,136 B | 857.3522 ns / 504 B |
-| Delay range | 3,201.9485 ns / 38,816 B | 5,196.2072 ns / 39,584 B | 1,821.4245 ns / 2,200 B |
+| Shift range | 3,201.9485 ns / 38,816 B | 5,196.2072 ns / 39,584 B | 1,821.4245 ns / 2,200 B |
 | DelayStart range | 895.5792 ns / 25,520 B | 2,132.5495 ns / 26,456 B | 319.5858 ns / 552 B |
-| Throttle burst | 2,677.1477 ns / 38,384 B | 2,383.1439 ns / 36,480 B | 1,496.8547 ns / 1,512 B |
-| Sample latest | 1,006.0773 ns / 26,072 B | 1,864.9357 ns / 26,264 B | 306.8848 ns / 664 B |
+| Calm burst | 2,677.1477 ns / 38,384 B | 2,383.1439 ns / 36,480 B | 1,496.8547 ns / 1,512 B |
+| Probe latest | 1,006.0773 ns / 26,072 B | 1,864.9357 ns / 26,264 B | 306.8848 ns / 664 B |
 | Timestamp range | 399.6629 ns / 312 B | 1,618.9009 ns / 1,608 B | 337.9970 ns / 152 B |
 | TimeInterval range | 488.7716 ns / 736 B | 1,651.9546 ns / 1,712 B | 426.0530 ns / 160 B |
-| Timeout idle | 978.2797 ns / 25,912 B | 1,165.9814 ns / 29,776 B | 385.2929 ns / 784 B |
+| Expire idle | 978.2797 ns / 25,912 B | 1,165.9814 ns / 29,776 B | 385.2929 ns / 784 B |
 | ObserveOn immediate | 24.7480 ns / 96 B | 16,606.7413 ns / 11,307 B | 887.0907 ns / 432 B |
-| Replay subscribe | 330.6935 ns / 320 B | 670.7762 ns / 696 B | 405.9421 ns / 688 B |
-| BehaviorSignal 32 values | 536.3309 ns / 176 B | 548.6943 ns / 200 B | 587.0951 ns / 192 B |
-| BehaviorSignal 1024 values | 14,775.5376 ns / 176 B | 14,855.1132 ns / 200 B | 15,217.1773 ns / 192 B |
+| History subscribe | 330.6935 ns / 320 B | 670.7762 ns / 696 B | 405.9421 ns / 688 B |
+| StateSignal 32 values | 536.3309 ns / 176 B | 548.6943 ns / 200 B | 587.0951 ns / 192 B |
+| StateSignal 1024 values | 14,775.5376 ns / 176 B | 14,855.1132 ns / 200 B | 15,217.1773 ns / 192 B |
 | Signal emit, 32 values | 69.9214 ns / 136 B | 98.0934 ns / 136 B | 127.8881 ns / 160 B |
 | Signal emit, 1024 values | 1,698.9894 ns / 136 B | 1,716.7062 ns / 136 B | 2,323.2927 ns / 160 B |
 | Signal subscribe/dispose, 8 observers | 235.0289 ns / 592 B | 313.7011 ns / 1,288 B | 440.8307 ns / 840 B |
 | Signal subscribe/dispose, 64 observers | 2,776.5985 ns / 3,800 B | 3,866.7501 ns / 38,472 B | 3,381.8103 ns / 6,216 B |
-| Publish live connect | 124.6251 ns / 384 B | 2,647.5393 ns / 2,696 B | 428.5325 ns / 368 B |
+| ShareLive connect | 124.6251 ns / 384 B | 2,647.5393 ns / 2,696 B | 428.5325 ns / 368 B |
 | Share live subscribe | 254.7125 ns / 848 B | 3,050.7448 ns / 2,880 B | 616.1204 ns / 488 B |
 | Replay live late subscribe | 662.7019 ns / 568 B | 3,683.1133 ns / 3,408 B | 923.3098 ns / 1,360 B |
-| RefCount subscribe | 232.0945 ns / 848 B | 2,832.0310 ns / 2,880 B | 595.3431 ns / 488 B |
+| AutoShare subscribe | 232.0945 ns / 848 B | 2,832.0310 ns / 2,880 B | 595.3431 ns / 488 B |
 | AutoConnect subscribe | 195.7574 ns / 728 B | 2,711.8025 ns / 2,736 B | 461.9903 ns / 368 B |
 | StateSignal updates | 526.8121 ns / 176 B | 526.5334 ns / 200 B | 575.4000 ns / 192 B |
 | ReadOnlyState projection | 125.7138 ns / 248 B | 89.6034 ns / 328 B | 166.5788 ns / 312 B |
@@ -728,38 +727,38 @@ Interpretation notes:
 
 - ReactiveUI.Primitives remains substantially faster and lower allocation in most factory, range, terminal collection, composition, sharing, and subject subscription scenarios.
 - The public API/operator matrix above is backed by deterministic smoke coverage in `Program.RunSmokeBenchmarksAsync`: every row has matching ReactiveUI.Primitives, System.Reactive, and R3 calls where alternatives exist, and the smoke run validates each benchmark path returns the same observable result before BenchmarkDotNet measures throughput and allocation unless the row is one of the documented scheduling-total exceptions below.
-- The only intentional smoke output differences are `Switch ranges`, `CombineLatest ranges`, and `WithLatest ranges`: System.Reactive produces different synchronous range totals for those coordinator operators, while ReactiveUI.Primitives and R3 agree on the emitted totals. `--smoke` permits only those System.Reactive differences and still fails if ReactiveUI.Primitives diverges from R3 or if any other benchmark group loses parity.
+- The only intentional smoke output differences are `SwitchTo ranges`, `SyncLatest ranges`, and `Latch ranges`: System.Reactive produces different synchronous range totals for those coordinator operators, while ReactiveUI.Primitives and R3 agree on the emitted totals. `--smoke` permits only those System.Reactive differences and still fails if ReactiveUI.Primitives diverges from R3 or if any other benchmark group loses parity.
 - Candidate scenarios where ReactiveUI.Primitives is not strictly both faster and lower-allocation than both alternatives are tracked explicitly below. Rows marked as exceptions are retained because the extra cost buys ReactiveUI.Primitives semantics (safe terminal/disposal behavior, `IObservable<T>`/`IObserver<T>` compatibility, deterministic `ISequencer` scheduling, or live-signal lifecycle ownership) while preserving the project rule that System.Reactive/R3 are benchmark-only dependencies.
-- Near-zero singleton measurements (`Return`, `Never`, and `Spark` paths) may trigger BenchmarkDotNet `ZeroMeasurement` warnings; those warnings mean the method duration is indistinguishable from the empty-method overhead, not that the benchmark failed.
+- Near-zero singleton measurements (`Emit`, `Silent`, and `Spark` paths) may trigger BenchmarkDotNet `ZeroMeasurement` warnings; those warnings mean the method duration is indistinguishable from the empty-method overhead, not that the benchmark failed.
 
 Candidate/performance exception matrix:
 
 | Scenario | Observed gap | Decision and trade-off |
 |---|---|---|
-| `Range subscribe` | allocation > R3 (96 B vs 80 B). | Accepted exception: the range factory keeps the public `IObservable<int>`/current-thread subscription shape; the small R3 allocation delta is documented while throughput remains faster than both alternatives. |
+| `Sequence subscribe` | allocation > R3 (96 B vs 80 B). | Accepted exception: the range factory keeps the public `IObservable<int>`/current-thread subscription shape; the small R3 allocation delta is documented while throughput remains faster than both alternatives. |
 | `Completed task bridge` | allocation ties R3 (88 B vs 88 B). | Accepted exception: the bridge already matches the lowest allocation and preserves task-observer completion semantics; strict-lower allocation is impossible for a tie. |
 | `Create subscribe` | time >= System.Reactive (47.2199 ns vs 45.7875 ns); allocation > System.Reactive (248 B vs 168 B); allocation > R3 (248 B vs 128 B). | Accepted exception: `Signal.Create` exposes the BCL `IObserver<T>` callback shape and wraps subscription disposal for terminal safety; the adapter cost avoids adding a runtime System.Reactive/R3 dependency. |
 | `CreateSafe subscribe` | time >= System.Reactive (47.3391 ns vs 45.6351 ns); allocation > System.Reactive (248 B vs 168 B); allocation > R3 (248 B vs 128 B). | Accepted exception: `CreateSafe` adds guarded terminal notification behavior over the raw factory callback; the safety contract is retained instead of optimizing away the wrapper. |
-| `Defer subscribe` | allocation > R3 (240 B vs 152 B). | Accepted exception: deferred construction allocates a factory subscription wrapper so disposal/errors route through the safe observer path; throughput remains ahead of both alternatives. |
+| `Lazy subscribe` | allocation > R3 (240 B vs 152 B). | Accepted exception: deferred construction allocates a factory subscription wrapper so disposal/errors route through the safe observer path; throughput remains ahead of both alternatives. |
 | `Start subscribe` | time >= R3 (60.3452 ns vs 56.4896 ns); allocation > R3 (376 B vs 160 B). | Accepted exception: `Start` uses the project `ISequencer` abstraction and preserves immediate/current-thread scheduling parity; R3’s specialized scheduler path is not interchangeable. |
 | `Unfold subscribe` | time >= R3 (190.6104 ns vs 93.6088 ns); allocation > R3 (736 B vs 128 B). | Accepted exception: the implementation keeps state-machine disposal and observer-safety guards for recursive generation; R3’s specialized observable shape is lower allocation. |
 | `Use subscribe` | time >= R3 (72.3636 ns vs 55.2117 ns); allocation > System.Reactive (432 B vs 168 B); allocation > R3 (432 B vs 128 B). | Accepted exception: `Use` owns resource lifetime and source subscription together so resources are released across completion, error, and unsubscribe; the extra allocation is the lifecycle trade-off. |
 | `FromAsyncEnumerable subscribe` | time >= System.Reactive (1,881.6833 ns vs 1,532.8305 ns); time >= R3 (1,881.6833 ns vs 1,060.5681 ns); allocation > R3 (2,062 B vs 1,023 B). | Accepted exception: the bridge preserves `IAsyncEnumerable<T>` cancellation/disposal and safe observer termination; the cost is isolated to async interop, not synchronous hot paths. |
-| `Switch ranges` | time >= R3 (755.5194 ns vs 688.3416 ns); allocation > R3 (1,376 B vs 392 B). | Accepted exception: `Switch` maintains an inner subscription slot and terminal arbitration for general `IObservable<IObservable<T>>`; R3’s range-specialized path is cheaper. |
-| `CombineLatest ranges` | allocation > R3 (504 B vs 344 B). | Accepted exception: `CombineLatest` stores readiness/value state for both sides to preserve general `IObservable<T>` semantics; throughput remains well ahead of R3. |
-| `WithLatest ranges` | allocation > R3 (504 B vs 248 B). | Accepted exception: the operator keeps left/right state and subscription ownership explicit for safe unsubscription; allocation premium buys generic semantics. |
-| `Delay range` | time >= R3 (3,201.9485 ns vs 1,821.4245 ns); allocation > R3 (38,816 B vs 2,200 B). | Accepted exception: `Delay` uses deterministic `ISequencer` timer/scheduled-disposable handling for cancellation and ordering; R3’s timer path is more allocation-efficient. |
+| `SwitchTo ranges` | time >= R3 (755.5194 ns vs 688.3416 ns); allocation > R3 (1,376 B vs 392 B). | Accepted exception: `SwitchTo` maintains an inner subscription slot and terminal arbitration for general `IObservable<IObservable<T>>`; R3's range-specialized path is cheaper. |
+| `SyncLatest ranges` | allocation > R3 (504 B vs 344 B). | Accepted exception: `SyncLatest` stores readiness/value state for both sides to preserve general `IObservable<T>` semantics; throughput remains well ahead of R3. |
+| `Latch ranges` | allocation > R3 (504 B vs 248 B). | Accepted exception: the operator keeps left/right state and subscription ownership explicit for safe unsubscription; allocation premium buys generic semantics. |
+| `Shift range` | time >= R3 (3,201.9485 ns vs 1,821.4245 ns); allocation > R3 (38,816 B vs 2,200 B). | Accepted exception: `Shift` uses deterministic `ISequencer` timer/scheduled-disposable handling for cancellation and ordering; R3's timer path is more allocation-efficient. |
 | `DelayStart range` | time >= R3 (895.5792 ns vs 319.5858 ns); allocation > R3 (25,520 B vs 552 B). | Accepted exception: start-delay creates scheduled work through `ISequencer` for deterministic virtual/current-thread behavior; R3 wins allocation with a specialized path. |
-| `Throttle burst` | time >= System.Reactive (2,677.1477 ns vs 2,383.1439 ns); time >= R3 (2,677.1477 ns vs 1,496.8547 ns); allocation > System.Reactive (38,384 B vs 36,480 B); allocation > R3 (38,384 B vs 1,512 B). | Accepted exception: throttling keeps disposable timer slots and safe observer state per burst so cancellation races are explicit; this is documented as scheduler-heavy. |
-| `Sample latest` | time >= R3 (1,006.0773 ns vs 306.8848 ns); allocation > R3 (26,072 B vs 664 B). | Accepted exception: `Sample` uses a coordinator and `ISequencer` timer loop to preserve latest-value/completion ordering; R3’s scheduler specialization is lower allocation. |
+| `Calm burst` | time >= System.Reactive (2,677.1477 ns vs 2,383.1439 ns); time >= R3 (2,677.1477 ns vs 1,496.8547 ns); allocation > System.Reactive (38,384 B vs 36,480 B); allocation > R3 (38,384 B vs 1,512 B). | Accepted exception: quiet-period scheduling keeps disposable timer slots and safe observer state per burst so cancellation races are explicit; this is documented as scheduler-heavy. |
+| `Probe latest` | time >= R3 (1,006.0773 ns vs 306.8848 ns); allocation > R3 (26,072 B vs 664 B). | Accepted exception: `Probe` uses a coordinator and `ISequencer` timer loop to preserve latest-value/completion ordering; R3's scheduler specialization is lower allocation. |
 | `Timestamp range` | time >= R3 (399.6629 ns vs 337.9970 ns); allocation > R3 (312 B vs 152 B). | Accepted exception: timestamps are produced through the project sequencer clock and `Moment<T>` path for deterministic scheduler injection; R3 is slightly cheaper natively. |
 | `TimeInterval range` | time >= R3 (488.7716 ns vs 426.0530 ns); allocation > R3 (736 B vs 160 B). | Accepted exception: interval measurement tracks prior timestamp state through `ISequencer`; allocation buys deterministic clock injection and System.Reactive-compatible semantics. |
-| `Timeout idle` | time >= R3 (978.2797 ns vs 385.2929 ns); allocation > R3 (25,912 B vs 784 B). | Accepted exception: `Timeout` owns a timer slot plus source subscription and routes timeout errors safely; the scheduler/disposal safety cost is retained. |
+| `Expire idle` | time >= R3 (978.2797 ns vs 385.2929 ns); allocation > R3 (25,912 B vs 784 B). | Accepted exception: `Expire` owns a timer slot plus source subscription and routes timeout errors safely; the scheduler/disposal safety cost is retained. |
 | `Signal emit, 32 values` | allocation ties System.Reactive (136 B vs 136 B). | Accepted exception: allocation ties System.Reactive while ReactiveUI.Primitives wins throughput and beats R3 allocation; strict-lower cannot be satisfied for a tie. |
 | `Signal emit, 1024 values` | allocation ties System.Reactive (136 B vs 136 B). | Accepted exception: allocation is flat and tied with System.Reactive while throughput remains fastest; no extra optimization is justified for a strict tie. |
-| `Publish live connect` | allocation > R3 (384 B vs 368 B). | Accepted exception: live publishing owns the `ConnectableSignal<T>` connection/disposal boundary; the small R3 allocation delta buys explicit lifecycle ownership. |
+| `ShareLive connect` | allocation > R3 (384 B vs 368 B). | Accepted exception: live sharing owns the `ConnectableSignal<T>` connection/disposal boundary; the small R3 allocation delta buys explicit lifecycle ownership. |
 | `Share live subscribe` | allocation > R3 (848 B vs 488 B). | Accepted exception: share/ref-count uses gate state to connect/disconnect the source safely across observers; R3’s lower allocation reflects a different specialized implementation. |
-| `RefCount subscribe` | allocation > R3 (848 B vs 488 B). | Accepted exception: ref-count keeps connection gate state and a disposable cleanup path for safe last-subscriber disconnect; throughput remains ahead while allocation is documented. |
+| `AutoShare subscribe` | allocation > R3 (848 B vs 488 B). | Accepted exception: auto-share keeps connection gate state and a disposable cleanup path for safe last-subscriber disconnect; throughput remains ahead while allocation is documented. |
 | `AutoConnect subscribe` | allocation > R3 (728 B vs 368 B). | Accepted exception: auto-connect tracks subscriber thresholds and connection lifetime explicitly; allocation premium buys predictable connect ownership without R3 at runtime. |
 | `StateSignal updates` | time >= System.Reactive (526.8121 ns vs 526.5334 ns). | Accepted exception: state updates retain current-value/state-signal semantics and lower allocation than both alternatives; the latest run is within noise of System.Reactive time while still faster than R3. |
 | `ReadOnlyState projection` | time >= System.Reactive (125.7138 ns vs 89.6034 ns). | Accepted exception: projection preserves `ReadOnlyStateSignal<T>` current-value semantics; System.Reactive is faster in this microcase but allocates more and lacks the state-signal contract. |
@@ -796,17 +795,16 @@ Performance constraints used by the project:
 ### Latest local validation used for this README
 
 ```powershell
-# Build tests
-dotnet build src/tests/ReactiveUI.Primitives.Tests/ReactiveUI.Primitives.Tests.csproj -c Release -f net10.0
+# Build solution
+dotnet build src/ReactiveUI.Primitives.slnx --no-restore -v:minimal
 
-# Direct Microsoft Testing Platform/TUnit execution
-dotnet src/tests/ReactiveUI.Primitives.Tests/bin/Release/net10.0/ReactiveUI.Primitives.Tests.dll --no-progress --disable-logo --minimum-expected-tests 179
-
-# Coverage
-dotnet src/tests/ReactiveUI.Primitives.Tests/bin/Release/net10.0/ReactiveUI.Primitives.Tests.dll --no-progress --disable-logo --minimum-expected-tests 179 --coverage --coverage-output coverage.cobertura.xml --coverage-output-format cobertura --results-directory src/tests/ReactiveUI.Primitives.Tests/TestResults/coverage-kanban-t_f3f3db71-20260528-final
+# Test with the Microsoft Testing Platform runner from the src directory.
+Push-Location src
+dotnet test .\ReactiveUI.Primitives.slnx --no-build -v:minimal
+Pop-Location
 ```
 
-Results: build passed with 0 warnings/0 errors; direct DLL test run passed 179/179; the latest coverage snapshot passed tests and reported 96.02% line (5285/5504) and 91.46% branch (1820/1990) coverage. That coverage remains below the original 100% line/branch final-review target and is documented as a signed-off release exception rather than represented as a 100% gate pass. `dotnet test` is not the validation command for this repository while the .NET 10 SDK/Microsoft.Testing.Platform VSTest-mode mismatch exists; use direct DLL execution instead.
+Results: build passed with 0 warnings/0 errors; `dotnet test` passed 537/537 tests across net8.0, net9.0, and net10.0. The latest coverage snapshot passed tests and reported 96.02% line (5285/5504) and 91.46% branch (1820/1990) coverage. That coverage remains below the original 100% line/branch final-review target and is documented as a signed-off release exception rather than represented as a 100% gate pass.
 
 ### Package verification
 
@@ -820,9 +818,9 @@ For NuGet package verification, inspect the generated `.nupkg` and confirm:
 
 ## Practical migration checklist
 
-1. Replace subject construction with `Signal<T>`, `StateSignal<T>`, or `ReplaySignal<T>` depending on current behavior.
-2. Replace factories: `Observable.Return/Empty/Throw/Timer/Interval` to `Signal.Return/Empty/Throw/Timer/Interval`.
-3. Replace hot-path operators with Primitives names: `Select -> Map`, `Where -> Keep`, `Do -> Tap`, `Aggregate -> Fold`, `Amb -> Race`.
+1. Replace subject construction with `Signal<T>`, `StateSignal<T>`, or `HistorySignal<T>` depending on current behavior.
+2. Replace factories: `Observable.Return/Empty/Throw/Timer/Interval` to `Signal.Emit/None/Fail/After/Pulse`.
+3. Replace hot-path operators with Primitives names: `Select -> Map`, `Where -> Keep`, `SelectMany -> FlatMap`, `Do -> Tap`, `Scan -> Fold`, `Aggregate -> Reduce`, `Amb -> Race`.
 4. Replace composite/serial disposables with `MultipleDisposable`/`Pocket` and `SingleReplaceableDisposable`/`Slot`.
 5. Keep System.Reactive/R3 at application boundaries only when required; use generated bridge methods when those packages are already referenced.
 6. Run build, tests, pack, and `git diff --check` before publishing or merging.

--- a/src/ReactiveUI.Primitives/ConnectableSignalMixins.cs
+++ b/src/ReactiveUI.Primitives/ConnectableSignalMixins.cs
@@ -35,22 +35,22 @@ public static class ConnectableSignalMixins
     }
 
     /// <summary>
-    /// Publishes source values through a live signal hub.
+    /// Shares source values through a live signal hub.
     /// </summary>
     /// <typeparam name="T">The value type.</typeparam>
-    /// <param name="source">Source sequence to publish.</param>
+    /// <param name="source">Source sequence to share.</param>
     /// <returns>A connectable live signal.</returns>
-    public static ConnectableSignal<T> PublishLive<T>(this IObservable<T> source) =>
+    public static ConnectableSignal<T> ShareLive<T>(this IObservable<T> source) =>
         source.Multicast(new Signal<T>());
 
     /// <summary>
-    /// Publishes source values through a live signal hub.
+    /// Shares source values through a live signal hub.
     /// </summary>
     /// <typeparam name="T">The value type.</typeparam>
-    /// <param name="source">Source sequence to publish.</param>
+    /// <param name="source">Source sequence to share.</param>
     /// <returns>A connectable live signal.</returns>
-    public static ConnectableSignal<T> Publish<T>(this IObservable<T> source) =>
-        source.PublishLive();
+    public static ConnectableSignal<T> Share<T>(this IObservable<T> source) =>
+        source.ShareLive();
 
     /// <summary>
     /// Replays source values through a bounded replay hub.
@@ -60,7 +60,7 @@ public static class ConnectableSignalMixins
     /// <param name="bufferSize">Maximum number of values to replay.</param>
     /// <returns>A connectable replay signal.</returns>
     public static ConnectableSignal<T> ReplayLive<T>(this IObservable<T> source, int bufferSize) =>
-        source.Multicast(new ReplaySignal<T>(bufferSize));
+        source.Multicast(new HistorySignal<T>(bufferSize));
 
     /// <summary>
     /// Replays source values through a replay hub constrained by count and time.
@@ -71,7 +71,7 @@ public static class ConnectableSignalMixins
     /// <param name="window">Maximum replay window.</param>
     /// <returns>A connectable replay signal.</returns>
     public static ConnectableSignal<T> ReplayLive<T>(this IObservable<T> source, int bufferSize, TimeSpan window) =>
-        source.Multicast(new ReplaySignal<T>(bufferSize, window));
+        source.Multicast(new HistorySignal<T>(bufferSize, window));
 
     /// <summary>
     /// Replays source values through a bounded replay hub.
@@ -100,15 +100,7 @@ public static class ConnectableSignalMixins
     /// <typeparam name="T">The value type.</typeparam>
     /// <param name="source">Source sequence to share.</param>
     /// <returns>A reference-counted live sequence.</returns>
-    public static IObservable<T> ShareLive<T>(this IObservable<T> source) => source.PublishLive().RefCount();
-
-    /// <summary>
-    /// Shares one live source subscription while at least one observer is subscribed.
-    /// </summary>
-    /// <typeparam name="T">The value type.</typeparam>
-    /// <param name="source">Source sequence to share.</param>
-    /// <returns>A reference-counted live sequence.</returns>
-    public static IObservable<T> Share<T>(this IObservable<T> source) => source.ShareLive();
+    public static IObservable<T> ShareLatest<T>(this IObservable<T> source) => source.ShareLive().AutoShare();
 
     /// <summary>
     /// Connects on first subscriber and disconnects when the last subscriber disposes.
@@ -116,14 +108,14 @@ public static class ConnectableSignalMixins
     /// <typeparam name="T">The value type.</typeparam>
     /// <param name="source">Connectable signal to reference count.</param>
     /// <returns>A reference-counted sequence.</returns>
-    public static IObservable<T> RefCount<T>(this ConnectableSignal<T> source)
+    public static IObservable<T> AutoShare<T>(this ConnectableSignal<T> source)
     {
         if (source == null)
         {
             throw new ArgumentNullException(nameof(source));
         }
 
-        var gate = RefCountGate<T>.For(source);
+        var gate = AutoShareGate<T>.For(source);
         return Signal.Create<T>(gate.Subscribe);
     }
 
@@ -163,7 +155,7 @@ public static class ConnectableSignalMixins
     /// Tracks reference-counted connection state.
     /// </summary>
     /// <typeparam name="TValue">The value type.</typeparam>
-    private sealed class RefCountGate<TValue>
+    private sealed class AutoShareGate<TValue>
     {
         /// <summary>
         /// Synchronizes reference-count state.
@@ -186,17 +178,17 @@ public static class ConnectableSignalMixins
         private IDisposable? _connection;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="RefCountGate{TValue}"/> class.
+        /// Initializes a new instance of the <see cref="AutoShareGate{TValue}"/> class.
         /// </summary>
         /// <param name="source">Connectable signal being reference-counted.</param>
-        private RefCountGate(ConnectableSignal<TValue> source) => _source = source;
+        private AutoShareGate(ConnectableSignal<TValue> source) => _source = source;
 
         /// <summary>
         /// Creates a reference-count gate for a connectable signal.
         /// </summary>
         /// <param name="source">Connectable signal being reference-counted.</param>
         /// <returns>A reference-count gate.</returns>
-        public static RefCountGate<TValue> For(ConnectableSignal<TValue> source) => new(source);
+        public static AutoShareGate<TValue> For(ConnectableSignal<TValue> source) => new(source);
 
         /// <summary>
         /// Subscribes an observer and manages the shared connection lifetime.

--- a/src/ReactiveUI.Primitives/DebuggerDisplay.Partials.cs
+++ b/src/ReactiveUI.Primitives/DebuggerDisplay.Partials.cs
@@ -251,6 +251,15 @@ namespace ReactiveUI.Primitives.Signals
         private string DebuggerDisplay => ToString() ?? string.Empty;
     }
 
+    public partial class FinalSignal<T>
+    {
+        /// <summary>
+        /// Gets the debugger display text.
+        /// </summary>
+        [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
+        private string DebuggerDisplay => ToString() ?? string.Empty;
+    }
+
     public sealed partial class CommandSignal<TResult>
     {
         /// <summary>
@@ -270,6 +279,15 @@ namespace ReactiveUI.Primitives.Signals
     }
 
     public partial class ReplaySignal<T>
+    {
+        /// <summary>
+        /// Gets the debugger display text.
+        /// </summary>
+        [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
+        private string DebuggerDisplay => ToString() ?? string.Empty;
+    }
+
+    public partial class HistorySignal<T>
     {
         /// <summary>
         /// Gets the debugger display text.

--- a/src/ReactiveUI.Primitives/Handle.cs
+++ b/src/ReactiveUI.Primitives/Handle.cs
@@ -32,5 +32,5 @@ internal static class Handle
         "S4018:Generic methods should provide type parameters",
         Justification = "The type parameter determines the empty sequence value type.")]
     public static IObservable<TSource> CatchIgnore<TSource>(Exception ex) =>
-        Signal.Empty<TSource>();
+        Signal.None<TSource>();
 }

--- a/src/ReactiveUI.Primitives/LinqMixins.cs
+++ b/src/ReactiveUI.Primitives/LinqMixins.cs
@@ -8,26 +8,10 @@ using ReactiveUI.Primitives.Signals;
 namespace ReactiveUI.Primitives;
 
 /// <summary>
-/// SelectMixins.
+/// Miscellaneous Primitives extensions.
 /// </summary>
 public static partial class LinqMixins
 {
-    /// <summary>
-    /// Selects the specified selector.
-    /// </summary>
-    /// <typeparam name="TSource">The type of the source.</typeparam>
-    /// <typeparam name="TResult">The type of the result.</typeparam>
-    /// <param name="source">The source.</param>
-    /// <param name="selector">The selector.</param>
-    /// <returns>A ISignals.</returns>
-    /// <exception cref="ArgumentNullException">
-    /// source
-    /// or
-    /// selector.
-    /// </exception>
-    public static IObservable<TResult> Select<TSource, TResult>(this IObservable<TSource> source, Func<TSource, TResult> selector)
-        => (source ?? throw new ArgumentNullException(nameof(source))).Map(selector ?? throw new ArgumentNullException(nameof(selector)));
-
     /// <summary>
     /// Buffers the specified count.
     /// </summary>
@@ -114,19 +98,4 @@ public static partial class LinqMixins
     /// <returns>A SingleDisposable.</returns>
     public static SingleDisposable DisposeWith(this IDisposable disposable, Action? action) =>
         new(disposable, action);
-
-    /// <summary>
-    /// Wheres the specified predicate.
-    /// </summary>
-    /// <typeparam name="T">The Type.</typeparam>
-    /// <param name="source">The source.</param>
-    /// <param name="predicate">The predicate.</param>
-    /// <returns>An ISignals.</returns>
-    /// <exception cref="ArgumentNullException">
-    /// source
-    /// or
-    /// predicate.
-    /// </exception>
-    public static IObservable<T> Where<T>(this IObservable<T> source, Func<T, bool> predicate)
-        => (source ?? throw new ArgumentNullException(nameof(source))).Keep(predicate ?? throw new ArgumentNullException(nameof(predicate)));
 }

--- a/src/ReactiveUI.Primitives/Signal/AsyncSignal{T}.cs
+++ b/src/ReactiveUI.Primitives/Signal/AsyncSignal{T}.cs
@@ -55,7 +55,7 @@ public partial class AsyncSignal<T> : IAwaitSignal<T>
     /// <value>
     /// The value.
     /// </value>
-    /// <exception cref="InvalidOperationException">AsyncSubject is not completed yet.</exception>
+    /// <exception cref="InvalidOperationException">The final signal is not completed yet.</exception>
     public T Value
     {
         get
@@ -63,7 +63,7 @@ public partial class AsyncSignal<T> : IAwaitSignal<T>
             ThrowIfDisposed();
             if (!IsCompleted)
             {
-                throw new InvalidOperationException("AsyncSubject is not completed yet");
+                throw new InvalidOperationException("FinalSignal is not completed yet");
             }
 
             _lastError.Rethrow();
@@ -261,7 +261,7 @@ public partial class AsyncSignal<T> : IAwaitSignal<T>
     }
 
     /// <summary>
-    /// Gets an awaitable object for the current AsyncSubject.
+    /// Gets an awaitable object for the current final signal.
     /// </summary>
     /// <returns>Object that can be awaited.</returns>
     public IAwaitSignal<T> GetAwaiter() => this;

--- a/src/ReactiveUI.Primitives/Signal/FinalSignal{T}.cs
+++ b/src/ReactiveUI.Primitives/Signal/FinalSignal{T}.cs
@@ -1,0 +1,12 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace ReactiveUI.Primitives.Signals;
+
+/// <summary>
+/// Signal that remembers only its final value and publishes it when completed.
+/// </summary>
+/// <typeparam name="T">The value type.</typeparam>
+[System.Diagnostics.DebuggerDisplay("{DebuggerDisplay,nq}")]
+public partial class FinalSignal<T> : AsyncSignal<T>;

--- a/src/ReactiveUI.Primitives/Signal/HistorySignal{T}.cs
+++ b/src/ReactiveUI.Primitives/Signal/HistorySignal{T}.cs
@@ -1,0 +1,90 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using ReactiveUI.Primitives.Concurrency;
+
+namespace ReactiveUI.Primitives.Signals;
+
+/// <summary>
+/// Replay-capable signal that stores a bounded or time-windowed history for later subscribers.
+/// </summary>
+/// <typeparam name="T">The value type.</typeparam>
+[System.Diagnostics.DebuggerDisplay("{DebuggerDisplay,nq}")]
+public partial class HistorySignal<T> : ReplaySignal<T>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HistorySignal{T}"/> class.
+    /// </summary>
+    public HistorySignal()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HistorySignal{T}"/> class.
+    /// </summary>
+    /// <param name="scheduler">The sequencer used for time-window trimming.</param>
+    public HistorySignal(ISequencer scheduler)
+        : base(scheduler)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HistorySignal{T}"/> class.
+    /// </summary>
+    /// <param name="bufferSize">Maximum number of values to replay.</param>
+    public HistorySignal(int bufferSize)
+        : base(bufferSize)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HistorySignal{T}"/> class.
+    /// </summary>
+    /// <param name="bufferSize">Maximum number of values to replay.</param>
+    /// <param name="scheduler">The sequencer used for time-window trimming.</param>
+    public HistorySignal(int bufferSize, ISequencer scheduler)
+        : base(bufferSize, scheduler)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HistorySignal{T}"/> class.
+    /// </summary>
+    /// <param name="window">Maximum replay window.</param>
+    public HistorySignal(TimeSpan window)
+        : base(window)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HistorySignal{T}"/> class.
+    /// </summary>
+    /// <param name="window">Maximum replay window.</param>
+    /// <param name="scheduler">The sequencer used for time-window trimming.</param>
+    public HistorySignal(TimeSpan window, ISequencer scheduler)
+        : base(window, scheduler)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HistorySignal{T}"/> class.
+    /// </summary>
+    /// <param name="bufferSize">Maximum number of values to replay.</param>
+    /// <param name="window">Maximum replay window.</param>
+    public HistorySignal(int bufferSize, TimeSpan window)
+        : base(bufferSize, window)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HistorySignal{T}"/> class.
+    /// </summary>
+    /// <param name="bufferSize">Maximum number of values to replay.</param>
+    /// <param name="window">Maximum replay window.</param>
+    /// <param name="scheduler">The sequencer used for time-window trimming.</param>
+    public HistorySignal(int bufferSize, TimeSpan window, ISequencer scheduler)
+        : base(bufferSize, window, scheduler)
+    {
+    }
+}

--- a/src/ReactiveUI.Primitives/SignalOperatorMixins.cs
+++ b/src/ReactiveUI.Primitives/SignalOperatorMixins.cs
@@ -11,8 +11,7 @@ using ReactiveUI.Primitives.Signals.Core;
 namespace ReactiveUI.Primitives;
 
 /// <summary>
-/// Additional ReactiveUI.Primitives operator surface. Canonical LINQ names are kept where idiomatic;
-/// Primitives aliases (`Map`, `Keep`, `Sparkify`, `Unspark`) make the public surface distinct.
+/// Additional ReactiveUI.Primitives operator surface using distinct Primitives vocabulary.
 /// </summary>
 public static partial class LinqMixins
 {
@@ -148,8 +147,8 @@ public static partial class LinqMixins
     [System.Diagnostics.CodeAnalysis.SuppressMessage(
         "Major Code Smell",
         "S4018:Generic methods should provide type parameters",
-        Justification = "LINQ-style OfType requires the caller to provide the result type.")]
-    public static IObservable<TResult> OfType<TResult>(this IObservable<object?> source)
+        Justification = "KeepType requires the caller to provide the result type.")]
+    public static IObservable<TResult> KeepType<TResult>(this IObservable<object?> source)
     {
         if (source == null)
         {
@@ -180,8 +179,8 @@ public static partial class LinqMixins
     [System.Diagnostics.CodeAnalysis.SuppressMessage(
         "Major Code Smell",
         "S4018:Generic methods should provide type parameters",
-        Justification = "LINQ-style Cast requires the caller to provide the result type.")]
-    public static IObservable<TResult> Cast<TResult>(this IObservable<object?> source)
+        Justification = "CastTo requires the caller to provide the result type.")]
+    public static IObservable<TResult> CastTo<TResult>(this IObservable<object?> source)
     {
         if (source == null)
         {
@@ -243,7 +242,7 @@ public static partial class LinqMixins
     /// <param name="accumulator">The function that combines the current state with the next source value.</param>
     /// <returns>A sequence of intermediate accumulated values.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="accumulator"/> is <see langword="null"/>.</exception>
-    public static IObservable<TAccumulate> Scan<TSource, TAccumulate>(this IObservable<TSource> source, TAccumulate seed, Func<TAccumulate, TSource, TAccumulate> accumulator)
+    public static IObservable<TAccumulate> Fold<TSource, TAccumulate>(this IObservable<TSource> source, TAccumulate seed, Func<TAccumulate, TSource, TAccumulate> accumulator)
     {
         if (source == null)
         {
@@ -279,7 +278,7 @@ public static partial class LinqMixins
     /// <param name="accumulator">The function that combines the current state with the next source value.</param>
     /// <returns>A sequence that emits one accumulated value on completion.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="accumulator"/> is <see langword="null"/>.</exception>
-    public static IObservable<TAccumulate> Fold<TSource, TAccumulate>(this IObservable<TSource> source, TAccumulate seed, Func<TAccumulate, TSource, TAccumulate> accumulator)
+    public static IObservable<TAccumulate> Reduce<TSource, TAccumulate>(this IObservable<TSource> source, TAccumulate seed, Func<TAccumulate, TSource, TAccumulate> accumulator)
     {
         if (source == null)
         {
@@ -447,8 +446,8 @@ public static partial class LinqMixins
     /// <param name="source">The source sequence.</param>
     /// <returns>A sequence with adjacent duplicates removed.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
-    public static IObservable<T> DistinctUntilChanged<T>(this IObservable<T> source) =>
-        source.DistinctUntilChanged(null);
+    public static IObservable<T> Unique<T>(this IObservable<T> source) =>
+        source.Unique(null);
 
     /// <summary>
     /// Suppresses adjacent duplicate values using the supplied comparer.
@@ -458,7 +457,7 @@ public static partial class LinqMixins
     /// <param name="comparer">The comparer used to compare adjacent values.</param>
     /// <returns>A sequence with adjacent duplicates removed.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
-    public static IObservable<T> DistinctUntilChanged<T>(this IObservable<T> source, IEqualityComparer<T>? comparer)
+    public static IObservable<T> Unique<T>(this IObservable<T> source, IEqualityComparer<T>? comparer)
     {
         if (source == null)
         {
@@ -494,7 +493,7 @@ public static partial class LinqMixins
     /// <param name="source">The source sequence.</param>
     /// <returns>A sequence of spark values representing source notifications; terminal sparks are followed by completion.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
-    public static IObservable<Spark<T>> Sparkify<T>(this IObservable<T> source)
+    public static IObservable<Spark<T>> Spark<T>(this IObservable<T> source)
     {
         if (source == null)
         {
@@ -502,15 +501,15 @@ public static partial class LinqMixins
         }
 
         return Signal.CreateSafe<Spark<T>>(observer => source.Subscribe(
-            value => observer.OnNext(Spark.CreateOnNext(value)),
+            value => observer.OnNext(ReactiveUI.Primitives.Core.Spark.CreateOnNext(value)),
             error =>
             {
-                observer.OnNext(Spark.CreateOnError<T>(error));
+                observer.OnNext(ReactiveUI.Primitives.Core.Spark.CreateOnError<T>(error));
                 observer.OnCompleted();
             },
             () =>
             {
-                observer.OnNext(Spark.CreateOnCompleted<T>());
+                observer.OnNext(ReactiveUI.Primitives.Core.Spark.CreateOnCompleted<T>());
                 observer.OnCompleted();
             }));
     }
@@ -542,7 +541,7 @@ public static partial class LinqMixins
     /// <param name="sources">The outer sequence of inner sequences.</param>
     /// <returns>A sequence that emits each inner sequence after the previous one completes.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="sources"/> is <see langword="null"/>.</exception>
-    public static IObservable<T> Concat<T>(this IObservable<IObservable<T>> sources)
+    public static IObservable<T> Chain<T>(this IObservable<IObservable<T>> sources)
     {
         if (sources == null)
         {
@@ -603,7 +602,7 @@ public static partial class LinqMixins
                 {
                     if (source == null)
                     {
-                        observer.OnError(new InvalidOperationException("Concat source contained null."));
+                        observer.OnError(new InvalidOperationException("Chain source contained null."));
                         return;
                     }
 
@@ -636,8 +635,8 @@ public static partial class LinqMixins
     /// <param name="first">The first sequence.</param>
     /// <param name="second">The second sequence.</param>
     /// <returns>A sequence that emits <paramref name="second"/> after <paramref name="first"/> completes.</returns>
-    public static IObservable<T> Concat<T>(this IObservable<T> first, IObservable<T> second) =>
-        Signal.Concat(first, second);
+    public static IObservable<T> Chain<T>(this IObservable<T> first, IObservable<T> second) =>
+        Signal.Chain(first, second);
 
     /// <summary>
     /// Subscribes to all inner sequences and forwards their values as they arrive.
@@ -646,7 +645,7 @@ public static partial class LinqMixins
     /// <param name="sources">The outer sequence of inner sequences.</param>
     /// <returns>A sequence containing values from all inner sequences.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="sources"/> is <see langword="null"/>.</exception>
-    public static IObservable<T> Merge<T>(this IObservable<IObservable<T>> sources)
+    public static IObservable<T> Blend<T>(this IObservable<IObservable<T>> sources)
     {
         if (sources == null)
         {
@@ -676,7 +675,7 @@ public static partial class LinqMixins
                 {
                     if (source == null)
                     {
-                        observer.OnError(new InvalidOperationException("Merge source contained null."));
+                        observer.OnError(new InvalidOperationException("Blend source contained null."));
                         return;
                     }
 
@@ -741,7 +740,7 @@ public static partial class LinqMixins
     /// <param name="selector">The function that combines paired values.</param>
     /// <returns>A sequence containing one result for each available value pair.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="left"/>, <paramref name="right"/>, or <paramref name="selector"/> is <see langword="null"/>.</exception>
-    public static IObservable<TResult> Zip<TLeft, TRight, TResult>(this IObservable<TLeft> left, IObservable<TRight> right, Func<TLeft, TRight, TResult> selector)
+    public static IObservable<TResult> Pair<TLeft, TRight, TResult>(this IObservable<TLeft> left, IObservable<TRight> right, Func<TLeft, TRight, TResult> selector)
     {
         if (left == null)
         {
@@ -777,7 +776,7 @@ public static partial class LinqMixins
     /// <param name="selector">The function that combines the latest values.</param>
     /// <returns>A sequence containing selected latest-value combinations.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="left"/>, <paramref name="right"/>, or <paramref name="selector"/> is <see langword="null"/>.</exception>
-    public static IObservable<TResult> CombineLatest<TLeft, TRight, TResult>(this IObservable<TLeft> left, IObservable<TRight> right, Func<TLeft, TRight, TResult> selector)
+    public static IObservable<TResult> SyncLatest<TLeft, TRight, TResult>(this IObservable<TLeft> left, IObservable<TRight> right, Func<TLeft, TRight, TResult> selector)
     {
         if (left == null)
         {
@@ -814,7 +813,7 @@ public static partial class LinqMixins
     /// <returns>A sequence containing selected left/latest-right combinations.</returns>
     /// <remarks>Left values produced before the first right value are ignored.</remarks>
     /// <exception cref="ArgumentNullException"><paramref name="left"/>, <paramref name="right"/>, or <paramref name="selector"/> is <see langword="null"/>.</exception>
-    public static IObservable<TResult> WithLatest<TLeft, TRight, TResult>(this IObservable<TLeft> left, IObservable<TRight> right, Func<TLeft, TRight, TResult> selector)
+    public static IObservable<TResult> Latch<TLeft, TRight, TResult>(this IObservable<TLeft> left, IObservable<TRight> right, Func<TLeft, TRight, TResult> selector)
     {
         if (left == null)
         {
@@ -881,7 +880,7 @@ public static partial class LinqMixins
     /// <param name="sources">The outer sequence of inner sequences.</param>
     /// <returns>A sequence that mirrors only the latest inner sequence.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="sources"/> is <see langword="null"/>.</exception>
-    public static IObservable<T> Switch<T>(this IObservable<IObservable<T>> sources)
+    public static IObservable<T> SwitchTo<T>(this IObservable<IObservable<T>> sources)
     {
         if (sources == null)
         {
@@ -900,7 +899,7 @@ public static partial class LinqMixins
     /// <returns>A sequence that retries the source before forwarding the final error.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentOutOfRangeException"><paramref name="retryCount"/> is less than zero.</exception>
-    public static IObservable<T> Retry<T>(this IObservable<T> source, int retryCount)
+    public static IObservable<T> Reattempt<T>(this IObservable<T> source, int retryCount)
     {
         if (source == null)
         {
@@ -949,8 +948,19 @@ public static partial class LinqMixins
     /// <param name="handler">The function that creates the recovery sequence for an error.</param>
     /// <returns>A sequence that continues with the handler result after an error.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="handler"/> is <see langword="null"/>.</exception>
+    public static IObservable<T> Recover<T>(this IObservable<T> source, Func<Exception, IObservable<T>> handler) =>
+        source.Recover<T, Exception>(handler);
+
+    /// <summary>
+    /// Recovers from errors by switching to a handler-provided sequence.
+    /// </summary>
+    /// <typeparam name="T">The value type.</typeparam>
+    /// <param name="source">The source sequence.</param>
+    /// <param name="handler">The function that creates the recovery sequence for an error.</param>
+    /// <returns>A sequence that continues with the handler result after an error.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="handler"/> is <see langword="null"/>.</exception>
     public static IObservable<T> Rescue<T>(this IObservable<T> source, Func<Exception, IObservable<T>> handler) =>
-        source.Catch<T, Exception>(handler);
+        source.Recover(handler);
 
     /// <summary>
     /// Continues with a fallback sequence after an error.
@@ -967,7 +977,7 @@ public static partial class LinqMixins
             throw new ArgumentNullException(nameof(fallback));
         }
 
-        return source.Catch<T, Exception>(_ => fallback);
+        return source.Recover<T, Exception>(_ => fallback);
     }
 
     /// <summary>
@@ -977,8 +987,8 @@ public static partial class LinqMixins
     /// <param name="source">The source sequence.</param>
     /// <param name="dueTime">The delay applied to each notification.</param>
     /// <returns>A sequence that forwards source notifications after the delay.</returns>
-    public static IObservable<T> Delay<T>(this IObservable<T> source, TimeSpan dueTime) =>
-        source.Delay(dueTime, null);
+    public static IObservable<T> Shift<T>(this IObservable<T> source, TimeSpan dueTime) =>
+        source.Shift(dueTime, null);
 
     /// <summary>
     /// Delays source notifications by the specified duration on a sequencer.
@@ -988,7 +998,7 @@ public static partial class LinqMixins
     /// <param name="dueTime">The delay applied to each notification.</param>
     /// <param name="scheduler">The sequencer used to schedule delayed notifications.</param>
     /// <returns>A sequence that forwards source notifications after the delay.</returns>
-    public static IObservable<T> Delay<T>(this IObservable<T> source, TimeSpan dueTime, ISequencer? scheduler)
+    public static IObservable<T> Shift<T>(this IObservable<T> source, TimeSpan dueTime, ISequencer? scheduler)
     {
         if (source == null)
         {
@@ -1016,8 +1026,8 @@ public static partial class LinqMixins
     /// <param name="source">The source sequence.</param>
     /// <param name="dueTime">The timeout duration.</param>
     /// <returns>A sequence that errors with <see cref="TimeoutException"/> when the timeout elapses first.</returns>
-    public static IObservable<T> Timeout<T>(this IObservable<T> source, TimeSpan dueTime) =>
-        source.Timeout(dueTime, null);
+    public static IObservable<T> Expire<T>(this IObservable<T> source, TimeSpan dueTime) =>
+        source.Expire(dueTime, null);
 
     /// <summary>
     /// Fails the sequence if it does not terminate before the sequencer timeout.
@@ -1027,7 +1037,7 @@ public static partial class LinqMixins
     /// <param name="dueTime">The timeout duration.</param>
     /// <param name="scheduler">The sequencer used to schedule the timeout.</param>
     /// <returns>A sequence that errors with <see cref="TimeoutException"/> when the timeout elapses first.</returns>
-    public static IObservable<T> Timeout<T>(this IObservable<T> source, TimeSpan dueTime, ISequencer? scheduler)
+    public static IObservable<T> Expire<T>(this IObservable<T> source, TimeSpan dueTime, ISequencer? scheduler)
     {
         if (source == null)
         {

--- a/src/ReactiveUI.Primitives/SignalOperatorParityMixins.FlatMap.cs
+++ b/src/ReactiveUI.Primitives/SignalOperatorParityMixins.FlatMap.cs
@@ -7,16 +7,16 @@ using ReactiveUI.Primitives.Disposables;
 namespace ReactiveUI.Primitives;
 
 /// <content>
-/// SelectMany helper implementations.
+/// FlatMap helper implementations.
 /// </content>
 public static partial class LinqMixins
 {
     /// <summary>
-    /// Concatenating SelectMany signal that avoids the Map + Concat composition path.
+    /// Chaining FlatMap signal that avoids the Map + Chain composition path.
     /// </summary>
     /// <typeparam name="TSource">The source value type.</typeparam>
     /// <typeparam name="TResult">The result value type.</typeparam>
-    private sealed class SelectManySignal<TSource, TResult> : IObservable<TResult>
+    private sealed class FlatMapSignal<TSource, TResult> : IObservable<TResult>
     {
         /// <summary>
         /// The source observable.
@@ -29,11 +29,11 @@ public static partial class LinqMixins
         private readonly Func<TSource, IObservable<TResult>> _selector;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="SelectManySignal{TSource, TResult}"/> class.
+        /// Initializes a new instance of the <see cref="FlatMapSignal{TSource, TResult}"/> class.
         /// </summary>
         /// <param name="source">The source observable.</param>
         /// <param name="selector">Projects source values to inner observables.</param>
-        internal SelectManySignal(IObservable<TSource> source, Func<TSource, IObservable<TResult>> selector)
+        internal FlatMapSignal(IObservable<TSource> source, Func<TSource, IObservable<TResult>> selector)
         {
             _source = source;
             _selector = selector;
@@ -47,17 +47,17 @@ public static partial class LinqMixins
                 throw new ArgumentNullException(nameof(observer));
             }
 
-            return new SelectManyCoordinator<TSource, TResult>(_source, _selector, observer).Run();
+            return new FlatMapCoordinator<TSource, TResult>(_source, _selector, observer).Run();
         }
     }
 
     /// <summary>
-    /// Concatenating SelectMany signal with an outer/inner result selector.
+    /// Chaining FlatMap signal with an outer/inner result selector.
     /// </summary>
     /// <typeparam name="TSource">The source value type.</typeparam>
     /// <typeparam name="TCollection">The inner value type.</typeparam>
     /// <typeparam name="TResult">The result value type.</typeparam>
-    private sealed class SelectManyResultSignal<TSource, TCollection, TResult> : IObservable<TResult>
+    private sealed class FlatMapResultSignal<TSource, TCollection, TResult> : IObservable<TResult>
     {
         /// <summary>
         /// The source observable.
@@ -75,12 +75,12 @@ public static partial class LinqMixins
         private readonly Func<TSource, TCollection, TResult> _resultSelector;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="SelectManyResultSignal{TSource, TCollection, TResult}"/> class.
+        /// Initializes a new instance of the <see cref="FlatMapResultSignal{TSource, TCollection, TResult}"/> class.
         /// </summary>
         /// <param name="source">The source observable.</param>
         /// <param name="collectionSelector">Projects source values to inner observables.</param>
         /// <param name="resultSelector">Projects outer and inner values to result values.</param>
-        internal SelectManyResultSignal(
+        internal FlatMapResultSignal(
             IObservable<TSource> source,
             Func<TSource, IObservable<TCollection>> collectionSelector,
             Func<TSource, TCollection, TResult> resultSelector)
@@ -98,7 +98,7 @@ public static partial class LinqMixins
                 throw new ArgumentNullException(nameof(observer));
             }
 
-            return new SelectManyResultCoordinator<TSource, TCollection, TResult>(
+            return new FlatMapResultCoordinator<TSource, TCollection, TResult>(
                 _source,
                 _collectionSelector,
                 _resultSelector,
@@ -107,11 +107,11 @@ public static partial class LinqMixins
     }
 
     /// <summary>
-    /// Coordinates concat-style SelectMany subscriptions.
+    /// Coordinates chain-style FlatMap subscriptions.
     /// </summary>
     /// <typeparam name="TSource">The source value type.</typeparam>
     /// <typeparam name="TResult">The result value type.</typeparam>
-    private sealed class SelectManyCoordinator<TSource, TResult> : IDisposable
+    private sealed class FlatMapCoordinator<TSource, TResult> : IDisposable
     {
         /// <summary>
         /// Synchronizes subscription state.
@@ -184,12 +184,12 @@ public static partial class LinqMixins
         private bool _completedInnerWhileSubscribing;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="SelectManyCoordinator{TSource, TResult}"/> class.
+        /// Initializes a new instance of the <see cref="FlatMapCoordinator{TSource, TResult}"/> class.
         /// </summary>
         /// <param name="source">The source observable.</param>
         /// <param name="selector">Projects source values to inner observables.</param>
         /// <param name="observer">The downstream observer.</param>
-        internal SelectManyCoordinator(
+        internal FlatMapCoordinator(
             IObservable<TSource> source,
             Func<TSource, IObservable<TResult>> selector,
             IObserver<TResult> observer)
@@ -254,7 +254,7 @@ public static partial class LinqMixins
             IObservable<TResult> inner;
             try
             {
-                inner = _selector(value) ?? throw new InvalidOperationException("The SelectMany selector returned null.");
+                inner = _selector(value) ?? throw new InvalidOperationException("The FlatMap selector returned null.");
             }
             catch (Exception error)
             {
@@ -511,13 +511,13 @@ public static partial class LinqMixins
             /// <summary>
             /// Owning coordinator.
             /// </summary>
-            private readonly SelectManyCoordinator<TSource, TResult> _parent;
+            private readonly FlatMapCoordinator<TSource, TResult> _parent;
 
             /// <summary>
             /// Initializes a new instance of the <see cref="OuterObserver"/> class.
             /// </summary>
             /// <param name="parent">Owning coordinator.</param>
-            internal OuterObserver(SelectManyCoordinator<TSource, TResult> parent) => _parent = parent;
+            internal OuterObserver(FlatMapCoordinator<TSource, TResult> parent) => _parent = parent;
 
             /// <inheritdoc/>
             public void OnCompleted() => _parent.OnOuterCompleted();
@@ -537,13 +537,13 @@ public static partial class LinqMixins
             /// <summary>
             /// Owning coordinator.
             /// </summary>
-            private readonly SelectManyCoordinator<TSource, TResult> _parent;
+            private readonly FlatMapCoordinator<TSource, TResult> _parent;
 
             /// <summary>
             /// Initializes a new instance of the <see cref="InnerObserver"/> class.
             /// </summary>
             /// <param name="parent">Owning coordinator.</param>
-            internal InnerObserver(SelectManyCoordinator<TSource, TResult> parent) => _parent = parent;
+            internal InnerObserver(FlatMapCoordinator<TSource, TResult> parent) => _parent = parent;
 
             /// <inheritdoc/>
             public void OnCompleted() => _parent.OnInnerCompleted();
@@ -557,33 +557,33 @@ public static partial class LinqMixins
     }
 
     /// <summary>
-    /// Coordinates concat-style SelectMany subscriptions with a result selector.
+    /// Coordinates chain-style FlatMap subscriptions with a result selector.
     /// </summary>
     /// <typeparam name="TSource">The source value type.</typeparam>
     /// <typeparam name="TCollection">The inner value type.</typeparam>
     /// <typeparam name="TResult">The result value type.</typeparam>
-    private sealed class SelectManyResultCoordinator<TSource, TCollection, TResult> : IDisposable
+    private sealed class FlatMapResultCoordinator<TSource, TCollection, TResult> : IDisposable
     {
         /// <summary>
-        /// The inner SelectMany coordinator.
+        /// The inner FlatMap coordinator.
         /// </summary>
-        private readonly SelectManyCoordinator<TSource, TResult> _inner;
+        private readonly FlatMapCoordinator<TSource, TResult> _inner;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="SelectManyResultCoordinator{TSource, TCollection, TResult}"/> class.
+        /// Initializes a new instance of the <see cref="FlatMapResultCoordinator{TSource, TCollection, TResult}"/> class.
         /// </summary>
         /// <param name="source">The source observable.</param>
         /// <param name="collectionSelector">Projects source values to inner observables.</param>
         /// <param name="resultSelector">Projects outer and inner values to result values.</param>
         /// <param name="observer">The downstream observer.</param>
-        internal SelectManyResultCoordinator(
+        internal FlatMapResultCoordinator(
             IObservable<TSource> source,
             Func<TSource, IObservable<TCollection>> collectionSelector,
             Func<TSource, TCollection, TResult> resultSelector,
             IObserver<TResult> observer) =>
-            _inner = new SelectManyCoordinator<TSource, TResult>(
+            _inner = new FlatMapCoordinator<TSource, TResult>(
                 source,
-                value => new SelectManyResultInnerSignal<TSource, TCollection, TResult>(
+                value => new FlatMapResultInnerSignal<TSource, TCollection, TResult>(
                     value,
                     collectionSelector(value),
                     resultSelector),
@@ -605,7 +605,7 @@ public static partial class LinqMixins
     /// <typeparam name="TSource">The source value type.</typeparam>
     /// <typeparam name="TCollection">The inner value type.</typeparam>
     /// <typeparam name="TResult">The result value type.</typeparam>
-    private sealed class SelectManyResultInnerSignal<TSource, TCollection, TResult> : IObservable<TResult>
+    private sealed class FlatMapResultInnerSignal<TSource, TCollection, TResult> : IObservable<TResult>
     {
         /// <summary>
         /// Captured outer value.
@@ -623,18 +623,18 @@ public static partial class LinqMixins
         private readonly Func<TSource, TCollection, TResult> _selector;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="SelectManyResultInnerSignal{TSource, TCollection, TResult}"/> class.
+        /// Initializes a new instance of the <see cref="FlatMapResultInnerSignal{TSource, TCollection, TResult}"/> class.
         /// </summary>
         /// <param name="sourceValue">Captured outer value.</param>
         /// <param name="source">Inner observable.</param>
         /// <param name="selector">Projects outer and inner values to result values.</param>
-        internal SelectManyResultInnerSignal(
+        internal FlatMapResultInnerSignal(
             TSource sourceValue,
             IObservable<TCollection> source,
             Func<TSource, TCollection, TResult> selector)
         {
             _sourceValue = sourceValue;
-            _source = source ?? throw new InvalidOperationException("The SelectMany collection selector returned null.");
+            _source = source ?? throw new InvalidOperationException("The FlatMap collection selector returned null.");
             _selector = selector;
         }
 

--- a/src/ReactiveUI.Primitives/SignalOperatorParityMixins.cs
+++ b/src/ReactiveUI.Primitives/SignalOperatorParityMixins.cs
@@ -44,47 +44,14 @@ public static partial class LinqMixins
     }
 
     /// <summary>
-    /// Appends a value after the source sequence completes.
-    /// </summary>
-    /// <typeparam name="T">The value type.</typeparam>
-    /// <param name="source">The source sequence.</param>
-    /// <param name="value">The value to emit after the source completes.</param>
-    /// <returns>A sequence that emits the source values followed by <paramref name="value"/>.</returns>
-    /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
-    public static IObservable<T> Append<T>(this IObservable<T> source, T value)
-    {
-        if (source == null)
-        {
-            throw new ArgumentNullException(nameof(source));
-        }
-
-        if (source is PrependSignal<T> prepended)
-        {
-            return new PrependAppendSignal<T>(prepended.GetSource(), prepended.GetValue(), value);
-        }
-
-        return new AppendSignal<T>(source, value);
-    }
-
-    /// <summary>
-    /// Prepends a value before the source sequence using the System.Reactive operator name.
-    /// </summary>
-    /// <typeparam name="T">The value type.</typeparam>
-    /// <param name="source">The source sequence.</param>
-    /// <param name="value">The value to emit before the source.</param>
-    /// <returns>A sequence that emits <paramref name="value"/> before the source values.</returns>
-    /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
-    public static IObservable<T> StartWith<T>(this IObservable<T> source, T value) => source.Prepend(value);
-
-    /// <summary>
-    /// Prepends values before the source sequence using the System.Reactive operator name.
+    /// Prepends values before the source sequence.
     /// </summary>
     /// <typeparam name="T">The value type.</typeparam>
     /// <param name="source">The source sequence.</param>
     /// <param name="values">The values to emit before the source.</param>
     /// <returns>A sequence that emits <paramref name="values"/> before the source values.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="values"/> is <see langword="null"/>.</exception>
-    public static IObservable<T> StartWith<T>(this IObservable<T> source, params T[] values)
+    public static IObservable<T> Prepend<T>(this IObservable<T> source, params T[] values)
     {
         if (source == null)
         {
@@ -110,14 +77,14 @@ public static partial class LinqMixins
     }
 
     /// <summary>
-    /// Prepends values before the source sequence using the System.Reactive operator name.
+    /// Prepends values before the source sequence.
     /// </summary>
     /// <typeparam name="T">The value type.</typeparam>
     /// <param name="source">The source sequence.</param>
     /// <param name="values">The values to emit before the source.</param>
     /// <returns>A sequence that emits <paramref name="values"/> before the source values.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="values"/> is <see langword="null"/>.</exception>
-    public static IObservable<T> StartWith<T>(this IObservable<T> source, IEnumerable<T> values)
+    public static IObservable<T> Prepend<T>(this IObservable<T> source, IEnumerable<T> values)
     {
         if (source == null)
         {
@@ -130,6 +97,29 @@ public static partial class LinqMixins
         }
 
         return new StartWithEnumerableSignal<T>(source, values);
+    }
+
+    /// <summary>
+    /// Appends a value after the source sequence completes.
+    /// </summary>
+    /// <typeparam name="T">The value type.</typeparam>
+    /// <param name="source">The source sequence.</param>
+    /// <param name="value">The value to emit after the source completes.</param>
+    /// <returns>A sequence that emits the source values followed by <paramref name="value"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+    public static IObservable<T> Append<T>(this IObservable<T> source, T value)
+    {
+        if (source == null)
+        {
+            throw new ArgumentNullException(nameof(source));
+        }
+
+        if (source is PrependSignal<T> prepended)
+        {
+            return new PrependAppendSignal<T>(prepended.GetSource(), prepended.GetValue(), value);
+        }
+
+        return new AppendSignal<T>(source, value);
     }
 
     /// <summary>
@@ -241,16 +231,6 @@ public static partial class LinqMixins
         source.DelayStart(dueTime, scheduler);
 
     /// <summary>
-    /// Runs a side effect for each source value using the System.Reactive operator name.
-    /// </summary>
-    /// <typeparam name="T">The value type.</typeparam>
-    /// <param name="source">The source sequence.</param>
-    /// <param name="onNext">The action to invoke for each value.</param>
-    /// <returns>The source values after <paramref name="onNext"/> runs.</returns>
-    /// <exception cref="ArgumentNullException"><paramref name="onNext"/> is <see langword="null"/>.</exception>
-    public static IObservable<T> Do<T>(this IObservable<T> source, Action<T> onNext) => source.Tap(onNext);
-
-    /// <summary>
     /// Invokes actions for each element in the observable sequence, for error notifications, and for successful
     /// completion.
     /// </summary>
@@ -262,7 +242,7 @@ public static partial class LinqMixins
     /// <returns>The source sequence with the side-effecting behavior applied.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="source"/>, <paramref name="onNext"/>, <paramref name="onError"/>, or <paramref
     /// name="onCompleted"/> is <see langword="null"/>.</exception>
-    public static IObservable<T> Do<T>(this IObservable<T> source, Action<T> onNext, Action<Exception> onError, Action onCompleted)
+    public static IObservable<T> Tap<T>(this IObservable<T> source, Action<T> onNext, Action<Exception> onError, Action onCompleted)
     {
         if (source == null)
         {
@@ -301,17 +281,6 @@ public static partial class LinqMixins
                 observer.OnCompleted();
             }));
     }
-
-    /// <summary>
-    /// Alias for <see cref="Rescue{T}(IObservable{T}, Func{Exception, IObservable{T}})"/> using the System.Reactive operator name.
-    /// </summary>
-    /// <typeparam name="T">The value type.</typeparam>
-    /// <param name="source">The source sequence.</param>
-    /// <param name="handler">The function that creates the recovery sequence for an error.</param>
-    /// <returns>A sequence that continues with the handler result after an error.</returns>
-    /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="handler"/> is <see langword="null"/>.</exception>
-    public static IObservable<T> Catch<T>(this IObservable<T> source, Func<Exception, IObservable<T>> handler) =>
-        source.Rescue(handler);
 
     /// <summary>
     /// Ignores all source values and only forwards terminal messages.
@@ -357,7 +326,7 @@ public static partial class LinqMixins
 
         if (source is ImmutableEmptySignal<T>)
         {
-            return Signal.Return(defaultValue);
+            return Signal.Emit(defaultValue);
         }
 
         if (source is RangeSignal { Count: > 0 })
@@ -414,8 +383,8 @@ public static partial class LinqMixins
     /// <param name="keySelector">The function that selects the comparison key.</param>
     /// <returns>A sequence with adjacent duplicate keys removed.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="keySelector"/> is <see langword="null"/>.</exception>
-    public static IObservable<T> DistinctUntilChangedBy<T, TKey>(this IObservable<T> source, Func<T, TKey> keySelector) =>
-        source.DistinctUntilChangedBy(keySelector, null);
+    public static IObservable<T> UniqueBy<T, TKey>(this IObservable<T> source, Func<T, TKey> keySelector) =>
+        source.UniqueBy(keySelector, null);
 
     /// <summary>
     /// Suppresses adjacent duplicate keys according to the comparer.
@@ -427,7 +396,7 @@ public static partial class LinqMixins
     /// <param name="comparer">The comparer used to compare adjacent keys.</param>
     /// <returns>A sequence with adjacent duplicate keys removed.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="keySelector"/> is <see langword="null"/>.</exception>
-    public static IObservable<T> DistinctUntilChangedBy<T, TKey>(this IObservable<T> source, Func<T, TKey> keySelector, IEqualityComparer<TKey>? comparer)
+    public static IObservable<T> UniqueBy<T, TKey>(this IObservable<T> source, Func<T, TKey> keySelector, IEqualityComparer<TKey>? comparer)
     {
         if (source == null)
         {
@@ -556,7 +525,7 @@ public static partial class LinqMixins
     /// <param name="selector">The function that projects each source value to an inner sequence.</param>
     /// <returns>A sequence containing the concatenated inner values.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="selector"/> is <see langword="null"/>.</exception>
-    public static IObservable<TResult> Bind<TSource, TResult>(this IObservable<TSource> source, Func<TSource, IObservable<TResult>> selector) => source.SelectMany(selector);
+    public static IObservable<TResult> Bind<TSource, TResult>(this IObservable<TSource> source, Func<TSource, IObservable<TResult>> selector) => source.FlatMap(selector);
 
     /// <summary>
     /// Projects each source value to an inner signal and concatenates all inner values.
@@ -567,7 +536,7 @@ public static partial class LinqMixins
     /// <param name="selector">The function that projects each source value to an inner sequence.</param>
     /// <returns>A sequence containing the concatenated inner values.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="selector"/> is <see langword="null"/>.</exception>
-    public static IObservable<TResult> SelectMany<TSource, TResult>(this IObservable<TSource> source, Func<TSource, IObservable<TResult>> selector)
+    public static IObservable<TResult> FlatMap<TSource, TResult>(this IObservable<TSource> source, Func<TSource, IObservable<TResult>> selector)
     {
         if (source == null)
         {
@@ -579,7 +548,7 @@ public static partial class LinqMixins
             throw new ArgumentNullException(nameof(selector));
         }
 
-        return new SelectManySignal<TSource, TResult>(source, selector);
+        return new FlatMapSignal<TSource, TResult>(source, selector);
     }
 
     /// <summary>
@@ -593,7 +562,7 @@ public static partial class LinqMixins
     /// <param name="resultSelector">The function that combines source and inner values.</param>
     /// <returns>A sequence containing selected outer/inner combinations.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="collectionSelector"/> or <paramref name="resultSelector"/> is <see langword="null"/>.</exception>
-    public static IObservable<TResult> SelectMany<TSource, TCollection, TResult>(
+    public static IObservable<TResult> FlatMap<TSource, TCollection, TResult>(
         this IObservable<TSource> source,
         Func<TSource, IObservable<TCollection>> collectionSelector,
         Func<TSource, TCollection, TResult> resultSelector)
@@ -608,7 +577,7 @@ public static partial class LinqMixins
             throw new ArgumentNullException(nameof(resultSelector));
         }
 
-        return new SelectManyResultSignal<TSource, TCollection, TResult>(source, collectionSelector, resultSelector);
+        return new FlatMapResultSignal<TSource, TCollection, TResult>(source, collectionSelector, resultSelector);
     }
 
     /// <summary>
@@ -838,8 +807,8 @@ public static partial class LinqMixins
     /// <param name="dueTime">The quiet period before emitting the latest value.</param>
     /// <returns>A sequence that emits the latest value after each quiet period.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
-    public static IObservable<T> Throttle<T>(this IObservable<T> source, TimeSpan dueTime) =>
-        source.Throttle(dueTime, null);
+    public static IObservable<T> Calm<T>(this IObservable<T> source, TimeSpan dueTime) =>
+        source.Calm(dueTime, null);
 
     /// <summary>
     /// Emits only the most recent value after the quiet period elapses.
@@ -850,7 +819,7 @@ public static partial class LinqMixins
     /// <param name="scheduler">The sequencer used to schedule quiet-period timers.</param>
     /// <returns>A sequence that emits the latest value after each quiet period.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
-    public static IObservable<T> Throttle<T>(this IObservable<T> source, TimeSpan dueTime, ISequencer? scheduler)
+    public static IObservable<T> Calm<T>(this IObservable<T> source, TimeSpan dueTime, ISequencer? scheduler)
     {
         if (source == null)
         {
@@ -894,6 +863,27 @@ public static partial class LinqMixins
     }
 
     /// <summary>
+    /// Emits only the most recent value after the quiet period elapses.
+    /// </summary>
+    /// <typeparam name="T">The value type.</typeparam>
+    /// <param name="source">The source sequence.</param>
+    /// <param name="dueTime">The quiet period before emitting the latest value.</param>
+    /// <returns>A sequence that emits the latest value after each quiet period.</returns>
+    public static IObservable<T> Stabilize<T>(this IObservable<T> source, TimeSpan dueTime) =>
+        source.Calm(dueTime);
+
+    /// <summary>
+    /// Emits only the most recent value after the quiet period elapses.
+    /// </summary>
+    /// <typeparam name="T">The value type.</typeparam>
+    /// <param name="source">The source sequence.</param>
+    /// <param name="dueTime">The quiet period before emitting the latest value.</param>
+    /// <param name="scheduler">The sequencer used to schedule quiet-period timers.</param>
+    /// <returns>A sequence that emits the latest value after each quiet period.</returns>
+    public static IObservable<T> Stabilize<T>(this IObservable<T> source, TimeSpan dueTime, ISequencer? scheduler) =>
+        source.Calm(dueTime, scheduler);
+
+    /// <summary>
     /// Emits the latest source value whenever the sampling period ticks.
     /// </summary>
     /// <typeparam name="T">The value type.</typeparam>
@@ -902,8 +892,8 @@ public static partial class LinqMixins
     /// <returns>A sequence that emits the latest source value on each sampling tick.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentOutOfRangeException"><paramref name="period"/> is less than <see cref="TimeSpan.Zero"/>.</exception>
-    public static IObservable<T> Sample<T>(this IObservable<T> source, TimeSpan period) =>
-        source.Sample(period, null);
+    public static IObservable<T> Probe<T>(this IObservable<T> source, TimeSpan period) =>
+        source.Probe(period, null);
 
     /// <summary>
     /// Emits the latest source value whenever the sampling period ticks.
@@ -915,7 +905,7 @@ public static partial class LinqMixins
     /// <returns>A sequence that emits the latest source value on each sampling tick.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentOutOfRangeException"><paramref name="period"/> is less than <see cref="TimeSpan.Zero"/>.</exception>
-    public static IObservable<T> Sample<T>(this IObservable<T> source, TimeSpan period, ISequencer? scheduler)
+    public static IObservable<T> Probe<T>(this IObservable<T> source, TimeSpan period, ISequencer? scheduler)
     {
         if (source == null)
         {
@@ -1017,11 +1007,11 @@ public static partial class LinqMixins
     /// <param name="selector">The function that combines the latest values.</param>
     /// <returns>A sequence containing selected latest-value combinations.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="left"/>, <paramref name="right"/>, or <paramref name="selector"/> is <see langword="null"/>.</exception>
-    public static IObservable<TResult> ZipLatest<TLeft, TRight, TResult>(this IObservable<TLeft> left, IObservable<TRight> right, Func<TLeft, TRight, TResult> selector) =>
-        left.CombineLatest(right, selector);
+    public static IObservable<TResult> PairLatest<TLeft, TRight, TResult>(this IObservable<TLeft> left, IObservable<TRight> right, Func<TLeft, TRight, TResult> selector) =>
+        left.SyncLatest(right, selector);
 
     /// <summary>
-    /// Alias for <see cref="ZipLatest{TLeft, TRight, TResult}(IObservable{TLeft}, IObservable{TRight}, Func{TLeft, TRight, TResult})"/>.
+    /// Alias for <see cref="PairLatest{TLeft, TRight, TResult}(IObservable{TLeft}, IObservable{TRight}, Func{TLeft, TRight, TResult})"/>.
     /// </summary>
     /// <typeparam name="TLeft">The left value type.</typeparam>
     /// <typeparam name="TRight">The right value type.</typeparam>
@@ -1032,7 +1022,7 @@ public static partial class LinqMixins
     /// <returns>A sequence containing selected latest-value combinations.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="left"/>, <paramref name="right"/>, or <paramref name="selector"/> is <see langword="null"/>.</exception>
     public static IObservable<TResult> FuseLatest<TLeft, TRight, TResult>(this IObservable<TLeft> left, IObservable<TRight> right, Func<TLeft, TRight, TResult> selector) =>
-        left.ZipLatest(right, selector);
+        left.PairLatest(right, selector);
 
     /// <summary>
     /// Waits for both sources to complete and emits one value from their last elements when both produced at least one value.

--- a/src/ReactiveUI.Primitives/Signals/Core/CatchSignal{T,TException}.cs
+++ b/src/ReactiveUI.Primitives/Signals/Core/CatchSignal{T,TException}.cs
@@ -98,7 +98,7 @@ internal sealed class CatchSignal<T, TException> : SignalsBase<T>
                 IObservable<T> next;
                 try
                 {
-                    next = _parent._errorHandler == Handle.CatchIgnore<T> ? Signal.Empty<T>() : _parent._errorHandler(e);
+                    next = _parent._errorHandler == Handle.CatchIgnore<T> ? Signal.None<T>() : _parent._errorHandler(e);
                 }
                 catch (Exception ex)
                 {

--- a/src/ReactiveUI.Primitives/Signals/Core/DeferSignal{T}.cs
+++ b/src/ReactiveUI.Primitives/Signals/Core/DeferSignal{T}.cs
@@ -39,7 +39,7 @@ internal sealed class DeferSignal<T> : SignalsBase<T>
         }
         catch (Exception ex)
         {
-            source = Signal.Throw<T>(ex);
+            source = Signal.Fail<T>(ex);
         }
 
         return source.Subscribe(observer);

--- a/src/ReactiveUI.Primitives/Signals/Signal{Catch}.cs
+++ b/src/ReactiveUI.Primitives/Signals/Signal{Catch}.cs
@@ -22,7 +22,7 @@ public static partial class Signal
     /// An observable sequence containing the source sequence's elements, followed by the handler sequence's elements when an exception occurs.
     /// </returns>
     /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="handler"/> is null.</exception>
-    public static IObservable<TSource> Catch<TSource, TException>(this IObservable<TSource> source, Func<TException, IObservable<TSource>> handler)
+    public static IObservable<TSource> Recover<TSource, TException>(this IObservable<TSource> source, Func<TException, IObservable<TSource>> handler)
         where TException : Exception
     {
         if (source == null)
@@ -45,7 +45,7 @@ public static partial class Signal
     /// <param name="sources">Observable sequences to catch exceptions for.</param>
     /// <returns>An observable sequence containing elements from consecutive source sequences until a source sequence terminates successfully.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="sources"/> is null.</exception>
-    public static IObservable<TSource> Catch<TSource>(params IObservable<TSource>[] sources)
+    public static IObservable<TSource> Recover<TSource>(params IObservable<TSource>[] sources)
     {
         if (sources == null)
         {
@@ -62,7 +62,7 @@ public static partial class Signal
     /// <param name="sources">Observable sequences to catch exceptions for.</param>
     /// <returns>An observable sequence containing elements from consecutive source sequences until a source sequence terminates successfully.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="sources"/> is null.</exception>
-    public static IObservable<TSource> Catch<TSource>(this IEnumerable<IObservable<TSource>> sources)
+    public static IObservable<TSource> Recover<TSource>(this IEnumerable<IObservable<TSource>> sources)
     {
         if (sources == null)
         {
@@ -79,6 +79,6 @@ public static partial class Signal
     /// <param name="source">The source.</param>
     /// <param name="finallyAction">The finally action.</param>
     /// <returns>An observable sequence containing elements from consecutive source sequences until a source sequence terminates successfully.</returns>
-    public static IObservable<T> Finally<T>(this IObservable<T> source, Action finallyAction) =>
+    public static IObservable<T> OnCleanup<T>(this IObservable<T> source, Action finallyAction) =>
         new FinallySignal<T>(source, finallyAction);
 }

--- a/src/ReactiveUI.Primitives/Signals/Signal{Create}.cs
+++ b/src/ReactiveUI.Primitives/Signals/Signal{Create}.cs
@@ -134,12 +134,12 @@ public static partial class Signal
     }
 
     /// <summary>
-    /// Defers the specified observable factory.
+    /// Lazily creates the source sequence for each subscription.
     /// </summary>
     /// <typeparam name="T">The type.</typeparam>
     /// <param name="observableFactory">The observable factory.</param>
     /// <returns>An Observable.</returns>
-    public static IObservable<T> Defer<T>(Func<IObservable<T>> observableFactory)
+    public static IObservable<T> Lazy<T>(Func<IObservable<T>> observableFactory)
     {
         if (observableFactory == null)
         {

--- a/src/ReactiveUI.Primitives/Signals/Signal{Empty}.cs
+++ b/src/ReactiveUI.Primitives/Signals/Signal{Empty}.cs
@@ -19,7 +19,7 @@ public static partial class Signal
     /// <param name="scheduler">The scheduler.</param>
     /// <returns>An Signals.</returns>
 #pragma warning disable S4018 // Result type is intentionally explicit for Rx-style factory APIs.
-    public static IObservable<T> Empty<T>(ISequencer scheduler)
+    public static IObservable<T> None<T>(ISequencer scheduler)
     {
         if (scheduler == Sequencer.Immediate)
         {
@@ -37,8 +37,8 @@ public static partial class Signal
     /// <param name="witness">The witness.</param>
     /// <returns>An Signals.</returns>
 #pragma warning disable RCS1163 // Unused parameter.
-    public static IObservable<T> Empty<T>(ISequencer scheduler, T witness) =>
-        Empty<T>(scheduler);
+    public static IObservable<T> None<T>(ISequencer scheduler, T witness) =>
+        None<T>(scheduler);
 #pragma warning restore RCS1163 // Unused parameter.
 
     /// <summary>
@@ -46,8 +46,8 @@ public static partial class Signal
     /// </summary>
     /// <typeparam name="T">The Type.</typeparam>
     /// <returns>An Signals.</returns>
-    public static IObservable<T> Empty<T>() =>
-        Empty<T>(Sequencer.Immediate);
+    public static IObservable<T> None<T>() =>
+        None<T>(Sequencer.Immediate);
 #pragma warning restore S4018
 
     /// <summary>
@@ -57,7 +57,7 @@ public static partial class Signal
     /// <param name="witness">The witness.</param>
     /// <returns>An Signals.</returns>
 #pragma warning disable RCS1163 // Unused parameter.
-    public static IObservable<T> Empty<T>(T witness) =>
-        Empty<T>(Sequencer.Immediate);
+    public static IObservable<T> None<T>(T witness) =>
+        None<T>(Sequencer.Immediate);
 #pragma warning restore RCS1163 // Unused parameter.
 }

--- a/src/ReactiveUI.Primitives/Signals/Signal{Factories}.cs
+++ b/src/ReactiveUI.Primitives/Signals/Signal{Factories}.cs
@@ -19,13 +19,13 @@ public static partial class Signal
     /// <summary>
     /// Creates a finite integer signal from <paramref name="start"/> for <paramref name="count"/> values.
     /// </summary>
-    public static IObservable<int> Range(int start, int count) =>
-        Range(start, count, Sequencer.CurrentThread);
+    public static IObservable<int> Sequence(int start, int count) =>
+        Sequence(start, count, Sequencer.CurrentThread);
 
     /// <summary>
     /// Creates a finite integer signal from <paramref name="start"/> for <paramref name="count"/> values on <paramref name="scheduler"/>.
     /// </summary>
-    public static IObservable<int> Range(int start, int count, ISequencer scheduler)
+    public static IObservable<int> Sequence(int start, int count, ISequencer scheduler)
     {
         if (count < 0)
         {
@@ -39,7 +39,7 @@ public static partial class Signal
 
         if (count == 0)
         {
-            return Empty<int>();
+            return None<int>();
         }
 
         if (scheduler == Sequencer.Immediate || scheduler == Sequencer.CurrentThread)
@@ -63,7 +63,7 @@ public static partial class Signal
     /// <summary>
     /// Creates a signal that repeats a value forever.
     /// </summary>
-    public static IObservable<T> Repeat<T>(T value) =>
+    public static IObservable<T> Loop<T>(T value) =>
         Create<T>(
             observer => Sequencer.CurrentThread.Schedule(self =>
             {
@@ -75,7 +75,7 @@ public static partial class Signal
     /// <summary>
     /// Creates a signal that repeats a value <paramref name="count"/> times.
     /// </summary>
-    public static IObservable<T> Repeat<T>(T value, int count)
+    public static IObservable<T> Loop<T>(T value, int count)
     {
         if (count < 0)
         {
@@ -84,7 +84,7 @@ public static partial class Signal
 
         if (count == 0)
         {
-            return Empty<T>();
+            return None<T>();
         }
 
         return new RepeatSignal<T>(value, count);
@@ -132,12 +132,12 @@ public static partial class Signal
     /// <summary>
     /// Generates a finite signal from state. Alias of <see cref="Unfold{TState, TResult}(TState, Func{TState, bool}, Func{TState, TState}, Func{TState, TResult})"/>.
     /// </summary>
-    public static IObservable<TResult> Generate<TState, TResult>(
+    public static IObservable<TResult> Iterate<TState, TResult>(
         TState initialState,
         Func<TState, bool> condition,
-        Func<TState, TState> iterate,
+        Func<TState, TState> iterator,
         Func<TState, TResult> resultSelector) =>
-        Unfold(initialState, condition, iterate, resultSelector);
+        Unfold(initialState, condition, iterator, resultSelector);
 
     /// <summary>
     /// Creates a signal whose subscription lifetime owns a resource.
@@ -174,13 +174,6 @@ public static partial class Signal
             return MultipleDisposable.Create(sourceSubscription, resource);
         });
     }
-
-    /// <summary>
-    /// Creates a signal whose subscription lifetime owns a resource.
-    /// </summary>
-    public static IObservable<T> Using<TResource, T>(Func<TResource> resourceFactory, Func<TResource, IObservable<T>> signalFactory)
-        where TResource : IDisposable =>
-        Use(resourceFactory, signalFactory);
 
     /// <summary>
     /// Converts an event into a signal of event pattern values.
@@ -278,18 +271,18 @@ public static partial class Signal
         if (task.Status == TaskStatus.RanToCompletion)
         {
 #pragma warning disable S4462 // Completed-task fast path avoids async state machine allocation.
-            return Return(task.GetAwaiter().GetResult());
+            return Emit(task.GetAwaiter().GetResult());
 #pragma warning restore S4462
         }
 
         if (task.IsCanceled)
         {
-            return Throw<T>(new TaskCanceledException(task));
+            return Fail<T>(new TaskCanceledException(task));
         }
 
         if (task.IsFaulted)
         {
-            return Throw<T>(task.Exception!.InnerException ?? task.Exception);
+            return Fail<T>(task.Exception!.InnerException ?? task.Exception);
         }
 
         return CreateSafe<T>(observer =>
@@ -333,7 +326,7 @@ public static partial class Signal
             throw new ArgumentNullException(nameof(taskFactory));
         }
 
-        return Defer(() => FromTask(taskFactory()));
+        return Lazy(() => FromTask(taskFactory()));
     }
 
     /// <summary>
@@ -352,7 +345,7 @@ public static partial class Signal
             throw new ArgumentNullException(nameof(taskFactory));
         }
 
-        return Defer(() => FromTask(taskFactory(cancellationToken)));
+        return Lazy(() => FromTask(taskFactory(cancellationToken)));
     }
 
     /// <summary>
@@ -467,6 +460,60 @@ public static partial class Signal
     }
 
     /// <summary>
+    /// Emits a single zero tick at the specified absolute due time.
+    /// </summary>
+    public static IObservable<long> After(DateTimeOffset dueTime) =>
+        After(dueTime, ThreadPoolSequencer.Instance);
+
+    /// <summary>
+    /// Emits a single zero tick at the specified absolute due time.
+    /// </summary>
+    public static IObservable<long> After(DateTimeOffset dueTime, ISequencer scheduler)
+    {
+        if (scheduler == null)
+        {
+            throw new ArgumentNullException(nameof(scheduler));
+        }
+
+        return After(Sequencer.Normalize(dueTime - scheduler.Now), scheduler);
+    }
+
+    /// <summary>
+    /// Emits first after <paramref name="dueTime"/> and then at <paramref name="period"/>.
+    /// </summary>
+    public static IObservable<long> After(TimeSpan dueTime, TimeSpan period) =>
+        After(dueTime, period, ThreadPoolSequencer.Instance);
+
+    /// <summary>
+    /// Emits first after <paramref name="dueTime"/> and then at <paramref name="period"/>.
+    /// </summary>
+    public static IObservable<long> After(TimeSpan dueTime, TimeSpan period, ISequencer scheduler)
+    {
+        if (scheduler == null)
+        {
+            throw new ArgumentNullException(nameof(scheduler));
+        }
+
+        return CreateSafe<long>(
+            observer =>
+            {
+                var pocket = new MultipleDisposable();
+                var current = 0L;
+                pocket.Add(
+                    scheduler.Schedule(
+                        Sequencer.Normalize(dueTime),
+                        () =>
+                        {
+                            observer.OnNext(current++);
+                            pocket.Add(Every(period, scheduler).Subscribe(value => observer.OnNext(current + value), observer.OnError, observer.OnCompleted));
+                        }));
+
+                return pocket;
+            },
+            scheduler == Sequencer.CurrentThread);
+    }
+
+    /// <summary>
     /// Emits monotonically increasing ticks at the specified period.
     /// </summary>
     public static IObservable<long> Every(TimeSpan period) =>
@@ -521,97 +568,23 @@ public static partial class Signal
     public static IObservable<long> Pulse(TimeSpan period, ISequencer scheduler) => Every(period, scheduler);
 
     /// <summary>
-    /// Alias for <see cref="Every(TimeSpan, ISequencer?)"/>.
-    /// </summary>
-    public static IObservable<long> Interval(TimeSpan period) => Every(period);
-
-    /// <summary>
-    /// Alias for <see cref="Every(TimeSpan, ISequencer?)"/>.
-    /// </summary>
-    public static IObservable<long> Interval(TimeSpan period, ISequencer scheduler) => Every(period, scheduler);
-
-    /// <summary>
-    /// Alias for <see cref="After(TimeSpan, ISequencer?)"/>.
-    /// </summary>
-    public static IObservable<long> Timer(TimeSpan dueTime) => After(dueTime);
-
-    /// <summary>
-    /// Alias for <see cref="After(TimeSpan, ISequencer?)"/>.
-    /// </summary>
-    public static IObservable<long> Timer(TimeSpan dueTime, ISequencer scheduler) => After(dueTime, scheduler);
-
-    /// <summary>
-    /// Emits a single zero tick at the specified absolute due time.
-    /// </summary>
-    public static IObservable<long> Timer(DateTimeOffset dueTime) =>
-        Timer(dueTime, ThreadPoolSequencer.Instance);
-
-    /// <summary>
-    /// Emits a single zero tick at the specified absolute due time.
-    /// </summary>
-    public static IObservable<long> Timer(DateTimeOffset dueTime, ISequencer scheduler)
-    {
-        if (scheduler == null)
-        {
-            throw new ArgumentNullException(nameof(scheduler));
-        }
-
-        return After(Sequencer.Normalize(dueTime - scheduler.Now), scheduler);
-    }
-
-    /// <summary>
-    /// Creates a timer that emits first after <paramref name="dueTime"/> and then at <paramref name="period"/>.
-    /// </summary>
-    public static IObservable<long> Timer(TimeSpan dueTime, TimeSpan period) =>
-        Timer(dueTime, period, ThreadPoolSequencer.Instance);
-
-    /// <summary>
-    /// Creates a timer that emits first after <paramref name="dueTime"/> and then at <paramref name="period"/>.
-    /// </summary>
-    public static IObservable<long> Timer(TimeSpan dueTime, TimeSpan period, ISequencer scheduler)
-    {
-        if (scheduler == null)
-        {
-            throw new ArgumentNullException(nameof(scheduler));
-        }
-
-        return CreateSafe<long>(
-            observer =>
-            {
-                var pocket = new MultipleDisposable();
-                var current = 0L;
-                pocket.Add(
-                    scheduler.Schedule(
-                        Sequencer.Normalize(dueTime),
-                        () =>
-                        {
-                            observer.OnNext(current++);
-                            pocket.Add(Every(period, scheduler).Subscribe(value => observer.OnNext(current + value), observer.OnError, observer.OnCompleted));
-                        }));
-
-                return pocket;
-            },
-            scheduler == Sequencer.CurrentThread);
-    }
-
-    /// <summary>
     /// Concatenates the supplied signals.
     /// </summary>
-    public static IObservable<T> Concat<T>(params IObservable<T>[] sources)
+    public static IObservable<T> Chain<T>(params IObservable<T>[] sources)
     {
         var validated = ValidateSources(sources);
         var rangeConcat = TryCreateRangeConcat(validated);
-        return rangeConcat == null ? FromEnumerable(validated).Concat() : (IObservable<T>)(object)rangeConcat;
+        return rangeConcat == null ? FromEnumerable(validated).Chain() : (IObservable<T>)(object)rangeConcat;
     }
 
     /// <summary>
     /// Merges the supplied signals.
     /// </summary>
-    public static IObservable<T> Merge<T>(params IObservable<T>[] sources)
+    public static IObservable<T> Blend<T>(params IObservable<T>[] sources)
     {
         var validated = ValidateSources(sources);
         var rangeConcat = TryCreateRangeConcat(validated);
-        return rangeConcat == null ? FromEnumerable(validated).Merge() : (IObservable<T>)(object)rangeConcat;
+        return rangeConcat == null ? FromEnumerable(validated).Blend() : (IObservable<T>)(object)rangeConcat;
     }
 
     /// <summary>
@@ -631,25 +604,20 @@ public static partial class Signal
     /// <summary>
     /// Mirrors the first supplied signal to produce a value or terminal signal.
     /// </summary>
-    public static IObservable<T> Amb<T>(params IObservable<T>[] sources) => Race(sources);
-
-    /// <summary>
-    /// Zips two signals with a result selector.
-    /// </summary>
-    public static IObservable<TResult> Zip<TLeft, TRight, TResult>(IObservable<TLeft> left, IObservable<TRight> right, Func<TLeft, TRight, TResult> selector) =>
-        left.Zip(right, selector);
+    public static IObservable<TResult> Pair<TLeft, TRight, TResult>(IObservable<TLeft> left, IObservable<TRight> right, Func<TLeft, TRight, TResult> selector) =>
+        left.Pair(right, selector);
 
     /// <summary>
     /// Combines the latest values from two signals.
     /// </summary>
-    public static IObservable<TResult> CombineLatest<TLeft, TRight, TResult>(IObservable<TLeft> left, IObservable<TRight> right, Func<TLeft, TRight, TResult> selector) =>
-        left.CombineLatest(right, selector);
+    public static IObservable<TResult> SyncLatest<TLeft, TRight, TResult>(IObservable<TLeft> left, IObservable<TRight> right, Func<TLeft, TRight, TResult> selector) =>
+        left.SyncLatest(right, selector);
 
     /// <summary>
     /// Combines latest values from two signals using latest-fusion semantics.
     /// </summary>
-    public static IObservable<TResult> ZipLatest<TLeft, TRight, TResult>(IObservable<TLeft> left, IObservable<TRight> right, Func<TLeft, TRight, TResult> selector) =>
-        left.ZipLatest(right, selector);
+    public static IObservable<TResult> PairLatest<TLeft, TRight, TResult>(IObservable<TLeft> left, IObservable<TRight> right, Func<TLeft, TRight, TResult> selector) =>
+        left.PairLatest(right, selector);
 
     /// <summary>
     /// Waits for both signals to complete and emits one result from their last values.

--- a/src/ReactiveUI.Primitives/Signals/Signal{FromTask}.cs
+++ b/src/ReactiveUI.Primitives/Signals/Signal{FromTask}.cs
@@ -203,7 +203,7 @@ public static partial class Signal
         ISequencer? scheduler,
         CancellationTokenSource? cancellationTokenSource) =>
         TaskSignal.Create<TResult>(
-            ao => Defer(() => Create<TResult>(observer => SubscribeTask(ao, execution, shouldEmit, observer))),
+            ao => Lazy(() => Create<TResult>(observer => SubscribeTask(ao, execution, shouldEmit, observer))),
             scheduler,
             cancellationTokenSource);
 

--- a/src/ReactiveUI.Primitives/Signals/Signal{GetAwaiter}.cs
+++ b/src/ReactiveUI.Primitives/Signals/Signal{GetAwaiter}.cs
@@ -15,7 +15,7 @@ public static partial class Signal
     /// </summary>
     /// <typeparam name="TSource">The type of the source.</typeparam>
     /// <param name="source">Source sequence to await.</param>
-    /// <returns>An AsyncSignal.</returns>
+    /// <returns>A final signal awaiter.</returns>
     /// <exception cref="ArgumentNullException">source.</exception>
     public static IAwaitSignal<TSource> GetAwaiter<TSource>(this IObservable<TSource> source)
     {
@@ -35,7 +35,7 @@ public static partial class Signal
     /// <param name="source">Source sequence to await.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>
-    /// An AsyncSignal.
+    /// A final signal awaiter.
     /// </returns>
     /// <exception cref="ArgumentNullException">source.</exception>
     public static IAwaitSignal<TSource> GetAwaiter<TSource>(this IObservable<TSource> source, CancellationToken cancellationToken)
@@ -60,7 +60,7 @@ public static partial class Signal
     private static IAwaitSignal<TSource> RunAsync<TSource>(IObservable<TSource> source, CancellationToken cancellationToken)
 #pragma warning restore RCS1047 // Non-asynchronous method name should not end with 'Async'.
     {
-        var s = new AsyncSignal<TSource>();
+        var s = new FinalSignal<TSource>();
 
         if (cancellationToken.IsCancellationRequested)
         {

--- a/src/ReactiveUI.Primitives/Signals/Signal{Never}.cs
+++ b/src/ReactiveUI.Primitives/Signals/Signal{Never}.cs
@@ -17,7 +17,7 @@ public static partial class Signal
     /// <typeparam name="T">The type.</typeparam>
     /// <returns>An Signals.</returns>
 #pragma warning disable S4018 // Result type is intentionally explicit for Rx-style factory APIs.
-    public static IObservable<T> Never<T>() => ImmutableNeverSignal<T>.Instance;
+    public static IObservable<T> Silent<T>() => ImmutableNeverSignal<T>.Instance;
 #pragma warning restore S4018
 
     /// <summary>
@@ -27,6 +27,6 @@ public static partial class Signal
     /// <param name="witness">The witness.</param>
     /// <returns>An Signals.</returns>
 #pragma warning disable RCS1163 // Unused parameter.
-    public static IObservable<T> Never<T>(T witness) => ImmutableNeverSignal<T>.Instance;
+    public static IObservable<T> Silent<T>(T witness) => ImmutableNeverSignal<T>.Instance;
 #pragma warning restore RCS1163 // Unused parameter.
 }

--- a/src/ReactiveUI.Primitives/Signals/Signal{Return}.cs
+++ b/src/ReactiveUI.Primitives/Signals/Signal{Return}.cs
@@ -13,13 +13,13 @@ namespace ReactiveUI.Primitives.Signals;
 public static partial class Signal
 {
     /// <summary>
-    /// Return single sequence on specified scheduler.
+    /// Emit a single value on the specified scheduler.
     /// </summary>
     /// <typeparam name="T">The type.</typeparam>
     /// <param name="value">The value.</param>
     /// <param name="scheduler">The scheduler.</param>
     /// <returns>An Signals.</returns>
-    public static IObservable<T> Return<T>(T value, ISequencer scheduler)
+    public static IObservable<T> Emit<T>(T value, ISequencer scheduler)
     {
         if (scheduler == Sequencer.Immediate)
         {
@@ -30,45 +30,45 @@ public static partial class Signal
     }
 
     /// <summary>
-    /// Return single sequence Immediately.
+    /// Emit a single value immediately.
     /// </summary>
     /// <typeparam name="T">The type.</typeparam>
     /// <param name="value">The value.</param>
     /// <returns>An Signals.</returns>
-    public static IObservable<T> Return<T>(T value) =>
-        Return(value, Sequencer.Immediate);
+    public static IObservable<T> Emit<T>(T value) =>
+        Emit(value, Sequencer.Immediate);
 
     /// <summary>
-    /// Return single sequence Immediately, optimized for RxVoid(no allocate memory).
+    /// Emit a single RxVoid value immediately, optimized for no allocation.
     /// </summary>
     /// <param name="value">The value.</param>
     /// <returns>An Signals.</returns>
 #pragma warning disable RCS1163 // Unused parameter.
-    public static IObservable<RxVoid> Return(RxVoid value) =>
+    public static IObservable<RxVoid> Emit(RxVoid value) =>
         ImmutableReturnRxVoidSignal.Instance;
 #pragma warning restore RCS1163 // Unused parameter.
 
     /// <summary>
-    /// Return single sequence Immediately, optimized for Boolean(no allocate memory).
+    /// Emit a single Boolean value immediately, optimized for no allocation.
     /// </summary>
     /// <param name="value">if set to <c>true</c> [value].</param>
     /// <returns>An Signals.</returns>
-    public static IObservable<bool> Return(bool value) => value
+    public static IObservable<bool> Emit(bool value) => value
             ? ImmutableReturnTrueSignal.Instance
             : ImmutableReturnFalseSignal.Instance;
 
     /// <summary>
-    /// Return single sequence Immediately, optimized for Int32.
+    /// Emit a single Int32 value immediately, optimized for cached values.
     /// </summary>
     /// <param name="value">The value.</param>
     /// <returns>An Signals.</returns>
-    public static IObservable<int> Return(int value) =>
+    public static IObservable<int> Emit(int value) =>
         ImmutableReturnInt32Signal.GetInt32Signals(value);
 
     /// <summary>
-    /// Same as Signals.Return(RxVoid.Default); but no allocate memory.
+    /// Same as Signals.Emit(RxVoid.Default); but no allocate memory.
     /// </summary>
     /// <returns>An Signals.</returns>
-    public static IObservable<RxVoid> ReturnRxVoid() =>
+    public static IObservable<RxVoid> EmitRxVoid() =>
         ImmutableReturnRxVoidSignal.Instance;
 }

--- a/src/ReactiveUI.Primitives/Signals/Signal{Throw}.cs
+++ b/src/ReactiveUI.Primitives/Signals/Signal{Throw}.cs
@@ -20,7 +20,7 @@ public static partial class Signal
     /// <param name="scheduler">The scheduler.</param>
     /// <returns>An Signals.</returns>
 #pragma warning disable S4018 // Result type is intentionally explicit for Rx-style factory APIs.
-    public static IObservable<T> Throw<T>(Exception error, ISequencer scheduler) => scheduler == Sequencer.Immediate
+    public static IObservable<T> Fail<T>(Exception error, ISequencer scheduler) => scheduler == Sequencer.Immediate
         ? new ImmediateThrowSignal<T>(error)
         : new ThrowSignal<T>(error, scheduler);
 
@@ -30,7 +30,7 @@ public static partial class Signal
     /// <typeparam name="T">The type.</typeparam>
     /// <param name="error">The error.</param>
     /// <returns>An Signals.</returns>
-    public static IObservable<T> Throw<T>(Exception error) =>
+    public static IObservable<T> Fail<T>(Exception error) =>
         new ImmediateThrowSignal<T>(error);
 #pragma warning restore S4018
 
@@ -42,7 +42,7 @@ public static partial class Signal
     /// <param name="witness">The witness.</param>
     /// <returns>An Signals.</returns>
 #pragma warning disable RCS1163 // Unused parameter.
-    public static IObservable<T> Throw<T>(Exception error, T witness) =>
+    public static IObservable<T> Fail<T>(Exception error, T witness) =>
         new ImmediateThrowSignal<T>(error);
 
     /// <summary>
@@ -53,7 +53,7 @@ public static partial class Signal
     /// <param name="scheduler">The scheduler.</param>
     /// <param name="witness">The witness.</param>
     /// <returns>An Signals.</returns>
-    public static IObservable<T> Throw<T>(Exception error, ISequencer scheduler, T witness) =>
-        Throw<T>(error, scheduler);
+    public static IObservable<T> Fail<T>(Exception error, ISequencer scheduler, T witness) =>
+        Fail<T>(error, scheduler);
 #pragma warning restore RCS1163 // Unused parameter.
 }

--- a/src/benchmarks/ReactiveUI.Primitives.Benchmarks/ConnectableShareBenchmarks.cs
+++ b/src/benchmarks/ReactiveUI.Primitives.Benchmarks/ConnectableShareBenchmarks.cs
@@ -26,7 +26,7 @@ public class ConnectableShareBenchmarks
     public int PrimitivesPublishLiveConnect()
     {
         var observer = new IntSignalObserver();
-        var connectable = Signal.Range(1, Count).PublishLive();
+        var connectable = Signal.Sequence(1, Count).ShareLive();
         using var subscription = connectable.Subscribe(observer);
         using var connection = connectable.Connect();
         return observer.Total;
@@ -68,7 +68,7 @@ public class ConnectableShareBenchmarks
     public int PrimitivesShareLiveSubscribe()
     {
         var observer = new IntSignalObserver();
-        using var subscription = Signal.Range(1, Count).ShareLive().Subscribe(observer);
+        using var subscription = Signal.Sequence(1, Count).ShareLatest().Subscribe(observer);
         return observer.Total;
     }
 
@@ -105,7 +105,7 @@ public class ConnectableShareBenchmarks
     public int PrimitivesReplayLiveLateSubscribe()
     {
         var observer = new IntSignalObserver();
-        var connectable = Signal.Range(1, Count).ReplayLive(Count);
+        var connectable = Signal.Sequence(1, Count).ReplayLive(Count);
         using var connection = connectable.Connect();
         using var subscription = connectable.Subscribe(observer);
         return observer.Total;
@@ -147,7 +147,7 @@ public class ConnectableShareBenchmarks
     public int PrimitivesRefCountSubscribe()
     {
         var observer = new IntSignalObserver();
-        using var subscription = Signal.Range(1, Count).PublishLive().RefCount().Subscribe(observer);
+        using var subscription = Signal.Sequence(1, Count).ShareLive().AutoShare().Subscribe(observer);
         return observer.Total;
     }
 
@@ -186,7 +186,7 @@ public class ConnectableShareBenchmarks
     public int PrimitivesAutoConnectSubscribe()
     {
         var observer = new IntSignalObserver();
-        using var subscription = Signal.Range(1, Count).PublishLive().AutoConnect().Subscribe(observer);
+        using var subscription = Signal.Sequence(1, Count).ShareLive().AutoConnect().Subscribe(observer);
         return observer.Total;
     }
 

--- a/src/benchmarks/ReactiveUI.Primitives.Benchmarks/FactoryAdapterExpansionBenchmarks.cs
+++ b/src/benchmarks/ReactiveUI.Primitives.Benchmarks/FactoryAdapterExpansionBenchmarks.cs
@@ -136,7 +136,7 @@ public class FactoryAdapterExpansionBenchmarks
     public int PrimitivesDeferSubscribe()
     {
         var observer = new IntSignalObserver();
-        using var subscription = Signal.Defer(() => Signal.Range(1, Count)).Subscribe(observer);
+        using var subscription = Signal.Lazy(() => Signal.Sequence(1, Count)).Subscribe(observer);
         return observer.Total;
     }
 
@@ -260,7 +260,7 @@ public class FactoryAdapterExpansionBenchmarks
     public int PrimitivesUseSubscribe()
     {
         var observer = new IntSignalObserver();
-        using var subscription = Signal.Use(static () => Disposable.Empty, static _ => Signal.Return(Value)).Subscribe(observer);
+        using var subscription = Signal.Use(static () => Disposable.Empty, static _ => Signal.Emit(Value)).Subscribe(observer);
         return observer.Total;
     }
 
@@ -348,7 +348,7 @@ public class FactoryAdapterExpansionBenchmarks
     public int PrimitivesNeverSubscribeDispose()
     {
         var observer = new IntSignalObserver();
-        using var subscription = Signal.Never<int>().Subscribe(observer);
+        using var subscription = Signal.Silent<int>().Subscribe(observer);
         return observer.NextCount + observer.CompletionCount + observer.ErrorCount;
     }
 

--- a/src/benchmarks/ReactiveUI.Primitives.Benchmarks/FactorySignalBenchmarks.cs
+++ b/src/benchmarks/ReactiveUI.Primitives.Benchmarks/FactorySignalBenchmarks.cs
@@ -32,7 +32,7 @@ public class FactorySignalBenchmarks
     public int PrimitivesEmptySubscribe()
     {
         var observer = new IntSignalObserver();
-        using var subscription = Signal.Empty<int>().Subscribe(observer);
+        using var subscription = Signal.None<int>().Subscribe(observer);
         return observer.CompletionCount;
     }
 
@@ -68,7 +68,7 @@ public class FactorySignalBenchmarks
     public int PrimitivesRangeSubscribe()
     {
         var observer = new IntSignalObserver();
-        using var subscription = Signal.Range(RangeStart, RangeCount).Subscribe(observer);
+        using var subscription = Signal.Sequence(RangeStart, RangeCount).Subscribe(observer);
         return observer.Total;
     }
 
@@ -104,7 +104,7 @@ public class FactorySignalBenchmarks
     public int PrimitivesRepeatSubscribe()
     {
         var observer = new IntSignalObserver();
-        using var subscription = Signal.Repeat(ThrowValue, RepeatCount).Subscribe(observer);
+        using var subscription = Signal.Loop(ThrowValue, RepeatCount).Subscribe(observer);
         return observer.Total;
     }
 
@@ -140,7 +140,7 @@ public class FactorySignalBenchmarks
     public int PrimitivesThrowSubscribe()
     {
         var observer = new IntSignalObserver();
-        using var subscription = Signal.Throw<int>(new InvalidOperationException()).Subscribe(observer);
+        using var subscription = Signal.Fail<int>(new InvalidOperationException()).Subscribe(observer);
         return observer.ErrorCount;
     }
 

--- a/src/benchmarks/ReactiveUI.Primitives.Benchmarks/OperatorFlatMapRangeBenchmarks.cs
+++ b/src/benchmarks/ReactiveUI.Primitives.Benchmarks/OperatorFlatMapRangeBenchmarks.cs
@@ -15,17 +15,17 @@ namespace ReactiveUI.Primitives.Benchmarks;
 /// Benchmarks for flattening selectors.
 /// </summary>
 [MemoryDiagnoser]
-public class OperatorSelectManyRangeBenchmarks
+public class OperatorFlatMapRangeBenchmarks
 {
     /// <summary>
     /// Baseline flatten and map chain using primitives.
     /// </summary>
     /// <returns>The sum of emitted values.</returns>
     [Benchmark(Baseline = true)]
-    public int PrimitivesSelectManyRange()
+    public int PrimitivesFlatMapRange()
     {
         var observer = new IntSignalObserver();
-        using var subscription = Signal.Range(1, 8).SelectMany(static x => Signal.Range(x * 10, 2))
+        using var subscription = Signal.Sequence(1, 8).FlatMap(static x => Signal.Sequence(x * 10, 2))
             .Subscribe(observer);
         return observer.Total;
     }
@@ -38,9 +38,8 @@ public class OperatorSelectManyRangeBenchmarks
     public int SystemReactiveSelectManyRange()
     {
         var observer = new IntSignalObserver();
-        using var subscription = RxObservable.SelectMany(
-                RxObservable.Range(1, 8),
-                static x => RxObservable.Range(x * 10, 2))
+        using var subscription = RxObservable.Range(1, 8)
+            .SelectMany(static x => RxObservable.Range(x * 10, 2))
             .Subscribe(observer);
         return observer.Total;
     }

--- a/src/benchmarks/ReactiveUI.Primitives.Benchmarks/OperatorHigherOrderBenchmarks.cs
+++ b/src/benchmarks/ReactiveUI.Primitives.Benchmarks/OperatorHigherOrderBenchmarks.cs
@@ -27,7 +27,7 @@ public class OperatorHigherOrderBenchmarks
     public int PrimitivesConcatRanges()
     {
         var observer = new IntSignalObserver();
-        using var subscription = Signal.Concat(Signal.Range(1, Count), Signal.Range(1, Count)).Subscribe(observer);
+        using var subscription = Signal.Chain(Signal.Sequence(1, Count), Signal.Sequence(1, Count)).Subscribe(observer);
         return observer.Total;
     }
 
@@ -65,7 +65,7 @@ public class OperatorHigherOrderBenchmarks
     public int PrimitivesMergeRanges()
     {
         var observer = new IntSignalObserver();
-        using var subscription = Signal.Merge(Signal.Range(1, Count), Signal.Range(1, Count)).Subscribe(observer);
+        using var subscription = Signal.Blend(Signal.Sequence(1, Count), Signal.Sequence(1, Count)).Subscribe(observer);
         return observer.Total;
     }
 
@@ -103,7 +103,7 @@ public class OperatorHigherOrderBenchmarks
     public int PrimitivesRaceRanges()
     {
         var observer = new IntSignalObserver();
-        using var subscription = Signal.Race(Signal.Range(1, Count), Signal.Range(100, Count)).Subscribe(observer);
+        using var subscription = Signal.Race(Signal.Sequence(1, Count), Signal.Sequence(100, Count)).Subscribe(observer);
         return observer.Total;
     }
 
@@ -141,8 +141,8 @@ public class OperatorHigherOrderBenchmarks
     public int PrimitivesSwitchRanges()
     {
         var observer = new IntSignalObserver();
-        using var subscription = Signal.FromEnumerable([Signal.Range(1, Count), Signal.Range(100, Count)])
-            .Switch()
+        using var subscription = Signal.FromEnumerable([Signal.Sequence(1, Count), Signal.Sequence(100, Count)])
+            .SwitchTo()
             .Subscribe(observer);
         return observer.Total;
     }
@@ -185,9 +185,9 @@ public class OperatorHigherOrderBenchmarks
     public int PrimitivesCombineLatestRanges()
     {
         var observer = new IntSignalObserver();
-        using var subscription = Signal.CombineLatest(
-            Signal.Range(1, Count),
-            Signal.Range(10, Count),
+        using var subscription = Signal.SyncLatest(
+            Signal.Sequence(1, Count),
+            Signal.Sequence(10, Count),
             static (left, right) => left + right).Subscribe(observer);
         return observer.Total;
     }
@@ -230,8 +230,8 @@ public class OperatorHigherOrderBenchmarks
     public int PrimitivesWithLatestRanges()
     {
         var observer = new IntSignalObserver();
-        using var subscription = Signal.Range(1, Count)
-            .WithLatest(Signal.Range(10, Count), static (left, right) => left + right)
+        using var subscription = Signal.Sequence(1, Count)
+            .Latch(Signal.Sequence(10, Count), static (left, right) => left + right)
             .Subscribe(observer);
         return observer.Total;
     }
@@ -275,8 +275,8 @@ public class OperatorHigherOrderBenchmarks
     {
         var observer = new IntSignalObserver();
         using var subscription = Signal.ForkJoin(
-            Signal.Range(1, Count),
-            Signal.Range(10, Count),
+            Signal.Sequence(1, Count),
+            Signal.Sequence(10, Count),
             static (left, right) => left + right).Subscribe(observer);
         return observer.Total;
     }

--- a/src/benchmarks/ReactiveUI.Primitives.Benchmarks/OperatorMapKeepBenchmarks.cs
+++ b/src/benchmarks/ReactiveUI.Primitives.Benchmarks/OperatorMapKeepBenchmarks.cs
@@ -30,7 +30,7 @@ public class OperatorMapKeepBenchmarks
     public int PrimitivesRangeMapKeep()
     {
         var observer = new IntSignalObserver();
-        using var subscription = Signal.Range(StartValue, RangeCount)
+        using var subscription = Signal.Sequence(StartValue, RangeCount)
             .Map(static x => x + 1)
             .Keep(static x => (x & 1) == 0)
             .Subscribe(observer);
@@ -45,9 +45,9 @@ public class OperatorMapKeepBenchmarks
     public int SystemReactiveRangeSelectWhere()
     {
         var observer = new IntSignalObserver();
-        using var subscription = RxObservable.Where(
-                RxObservable.Select(RxObservable.Range(StartValue, RangeCount), static x => x + 1),
-                static x => (x & 1) == 0)
+        using var subscription = RxObservable.Range(StartValue, RangeCount)
+            .Select(static x => x + 1)
+            .Where(static x => (x & 1) == 0)
             .Subscribe(observer);
         return observer.Total;
     }
@@ -78,11 +78,11 @@ public class OperatorMapKeepBenchmarks
     {
         var count = new IntSignalObserver();
         var any = new BooleanSignalObserver();
-        using var countSubscription = Signal.Range(StartValue, RangeCount)
+        using var countSubscription = Signal.Sequence(StartValue, RangeCount)
             .DistinctBy(static x => x / 2)
             .Count()
             .Subscribe(count);
-        using var anySubscription = Signal.Range(StartValue, RangeCount)
+        using var anySubscription = Signal.Sequence(StartValue, RangeCount)
             .Any(static x => x == 31)
             .Subscribe(any);
         return any.Value ? count.Total : -count.Total;
@@ -97,9 +97,10 @@ public class OperatorMapKeepBenchmarks
     {
         var count = new IntSignalObserver();
         var any = new BooleanSignalObserver();
-        using var countSubscription = RxObservable.Count(
-                RxObservable.Distinct(
-                    RxObservable.Select(RxObservable.Range(StartValue, RangeCount), static x => x / 2)))
+        using var countSubscription = RxObservable.Range(StartValue, RangeCount)
+            .Select(static x => x / 2)
+            .Distinct()
+            .Count()
             .Subscribe(count);
         using var anySubscription = RxObservable.Any(RxObservable.Range(StartValue, RangeCount), static x => x == 31)
             .Subscribe(any);

--- a/src/benchmarks/ReactiveUI.Primitives.Benchmarks/OperatorStartWithAppendDefaultIfEmptyBenchmarks.cs
+++ b/src/benchmarks/ReactiveUI.Primitives.Benchmarks/OperatorStartWithAppendDefaultIfEmptyBenchmarks.cs
@@ -26,9 +26,9 @@ public class OperatorStartWithAppendDefaultIfEmptyBenchmarks
     public int PrimitivesStartWithAppendDefaultIfEmpty()
     {
         var observer = new IntSignalObserver();
-        using var subscription = Signal.Empty<int>()
+        using var subscription = Signal.None<int>()
             .DefaultIfEmpty(2)
-            .StartWith(1)
+            .Prepend(1)
             .Append(3)
             .Subscribe(observer);
         return observer.Total;
@@ -42,7 +42,7 @@ public class OperatorStartWithAppendDefaultIfEmptyBenchmarks
     public int PrimitivesDefaultIfEmptyEmpty()
     {
         var observer = new IntSignalObserver();
-        using var subscription = Signal.Empty<int>()
+        using var subscription = Signal.None<int>()
             .DefaultIfEmpty(2)
             .Subscribe(observer);
         return observer.Total;
@@ -56,11 +56,10 @@ public class OperatorStartWithAppendDefaultIfEmptyBenchmarks
     public int SystemReactiveStartWithAppendDefaultIfEmpty()
     {
         var observer = new IntSignalObserver();
-        using var subscription = RxObservable.Append(
-                RxObservable.StartWith(
-                    RxObservable.DefaultIfEmpty(RxObservable.Empty<int>(), 2),
-                    1),
-                3)
+        using var subscription = RxObservable.Empty<int>()
+            .DefaultIfEmpty(2)
+            .StartWith(1)
+            .Append(3)
             .Subscribe(observer);
         return observer.Total;
     }

--- a/src/benchmarks/ReactiveUI.Primitives.Benchmarks/OperatorTimeSchedulerBenchmarks.cs
+++ b/src/benchmarks/ReactiveUI.Primitives.Benchmarks/OperatorTimeSchedulerBenchmarks.cs
@@ -32,7 +32,7 @@ public class OperatorTimeSchedulerBenchmarks
     {
         var clock = new TestClock();
         var observer = new IntSignalObserver();
-        using var subscription = Signal.Range(1, Count).Delay(TimeSpan.FromTicks(1), clock).Subscribe(observer);
+        using var subscription = Signal.Sequence(1, Count).Shift(TimeSpan.FromTicks(1), clock).Subscribe(observer);
         clock.AdvanceBy(TimeSpan.FromTicks(1));
         return observer.Total;
     }
@@ -78,7 +78,7 @@ public class OperatorTimeSchedulerBenchmarks
     {
         var clock = new TestClock();
         var observer = new IntSignalObserver();
-        using var subscription = Signal.Range(1, Count).DelayStart(TimeSpan.FromTicks(1), clock).Subscribe(observer);
+        using var subscription = Signal.Sequence(1, Count).DelayStart(TimeSpan.FromTicks(1), clock).Subscribe(observer);
         clock.AdvanceBy(TimeSpan.FromTicks(1));
         return observer.Total;
     }
@@ -127,7 +127,7 @@ public class OperatorTimeSchedulerBenchmarks
         var clock = new TestClock();
         var observer = new IntSignalObserver();
         using var source = new Signal<int>();
-        using var subscription = source.Throttle(TimeSpan.FromTicks(1), clock).Subscribe(observer);
+        using var subscription = source.Calm(TimeSpan.FromTicks(1), clock).Subscribe(observer);
         for (var i = 0; i < Count; i++)
         {
             source.OnNext(i);
@@ -188,7 +188,7 @@ public class OperatorTimeSchedulerBenchmarks
         var clock = new TestClock();
         var observer = new IntSignalObserver();
         using var source = new Signal<int>();
-        using var subscription = source.Sample(TimeSpan.FromTicks(1), clock).Subscribe(observer);
+        using var subscription = source.Probe(TimeSpan.FromTicks(1), clock).Subscribe(observer);
         source.OnNext(Count);
         clock.AdvanceBy(TimeSpan.FromTicks(1));
         return observer.Total;
@@ -235,7 +235,7 @@ public class OperatorTimeSchedulerBenchmarks
     public int PrimitivesTimestampRange()
     {
         var count = 0;
-        using var subscription = Signal.Range(1, Count).Timestamp(Sequencer.Immediate).Subscribe(_ => count++);
+        using var subscription = Signal.Sequence(1, Count).Timestamp(Sequencer.Immediate).Subscribe(_ => count++);
         return count;
     }
 
@@ -271,7 +271,7 @@ public class OperatorTimeSchedulerBenchmarks
     public int PrimitivesTimeIntervalRange()
     {
         var count = 0;
-        using var subscription = Signal.Range(1, Count).TimeInterval(Sequencer.Immediate).Subscribe(_ => count++);
+        using var subscription = Signal.Sequence(1, Count).TimeInterval(Sequencer.Immediate).Subscribe(_ => count++);
         return count;
     }
 
@@ -311,7 +311,7 @@ public class OperatorTimeSchedulerBenchmarks
         var clock = new TestClock();
         var observer = new IntSignalObserver();
         using var source = new Signal<int>();
-        using var subscription = source.Timeout(TimeSpan.FromTicks(1), clock).Subscribe(observer);
+        using var subscription = source.Expire(TimeSpan.FromTicks(1), clock).Subscribe(observer);
         source.OnNext(0);
         clock.AdvanceBy(TimeSpan.FromTicks(1));
         return observer.ErrorCount;
@@ -361,7 +361,7 @@ public class OperatorTimeSchedulerBenchmarks
     public int PrimitivesObserveOnImmediate()
     {
         var observer = new IntSignalObserver();
-        using var subscription = Signal.Range(1, Count).ObserveOn(Sequencer.Immediate).Subscribe(observer);
+        using var subscription = Signal.Sequence(1, Count).ObserveOn(Sequencer.Immediate).Subscribe(observer);
         return observer.Total;
     }
 

--- a/src/benchmarks/ReactiveUI.Primitives.Benchmarks/OperatorZipBenchmarks.cs
+++ b/src/benchmarks/ReactiveUI.Primitives.Benchmarks/OperatorZipBenchmarks.cs
@@ -29,9 +29,9 @@ public class OperatorZipBenchmarks
     public int PrimitivesZip()
     {
         var observer = new IntSignalObserver();
-        using var subscription = Signal.Zip(
-                Signal.Range(LeftStart, Count),
-                Signal.Range(RightStart, Count),
+        using var subscription = Signal.Pair(
+                Signal.Sequence(LeftStart, Count),
+                Signal.Sequence(RightStart, Count),
                 static (left, right) => left + right)
             .Subscribe(observer);
         return observer.Total;
@@ -45,10 +45,8 @@ public class OperatorZipBenchmarks
     public int SystemReactiveZip()
     {
         var observer = new IntSignalObserver();
-        using var subscription = RxObservable.Zip(
-                RxObservable.Range(LeftStart, Count),
-                RxObservable.Range(RightStart, Count),
-                static (left, right) => left + right)
+        using var subscription = RxObservable.Range(LeftStart, Count)
+            .Zip(RxObservable.Range(RightStart, Count), static (left, right) => left + right)
             .Subscribe(observer);
         return observer.Total;
     }

--- a/src/benchmarks/ReactiveUI.Primitives.Benchmarks/Program.cs
+++ b/src/benchmarks/ReactiveUI.Primitives.Benchmarks/Program.cs
@@ -89,10 +89,10 @@ internal static class Program
         Console.WriteLine($"SystemReactiveDefaultIfEmptyEmpty={startWith.SystemReactiveDefaultIfEmptyEmpty()}");
         Console.WriteLine($"R3DefaultIfEmptyEmpty={startWith.R3DefaultIfEmptyEmpty()}");
 
-        var selectMany = new OperatorSelectManyRangeBenchmarks();
-        Console.WriteLine($"PrimitivesSelectManyRange={selectMany.PrimitivesSelectManyRange()}");
-        Console.WriteLine($"SystemReactiveSelectManyRange={selectMany.SystemReactiveSelectManyRange()}");
-        Console.WriteLine($"R3SelectManyRange={selectMany.R3SelectManyRange()}");
+        var flatMap = new OperatorFlatMapRangeBenchmarks();
+        Console.WriteLine($"PrimitivesFlatMapRange={flatMap.PrimitivesFlatMapRange()}");
+        Console.WriteLine($"SystemReactiveSelectManyRange={flatMap.SystemReactiveSelectManyRange()}");
+        Console.WriteLine($"R3SelectManyRange={flatMap.R3SelectManyRange()}");
 
         var zip = new OperatorZipBenchmarks();
         Console.WriteLine($"PrimitivesZip={zip.PrimitivesZip()}");
@@ -118,17 +118,17 @@ internal static class Program
         Console.WriteLine($"R3SubjectSubscribeDispose64={subscriptions.R3SubjectSubscribeDispose64()}");
 
         var stateful = new StatefulSignalBenchmarks();
-        Console.WriteLine($"PrimitivesBehaviourSignal32={stateful.PrimitivesBehaviourSignal32()}");
+        Console.WriteLine($"PrimitivesStateSignal32={stateful.PrimitivesStateSignal32()}");
         Console.WriteLine($"SystemReactiveBehaviorSubject32={stateful.SystemReactiveBehaviorSubject32()}");
         Console.WriteLine($"R3BehaviorSubject32={stateful.R3BehaviorSubject32()}");
-        Console.WriteLine($"PrimitivesBehaviourSignal1024={stateful.PrimitivesBehaviourSignal1024()}");
+        Console.WriteLine($"PrimitivesStateSignal1024={stateful.PrimitivesStateSignal1024()}");
         Console.WriteLine($"SystemReactiveBehaviorSubject1024={stateful.SystemReactiveBehaviorSubject1024()}");
         Console.WriteLine($"R3BehaviorSubject1024={stateful.R3BehaviorSubject1024()}");
 
-        var replay = new ReplaySignalBenchmarks();
-        Console.WriteLine($"PrimitivesReplaySubscribe={replay.PrimitivesReplaySubscribe()}");
-        Console.WriteLine($"SystemReactiveReplaySubscribe={replay.SystemReactiveReplaySubscribe()}");
-        Console.WriteLine($"R3ReplaySubscribe={replay.R3ReplaySubscribe()}");
+        var history = new HistorySignalBenchmarks();
+        Console.WriteLine($"PrimitivesHistorySubscribe={history.PrimitivesHistorySubscribe()}");
+        Console.WriteLine($"SystemReactiveReplaySubscribe={history.SystemReactiveReplaySubscribe()}");
+        Console.WriteLine($"R3ReplaySubscribe={history.R3ReplaySubscribe()}");
 
         var taskBridge = new AsyncBridgeBenchmarks();
         Console.WriteLine($"PrimitivesCompletedTaskBridge={taskBridge.PrimitivesCompletedTaskBridge()}");

--- a/src/benchmarks/ReactiveUI.Primitives.Benchmarks/ReplaySignalBenchmarks.cs
+++ b/src/benchmarks/ReactiveUI.Primitives.Benchmarks/ReplaySignalBenchmarks.cs
@@ -13,21 +13,21 @@ using RxReplaySubject = System.Reactive.Subjects.ReplaySubject<int>;
 namespace ReactiveUI.Primitives.Benchmarks;
 
 /// <summary>
-/// Benchmarks replay/snapshot behavior for bounded replay buffers.
+/// Benchmarks history/snapshot behavior for bounded replay buffers.
 /// </summary>
 [MemoryDiagnoser]
-public class ReplaySignalBenchmarks
+public class HistorySignalBenchmarks
 {
     /// <summary>
     /// Baseline bounded replay subscription benchmark for primitives.
     /// </summary>
     /// <returns>The sum replayed to a late subscriber.</returns>
     [Benchmark(Baseline = true)]
-    public int PrimitivesReplaySubscribe()
+    public int PrimitivesHistorySubscribe()
     {
         var observer = new IntSignalObserver();
-        using var subject = new ReplaySignal<int>(16);
-        PopulateReplaySubject(subject);
+        using var subject = new HistorySignal<int>(16);
+        PopulateHistorySignal(subject);
         using var subscription = subject.Subscribe(observer);
         return observer.Total;
     }
@@ -60,7 +60,7 @@ public class ReplaySignalBenchmarks
         return observer.Total;
     }
 
-    private static void PopulateReplaySubject(ReplaySignal<int> subject)
+    private static void PopulateHistorySignal(HistorySignal<int> subject)
     {
         for (var i = 0; i < 16; i++)
         {

--- a/src/benchmarks/ReactiveUI.Primitives.Benchmarks/ScalarSignalBenchmarks.cs
+++ b/src/benchmarks/ReactiveUI.Primitives.Benchmarks/ScalarSignalBenchmarks.cs
@@ -28,7 +28,7 @@ public class ScalarSignalBenchmarks
     public int PrimitivesReturnSubscribe()
     {
         var observer = new IntSignalObserver();
-        using var subscription = Signal.Return(ScalarValue).Subscribe(observer);
+        using var subscription = Signal.Emit(ScalarValue).Subscribe(observer);
         return observer.LastValue;
     }
 

--- a/src/benchmarks/ReactiveUI.Primitives.Benchmarks/StateTaskCommandBenchmarks.cs
+++ b/src/benchmarks/ReactiveUI.Primitives.Benchmarks/StateTaskCommandBenchmarks.cs
@@ -97,7 +97,7 @@ public class StateTaskCommandBenchmarks
     {
         var current = 0;
         using var state = new System.Reactive.Subjects.BehaviorSubject<int>(Value);
-        using var subscription = state.Select(static value => value + 1).Subscribe(value => current = value);
+        using var subscription = state.Map(static value => value + 1).Subscribe(value => current = value);
         state.OnNext(Value + 1);
         return current;
     }

--- a/src/benchmarks/ReactiveUI.Primitives.Benchmarks/StatefulSignalBenchmarks.cs
+++ b/src/benchmarks/ReactiveUI.Primitives.Benchmarks/StatefulSignalBenchmarks.cs
@@ -12,7 +12,7 @@ using RxBehaviorSubject = System.Reactive.Subjects.BehaviorSubject<int>;
 namespace ReactiveUI.Primitives.Benchmarks;
 
 /// <summary>
-/// Benchmarks for stateful behaviour/replay-like signal subscriptions.
+/// Benchmarks for stateful latest-value and replay-like signal subscriptions.
 /// </summary>
 [MemoryDiagnoser]
 public class StatefulSignalBenchmarks
@@ -21,13 +21,13 @@ public class StatefulSignalBenchmarks
     private const int Count1024 = 1024;
 
     /// <summary>
-    /// Baseline behavior-like stream updates with 32 notifications.
+    /// Baseline state signal updates with 32 notifications.
     /// </summary>
     /// <returns>The final sum plus latest value.</returns>
     [Benchmark(Baseline = true)]
-    public int PrimitivesBehaviourSignal32()
+    public int PrimitivesStateSignal32()
     {
-        return EmitAndReadBehaviourSignal(Count32);
+        return EmitAndReadStateSignal(Count32);
     }
 
     /// <summary>
@@ -51,13 +51,13 @@ public class StatefulSignalBenchmarks
     }
 
     /// <summary>
-    /// Baseline behavior-like stream updates with 1024 notifications.
+    /// Baseline state signal updates with 1024 notifications.
     /// </summary>
     /// <returns>The final sum plus latest value.</returns>
     [Benchmark]
-    public int PrimitivesBehaviourSignal1024()
+    public int PrimitivesStateSignal1024()
     {
-        return EmitAndReadBehaviourSignal(Count1024);
+        return EmitAndReadStateSignal(Count1024);
     }
 
     /// <summary>
@@ -80,10 +80,10 @@ public class StatefulSignalBenchmarks
         return EmitAndReadR3BehaviorSubject(Count1024);
     }
 
-    private static int EmitAndReadBehaviourSignal(int count)
+    private static int EmitAndReadStateSignal(int count)
     {
         var observer = new IntSignalObserver();
-        using var subject = new BehaviorSignal<int>(0);
+        using var subject = new StateSignal<int>(0);
         using var subscription = subject.Subscribe(observer);
         for (var i = 1; i <= count; i++)
         {

--- a/src/benchmarks/ReactiveUI.Primitives.Benchmarks/TerminalCollectionBenchmarks.cs
+++ b/src/benchmarks/ReactiveUI.Primitives.Benchmarks/TerminalCollectionBenchmarks.cs
@@ -29,7 +29,7 @@ public class TerminalCollectionBenchmarks
     public int PrimitivesCollectList()
     {
         var result = 0;
-        using var subscription = Signal.Range(1, Count).CollectList().Subscribe(values => result = values.Count);
+        using var subscription = Signal.Sequence(1, Count).CollectList().Subscribe(values => result = values.Count);
         return result;
     }
 
@@ -64,7 +64,7 @@ public class TerminalCollectionBenchmarks
     public int PrimitivesCollectArray()
     {
         var result = 0;
-        using var subscription = Signal.Range(1, Count).CollectArray().Subscribe(values => result = values.Length);
+        using var subscription = Signal.Sequence(1, Count).CollectArray().Subscribe(values => result = values.Length);
         return result;
     }
 
@@ -98,7 +98,7 @@ public class TerminalCollectionBenchmarks
     [Benchmark]
     public async Task<int> PrimitivesCollectArrayAsync()
     {
-        return (await Signal.Range(1, Count).CollectArrayAsync().ConfigureAwait(false)).Length;
+        return (await Signal.Sequence(1, Count).CollectArrayAsync().ConfigureAwait(false)).Length;
     }
 
     /// <summary>
@@ -128,7 +128,7 @@ public class TerminalCollectionBenchmarks
     /// <returns>The first value.</returns>
     [Benchmark]
     public Task<int> PrimitivesFirstAsync() =>
-        Signal.Range(1, Count).FirstAsync();
+        Signal.Sequence(1, Count).FirstAsync();
 
     /// <summary>
     /// Benchmarks first-value task conversion using System.Reactive.
@@ -152,7 +152,7 @@ public class TerminalCollectionBenchmarks
     /// <returns>The last value.</returns>
     [Benchmark]
     public Task<int> PrimitivesToTask() =>
-        Signal.Range(1, Count).ToTask();
+        Signal.Sequence(1, Count).ToTask();
 
     /// <summary>
     /// Benchmarks last-value task conversion using System.Reactive.
@@ -178,7 +178,7 @@ public class TerminalCollectionBenchmarks
     public int PrimitivesCountPredicate()
     {
         var observer = new IntSignalObserver();
-        using var subscription = Signal.Range(1, Count).Count(static value => value % 2 == 0).Subscribe(observer);
+        using var subscription = Signal.Sequence(1, Count).Count(static value => value % 2 == 0).Subscribe(observer);
         return observer.Total;
     }
 
@@ -213,7 +213,7 @@ public class TerminalCollectionBenchmarks
     public long PrimitivesLongCountPredicate()
     {
         var observer = new LongSignalObserver();
-        using var subscription = Signal.Range(1, Count).LongCount(static value => value % 2 == 0).Subscribe(observer);
+        using var subscription = Signal.Sequence(1, Count).LongCount(static value => value % 2 == 0).Subscribe(observer);
         return observer.Total;
     }
 
@@ -248,7 +248,7 @@ public class TerminalCollectionBenchmarks
     public int PrimitivesAllRange()
     {
         var observer = new BoolSignalObserver();
-        using var subscription = Signal.Range(1, Count).All(static value => value > 0).Subscribe(observer);
+        using var subscription = Signal.Sequence(1, Count).All(static value => value > 0).Subscribe(observer);
         return observer.Total;
     }
 
@@ -283,7 +283,7 @@ public class TerminalCollectionBenchmarks
     public int PrimitivesContainsRange()
     {
         var observer = new BoolSignalObserver();
-        using var subscription = Signal.Range(1, Count).Contains(Count).Subscribe(observer);
+        using var subscription = Signal.Sequence(1, Count).Contains(Count).Subscribe(observer);
         return observer.Total;
     }
 
@@ -319,8 +319,8 @@ public class TerminalCollectionBenchmarks
     {
         var allObserver = new BoolSignalObserver();
         var containsObserver = new BoolSignalObserver();
-        using var all = Signal.Range(1, Count).All(static value => value > 0).Subscribe(allObserver);
-        using var contains = Signal.Range(1, Count).Contains(Count).Subscribe(containsObserver);
+        using var all = Signal.Sequence(1, Count).All(static value => value > 0).Subscribe(allObserver);
+        using var contains = Signal.Sequence(1, Count).Contains(Count).Subscribe(containsObserver);
         return allObserver.Total + containsObserver.Total;
     }
 

--- a/src/tests/ReactiveUI.Primitives.Tests/CoverageCompletionTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/CoverageCompletionTests.cs
@@ -270,8 +270,8 @@ public class CoverageCompletionTests
     [Test]
     public void NullGuardsCoverPublicFactoryOperatorAndObserverContracts()
     {
-        IObservable<int> source = Signal.Return(1);
-        IObservable<object?> objects = Signal.Return<object?>("value");
+        IObservable<int> source = Signal.Emit(1);
+        IObservable<object?> objects = Signal.Emit<object?>("value");
 
         CoverUnaryOperatorNullGuards(source);
         CoverHigherOrderOperatorNullGuards(source);
@@ -290,14 +290,14 @@ public class CoverageCompletionTests
         var terminal = 0;
 
         Signal.FromEnumerable(new object?[] { "a", null, Two, "bbb", "cc", Three })
-            .OfType<string>()
+            .KeepType<string>()
             .MapWith("!", (suffix, value) => value + suffix)
             .KeepWith(Two, (min, value) => value.Length >= min)
             .TapWith(sideEffects, (sink, value) => sink.Add(value))
-            .Cast<string>()
+            .CastTo<string>()
             .Skip(1)
             .Distinct(StringComparer.OrdinalIgnoreCase)
-            .DistinctUntilChanged(StringComparer.OrdinalIgnoreCase)
+            .Unique(StringComparer.OrdinalIgnoreCase)
             .Subscribe(values.Add, ex => throw ex, () => terminal++);
 
         Assert.Equal(ExpectedOperatorValues, values);
@@ -310,12 +310,12 @@ public class CoverageCompletionTests
 
         var emptyTake = new List<int>();
         var emptyTakeCompleted = 0;
-        Signal.Range(1, Three).Take(0).Subscribe(emptyTake.Add, ex => throw ex, () => emptyTakeCompleted++);
+        Signal.Sequence(1, Three).Take(0).Subscribe(emptyTake.Add, ex => throw ex, () => emptyTakeCompleted++);
         Assert.Equal(0, emptyTake.Count);
         Assert.Equal(1, emptyTakeCompleted);
 
         var skipAll = new List<int>();
-        Signal.Range(1, Three).Skip(Ten).Subscribe(skipAll.Add);
+        Signal.Sequence(1, Three).Skip(Ten).Subscribe(skipAll.Add);
         Assert.Equal(0, skipAll.Count);
 
         var anyFalse = new List<bool>();
@@ -333,7 +333,7 @@ public class CoverageCompletionTests
 
         var selectMany = new List<string>();
         Signal.FromEnumerable([1, Two])
-            .SelectMany(value => Signal.FromEnumerable([value, value + Ten]), (outer, inner) => outer + ":" + inner)
+            .FlatMap(value => Signal.FromEnumerable([value, value + Ten]), (outer, inner) => outer + ":" + inner)
             .Subscribe(selectMany.Add);
         Assert.Equal(ExpectedSelectMany, selectMany);
     }
@@ -352,8 +352,8 @@ public class CoverageCompletionTests
         var resumeValues = new List<int>();
         var finalErrors = new List<string>();
 
-        Signal.Throw<int>(new InvalidOperationException("spark"))
-            .Sparkify()
+        Signal.Fail<int>(new InvalidOperationException("spark"))
+            .Spark()
             .Subscribe(spark =>
             {
                 sparkKinds.Add(spark.Kind);
@@ -374,16 +374,16 @@ public class CoverageCompletionTests
             .Unspark()
             .Subscribe(unsparkValues.Add, ex => unsparkErrors.Add(ex.Message));
 
-        Signal.Throw<int>(new InvalidOperationException("recover"))
-            .Rescue(error => Signal.Return(error.Message.Length))
+        Signal.Fail<int>(new InvalidOperationException("recover"))
+            .Rescue(error => Signal.Emit(error.Message.Length))
             .Subscribe(rescueValues.Add);
 
-        Signal.Throw<int>(new InvalidOperationException("resume"))
+        Signal.Fail<int>(new InvalidOperationException("resume"))
             .Resume(Signal.FromEnumerable([Four, Five]))
             .Subscribe(resumeValues.Add);
 
-        Signal.Defer(() => Signal.Throw<int>(new InvalidOperationException("stop")))
-            .Retry(1)
+        Signal.Lazy(() => Signal.Fail<int>(new InvalidOperationException("stop")))
+            .Reattempt(1)
             .Subscribe(_ => { }, ex => finalErrors.Add(ex.Message));
 
         Assert.Equal(ExpectedSparkKinds, sparkKinds);
@@ -413,7 +413,7 @@ public class CoverageCompletionTests
         var forkJoinEmpty = new List<int>();
         var completed = new Dictionary<string, int>();
 
-        outer.Concat().Subscribe(concatValues.Add, ex => throw ex, () => completed["concat"] = 1);
+        outer.Chain().Subscribe(concatValues.Add, ex => throw ex, () => completed["concat"] = 1);
         outer.OnNext(first);
         outer.OnNext(second);
         first.OnNext(1);
@@ -424,7 +424,7 @@ public class CoverageCompletionTests
         second.OnCompleted();
         outer.OnCompleted();
 
-        Signal.Merge(Signal.FromEnumerable([1, Two]), Signal.FromEnumerable([Three]))
+        Signal.Blend(Signal.FromEnumerable([1, Two]), Signal.FromEnumerable([Three]))
             .Subscribe(mergeValues.Add, ex => throw ex, () => completed["merge"] = 1);
 
         var raceLoser = new Signal<int>();
@@ -437,7 +437,7 @@ public class CoverageCompletionTests
         var switchOuter = new Signal<IObservable<int>>();
         var oldInner = new Signal<int>();
         var newInner = new Signal<int>();
-        switchOuter.Switch().Subscribe(switchValues.Add, ex => throw ex, () => completed["switch"] = 1);
+        switchOuter.SwitchTo().Subscribe(switchValues.Add, ex => throw ex, () => completed["switch"] = 1);
         switchOuter.OnNext(oldInner);
         oldInner.OnNext(1);
         switchOuter.OnNext(newInner);
@@ -448,7 +448,7 @@ public class CoverageCompletionTests
 
         var left = new Signal<int>();
         var right = new Signal<string>();
-        left.WithLatest(right, (l, r) => l + r).Subscribe(withLatestValues.Add);
+        left.Latch(right, (l, r) => l + r).Subscribe(withLatestValues.Add);
         left.OnNext(1);
         right.OnNext("a");
         left.OnNext(Two);
@@ -457,10 +457,10 @@ public class CoverageCompletionTests
         left.OnCompleted();
 
         Signal.FromEnumerable([1, Two, Three])
-            .Zip(Signal.Return(Ten), (l, r) => l + r)
+            .Pair(Signal.Emit(Ten), (l, r) => l + r)
             .Subscribe(zipShortValues.Add, ex => throw ex, () => completed["zip"] = 1);
-        Signal.Empty<int>()
-            .ForkJoin(Signal.Return(1), (l, r) => l + r)
+        Signal.None<int>()
+            .ForkJoin(Signal.Emit(1), (l, r) => l + r)
             .Subscribe(forkJoinEmpty.Add, ex => throw ex, () => completed["forkJoinEmpty"] = 1);
 
         Assert.Equal(ExpectedConcatValues, concatValues);
@@ -502,21 +502,21 @@ public class CoverageCompletionTests
         manual.OnNext(Two);
         Assert.Equal(ExpectedDelayStartValues, delayStartValues);
 
-        Signal.FromEnumerable([Three, Four]).Delay(TimeSpan.FromTicks(Three), clock).Subscribe(delayedValues.Add);
+        Signal.FromEnumerable([Three, Four]).Shift(TimeSpan.FromTicks(Three), clock).Subscribe(delayedValues.Add);
         clock.AdvanceBy(TimeSpan.FromTicks(Two));
         Assert.Equal(0, delayedValues.Count);
         clock.AdvanceBy(TimeSpan.FromTicks(1));
         Assert.Equal(ExpectedDelayedValues, delayedValues);
 
         var never = new Signal<int>();
-        never.Timeout(TimeSpan.FromTicks(Four), clock).Subscribe(timeoutValues.Add, ex => timeoutErrors.Add(ex.GetType().Name));
+        never.Expire(TimeSpan.FromTicks(Four), clock).Subscribe(timeoutValues.Add, ex => timeoutErrors.Add(ex.GetType().Name));
         clock.AdvanceBy(TimeSpan.FromTicks(Four));
         never.OnNext(FortyTwo);
         Assert.Equal(0, timeoutValues.Count);
         Assert.Equal(ExpectedTimeoutErrors, timeoutErrors);
 
         var completed = new Signal<int>();
-        completed.Timeout(TimeSpan.FromTicks(Ten), clock).Subscribe(timeoutValues.Add);
+        completed.Expire(TimeSpan.FromTicks(Ten), clock).Subscribe(timeoutValues.Add);
         completed.OnNext(Seven);
         completed.OnCompleted();
         clock.AdvanceBy(TimeSpan.FromTicks(Ten));
@@ -527,7 +527,7 @@ public class CoverageCompletionTests
         pulse.Dispose();
         Assert.Equal(ExpectedTimerValues, pulseValues);
 
-        var timer = Signal.Timer(TimeSpan.FromTicks(Three), TimeSpan.FromTicks(Two), clock).Subscribe(timerValues.Add);
+        var timer = Signal.After(TimeSpan.FromTicks(Three), TimeSpan.FromTicks(Two), clock).Subscribe(timerValues.Add);
         clock.AdvanceBy(TimeSpan.FromTicks(Three));
         clock.AdvanceBy(TimeSpan.FromTicks(Four));
         timer.Dispose();
@@ -551,7 +551,7 @@ public class CoverageCompletionTests
         var asyncErrors = new List<string>();
 
         Signal.Use(() => Disposable.Empty, _ => (IObservable<int>)null!).Subscribe(_ => { }, ex => useErrors.Add(ex.Message));
-        Signal.Use<IDisposable, int>(() => throw new InvalidOperationException("resource"), _ => Signal.Return(1)).Subscribe(_ => { }, ex => useErrors.Add(ex.Message));
+        Signal.Use<IDisposable, int>(() => throw new InvalidOperationException("resource"), _ => Signal.Emit(1)).Subscribe(_ => { }, ex => useErrors.Add(ex.Message));
 
         await ObserveTaskError(Task.FromCanceled<int>(new CancellationToken(true)), taskErrors);
         await ObserveTaskError(Task.FromException<int>(new InvalidOperationException("faulted")), taskErrors);
@@ -566,12 +566,12 @@ public class CoverageCompletionTests
         Signal.FromAsyncEnumerable(ThrowingAsyncEnumerable()).Subscribe(asyncValues.Add, ex => asyncErrors.Add(ex.Message));
         await SpinUntil(() => asyncErrors.Count == 1, TimeSpan.FromSeconds(2));
 
-        var firstFailure = await AssertTaskFault(() => Signal.Empty<int>().FirstAsync(), typeof(InvalidOperationException));
+        var firstFailure = await AssertTaskFault(() => Signal.None<int>().FirstAsync(), typeof(InvalidOperationException));
         var collectFailure = await AssertTaskFault(
-            () => Signal.Throw<int>(new InvalidOperationException("collect")).CollectArrayAsync(),
+            () => Signal.Fail<int>(new InvalidOperationException("collect")).CollectArrayAsync(),
             typeof(InvalidOperationException));
         var listFailure = await AssertTaskFault(
-            () => Signal.Throw<int>(new InvalidOperationException("list")).CollectListAsync(),
+            () => Signal.Fail<int>(new InvalidOperationException("list")).CollectListAsync(),
             typeof(InvalidOperationException));
 
         Assert.Equal(ExpectedUseErrors, useErrors);
@@ -764,24 +764,24 @@ public class CoverageCompletionTests
         Assert.Throws<ArgumentNullException>(() => ((IObservable<int>)null!).KeepWith(1, (_, _) => true));
         Assert.Throws<ArgumentNullException>(() => source.KeepWith<int, int>(1, null!));
         Assert.Throws<ArgumentNullException>(() => ((IObservable<string?>)null!).KeepNotNull());
-        Assert.Throws<ArgumentNullException>(() => ((IObservable<object>)null!).OfType<string>());
-        Assert.Throws<ArgumentNullException>(() => ((IObservable<object>)null!).Cast<string>());
+        Assert.Throws<ArgumentNullException>(() => ((IObservable<object>)null!).KeepType<string>());
+        Assert.Throws<ArgumentNullException>(() => ((IObservable<object>)null!).CastTo<string>());
         Assert.Throws<ArgumentNullException>(() => ((IObservable<int>)null!).Tap(value => { }));
         Assert.Throws<ArgumentNullException>(() => source.Tap<int>(null!));
         Assert.Throws<ArgumentNullException>(() => ((IObservable<int>)null!).TapWith(1, (_, _) => { }));
         Assert.Throws<ArgumentNullException>(() => source.TapWith<int, int>(1, null!));
-        Assert.Throws<ArgumentNullException>(() => ((IObservable<int>)null!).Scan(0, (left, right) => left + right));
-        Assert.Throws<ArgumentNullException>(() => source.Scan(0, null!));
         Assert.Throws<ArgumentNullException>(() => ((IObservable<int>)null!).Fold(0, (left, right) => left + right));
         Assert.Throws<ArgumentNullException>(() => source.Fold(0, null!));
+        Assert.Throws<ArgumentNullException>(() => ((IObservable<int>)null!).Reduce(0, (left, right) => left + right));
+        Assert.Throws<ArgumentNullException>(() => source.Reduce(0, null!));
         Assert.Throws<ArgumentNullException>(() => ((IObservable<int>)null!).Take(1));
         Assert.Throws<ArgumentNullException>(() => ((IObservable<int>)null!).Skip(1));
         Assert.Throws<ArgumentNullException>(() => ((IObservable<int>)null!).Distinct());
-        Assert.Throws<ArgumentNullException>(() => ((IObservable<int>)null!).DistinctUntilChanged());
-        Assert.Throws<ArgumentNullException>(() => ((IObservable<int>)null!).Sparkify());
+        Assert.Throws<ArgumentNullException>(() => ((IObservable<int>)null!).Unique());
+        Assert.Throws<ArgumentNullException>(() => ((IObservable<int>)null!).Spark());
         Assert.Throws<ArgumentNullException>(() => ((IObservable<Spark<int>>)null!).Unspark());
-        Assert.Throws<ArgumentNullException>(() => ((IObservable<int>)null!).Delay(TimeSpan.Zero, Sequencer.Immediate));
-        Assert.Throws<ArgumentNullException>(() => ((IObservable<int>)null!).Timeout(TimeSpan.Zero, Sequencer.Immediate));
+        Assert.Throws<ArgumentNullException>(() => ((IObservable<int>)null!).Shift(TimeSpan.Zero, Sequencer.Immediate));
+        Assert.Throws<ArgumentNullException>(() => ((IObservable<int>)null!).Expire(TimeSpan.Zero, Sequencer.Immediate));
         Assert.Throws<ArgumentNullException>(() => ((IObservable<int>)null!).CollectList());
         Assert.Throws<ArgumentNullException>(() => ((IObservable<int>)null!).ToSignal());
     }
@@ -792,24 +792,24 @@ public class CoverageCompletionTests
     /// <param name="source">The non-null source used for null argument checks.</param>
     private static void CoverHigherOrderOperatorNullGuards(IObservable<int> source)
     {
-        Assert.Throws<ArgumentNullException>(() => ((IObservable<IObservable<int>>)null!).Concat());
-        Assert.Throws<ArgumentNullException>(() => Signal.Concat<int>(null!));
-        Assert.Throws<ArgumentNullException>(() => Signal.Concat(source, null!));
-        Assert.Throws<ArgumentNullException>(() => Signal.Merge<int>(null!));
-        Assert.Throws<ArgumentNullException>(() => Signal.Merge(source, null!));
+        Assert.Throws<ArgumentNullException>(() => ((IObservable<IObservable<int>>)null!).Chain());
+        Assert.Throws<ArgumentNullException>(() => Signal.Chain<int>(null!));
+        Assert.Throws<ArgumentNullException>(() => Signal.Chain(source, null!));
+        Assert.Throws<ArgumentNullException>(() => Signal.Blend<int>(null!));
+        Assert.Throws<ArgumentNullException>(() => Signal.Blend(source, null!));
         Assert.Throws<ArgumentNullException>(() => Signal.Race<int>(null!));
         Assert.Throws<ArgumentNullException>(() => Signal.Race(source, null!));
-        Assert.Throws<ArgumentNullException>(() => ((IObservable<int>)null!).Zip(source, (left, _) => left));
-        Assert.Throws<ArgumentNullException>(() => source.Zip<int, int, int>(null!, (left, _) => left));
-        Assert.Throws<ArgumentNullException>(() => source.Zip<int, int, int>(source, null!));
-        Assert.Throws<ArgumentNullException>(() => ((IObservable<int>)null!).CombineLatest(source, (left, _) => left));
-        Assert.Throws<ArgumentNullException>(() => source.CombineLatest<int, int, int>(null!, (left, _) => left));
-        Assert.Throws<ArgumentNullException>(() => source.CombineLatest<int, int, int>(source, null!));
-        Assert.Throws<ArgumentNullException>(() => ((IObservable<int>)null!).WithLatest(source, (left, _) => left));
-        Assert.Throws<ArgumentNullException>(() => source.WithLatest<int, int, int>(null!, (left, _) => left));
-        Assert.Throws<ArgumentNullException>(() => source.WithLatest<int, int, int>(source, null!));
-        Assert.Throws<ArgumentNullException>(() => ((IObservable<IObservable<int>>)null!).Switch());
-        Assert.Throws<ArgumentNullException>(() => ((IObservable<int>)null!).Retry(1));
+        Assert.Throws<ArgumentNullException>(() => ((IObservable<int>)null!).Pair(source, (left, _) => left));
+        Assert.Throws<ArgumentNullException>(() => source.Pair<int, int, int>(null!, (left, _) => left));
+        Assert.Throws<ArgumentNullException>(() => source.Pair<int, int, int>(source, null!));
+        Assert.Throws<ArgumentNullException>(() => ((IObservable<int>)null!).SyncLatest(source, (left, _) => left));
+        Assert.Throws<ArgumentNullException>(() => source.SyncLatest<int, int, int>(null!, (left, _) => left));
+        Assert.Throws<ArgumentNullException>(() => source.SyncLatest<int, int, int>(source, null!));
+        Assert.Throws<ArgumentNullException>(() => ((IObservable<int>)null!).Latch(source, (left, _) => left));
+        Assert.Throws<ArgumentNullException>(() => source.Latch<int, int, int>(null!, (left, _) => left));
+        Assert.Throws<ArgumentNullException>(() => source.Latch<int, int, int>(source, null!));
+        Assert.Throws<ArgumentNullException>(() => ((IObservable<IObservable<int>>)null!).SwitchTo());
+        Assert.Throws<ArgumentNullException>(() => ((IObservable<int>)null!).Reattempt(1));
         Assert.Throws<ArgumentNullException>(() => ((IObservable<int>)null!).Resume(source));
         Assert.Throws<ArgumentNullException>(() => source.Resume(null!));
     }
@@ -826,22 +826,22 @@ public class CoverageCompletionTests
         Assert.Throws<ArgumentNullException>(() => ((IObservable<int>)null!).DefaultIfEmpty());
         Assert.Throws<ArgumentNullException>(() => ((IObservable<int>)null!).DistinctBy(value => value));
         Assert.Throws<ArgumentNullException>(() => source.DistinctBy<int, int>(null!));
-        Assert.Throws<ArgumentNullException>(() => ((IObservable<int>)null!).DistinctUntilChangedBy(value => value));
-        Assert.Throws<ArgumentNullException>(() => source.DistinctUntilChangedBy<int, int>(null!));
+        Assert.Throws<ArgumentNullException>(() => ((IObservable<int>)null!).UniqueBy(value => value));
+        Assert.Throws<ArgumentNullException>(() => source.UniqueBy<int, int>(null!));
         Assert.Throws<ArgumentNullException>(() => ((IObservable<int>)null!).TakeWhile(value => true));
         Assert.Throws<ArgumentNullException>(() => source.TakeWhile<int>(null!));
         Assert.Throws<ArgumentNullException>(() => ((IObservable<int>)null!).SkipWhile(value => true));
         Assert.Throws<ArgumentNullException>(() => source.SkipWhile<int>(null!));
-        Assert.Throws<ArgumentNullException>(() => ((IObservable<int>)null!).SelectMany(value => source));
-        Assert.Throws<ArgumentNullException>(() => source.SelectMany<int, int>(null!));
+        Assert.Throws<ArgumentNullException>(() => ((IObservable<int>)null!).FlatMap(value => source));
+        Assert.Throws<ArgumentNullException>(() => source.FlatMap<int, int>(null!));
         Assert.Throws<ArgumentNullException>(() => ((IObservable<int>)null!).Count());
         Assert.Throws<ArgumentNullException>(() => ((IObservable<int>)null!).LongCount());
         Assert.Throws<ArgumentNullException>(() => ((IObservable<int>)null!).Any());
         Assert.Throws<ArgumentNullException>(() => ((IObservable<int>)null!).All(value => true));
         Assert.Throws<ArgumentNullException>(() => source.All<int>(null!));
         Assert.Throws<ArgumentNullException>(() => ((IObservable<int>)null!).DelayStart(TimeSpan.Zero, Sequencer.Immediate));
-        Assert.Throws<ArgumentNullException>(() => ((IObservable<int>)null!).Throttle(TimeSpan.Zero, Sequencer.Immediate));
-        Assert.Throws<ArgumentNullException>(() => ((IObservable<int>)null!).Sample(TimeSpan.Zero, Sequencer.Immediate));
+        Assert.Throws<ArgumentNullException>(() => ((IObservable<int>)null!).Calm(TimeSpan.Zero, Sequencer.Immediate));
+        Assert.Throws<ArgumentNullException>(() => ((IObservable<int>)null!).Probe(TimeSpan.Zero, Sequencer.Immediate));
         Assert.Throws<ArgumentNullException>(() => ((IObservable<int>)null!).Timestamp(Sequencer.Immediate));
         Assert.Throws<ArgumentNullException>(() => ((IObservable<int>)null!).TimeInterval(Sequencer.Immediate));
         Assert.Throws<ArgumentNullException>(() => ((IObservable<int>)null!).ForkJoin(source, (left, _) => left));
@@ -858,19 +858,19 @@ public class CoverageCompletionTests
     private static void CoverFactoryAndObserverNullGuards(IObservable<object?> objects)
     {
         Assert.Throws<ArgumentNullException>(() => Signal.Create<int>(null!));
-        Assert.Throws<ArgumentNullException>(() => Signal.Defer<int>(null!));
+        Assert.Throws<ArgumentNullException>(() => Signal.Lazy<int>(null!));
         Assert.Throws<ArgumentNullException>(() => Signal.FromEnumerable<int>(null!));
         Assert.Throws<ArgumentNullException>(() => Signal.FromTask((Task<int>)null!));
         Assert.Throws<ArgumentNullException>(() => Signal.FromAsyncEnumerable<int>(null!));
-        Assert.Throws<ArgumentNullException>(() => Signal.Using<IDisposable, int>(null!, resource => Signal.Return(1)));
-        Assert.Throws<ArgumentNullException>(() => Signal.Using(() => Disposable.Empty, (Func<IDisposable, IObservable<int>>)null!));
-        Assert.Throws<ArgumentNullException>(() => Signal.Use<IDisposable, int>(null!, resource => Signal.Return(1)));
+        Assert.Throws<ArgumentNullException>(() => Signal.Use<IDisposable, int>(null!, resource => Signal.Emit(1)));
+        Assert.Throws<ArgumentNullException>(() => Signal.Use(() => Disposable.Empty, (Func<IDisposable, IObservable<int>>)null!));
+        Assert.Throws<ArgumentNullException>(() => Signal.Use<IDisposable, int>(null!, resource => Signal.Emit(1)));
         Assert.Throws<ArgumentNullException>(() => Signal.Use(() => Disposable.Empty, (Func<IDisposable, IObservable<int>>)null!));
         Assert.Throws<ArgumentNullException>(() => ((IObservable<int>)null!).Subscribe(value => { }));
-        Assert.Throws<ArgumentNullException>(() => Signal.Return(1).Subscribe((Action<int>)null!));
-        Assert.Throws<ArgumentNullException>(() => Signal.Return(1).Subscribe(value => { }, (Action<Exception>)null!));
-        Assert.Throws<ArgumentNullException>(() => Signal.Return(1).Subscribe(value => { }, ex => { }, null!));
-        Assert.Throws<ArgumentNullException>(() => objects.Cast<string>().Subscribe((IObserver<string>)null!));
+        Assert.Throws<ArgumentNullException>(() => Signal.Emit(1).Subscribe((Action<int>)null!));
+        Assert.Throws<ArgumentNullException>(() => Signal.Emit(1).Subscribe(value => { }, (Action<Exception>)null!));
+        Assert.Throws<ArgumentNullException>(() => Signal.Emit(1).Subscribe(value => { }, ex => { }, null!));
+        Assert.Throws<ArgumentNullException>(() => objects.CastTo<string>().Subscribe((IObserver<string>)null!));
     }
 
     /// <summary>

--- a/src/tests/ReactiveUI.Primitives.Tests/CoverageExpansionTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/CoverageExpansionTests.cs
@@ -102,14 +102,14 @@ public class CoverageExpansionTests
     {
         var returned = new List<int>();
         var returnCompleted = 0;
-        Signal.Return(First, Sequencer.CurrentThread).Subscribe(returned.Add, ex => throw ex, () => returnCompleted++);
+        Signal.Emit(First, Sequencer.CurrentThread).Subscribe(returned.Add, ex => throw ex, () => returnCompleted++);
 
         var emptyCompleted = 0;
-        Signal.Empty<int>(Sequencer.CurrentThread).Subscribe(_ => { }, ex => throw ex, () => emptyCompleted++);
+        Signal.None<int>(Sequencer.CurrentThread).Subscribe(_ => { }, ex => throw ex, () => emptyCompleted++);
 
         var error = new InvalidOperationException("scheduled");
         var thrown = new List<Exception>();
-        Signal.Throw<int>(error, Sequencer.CurrentThread).Subscribe(_ => { }, thrown.Add, () => { });
+        Signal.Fail<int>(error, Sequencer.CurrentThread).Subscribe(_ => { }, thrown.Add, () => { });
 
         Assert.Equal(SingleFirstExpected, returned);
         Assert.Equal(1, returnCompleted);
@@ -155,7 +155,7 @@ public class CoverageExpansionTests
         Assert.Throws<ArgumentNullException>(() => Signal.CreateSafe<int>(null!, true));
         Assert.Throws<ArgumentNullException>(() => Signal.CreateWithState<int, int>(First, null!));
         Assert.Throws<ArgumentNullException>(() => Signal.CreateWithState<int, int>(First, null!, true));
-        Assert.Throws<ArgumentNullException>(() => Signal.Defer<int>(null!));
+        Assert.Throws<ArgumentNullException>(() => Signal.Lazy<int>(null!));
     }
 
     /// <summary>
@@ -170,7 +170,7 @@ public class CoverageExpansionTests
 
         using var canceledBeforeSubscribe = new CancellationTokenSource();
         canceledBeforeSubscribe.Cancel();
-        var alreadyCanceled = Signal.Never<int>().GetAwaiter(canceledBeforeSubscribe.Token);
+        var alreadyCanceled = Signal.Silent<int>().GetAwaiter(canceledBeforeSubscribe.Token);
         Assert.True(alreadyCanceled.IsCompleted);
         Assert.Throws<OperationCanceledException>(() => alreadyCanceled.GetResult());
 
@@ -191,42 +191,42 @@ public class CoverageExpansionTests
     public void CatchParamsFactoryCoversRecoveryAndFailureBranches()
     {
         var recovered = new List<int>();
-        Signal.Catch(
-                Signal.Throw<int>(new InvalidOperationException(FirstMessage)),
+        Signal.Recover(
+                Signal.Fail<int>(new InvalidOperationException(FirstMessage)),
                 Signal.FromEnumerable(CatchRecoveryExpected),
-                Signal.Throw<int>(new InvalidOperationException("unused")))
+                Signal.Fail<int>(new InvalidOperationException("unused")))
             .Subscribe(recovered.Add);
         Assert.Equal(CatchRecoveryExpected, recovered);
 
         var finalErrors = new List<Exception>();
         var finalError = new InvalidOperationException("last");
-        Signal.Catch(Signal.Throw<int>(new InvalidOperationException(FirstMessage)), Signal.Throw<int>(finalError))
+        Signal.Recover(Signal.Fail<int>(new InvalidOperationException(FirstMessage)), Signal.Fail<int>(finalError))
             .Subscribe(_ => { }, finalErrors.Add, () => { });
         Assert.Same(finalError, finalErrors[0]);
 
         var completed = 0;
-        var completedSubscription = Signal.Catch(Array.Empty<IObservable<int>>()).Subscribe(_ => { }, ex => throw ex, () => completed++);
+        var completedSubscription = Signal.Recover(Array.Empty<IObservable<int>>()).Subscribe(_ => { }, ex => throw ex, () => completed++);
         completedSubscription.Dispose();
         completedSubscription.Dispose();
         Assert.Equal(1, completed);
 
-        var activeSubscription = Signal.Catch(Signal.Never<int>()).Subscribe(_ => { }, ex => throw ex, () => { });
+        var activeSubscription = Signal.Recover(Signal.Silent<int>()).Subscribe(_ => { }, ex => throw ex, () => { });
         activeSubscription.Dispose();
 
         var nullSourceErrors = new List<Exception>();
-        Signal.Catch(new IObservable<int>?[] { null! }!)
+        Signal.Recover(new IObservable<int>?[] { null! }!)
             .Subscribe(_ => { }, nullSourceErrors.Add, () => { });
         Assert.True(nullSourceErrors[0] is InvalidOperationException);
 
         var moveNextErrors = new List<Exception>();
         var moveNextError = new InvalidOperationException("move-next");
-        new ThrowingMoveNextEnumerable<IObservable<int>>(moveNextError).Catch()
+        new ThrowingMoveNextEnumerable<IObservable<int>>(moveNextError).Recover()
             .Subscribe(_ => { }, moveNextErrors.Add, () => { });
         Assert.Same(moveNextError, moveNextErrors[0]);
 
         var getEnumeratorError = new InvalidOperationException("enumerator");
         Assert.Throws<InvalidOperationException>(() =>
-            new ThrowingEnumerable<IObservable<int>>(getEnumeratorError).Catch()
+            new ThrowingEnumerable<IObservable<int>>(getEnumeratorError).Recover()
                 .Subscribe(_ => { }, _ => { }, () => { }));
     }
 
@@ -250,7 +250,7 @@ public class CoverageExpansionTests
 
         var error = new InvalidOperationException("thread-pool");
         var observed = new TaskCompletionSource<Exception>(TaskCreationOptions.RunContinuationsAsynchronously);
-        using (Signal.Throw<int>(error)
+        using (Signal.Fail<int>(error)
                    .WitnessOn(ThreadPoolSequencer.Instance)
                    .Subscribe(_ => { }, observed.SetResult, () => { }))
         {

--- a/src/tests/ReactiveUI.Primitives.Tests/CoverageRemainderTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/CoverageRemainderTests.cs
@@ -59,29 +59,29 @@ public class CoverageRemainderTests
         var forkJoinRange = new List<int>();
 
         source
-            .Do(
+            .Tap(
                 value => sideEffects.Add("next:" + value),
                 error => sideEffects.Add("error:" + error.Message),
                 () => sideEffects.Add("completed"))
             .Subscribe(values.Add, ex => throw ex, () => completed++);
-        Signal.Throw<int>(new InvalidOperationException("do-error"))
-            .Do(value => sideEffects.Add(value.ToString()), error => sideEffects.Add("error:" + error.Message), () => sideEffects.Add("unused"))
+        Signal.Fail<int>(new InvalidOperationException("do-error"))
+            .Tap(value => sideEffects.Add(value.ToString()), error => sideEffects.Add("error:" + error.Message), () => sideEffects.Add("unused"))
             .Subscribe(_ => { }, _ => { }, () => { });
 
-        Signal.Empty<int?>().DefaultIfEmpty().Subscribe(defaultValue.Add);
+        Signal.None<int?>().DefaultIfEmpty().Subscribe(defaultValue.Add);
         source.IgnoreValues().Subscribe(_ => values.Add(NinetyNine), ex => throw ex, () => ignoreCompleted++);
         Signal.FromEnumerable([One, Two, Three, Four]).TakeWhile(value => value < Three).Subscribe(takeWhile.Add);
         Signal.FromEnumerable([One, Two, Three, Four]).SkipWhile(value => value < Three).Subscribe(skipWhile.Add);
         Signal.FromEnumerable(["aa", "bb", "ccc", "dd", "e"])
-            .DistinctUntilChangedBy(value => value.Length)
+            .UniqueBy(value => value.Length)
             .Subscribe(distinctKeys.Add);
-        Signal.Empty<int>().IsEmpty().Subscribe(isEmptyValues.Add);
-        Signal.Range(One, Three).IsEmpty().Subscribe(isEmptyValues.Add);
+        Signal.None<int>().IsEmpty().Subscribe(isEmptyValues.Add);
+        Signal.Sequence(One, Three).IsEmpty().Subscribe(isEmptyValues.Add);
         source.CollectList().Subscribe(listValues.Add);
         source.CollectArray().Subscribe(arrayValues.Add);
-        Signal.Range(Three, Three).CollectList().Subscribe(rangeListValues.Add);
-        Signal.Range(Three, Three).CollectArray().Subscribe(rangeArrayValues.Add);
-        Signal.Range(One, Four).ForkJoin(Signal.Range(Three, Three), (left, right) => left + right).Subscribe(forkJoinRange.Add);
+        Signal.Sequence(Three, Three).CollectList().Subscribe(rangeListValues.Add);
+        Signal.Sequence(Three, Three).CollectArray().Subscribe(rangeArrayValues.Add);
+        Signal.Sequence(One, Four).ForkJoin(Signal.Sequence(Three, Three), (left, right) => left + right).Subscribe(forkJoinRange.Add);
 
         Assert.Equal(new[] { One, Two, Three, Four }, values);
         Assert.Equal(new[] { "next:1", "next:2", "next:3", "next:4", "completed", "error:do-error" }, sideEffects);
@@ -98,31 +98,31 @@ public class CoverageRemainderTests
         Assert.Equal<int>([Three, Four, Five], rangeArrayValues[0]);
         Assert.Equal(new[] { Nine }, forkJoinRange);
 
-        Assert.Throws<ArgumentNullException>(() => LinqMixins.StartWith<int>(null!, One, Two));
-        Assert.Throws<ArgumentNullException>(() => source.StartWith((int[])null!));
-        Assert.Throws<ArgumentNullException>(() => LinqMixins.StartWith<int>(null!, (IEnumerable<int>)[One]));
-        Assert.Throws<ArgumentNullException>(() => source.StartWith((IEnumerable<int>)null!));
+        Assert.Throws<ArgumentNullException>(() => LinqMixins.Prepend<int>(null!, One, Two));
+        Assert.Throws<ArgumentNullException>(() => source.Prepend((int[])null!));
+        Assert.Throws<ArgumentNullException>(() => LinqMixins.Prepend<int>(null!, (IEnumerable<int>)[One]));
+        Assert.Throws<ArgumentNullException>(() => source.Prepend((IEnumerable<int>)null!));
         Assert.Throws<ArgumentNullException>(() => LinqMixins.ObserveOn<int>(null!, Sequencer.Immediate));
         Assert.Throws<ArgumentNullException>(() => source.ObserveOn(null!));
         Assert.Throws<ArgumentNullException>(() => LinqMixins.SubscribeOn<int>(null!, Sequencer.Immediate));
         Assert.Throws<ArgumentNullException>(() => source.SubscribeOn(null!));
-        Assert.Throws<ArgumentNullException>(() => LinqMixins.Do<int>(null!, _ => { }, _ => { }, () => { }));
-        Assert.Throws<ArgumentNullException>(() => source.Do(null!, _ => { }, () => { }));
-        Assert.Throws<ArgumentNullException>(() => source.Do(_ => { }, null!, () => { }));
-        Assert.Throws<ArgumentNullException>(() => source.Do(_ => { }, _ => { }, null!));
+        Assert.Throws<ArgumentNullException>(() => LinqMixins.Tap<int>(null!, _ => { }, _ => { }, () => { }));
+        Assert.Throws<ArgumentNullException>(() => source.Tap(null!, _ => { }, () => { }));
+        Assert.Throws<ArgumentNullException>(() => source.Tap(_ => { }, null!, () => { }));
+        Assert.Throws<ArgumentNullException>(() => source.Tap(_ => { }, _ => { }, null!));
         Assert.Throws<ArgumentNullException>(() => LinqMixins.IgnoreValues<int>(null!));
         Assert.Throws<ArgumentNullException>(() => LinqMixins.DistinctBy<int, int>(null!, value => value));
         Assert.Throws<ArgumentNullException>(() => source.DistinctBy<int, int>(null!));
-        Assert.Throws<ArgumentNullException>(() => LinqMixins.DistinctUntilChangedBy<int, int>(null!, value => value));
-        Assert.Throws<ArgumentNullException>(() => source.DistinctUntilChangedBy<int, int>(null!));
+        Assert.Throws<ArgumentNullException>(() => LinqMixins.UniqueBy<int, int>(null!, value => value));
+        Assert.Throws<ArgumentNullException>(() => source.UniqueBy<int, int>(null!));
         Assert.Throws<ArgumentNullException>(() => LinqMixins.TakeWhile<int>(null!, value => true));
         Assert.Throws<ArgumentNullException>(() => source.TakeWhile(null!));
         Assert.Throws<ArgumentNullException>(() => LinqMixins.SkipWhile<int>(null!, value => true));
         Assert.Throws<ArgumentNullException>(() => source.SkipWhile(null!));
-        Assert.Throws<ArgumentNullException>(() => LinqMixins.SelectMany<int, int>(null!, value => Signal.Return(value)));
-        Assert.Throws<ArgumentNullException>(() => source.SelectMany<int, int>(null!));
-        Assert.Throws<ArgumentNullException>(() => source.SelectMany<int, int, int>(null!, (outer, inner) => outer + inner));
-        Assert.Throws<ArgumentNullException>(() => source.SelectMany(value => Signal.Return(value), (Func<int, int, int>)null!));
+        Assert.Throws<ArgumentNullException>(() => LinqMixins.FlatMap<int, int>(null!, value => Signal.Emit(value)));
+        Assert.Throws<ArgumentNullException>(() => source.FlatMap<int, int>(null!));
+        Assert.Throws<ArgumentNullException>(() => source.FlatMap<int, int, int>(null!, (outer, inner) => outer + inner));
+        Assert.Throws<ArgumentNullException>(() => source.FlatMap(value => Signal.Emit(value), (Func<int, int, int>)null!));
         Assert.Throws<ArgumentNullException>(() => LinqMixins.Count<int>(null!));
         Assert.Throws<ArgumentNullException>(() => source.Count(null!));
         Assert.Throws<ArgumentNullException>(() => LinqMixins.LongCount<int>(null!));
@@ -134,19 +134,19 @@ public class CoverageRemainderTests
         Assert.Throws<ArgumentNullException>(() => source.All(null!));
         Assert.Throws<ArgumentNullException>(() => LinqMixins.Contains<int>(null!, One));
         Assert.Throws<ArgumentNullException>(() => LinqMixins.DelayStart<int>(null!, TimeSpan.Zero));
-        Assert.Throws<ArgumentNullException>(() => LinqMixins.Throttle<int>(null!, TimeSpan.Zero));
-        Assert.Throws<ArgumentOutOfRangeException>(() => source.Sample(TimeSpan.FromTicks(-1)));
+        Assert.Throws<ArgumentNullException>(() => LinqMixins.Calm<int>(null!, TimeSpan.Zero));
+        Assert.Throws<ArgumentOutOfRangeException>(() => source.Probe(TimeSpan.FromTicks(-1)));
         Assert.Throws<ArgumentNullException>(() => LinqMixins.Timestamp<int>(null!));
         Assert.Throws<ArgumentNullException>(() => LinqMixins.TimeInterval<int>(null!));
-        Assert.Throws<ArgumentNullException>(() => LinqMixins.ForkJoin<int, int, int>(null!, Signal.Return(One), (left, right) => left + right));
+        Assert.Throws<ArgumentNullException>(() => LinqMixins.ForkJoin<int, int, int>(null!, Signal.Emit(One), (left, right) => left + right));
         Assert.Throws<ArgumentNullException>(() => LinqMixins.ForkJoin<int, int, int>(source, null!, (left, right) => left + right));
-        Assert.Throws<ArgumentNullException>(() => LinqMixins.ForkJoin<int, int, int>(source, Signal.Return(One), null!));
+        Assert.Throws<ArgumentNullException>(() => LinqMixins.ForkJoin<int, int, int>(source, Signal.Emit(One), null!));
         Assert.Throws<ArgumentNullException>(() => ((IObservable<int>)null!).AsObservable());
         Assert.Throws<ArgumentNullException>(() => ((IEnumerable<int>)null!).ToObservable());
         Assert.Throws<ArgumentNullException>(() => ((IEnumerable<int>)null!).ToObservable(CancellationToken.None));
         Assert.Throws<ArgumentOutOfRangeException>(() => source.Take(-1));
         Assert.Throws<ArgumentOutOfRangeException>(() => source.Skip(-1));
-        Assert.Throws<ArgumentOutOfRangeException>(() => source.Retry(-1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => source.Reattempt(-1));
     }
 
     /// <summary>
@@ -222,9 +222,9 @@ public class CoverageRemainderTests
         var timerPeriodicValues = new List<long>();
         var clock = new TestClock(DateTimeOffset.UnixEpoch);
 
-        Signal.Range(Three, Three, Sequencer.CurrentThread).Subscribe(rangeValues.Add);
-        Signal.Repeat("r").Take(Three).Subscribe(repeatValues.Add);
-        Signal.Repeat(Five, Two).Subscribe(repeatCountValues.Add);
+        Signal.Sequence(Three, Three, Sequencer.CurrentThread).Subscribe(rangeValues.Add);
+        Signal.Loop("r").Take(Three).Subscribe(repeatValues.Add);
+        Signal.Loop(Five, Two).Subscribe(repeatCountValues.Add);
         Signal.Start(() => Seven, Sequencer.CurrentThread).Subscribe(startValues.Add);
         Signal.Start(() => startActions++, Sequencer.CurrentThread).Subscribe(_ => { });
 
@@ -238,8 +238,8 @@ public class CoverageRemainderTests
 
         Signal.After(TimeSpan.FromTicks(Two), clock).Subscribe(afterValues.Add);
         Signal.Every(TimeSpan.FromTicks(Two), clock).Take(Three).Subscribe(everyValues.Add);
-        Signal.Timer(DateTimeOffset.UnixEpoch.AddTicks(Three), clock).Subscribe(timerDateValues.Add);
-        Signal.Timer(TimeSpan.FromTicks(Three), TimeSpan.FromTicks(Two), clock).Subscribe(timerPeriodicValues.Add);
+        Signal.After(DateTimeOffset.UnixEpoch.AddTicks(Three), clock).Subscribe(timerDateValues.Add);
+        Signal.After(TimeSpan.FromTicks(Three), TimeSpan.FromTicks(Two), clock).Subscribe(timerPeriodicValues.Add);
         clock.AdvanceBy(TimeSpan.FromTicks(Two));
         clock.AdvanceBy(TimeSpan.FromTicks(One));
         clock.AdvanceBy(TimeSpan.FromTicks(Four));
@@ -256,9 +256,9 @@ public class CoverageRemainderTests
         Assert.Equal(new long[] { 0L }, timerDateValues);
         Assert.Equal(new long[] { 0L, 1L, 2L }, timerPeriodicValues);
 
-        Assert.Throws<ArgumentNullException>(() => Signal.Range(One, Two, null!));
-        Assert.Throws<ArgumentOutOfRangeException>(() => Signal.Range(One, -1));
-        Assert.Throws<ArgumentOutOfRangeException>(() => Signal.Repeat(One, -1));
+        Assert.Throws<ArgumentNullException>(() => Signal.Sequence(One, Two, null!));
+        Assert.Throws<ArgumentOutOfRangeException>(() => Signal.Sequence(One, -1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => Signal.Loop(One, -1));
         Assert.Throws<ArgumentNullException>(() => Signal.FromEnumerable<int>(null!));
         Assert.Throws<ArgumentNullException>(() => Signal.FromEnumerable<int>(null!, CancellationToken.None));
         Assert.Throws<ArgumentNullException>(() => Signal.FromTask<int>((Task<int>)null!));
@@ -272,9 +272,9 @@ public class CoverageRemainderTests
         Assert.Throws<ArgumentNullException>(() => Signal.FromAsyncEnumerable<int>(null!, CancellationToken.None));
         Assert.Throws<ArgumentNullException>(() => Signal.After(TimeSpan.Zero, null!));
         Assert.Throws<ArgumentNullException>(() => Signal.Every(TimeSpan.FromTicks(One), null!));
-        Assert.Throws<ArgumentNullException>(() => Signal.Timer(TimeSpan.Zero, null!));
-        Assert.Throws<ArgumentNullException>(() => Signal.Timer(DateTimeOffset.UnixEpoch, null!));
-        Assert.Throws<ArgumentNullException>(() => Signal.Timer(TimeSpan.Zero, TimeSpan.FromTicks(One), null!));
+        Assert.Throws<ArgumentNullException>(() => Signal.After(TimeSpan.Zero, null!));
+        Assert.Throws<ArgumentNullException>(() => Signal.After(DateTimeOffset.UnixEpoch, null!));
+        Assert.Throws<ArgumentNullException>(() => Signal.After(TimeSpan.Zero, TimeSpan.FromTicks(One), null!));
     }
 
     /// <summary>
@@ -383,7 +383,7 @@ public class CoverageRemainderTests
     {
         var canceled = new List<Exception>();
         using var cts = new CancellationTokenSource();
-        var taskSignal = new TaskSignal<int>(_ => Signal.Never<int>(), Sequencer.CurrentThread, cts);
+        var taskSignal = new TaskSignal<int>(_ => Signal.Silent<int>(), Sequencer.CurrentThread, cts);
         taskSignal.GetOperationCanceled(Witness.Create<Exception>(canceled.Add));
         Assert.False(taskSignal.IsCancellationRequested);
         taskSignal.Dispose();
@@ -409,16 +409,16 @@ public class CoverageRemainderTests
         var timeoutErrors = new List<string>();
         var clock = new TestClock(DateTimeOffset.UnixEpoch);
 
-        source.StartWith(Two).Subscribe(startOne.Add);
-        source.StartWith((IEnumerable<int>)[One, Two]).Subscribe(startMany.Add);
+        source.Prepend(Two).Subscribe(startOne.Add);
+        source.Prepend((IEnumerable<int>)[One, Two]).Subscribe(startMany.Add);
         Assert.Same(source, source.ObserveOn(Sequencer.Immediate));
-        var range = Signal.Range(One, Three);
+        var range = Signal.Sequence(One, Three);
         Assert.Same(range, range.DefaultIfEmpty(NinetyNine));
-        Assert.NotNull(source.Delay(TimeSpan.Zero));
-        Assert.NotNull(source.Timeout(TimeSpan.FromTicks(One)));
-        source.DelaySubscription(TimeSpan.FromTicks(Two), clock).Subscribe(delayed.Add);
-        Signal.Throw<int>(new InvalidOperationException("delay-error")).Delay(TimeSpan.FromTicks(Two), clock).Subscribe(_ => { }, ex => delayErrors.Add(ex.Message));
-        Signal.Never<int>().Timeout(TimeSpan.FromTicks(Three), clock).Subscribe(_ => { }, ex => timeoutErrors.Add(ex.GetType().Name));
+        Assert.NotNull(source.Shift(TimeSpan.Zero));
+        Assert.NotNull(source.Expire(TimeSpan.FromTicks(One)));
+        source.DelayStart(TimeSpan.FromTicks(Two), clock).Subscribe(delayed.Add);
+        Signal.Fail<int>(new InvalidOperationException("delay-error")).Shift(TimeSpan.FromTicks(Two), clock).Subscribe(_ => { }, ex => delayErrors.Add(ex.Message));
+        Signal.Silent<int>().Expire(TimeSpan.FromTicks(Three), clock).Subscribe(_ => { }, ex => timeoutErrors.Add(ex.GetType().Name));
         clock.AdvanceBy(TimeSpan.FromTicks(Three));
 
         Assert.Equal(new[] { Two, Three, Four }, startOne);
@@ -431,9 +431,9 @@ public class CoverageRemainderTests
         var falseValues = new List<bool>();
         var rxVoidValues = new List<RxVoid>();
         var inlineCompleted = 0;
-        var trueSignal = Signal.Return(true);
-        var falseSignal = Signal.Return(false);
-        var rxVoidSignal = Signal.ReturnRxVoid();
+        var trueSignal = Signal.Emit(true);
+        var falseSignal = Signal.Emit(false);
+        var rxVoidSignal = Signal.EmitRxVoid();
         trueSignal.Subscribe(new RecordingObserver<bool>());
         falseSignal.Subscribe(new RecordingObserver<bool>());
         rxVoidSignal.Subscribe(new RecordingObserver<RxVoid>());
@@ -524,7 +524,7 @@ public class CoverageRemainderTests
         Assert.Equal(1, buffers.Count);
         Assert.Equal(new[] { One, Two }, buffers[0]);
 
-        var errorBuffer = new BufferSignal<int, List<int>>(Signal.Throw<int>(new InvalidOperationException("buffer-error")), Two, One);
+        var errorBuffer = new BufferSignal<int, List<int>>(Signal.Fail<int>(new InvalidOperationException("buffer-error")), Two, One);
         Assert.True(errorBuffer.IsDisposed || !errorBuffer.HasObservers);
     }
 
@@ -548,20 +548,20 @@ public class CoverageRemainderTests
         Assert.Throws<InvalidOperationException>(() => Signal.FromEnumerable(["a", "bb"])
             .DistinctBy(value => value.Length == 1 ? value.Length : throw new InvalidOperationException("distinct-key"))
             .Subscribe(_ => { }, ex => distinctErrors.Add(ex.Message)).Dispose());
-        ReactiveUI.Primitives.Signals.Signal.Catch<int, InvalidOperationException>(
-                Signal.Throw<int>(new InvalidOperationException("typed-catch")),
-                _ => Signal.Return(Five))
+        ReactiveUI.Primitives.Signals.Signal.Recover<int, InvalidOperationException>(
+                Signal.Fail<int>(new InvalidOperationException("typed-catch")),
+                _ => Signal.Emit(Five))
             .Subscribe(catchValues.Add, ex => catchErrors.Add(ex.Message));
-        ReactiveUI.Primitives.Signals.Signal.Catch<int, InvalidOperationException>(
-                Signal.Throw<int>(new InvalidOperationException("handler-fault")),
+        ReactiveUI.Primitives.Signals.Signal.Recover<int, InvalidOperationException>(
+                Signal.Fail<int>(new InvalidOperationException("handler-fault")),
                 _ => throw new FormatException("handler-threw"))
             .Subscribe(_ => { }, ex => catchErrors.Add(ex.Message));
-        ReactiveUI.Primitives.Signals.Signal.Catch<int, InvalidOperationException>(
-                Signal.Throw<int>(new ArgumentException("not-matched")),
-                _ => Signal.Return(Six))
+        ReactiveUI.Primitives.Signals.Signal.Recover<int, InvalidOperationException>(
+                Signal.Fail<int>(new ArgumentException("not-matched")),
+                _ => Signal.Emit(Six))
             .Subscribe(_ => { }, ex => catchErrors.Add(ex.Message));
-        Signal.Throw<int>(new InvalidOperationException("finally-error"))
-            .Finally(() => finallyCalls++)
+        Signal.Fail<int>(new InvalidOperationException("finally-error"))
+            .OnCleanup(() => finallyCalls++)
             .Subscribe(_ => { }, _ => { });
 
         Assert.Equal(new[] { "keep-predicate" }, keepErrors);
@@ -702,15 +702,15 @@ public class CoverageRemainderTests
         var emptyScheduled = new List<int>();
         var emptyCompleted = 0;
         var emptyClock = new TestClock(DateTimeOffset.UnixEpoch);
-        Signal.Empty<int>(emptyClock).Subscribe(emptyScheduled.Add, ex => throw ex, () => emptyCompleted++);
+        Signal.None<int>(emptyClock).Subscribe(emptyScheduled.Add, ex => throw ex, () => emptyCompleted++);
         Assert.Equal(0, emptyCompleted);
         emptyClock.Start();
         Assert.Equal(1, emptyCompleted);
-        Assert.Throws<ArgumentNullException>(() => Signal.Empty<int>().Subscribe((IObserver<int>)null!));
+        Assert.Throws<ArgumentNullException>(() => Signal.None<int>().Subscribe((IObserver<int>)null!));
 
         var repeatValues = new List<int>();
         var repeatCompleted = 0;
-        var repeat = Signal.Repeat(Seven, Three);
+        var repeat = Signal.Loop(Seven, Three);
         Assert.False(((IRequireCurrentThread<int>)repeat).IsRequiredSubscribeOnCurrentThread());
         repeat.Subscribe(new RecordingObserver<int>()).Dispose();
         Assert.Throws<ArgumentNullException>(() => repeat.Subscribe((IObserver<int>)null!));
@@ -721,7 +721,7 @@ public class CoverageRemainderTests
 
         var zippedValues = new List<int>();
         var zippedCompleted = 0;
-        var zipped = Signal.Range(One, Three).Zip(Signal.Range(Four, Three), (left, right) => left + right);
+        var zipped = Signal.Sequence(One, Three).Pair(Signal.Sequence(Four, Three), (left, right) => left + right);
         Assert.False(((IRequireCurrentThread<int>)zipped).IsRequiredSubscribeOnCurrentThread());
         Assert.Throws<ArgumentNullException>(() => zipped.Subscribe((IObserver<int>)null!));
         Assert.Throws<ArgumentNullException>(() => ((IInlineSignal<int>)zipped).Subscribe(null!, _ => { }, () => { }));
@@ -732,12 +732,12 @@ public class CoverageRemainderTests
         var returned = new List<string>();
         var returnCompleted = 0;
         var returnClock = new TestClock(DateTimeOffset.UnixEpoch);
-        Signal.Return("scheduled", returnClock).Subscribe(returned.Add, ex => throw ex, () => returnCompleted++);
+        Signal.Emit("scheduled", returnClock).Subscribe(returned.Add, ex => throw ex, () => returnCompleted++);
         Assert.Equal(0, returnCompleted);
         returnClock.AdvanceBy(TimeSpan.FromTicks(One));
         Assert.Equal(new[] { "scheduled" }, returned);
         Assert.Equal(1, returnCompleted);
-        Assert.Throws<ArgumentNullException>(() => Signal.Return("immediate").Subscribe((IObserver<string>)null!));
+        Assert.Throws<ArgumentNullException>(() => Signal.Emit("immediate").Subscribe((IObserver<string>)null!));
 
         var mappedErrors = new List<string>();
         Signal.FromEnumerable([One, Two]).Map(value => value == One ? value : throw new InvalidOperationException("map-fault"))
@@ -752,35 +752,35 @@ public class CoverageRemainderTests
     public void InlineOperatorObserverAndErrorCleanupPathsCoverRemainingBranches()
     {
         var observerValues = new RecordingObserver<int>();
-        Signal.Return(Three).StartWith(Two).Subscribe(observerValues).Dispose();
+        Signal.Emit(Three).Prepend(Two).Subscribe(observerValues).Dispose();
         Assert.Equal(new[] { Two, Three }, observerValues.Values);
         Assert.Equal(1, observerValues.Completed);
 
         var enumerableValues = new RecordingObserver<int>();
-        LinqMixins.StartWith(Signal.Return(Three), (IEnumerable<int>)[One, Two]).Subscribe(enumerableValues).Dispose();
+        LinqMixins.Prepend(Signal.Emit(Three), (IEnumerable<int>)[One, Two]).Subscribe(enumerableValues).Dispose();
         Assert.Equal(new[] { One, Two, Three }, enumerableValues.Values);
         Assert.Equal(1, enumerableValues.Completed);
 
         var prependAppendValues = new RecordingObserver<int>();
-        Signal.Return(Two).Prepend(One).Append(Three).Subscribe(prependAppendValues).Dispose();
+        Signal.Emit(Two).Prepend(One).Append(Three).Subscribe(prependAppendValues).Dispose();
         Assert.Equal(new[] { One, Two, Three }, prependAppendValues.Values);
         Assert.Equal(1, prependAppendValues.Completed);
 
-        Assert.Throws<ArgumentNullException>(() => Signal.Return(One).Prepend(Two).Subscribe((IObserver<int>)null!));
-        Assert.Throws<ArgumentNullException>(() => LinqMixins.StartWith(Signal.Return(One), (IEnumerable<int>)[Two]).Subscribe((IObserver<int>)null!));
-        Assert.Throws<ArgumentNullException>(() => Signal.Return(One).Prepend(Two).Append(Three).Subscribe((IObserver<int>)null!));
-        Assert.Throws<ArgumentNullException>(() => Signal.Return(One).Append(Two).Subscribe((IObserver<int>)null!));
+        Assert.Throws<ArgumentNullException>(() => Signal.Emit(One).Prepend(Two).Subscribe((IObserver<int>)null!));
+        Assert.Throws<ArgumentNullException>(() => LinqMixins.Prepend(Signal.Emit(One), (IEnumerable<int>)[Two]).Subscribe((IObserver<int>)null!));
+        Assert.Throws<ArgumentNullException>(() => Signal.Emit(One).Prepend(Two).Append(Three).Subscribe((IObserver<int>)null!));
+        Assert.Throws<ArgumentNullException>(() => Signal.Emit(One).Append(Two).Subscribe((IObserver<int>)null!));
 
-        Assert.Throws<InvalidOperationException>(() => Signal.Return(One).Append(Two).Subscribe(new ThrowingObserver<int>(throwOnNext: true)).Dispose());
+        Assert.Throws<InvalidOperationException>(() => Signal.Emit(One).Append(Two).Subscribe(new ThrowingObserver<int>(throwOnNext: true)).Dispose());
         var appendErrorObserver = new ThrowingObserver<int>(throwOnError: true);
-        Assert.Throws<InvalidOperationException>(() => Signal.Throw<int>(new InvalidOperationException("append-error")).Append(Two).Subscribe(appendErrorObserver).Dispose());
+        Assert.Throws<InvalidOperationException>(() => Signal.Fail<int>(new InvalidOperationException("append-error")).Append(Two).Subscribe(appendErrorObserver).Dispose());
         Assert.True(appendErrorObserver.SeenError);
 
-        Assert.Throws<InvalidOperationException>(() => Signal.Return(One).DefaultIfEmpty(Two).Subscribe(new ThrowingObserver<int>(throwOnNext: true)).Dispose());
+        Assert.Throws<InvalidOperationException>(() => Signal.Emit(One).DefaultIfEmpty(Two).Subscribe(new ThrowingObserver<int>(throwOnNext: true)).Dispose());
 
         var delegateErrors = 0;
-        Assert.Throws<InvalidOperationException>(() => Signal.Return(Two).Prepend(One).Append(Three).Subscribe(_ => throw new InvalidOperationException("delegate-next"), _ => delegateErrors++, () => { }).Dispose());
-        Signal.Throw<int>(new InvalidOperationException("delegate-error")).Prepend(One).Append(Three).Subscribe(_ => { }, _ => delegateErrors++, () => { }).Dispose();
+        Assert.Throws<InvalidOperationException>(() => Signal.Emit(Two).Prepend(One).Append(Three).Subscribe(_ => throw new InvalidOperationException("delegate-next"), _ => delegateErrors++, () => { }).Dispose());
+        Signal.Fail<int>(new InvalidOperationException("delegate-error")).Prepend(One).Append(Three).Subscribe(_ => { }, _ => delegateErrors++, () => { }).Dispose();
         Assert.Equal(1, delegateErrors);
     }
 
@@ -799,8 +799,8 @@ public class CoverageRemainderTests
 
         var rangeDistinctCount = new RecordingObserver<int>();
         var rangeDistinctLongCount = new RecordingObserver<long>();
-        Signal.Range(One, Four).DistinctBy(value => value % Two, EqualityComparer<int>.Default).Count().Subscribe(rangeDistinctCount).Dispose();
-        Signal.Range(One, Four).DistinctBy(value => value % Two, EqualityComparer<int>.Default).LongCount().Subscribe(rangeDistinctLongCount).Dispose();
+        Signal.Sequence(One, Four).DistinctBy(value => value % Two, EqualityComparer<int>.Default).Count().Subscribe(rangeDistinctCount).Dispose();
+        Signal.Sequence(One, Four).DistinctBy(value => value % Two, EqualityComparer<int>.Default).LongCount().Subscribe(rangeDistinctLongCount).Dispose();
         Assert.Equal(new[] { Two }, rangeDistinctCount.Values);
         Assert.Equal(new long[] { 2L }, rangeDistinctLongCount.Values);
 
@@ -821,7 +821,7 @@ public class CoverageRemainderTests
         Assert.Equal(0, anyErrors.Values.Count);
 
         var containsRange = new RecordingObserver<bool>();
-        Signal.Range(One, Four).Contains(Three, EqualityComparer<int>.Default).Subscribe(containsRange).Dispose();
+        Signal.Sequence(One, Four).Contains(Three, EqualityComparer<int>.Default).Subscribe(containsRange).Dispose();
         Assert.Equal(new[] { true }, containsRange.Values);
     }
 
@@ -835,7 +835,7 @@ public class CoverageRemainderTests
         var raceLoser = new Signal<int>();
         var raceErrorOuter = new Signal<IObservable<int>>();
         var raceErrorSubscription = raceErrorOuter.Race().Subscribe(raceErrorWinner);
-        raceErrorOuter.OnNext(Signal.Throw<int>(new InvalidOperationException("race-error")));
+        raceErrorOuter.OnNext(Signal.Fail<int>(new InvalidOperationException("race-error")));
         raceErrorOuter.OnNext(raceLoser);
         raceLoser.OnCompleted();
         raceErrorSubscription.Dispose();
@@ -856,7 +856,7 @@ public class CoverageRemainderTests
         var left = new Signal<int>();
         var right = new Signal<int>();
         var combined = new RecordingObserver<int>();
-        var combineSubscription = left.CombineLatest(right, (l, r) => l + r).Subscribe(combined);
+        var combineSubscription = left.SyncLatest(right, (l, r) => l + r).Subscribe(combined);
         left.OnNext(One);
         right.OnNext(Two);
         left.OnNext(Three);
@@ -871,7 +871,7 @@ public class CoverageRemainderTests
         var firstInner = new Signal<int>();
         var secondInner = new Signal<int>();
         var switched = new RecordingObserver<int>();
-        var switchSubscription = switchOuter.Switch().Subscribe(switched);
+        var switchSubscription = switchOuter.SwitchTo().Subscribe(switched);
         switchOuter.OnNext(firstInner);
         switchOuter.OnNext(secondInner);
         firstInner.OnNext(One);
@@ -942,11 +942,11 @@ public class CoverageRemainderTests
         Assert.Equal("create-error", createErrors.Errors[0].Message);
 
         var deferErrors = new RecordingObserver<int>();
-        Signal.Defer<int>(() => throw new InvalidOperationException("defer-factory")).Subscribe(deferErrors).Dispose();
+        Signal.Lazy<int>(() => throw new InvalidOperationException("defer-factory")).Subscribe(deferErrors).Dispose();
         Assert.Equal("defer-factory", deferErrors.Errors[0].Message);
 
         var immediateThrow = new RecordingObserver<int>();
-        Signal.Throw<int>(new InvalidOperationException("immediate-throw"), Sequencer.Immediate).Subscribe(immediateThrow).Dispose();
+        Signal.Fail<int>(new InvalidOperationException("immediate-throw"), Sequencer.Immediate).Subscribe(immediateThrow).Dispose();
         Assert.Equal("immediate-throw", immediateThrow.Errors[0].Message);
     }
 

--- a/src/tests/ReactiveUI.Primitives.Tests/CoverageTopUpTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/CoverageTopUpTests.cs
@@ -41,48 +41,48 @@ public sealed class CoverageTopUpTests
     {
         IObservable<int> source = Signal.FromEnumerable([Three, Four]);
         var values = new List<int>();
-        source.StartWith(Two).Subscribe(values.Add);
+        source.Prepend(Two).Subscribe(values.Add);
         Assert.Equal(new[] { Two, Three, Four }, values);
 
         var delayedStart = source.DelayStart(TimeSpan.Zero);
         Assert.NotNull(delayedStart);
 
         var fused = new List<int>();
-        Signal.Return(One).FuseLatest(Signal.FromEnumerable([Two, Three]), (left, right) => left + right).Subscribe(fused.Add);
+        Signal.Emit(One).FuseLatest(Signal.FromEnumerable([Two, Three]), (left, right) => left + right).Subscribe(fused.Add);
         Assert.Equal(new[] { Three, Four }, fused);
 
         var rangeArray = new List<int[]>();
         var rangeList = new List<IList<int>>();
-        Signal.Range(Five, Three).CollectArray().Subscribe(rangeArray.Add);
-        Signal.Range(Five, Three).CollectList().Subscribe(rangeList.Add);
+        Signal.Sequence(Five, Three).CollectArray().Subscribe(rangeArray.Add);
+        Signal.Sequence(Five, Three).CollectList().Subscribe(rangeList.Add);
         Assert.Equal<int>([Five, Six, Seven], rangeArray[0]);
         Assert.Equal<int>([Five, Six, Seven], rangeList[0]);
 
-        Assert.Equal(Ten, await Signal.Range(Ten, Three).FirstAsync().ConfigureAwait(false));
-        Assert.Equal(Ten, await Signal.Range(Ten, Three).FirstOrDefaultAsync().ConfigureAwait(false));
-        Assert.Equal(Ten, await Signal.Range(Ten, Three).FirstOrDefaultAsync(Nine).ConfigureAwait(false));
-        Assert.Equal(Twelve, await Signal.Range(Ten, Three).LastAsync().ConfigureAwait(false));
-        Assert.Equal(Twelve, await Signal.Range(Ten, Three).LastOrDefaultAsync().ConfigureAwait(false));
-        Assert.Equal(Nine, await Signal.Empty<int>().LastOrDefaultAsync(Nine).ConfigureAwait(false));
-        Assert.Equal(Three, await Signal.Range(One, Three).CountAsync(CancellationToken.None).ConfigureAwait(false));
-        Assert.Equal(Two, await Signal.Range(One, Three).CountAsync(value => value > One, CancellationToken.None).ConfigureAwait(false));
-        Assert.Equal(3L, await Signal.Range(One, Three).LongCount().ToTask(CancellationToken.None).ConfigureAwait(false));
-        Assert.Equal(2L, await Signal.Range(One, Three).LongCount(value => value > One).ToTask(CancellationToken.None).ConfigureAwait(false));
-        Assert.True(await Signal.Range(One, Three).AnyAsync(CancellationToken.None).ConfigureAwait(false));
-        Assert.True(await Signal.Range(One, Three).AnyAsync(value => value == Two, CancellationToken.None).ConfigureAwait(false));
-        Assert.True(await Signal.Range(One, Three).All(value => value < Four).ToTask(CancellationToken.None).ConfigureAwait(false));
-        Assert.True(await Signal.Range(One, Three).Contains(Three).ToTask(CancellationToken.None).ConfigureAwait(false));
-        Assert.Equal<int>([Five, Six, Seven], await Signal.Range(Five, Three).CollectArrayAsync().ConfigureAwait(false));
-        Assert.Equal<int>([Five, Six, Seven], await Signal.Range(Five, Three).CollectListAsync().ConfigureAwait(false));
+        Assert.Equal(Ten, await Signal.Sequence(Ten, Three).FirstAsync().ConfigureAwait(false));
+        Assert.Equal(Ten, await Signal.Sequence(Ten, Three).FirstOrDefaultAsync().ConfigureAwait(false));
+        Assert.Equal(Ten, await Signal.Sequence(Ten, Three).FirstOrDefaultAsync(Nine).ConfigureAwait(false));
+        Assert.Equal(Twelve, await Signal.Sequence(Ten, Three).LastAsync().ConfigureAwait(false));
+        Assert.Equal(Twelve, await Signal.Sequence(Ten, Three).LastOrDefaultAsync().ConfigureAwait(false));
+        Assert.Equal(Nine, await Signal.None<int>().LastOrDefaultAsync(Nine).ConfigureAwait(false));
+        Assert.Equal(Three, await Signal.Sequence(One, Three).CountAsync(CancellationToken.None).ConfigureAwait(false));
+        Assert.Equal(Two, await Signal.Sequence(One, Three).CountAsync(value => value > One, CancellationToken.None).ConfigureAwait(false));
+        Assert.Equal(3L, await Signal.Sequence(One, Three).LongCount().ToTask(CancellationToken.None).ConfigureAwait(false));
+        Assert.Equal(2L, await Signal.Sequence(One, Three).LongCount(value => value > One).ToTask(CancellationToken.None).ConfigureAwait(false));
+        Assert.True(await Signal.Sequence(One, Three).AnyAsync(CancellationToken.None).ConfigureAwait(false));
+        Assert.True(await Signal.Sequence(One, Three).AnyAsync(value => value == Two, CancellationToken.None).ConfigureAwait(false));
+        Assert.True(await Signal.Sequence(One, Three).All(value => value < Four).ToTask(CancellationToken.None).ConfigureAwait(false));
+        Assert.True(await Signal.Sequence(One, Three).Contains(Three).ToTask(CancellationToken.None).ConfigureAwait(false));
+        Assert.Equal<int>([Five, Six, Seven], await Signal.Sequence(Five, Three).CollectArrayAsync().ConfigureAwait(false));
+        Assert.Equal<int>([Five, Six, Seven], await Signal.Sequence(Five, Three).CollectListAsync().ConfigureAwait(false));
 
         using var canceled = new CancellationTokenSource();
         await canceled.CancelAsync().ConfigureAwait(false);
-        var canceledTask = Signal.Never<int>().ToTask(canceled.Token);
+        var canceledTask = Signal.Silent<int>().ToTask(canceled.Token);
         Assert.True(canceledTask.IsCanceled);
 
         Assert.Throws<ArgumentNullException>(() => LinqMixins.Count<int>(null!, value => value > 0));
         Assert.Throws<ArgumentNullException>(() => LinqMixins.LongCount<int>(null!, value => value > 0));
-        Assert.Throws<ArgumentNullException>(() => LinqMixins.Merge<int>(null!));
+        Assert.Throws<ArgumentNullException>(() => LinqMixins.Blend<int>(null!));
         Assert.Throws<ArgumentNullException>(() => LinqMixins.Race<int>(null!));
         Assert.Throws<ArgumentNullException>(() => LinqMixins.CollectArray<int>(null!));
         Assert.Throws<ArgumentNullException>(() => SubscribeMixins.Subscribe<int>(null!, _ => { }));
@@ -90,8 +90,8 @@ public sealed class CoverageTopUpTests
         Assert.Throws<ArgumentNullException>(() => SubscribeMixins.Subscribe<int>(null!, _ => { }, _ => { }));
         Assert.Throws<ArgumentNullException>(() => source.Subscribe(null!, _ => { }));
         Assert.Throws<ArgumentNullException>(() => source.Subscribe(_ => { }, (Action<Exception>)null!));
-        Assert.Throws<ArgumentNullException>(() => ReactiveUI.Primitives.Signals.Signal.Catch<int, InvalidOperationException>(Signal.Empty<int>(), null!));
-        Assert.Throws<ArgumentNullException>(() => ReactiveUI.Primitives.Signals.Signal.Catch<int>((IEnumerable<IObservable<int>>)null!));
+        Assert.Throws<ArgumentNullException>(() => ReactiveUI.Primitives.Signals.Signal.Recover<int, InvalidOperationException>(Signal.None<int>(), null!));
+        Assert.Throws<ArgumentNullException>(() => ReactiveUI.Primitives.Signals.Signal.Recover<int>((IEnumerable<IObservable<int>>)null!));
         Assert.Throws<ArgumentNullException>(() => ReactiveUI.Primitives.Signals.Signal.CreateSafe<int>(null!));
         Assert.Throws<ArgumentNullException>(() => StateSignalMixins.ToReadOnlyState<int, int>(null!, One, value => value));
         Assert.Throws<ArgumentNullException>(() => source.ToReadOnlyState(One, null!));
@@ -102,22 +102,22 @@ public sealed class CoverageTopUpTests
     public void ImmediateCoreSignalsRangeZipRepeatAndObserverFailuresCoverRemainders()
     {
         var completed = 0;
-        Signal.Empty<int>(Sequencer.Immediate).Subscribe(_ => { }, ex => throw ex, () => completed++);
-        Signal.Empty<int>(default(int)).Subscribe(_ => { }, ex => throw ex, () => completed++);
+        Signal.None<int>(Sequencer.Immediate).Subscribe(_ => { }, ex => throw ex, () => completed++);
+        Signal.None<int>(default(int)).Subscribe(_ => { }, ex => throw ex, () => completed++);
         Assert.Equal(Two, completed);
 
         var returnValues = new List<int>();
-        Signal.Return(FortyTwo, Sequencer.Immediate).Subscribe(returnValues.Add);
+        Signal.Emit(FortyTwo, Sequencer.Immediate).Subscribe(returnValues.Add);
         Assert.Equal(new[] { FortyTwo }, returnValues);
 
         var throwErrors = new List<string>();
-        Signal.Throw<int>(new InvalidOperationException("immediate"), Sequencer.Immediate).Subscribe(_ => { }, ex => throwErrors.Add(ex.Message));
-        Signal.Throw(new InvalidOperationException("witness"), Sequencer.Immediate, default(int)).Subscribe(_ => { }, ex => throwErrors.Add(ex.Message));
+        Signal.Fail<int>(new InvalidOperationException("immediate"), Sequencer.Immediate).Subscribe(_ => { }, ex => throwErrors.Add(ex.Message));
+        Signal.Fail(new InvalidOperationException("witness"), Sequencer.Immediate, default(int)).Subscribe(_ => { }, ex => throwErrors.Add(ex.Message));
         Assert.Equal(new[] { "immediate", "witness" }, throwErrors);
 
-        var never = Signal.Never<int>(default(int));
+        var never = Signal.Silent<int>(default(int));
         Assert.False(((IRequireCurrentThread<int>)never).IsRequiredSubscribeOnCurrentThread());
-        Assert.False(((IRequireCurrentThread<RxVoid>)Signal.ReturnRxVoid()).IsRequiredSubscribeOnCurrentThread());
+        Assert.False(((IRequireCurrentThread<RxVoid>)Signal.EmitRxVoid()).IsRequiredSubscribeOnCurrentThread());
         Assert.True(new RxVoid() == new RxVoid());
         Assert.False(new RxVoid() != new RxVoid());
 
@@ -156,9 +156,9 @@ public sealed class CoverageTopUpTests
         Assert.False(new RangeConcatSignal([new RangeSignal(One, Two), new RangeSignal(Three, Two)]).IsRequiredSubscribeOnCurrentThread());
         Assert.False(new SignalsBaseProbe<int>(false).IsRequiredSubscribeOnCurrentThread());
 
-        Assert.Throws<InvalidOperationException>(() => Signal.Return(One, Sequencer.Immediate).Subscribe(new ThrowingObserver<int>(throwOnNext: true)).Dispose());
-        Assert.Throws<InvalidOperationException>(() => Signal.Empty<int>(Sequencer.Immediate).Subscribe(new ThrowingObserver<int>(throwOnCompleted: true)).Dispose());
-        Assert.Throws<InvalidOperationException>(() => Signal.Throw<int>(new InvalidOperationException("observer"), Sequencer.Immediate).Subscribe(new ThrowingObserver<int>(throwOnError: true)).Dispose());
+        Assert.Throws<InvalidOperationException>(() => Signal.Emit(One, Sequencer.Immediate).Subscribe(new ThrowingObserver<int>(throwOnNext: true)).Dispose());
+        Assert.Throws<InvalidOperationException>(() => Signal.None<int>(Sequencer.Immediate).Subscribe(new ThrowingObserver<int>(throwOnCompleted: true)).Dispose());
+        Assert.Throws<InvalidOperationException>(() => Signal.Fail<int>(new InvalidOperationException("observer"), Sequencer.Immediate).Subscribe(new ThrowingObserver<int>(throwOnError: true)).Dispose());
         Assert.Throws<ArgumentNullException>(() => new ImmediateThrowSignal<int>(new InvalidOperationException("null-observer")).Subscribe((IObserver<int>)null!));
     }
 
@@ -220,8 +220,8 @@ public sealed class CoverageTopUpTests
         windowedReplay.Subscribe(windowedLate).Dispose();
         Assert.Equal(new[] { Two }, windowedLate.Values);
 
-        var shared = Signal.Range(One, Three).Share();
-        var replayed = Signal.Range(One, Three).Replay(2);
+        var shared = Signal.Sequence(One, Three).Share();
+        var replayed = Signal.Sequence(One, Three).Replay(2);
         Assert.NotNull(shared);
         Assert.NotNull(replayed);
 
@@ -297,19 +297,19 @@ public sealed class CoverageTopUpTests
         var scheduledRangeClock = new TestClock(DateTimeOffset.UnixEpoch);
         var scheduledRange = new List<int>();
         var scheduledRangeCompleted = 0;
-        Signal.Range(Three, Three, scheduledRangeClock).Subscribe(scheduledRange.Add, ex => throw ex, () => scheduledRangeCompleted++);
+        Signal.Sequence(Three, Three, scheduledRangeClock).Subscribe(scheduledRange.Add, ex => throw ex, () => scheduledRangeCompleted++);
         scheduledRangeClock.Start();
         Assert.Equal<int>([Three, Four, Five], scheduledRange);
         Assert.Equal(1, scheduledRangeCompleted);
 
         Assert.NotNull(Signal.After(TimeSpan.FromTicks(One)));
         Assert.NotNull(Signal.Pulse(TimeSpan.FromTicks(One)));
-        Assert.NotNull(Signal.Interval(TimeSpan.FromTicks(One)));
-        Assert.NotNull(Signal.Interval(TimeSpan.FromTicks(One), new TestClock(DateTimeOffset.UnixEpoch)));
-        Assert.NotNull(Signal.Timer(TimeSpan.FromTicks(One)));
-        Assert.NotNull(Signal.Timer(DateTimeOffset.UtcNow.AddMilliseconds(1)));
-        Assert.NotNull(Signal.Timer(TimeSpan.FromTicks(One), TimeSpan.FromTicks(One)));
-        Assert.NotNull(Signal.ZipLatest(Signal.Range(One, Two), Signal.Range(Three, Two), (left, right) => left + right));
+        Assert.NotNull(Signal.Pulse(TimeSpan.FromTicks(One)));
+        Assert.NotNull(Signal.Pulse(TimeSpan.FromTicks(One), new TestClock(DateTimeOffset.UnixEpoch)));
+        Assert.NotNull(Signal.After(TimeSpan.FromTicks(One)));
+        Assert.NotNull(Signal.After(DateTimeOffset.UtcNow.AddMilliseconds(1)));
+        Assert.NotNull(Signal.After(TimeSpan.FromTicks(One), TimeSpan.FromTicks(One)));
+        Assert.NotNull(Signal.PairLatest(Signal.Sequence(One, Two), Signal.Sequence(Three, Two), (left, right) => left + right));
 
         var toSignalValues = new List<int>();
         new[] { One, Two }.ToSignal().Subscribe(toSignalValues.Add);
@@ -324,27 +324,27 @@ public sealed class CoverageTopUpTests
         Assert.Equal(default(int), await Task.FromCanceled<int>(new CancellationToken(true)).HandleCancellation().ConfigureAwait(false));
 
         var longCount = new List<long>();
-        Signal.Range(One, Four).LongCount(value => value % 2 == 0).Subscribe(longCount.Add);
+        Signal.Sequence(One, Four).LongCount(value => value % 2 == 0).Subscribe(longCount.Add);
         Assert.Equal(new long[] { 2L }, longCount);
 
         var containsWithComparer = new List<bool>();
-        Signal.Range(One, Three).Contains(Three, EqualityComparer<int>.Default).Subscribe(containsWithComparer.Add);
-        Signal.Range(One, Three).Contains(Nine, EqualityComparer<int>.Default).Subscribe(containsWithComparer.Add);
-        Signal.Range(One, Three).Contains(Three, new PassthroughComparer()).Subscribe(containsWithComparer.Add);
-        Signal.Range(One, Three).Contains(Nine, new PassthroughComparer()).Subscribe(containsWithComparer.Add);
+        Signal.Sequence(One, Three).Contains(Three, EqualityComparer<int>.Default).Subscribe(containsWithComparer.Add);
+        Signal.Sequence(One, Three).Contains(Nine, EqualityComparer<int>.Default).Subscribe(containsWithComparer.Add);
+        Signal.Sequence(One, Three).Contains(Three, new PassthroughComparer()).Subscribe(containsWithComparer.Add);
+        Signal.Sequence(One, Three).Contains(Nine, new PassthroughComparer()).Subscribe(containsWithComparer.Add);
         Assert.Equal(new[] { true, false, true, false }, containsWithComparer);
 
         var startWithAlias = new List<int>();
-        LinqMixins.StartWith(Signal.Return(Two), One).Subscribe(startWithAlias.Add);
+        LinqMixins.Prepend(Signal.Emit(Two), One).Subscribe(startWithAlias.Add);
         Assert.Equal(new[] { One, Two }, startWithAlias);
-        Assert.NotNull(LinqMixins.DelayStart(Signal.Return(One), TimeSpan.Zero));
-        Assert.Equal(0, await Signal.Empty<int>().FirstOrDefaultAsync().ConfigureAwait(false));
+        Assert.NotNull(LinqMixins.DelayStart(Signal.Emit(One), TimeSpan.Zero));
+        Assert.Equal(0, await Signal.None<int>().FirstOrDefaultAsync().ConfigureAwait(false));
 
         Assert.Throws<ArgumentNullException>(() => LinqMixins.Buffer<int>(null!, One));
-        Assert.Throws<ArgumentOutOfRangeException>(() => Signal.Return(One).Buffer(0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => Signal.Emit(One).Buffer(0));
         Assert.Throws<ArgumentNullException>(() => LinqMixins.Buffer<int>(null!, One, One));
-        Assert.Throws<ArgumentOutOfRangeException>(() => Signal.Return(One).Buffer(0, One));
-        Assert.Throws<ArgumentOutOfRangeException>(() => Signal.Return(One).Buffer(One, 0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => Signal.Emit(One).Buffer(0, One));
+        Assert.Throws<ArgumentOutOfRangeException>(() => Signal.Emit(One).Buffer(One, 0));
 
         Assert.Throws<ArgumentNullException>(() => ((IObservable<int>)null!).FirstAsync());
         Assert.Throws<ArgumentNullException>(() => ((IObservable<int>)null!).FirstOrDefaultAsync());
@@ -405,7 +405,7 @@ public sealed class CoverageTopUpTests
         var secondInner = new Signal<int>();
         var selectManyValues = new List<int>();
         var selectManyCompleted = 0;
-        using (outer.SelectMany(inner => inner).Subscribe(selectManyValues.Add, ex => throw ex, () => selectManyCompleted++))
+        using (outer.FlatMap(inner => inner).Subscribe(selectManyValues.Add, ex => throw ex, () => selectManyCompleted++))
         {
             outer.OnNext(firstInner);
             outer.OnNext(secondInner);
@@ -422,7 +422,7 @@ public sealed class CoverageTopUpTests
         var disposedOuter = new Signal<IObservable<int>>();
         var disposedInner = new Signal<int>();
         var disposedValues = new List<int>();
-        var disposedSubscription = disposedOuter.SelectMany(inner => inner).Subscribe(disposedValues.Add);
+        var disposedSubscription = disposedOuter.FlatMap(inner => inner).Subscribe(disposedValues.Add);
         disposedOuter.OnNext(disposedInner);
         disposedSubscription.Dispose();
         disposedSubscription.Dispose();
@@ -430,8 +430,8 @@ public sealed class CoverageTopUpTests
         Assert.Equal(0, disposedValues.Count);
 
         var subscribeErrors = new List<string>();
-        Signal.Return(One)
-            .SelectMany(_ => new ThrowOnSubscribeObservable<int>(new InvalidOperationException("inner-subscribe")))
+        Signal.Emit(One)
+            .FlatMap(_ => new ThrowOnSubscribeObservable<int>(new InvalidOperationException("inner-subscribe")))
             .Subscribe(_ => { }, ex => subscribeErrors.Add(ex.Message));
         Assert.Equal(new[] { "inner-subscribe" }, subscribeErrors);
     }

--- a/src/tests/ReactiveUI.Primitives.Tests/CoverageTopUpTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/CoverageTopUpTests.cs
@@ -46,10 +46,22 @@ public sealed class CoverageTopUpTests
 
         var delayedStart = source.DelayStart(TimeSpan.Zero);
         Assert.NotNull(delayedStart);
+        Assert.NotNull(source.DelaySubscription(TimeSpan.Zero));
+        Assert.NotNull(source.DelaySubscription(TimeSpan.Zero, Sequencer.Immediate));
+        Assert.NotNull(source.Stabilize(TimeSpan.Zero));
+        Assert.NotNull(source.Stabilize(TimeSpan.Zero, Sequencer.Immediate));
 
         var fused = new List<int>();
         Signal.Emit(One).FuseLatest(Signal.FromEnumerable([Two, Three]), (left, right) => left + right).Subscribe(fused.Add);
         Assert.Equal(new[] { Three, Four }, fused);
+
+        var chainedStrings = new List<string>();
+        Signal.Chain(Signal.Emit("value")).Subscribe(chainedStrings.Add);
+        Assert.Equal(new[] { "value" }, chainedStrings);
+
+        var ignoredCatchCompleted = 0;
+        Signal.Fail<int>(new InvalidOperationException("ignored")).Recover<int, Exception>(Handle.CatchIgnore<int>).Subscribe(_ => { }, ex => throw ex, () => ignoredCatchCompleted++);
+        Assert.Equal(1, ignoredCatchCompleted);
 
         var rangeArray = new List<int[]>();
         var rangeList = new List<IList<int>>();
@@ -339,6 +351,9 @@ public sealed class CoverageTopUpTests
         Assert.Equal(new[] { One, Two }, startWithAlias);
         Assert.NotNull(LinqMixins.DelayStart(Signal.Emit(One), TimeSpan.Zero));
         Assert.Equal(0, await Signal.None<int>().FirstOrDefaultAsync().ConfigureAwait(false));
+        var noneWitnessCompleted = 0;
+        Signal.None(Sequencer.Immediate, One).Subscribe(_ => { }, ex => throw ex, () => noneWitnessCompleted++);
+        Assert.Equal(1, noneWitnessCompleted);
 
         Assert.Throws<ArgumentNullException>(() => LinqMixins.Buffer<int>(null!, One));
         Assert.Throws<ArgumentOutOfRangeException>(() => Signal.Emit(One).Buffer(0));
@@ -428,6 +443,21 @@ public sealed class CoverageTopUpTests
         disposedSubscription.Dispose();
         disposedInner.OnNext(Three);
         Assert.Equal(0, disposedValues.Count);
+
+        Assert.Throws<ArgumentNullException>(() => outer.FlatMap(inner => inner).Subscribe(null!));
+        Assert.Throws<ArgumentNullException>(() => outer.FlatMap(inner => inner, (left, right) => right).Subscribe(null!));
+
+        var nullSelectorErrors = new List<string>();
+        Signal.Emit(One).FlatMap<int, int>(_ => null!).Subscribe(_ => { }, ex => nullSelectorErrors.Add(ex.Message));
+        Assert.Equal(new[] { "The FlatMap selector returned null." }, nullSelectorErrors);
+
+        var nullCollectionErrors = new List<string>();
+        Signal.Emit(One).FlatMap<int, int, int>(_ => null!, (left, right) => left + right).Subscribe(_ => { }, ex => nullCollectionErrors.Add(ex.Message));
+        Assert.Equal(new[] { "The FlatMap collection selector returned null." }, nullCollectionErrors);
+
+        var resultInnerErrors = new List<string>();
+        Signal.Emit(One).FlatMap(_ => Signal.Fail<int>(new InvalidOperationException("result-inner")), (left, right) => left + right).Subscribe(_ => { }, ex => resultInnerErrors.Add(ex.Message));
+        Assert.Equal(new[] { "result-inner" }, resultInnerErrors);
 
         var subscribeErrors = new List<string>();
         Signal.Emit(One)

--- a/src/tests/ReactiveUI.Primitives.Tests/FactoryOperatorContractTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/FactoryOperatorContractTests.cs
@@ -300,10 +300,10 @@ public class FactoryOperatorContractTests
         var completed = 0;
         var disposed = 0;
 
-        Signal.Range(SecondValue, RetrySuccessAttempt)
-            .Concat(Signal.Repeat(RepeatValue, SecondValue))
-            .Concat(Signal.Unfold(FirstValue, state => state <= RetrySuccessAttempt, state => state + FirstValue, state => state * ProjectionMultiplier))
-            .Concat(Signal.Use(
+        Signal.Sequence(SecondValue, RetrySuccessAttempt)
+            .Chain(Signal.Loop(RepeatValue, SecondValue))
+            .Chain(Signal.Unfold(FirstValue, state => state <= RetrySuccessAttempt, state => state + FirstValue, state => state * ProjectionMultiplier))
+            .Chain(Signal.Use(
                 () => Disposable.Create(() => disposed++),
                 _ => Signal.FromEnumerable([ResourceFirstValue, ResourceSecondValue])))
             .Subscribe(values.Add, ex => throw ex, () => completed++);
@@ -327,15 +327,15 @@ public class FactoryOperatorContractTests
         Signal.FromEnumerable([FirstValue, SecondValue, SecondValue, RetrySuccessAttempt, FourthValue])
             .Map(value => value * SecondValue)
             .Keep(value => value >= FourthValue)
-            .DistinctUntilChanged()
+            .Unique()
             .Tap(_ => taps++)
-            .Scan(0, (sum, value) => sum + value)
+            .Fold(0, (sum, value) => sum + value)
             .Take(RetrySuccessAttempt)
-            .Sparkify()
+            .Spark()
             .Subscribe(sparks.Add);
 
         Signal.FromEnumerable(sparks).Unspark().Subscribe(values.Add);
-        Signal.FromEnumerable(FourItemExpected).Fold(0, (sum, value) => sum + value).Subscribe(terminal.Add);
+        Signal.FromEnumerable(FourItemExpected).Reduce(0, (sum, value) => sum + value).Subscribe(terminal.Add);
 
         Assert.Equal(UnaryExpected, values);
         Assert.Equal(new[] { ProjectedFirstValue }, terminal);
@@ -344,14 +344,14 @@ public class FactoryOperatorContractTests
     }
 
     /// <summary>
-    /// Verifies cold select and where operators detach from their source when disposed.
+    /// Verifies cold map and keep operators detach from their source when disposed.
     /// </summary>
     [Test]
-    public void SelectAndWhereStayColdUntilSubscribedAndDetachOnDispose()
+    public void MapAndKeepStayColdUntilSubscribedAndDetachOnDispose()
     {
         var source = new Signal<int>();
-        var selected = source.Select(static value => value + 1);
-        var filtered = source.Where(static value => value > 1);
+        var selected = source.Map(static value => value + 1);
+        var filtered = source.Keep(static value => value > 1);
 
         Assert.False(source.HasObservers);
 
@@ -392,19 +392,19 @@ public class FactoryOperatorContractTests
         var rangeForkJoin = new List<int>();
         var rangeObserver = new RecordingObserver<int>();
 
-        var rangeConcatSignal = Signal.Concat(Signal.Range(FirstValue, SecondValue), Signal.Range(RetrySuccessAttempt, SecondValue));
-        Signal.Merge(Signal.FromEnumerable(TakeWhileExpected), Signal.FromEnumerable([RetrySuccessAttempt, FourthValue])).Subscribe(merged.Add);
-        Signal.Concat(Signal.FromEnumerable(TakeWhileExpected), Signal.FromEnumerable([RetrySuccessAttempt, FourthValue])).Subscribe(concatenated.Add);
-        Signal.Zip(Signal.FromEnumerable(TakeWhileExpected), Signal.FromEnumerable([ProjectedFirstValue, ProjectedThirdValue]), (left, right) => left + right).Subscribe(zipped.Add);
-        Signal.CombineLatest(Signal.FromEnumerable(TakeWhileExpected), Signal.FromEnumerable(["a", "b"]), (left, right) => left + right).Subscribe(latest.Add);
+        var rangeConcatSignal = Signal.Chain(Signal.Sequence(FirstValue, SecondValue), Signal.Sequence(RetrySuccessAttempt, SecondValue));
+        Signal.Blend(Signal.FromEnumerable(TakeWhileExpected), Signal.FromEnumerable([RetrySuccessAttempt, FourthValue])).Subscribe(merged.Add);
+        Signal.Chain(Signal.FromEnumerable(TakeWhileExpected), Signal.FromEnumerable([RetrySuccessAttempt, FourthValue])).Subscribe(concatenated.Add);
+        Signal.Pair(Signal.FromEnumerable(TakeWhileExpected), Signal.FromEnumerable([ProjectedFirstValue, ProjectedThirdValue]), (left, right) => left + right).Subscribe(zipped.Add);
+        Signal.SyncLatest(Signal.FromEnumerable(TakeWhileExpected), Signal.FromEnumerable(["a", "b"]), (left, right) => left + right).Subscribe(latest.Add);
         rangeConcatSignal.Subscribe(rangeConcatenated.Add);
         rangeConcatSignal.Subscribe(rangeObserver);
-        Signal.Merge(Signal.Range(FirstValue, SecondValue), Signal.Range(RetrySuccessAttempt, SecondValue)).Subscribe(rangeMerged.Add);
-        Signal.Race(Signal.Range(FirstValue, SecondValue), Signal.Range(RetrySuccessAttempt, SecondValue)).Subscribe(rangeRace.Add);
-        Signal.Amb(Signal.Range(FirstValue, SecondValue), Signal.Range(RetrySuccessAttempt, SecondValue)).Subscribe(rangeAmb.Add);
-        Signal.CombineLatest(Signal.Range(FirstValue, SecondValue), Signal.Range(ProjectionMultiplier, SecondValue), static (left, right) => left + right).Subscribe(rangeLatest.Add);
-        Signal.Range(FirstValue, SecondValue).WithLatest(Signal.Range(ProjectionMultiplier, SecondValue), static (left, right) => left + right).Subscribe(rangeWithLatest.Add);
-        Signal.ForkJoin(Signal.Range(FirstValue, SecondValue), Signal.Range(ProjectionMultiplier, SecondValue), static (left, right) => left + right).Subscribe(rangeForkJoin.Add);
+        Signal.Blend(Signal.Sequence(FirstValue, SecondValue), Signal.Sequence(RetrySuccessAttempt, SecondValue)).Subscribe(rangeMerged.Add);
+        Signal.Race(Signal.Sequence(FirstValue, SecondValue), Signal.Sequence(RetrySuccessAttempt, SecondValue)).Subscribe(rangeRace.Add);
+        Signal.Race(Signal.Sequence(FirstValue, SecondValue), Signal.Sequence(RetrySuccessAttempt, SecondValue)).Subscribe(rangeAmb.Add);
+        Signal.SyncLatest(Signal.Sequence(FirstValue, SecondValue), Signal.Sequence(ProjectionMultiplier, SecondValue), static (left, right) => left + right).Subscribe(rangeLatest.Add);
+        Signal.Sequence(FirstValue, SecondValue).Latch(Signal.Sequence(ProjectionMultiplier, SecondValue), static (left, right) => left + right).Subscribe(rangeWithLatest.Add);
+        Signal.ForkJoin(Signal.Sequence(FirstValue, SecondValue), Signal.Sequence(ProjectionMultiplier, SecondValue), static (left, right) => left + right).Subscribe(rangeForkJoin.Add);
         Assert.Throws<ArgumentNullException>(() => rangeConcatSignal.Subscribe((IObserver<int>)null!));
         Assert.Throws<ArgumentNullException>(() => ((IInlineSignal<int>)rangeConcatSignal).Subscribe(null!, _ => { }, () => { }));
         Assert.Throws<ArgumentNullException>(() => ((IInlineSignal<int>)rangeConcatSignal).Subscribe(_ => { }, _ => { }, null!));
@@ -433,7 +433,7 @@ public class FactoryOperatorContractTests
         var values = new List<int>();
         var completed = 0;
 
-        Signal.Zip(Signal.Range(FirstValue, FourthValue), Signal.Range(ProjectionMultiplier, SecondValue), static (left, right) => left + right)
+        Signal.Pair(Signal.Sequence(FirstValue, FourthValue), Signal.Sequence(ProjectionMultiplier, SecondValue), static (left, right) => left + right)
             .Subscribe(values.Add, _ => { }, () => completed++);
 
         Assert.Equal(RangeZipShorterExpected, values);
@@ -449,14 +449,14 @@ public class FactoryOperatorContractTests
         var attempts = 0;
         var values = new List<int>();
 
-        Signal.Defer(() =>
+        Signal.Lazy(() =>
             {
                 attempts++;
                 return attempts < RetrySuccessAttempt
-                    ? Signal.Throw<int>(new InvalidOperationException("try again"))
-                    : Signal.Return(RetryResult);
+                    ? Signal.Fail<int>(new InvalidOperationException("try again"))
+                    : Signal.Emit(RetryResult);
             })
-            .Retry(RetrySuccessAttempt)
+            .Reattempt(RetrySuccessAttempt)
             .Subscribe(values.Add);
 
         Assert.Equal(RetrySuccessAttempt, attempts);
@@ -527,7 +527,7 @@ public class FactoryOperatorContractTests
         var every = new List<long>();
 
         Signal.After(TimeSpan.FromTicks(AfterTicks), clock).Subscribe(after.Add);
-        Signal.Timer(clock.Now.AddTicks(AfterTicks), clock).Subscribe(absoluteTimer.Add);
+        Signal.After(clock.Now.AddTicks(AfterTicks), clock).Subscribe(absoluteTimer.Add);
         var subscription = Signal.Every(TimeSpan.FromTicks(EveryTicks), clock).Subscribe(every.Add);
 
         clock.AdvanceBy(TimeSpan.FromTicks(InitialAdvanceTicks));
@@ -570,13 +570,13 @@ public class FactoryOperatorContractTests
         var source = new Signal<int>();
 
         Signal.FromEnumerable([SecondValue, RetrySuccessAttempt])
-            .StartWith(0, FirstValue)
-            .Do(sideEffects.Add)
+            .Prepend(0, FirstValue)
+            .Tap(sideEffects.Add)
             .AsObservable()
             .Subscribe(values.Add);
 
-        Signal.Throw<int>(new InvalidOperationException("recover"))
-            .Catch(_ => Signal.Return(RetryResult))
+        Signal.Fail<int>(new InvalidOperationException("recover"))
+            .Recover(_ => Signal.Emit(RetryResult))
             .Subscribe(recovered.Add);
 
         source.ObserveOn(clock).Subscribe(observed.Add);
@@ -608,8 +608,8 @@ public class FactoryOperatorContractTests
         var latest = new List<string>();
         var forkJoined = new List<int>();
 
-        source.Throttle(TimeSpan.FromTicks(AfterTicks), clock).Subscribe(throttled.Add);
-        source.Sample(TimeSpan.FromTicks(InitialAdvanceTicks), clock).Subscribe(sampled.Add);
+        source.Calm(TimeSpan.FromTicks(AfterTicks), clock).Subscribe(throttled.Add);
+        source.Probe(TimeSpan.FromTicks(InitialAdvanceTicks), clock).Subscribe(sampled.Add);
         source.TimeInterval(clock).Subscribe(intervals.Add);
 
         source.OnNext(FirstValue);
@@ -621,7 +621,7 @@ public class FactoryOperatorContractTests
         source.OnCompleted();
         clock.AdvanceBy(TimeSpan.FromTicks(InitialAdvanceTicks));
 
-        Signal.FromEnumerable(TakeWhileExpected).ZipLatest(Signal.FromEnumerable(["a", "b"]), (left, right) => left + right).Subscribe(latest.Add);
+        Signal.FromEnumerable(TakeWhileExpected).PairLatest(Signal.FromEnumerable(["a", "b"]), (left, right) => left + right).Subscribe(latest.Add);
         Signal.ForkJoin(Signal.FromEnumerable(TakeWhileExpected), Signal.FromEnumerable([ProjectedFirstValue, ProjectedThirdValue]), (left, right) => left + right).Subscribe(forkJoined.Add);
 
         Assert.Equal(ThrottleExpected, throttled);
@@ -642,13 +642,13 @@ public class FactoryOperatorContractTests
     {
         var first = await Signal.FromEnumerable([RetrySuccessAttempt, FourthValue]).FirstAsync();
         var collected = await Signal.FromEnumerable([FirstValue, SecondValue, RetrySuccessAttempt]).CollectArrayAsync();
-        var none = await Signal.Empty<int>().FirstOrDefaultAsync(RetryResult);
-        var rangeFirst = await Signal.Range(FirstValue, FourthValue).FirstAsync();
-        var rangeLast = await Signal.Range(FirstValue, FourthValue).ToTask();
-        var rangeCollected = await Signal.Range(FirstValue, RetrySuccessAttempt).CollectListAsync();
-        var count = await Signal.Range(FirstValue, FourthValue).CountAsync();
-        var countEven = await Signal.Range(FirstValue, FourthValue).CountAsync(static value => value % 2 == 0);
-        var any = await Signal.Range(FirstValue, FourthValue).AnyAsync(static value => value == FourthValue);
+        var none = await Signal.None<int>().FirstOrDefaultAsync(RetryResult);
+        var rangeFirst = await Signal.Sequence(FirstValue, FourthValue).FirstAsync();
+        var rangeLast = await Signal.Sequence(FirstValue, FourthValue).ToTask();
+        var rangeCollected = await Signal.Sequence(FirstValue, RetrySuccessAttempt).CollectListAsync();
+        var count = await Signal.Sequence(FirstValue, FourthValue).CountAsync();
+        var countEven = await Signal.Sequence(FirstValue, FourthValue).CountAsync(static value => value % 2 == 0);
+        var any = await Signal.Sequence(FirstValue, FourthValue).AnyAsync(static value => value == FourthValue);
 
         Assert.Equal(RetrySuccessAttempt, first);
         Assert.Equal(CollectedExpected, (IEnumerable<int>)collected);
@@ -674,9 +674,9 @@ public class FactoryOperatorContractTests
         using var cancelled = new CancellationTokenSource();
         await cancelled.CancelAsync();
 
-        Assert.Throws<ArgumentOutOfRangeException>(() => Signal.Range(FirstValue, -1));
-        Assert.Throws<ArgumentNullException>(() => Signal.Range(FirstValue, SecondValue, null!));
-        Assert.Throws<ArgumentOutOfRangeException>(() => Signal.Repeat(FirstValue, -1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => Signal.Sequence(FirstValue, -1));
+        Assert.Throws<ArgumentNullException>(() => Signal.Sequence(FirstValue, SecondValue, null!));
+        Assert.Throws<ArgumentOutOfRangeException>(() => Signal.Loop(FirstValue, -1));
         Assert.Throws<ArgumentNullException>(() => Signal.Unfold<int, int>(0, null!, static state => state, static state => state));
         Assert.Throws<ArgumentNullException>(() => Signal.Unfold<int, int>(0, static _ => true, null!, static state => state));
         Assert.Throws<ArgumentNullException>(() => Signal.Unfold<int, int>(0, static _ => true, static state => state, null!));
@@ -688,18 +688,18 @@ public class FactoryOperatorContractTests
         Assert.Throws<ArgumentNullException>(() => Signal.Start(static () => FirstValue, null!));
         Assert.Throws<ArgumentNullException>(() => Signal.Start((Action)null!));
         Assert.Throws<ArgumentNullException>(() => Signal.After(TimeSpan.Zero, null!));
-        Assert.Throws<ArgumentNullException>(() => Signal.Timer(DateTimeOffset.UnixEpoch, null!));
+        Assert.Throws<ArgumentNullException>(() => Signal.After(DateTimeOffset.UnixEpoch, null!));
         Assert.Throws<ArgumentOutOfRangeException>(() => Signal.Every(TimeSpan.FromTicks(-1)));
-        Assert.Throws<ArgumentNullException>(() => Signal.Timer(TimeSpan.Zero, TimeSpan.Zero, null!));
+        Assert.Throws<ArgumentNullException>(() => Signal.After(TimeSpan.Zero, TimeSpan.Zero, null!));
         Assert.Throws<ArgumentNullException>(() => Signal.FromAsync<int>((Func<Task<int>>)null!));
         Assert.Throws<ArgumentNullException>(() => Signal.FromAsync<int>((Func<CancellationToken, Task<int>>)null!));
         Assert.Throws<ArgumentNullException>(() => ((IObservable<int>)null!).SubscribeOn(Sequencer.Immediate));
-        Assert.Throws<ArgumentNullException>(() => Signal.Empty<int>().SubscribeOn(null!));
+        Assert.Throws<ArgumentNullException>(() => Signal.None<int>().SubscribeOn(null!));
 
-        Signal.Range(FirstValue, 0).Subscribe(values.Add, errors.Add, () => completed++);
-        Signal.Repeat(FirstValue, 0).Subscribe(values.Add, errors.Add, () => completed++);
-        Signal.Generate(FirstValue, value => value <= SecondValue, value => value + 1, value => value).Subscribe(values.Add);
-        Signal.Range(FirstValue, SecondValue).SubscribeOn(Sequencer.Immediate).Subscribe(values.Add);
+        Signal.Sequence(FirstValue, 0).Subscribe(values.Add, errors.Add, () => completed++);
+        Signal.Loop(FirstValue, 0).Subscribe(values.Add, errors.Add, () => completed++);
+        Signal.Iterate(FirstValue, value => value <= SecondValue, value => value + 1, value => value).Subscribe(values.Add);
+        Signal.Sequence(FirstValue, SecondValue).SubscribeOn(Sequencer.Immediate).Subscribe(values.Add);
         new[] { FirstValue, SecondValue }.ToObservable(cancelled.Token).Subscribe(values.Add, errors.Add, () => completed++);
         Signal.Start<int>(() => throw new InvalidOperationException("start failed"), Sequencer.Immediate).Subscribe(values.Add, errors.Add, () => completed++);
 
@@ -742,7 +742,7 @@ public class FactoryOperatorContractTests
             .Subscribe(distinctBy.Add);
         Signal.FromEnumerable([FirstValue, SecondValue, RetrySuccessAttempt, FirstValue]).TakeWhile(value => value < RetrySuccessAttempt).Subscribe(takeWhile.Add);
         Signal.FromEnumerable([FirstValue, SecondValue, RetrySuccessAttempt, FirstValue]).SkipWhile(value => value < RetrySuccessAttempt).Subscribe(skipWhile.Add);
-        Signal.Empty<int>().DefaultIfEmpty(RetryResult).Subscribe(defaulted.Add);
+        Signal.None<int>().DefaultIfEmpty(RetryResult).Subscribe(defaulted.Add);
 
         Assert.Equal(LeadAppendExpected, leadAppend);
         Assert.Equal(0, ignored.Count);
@@ -767,7 +767,7 @@ public class FactoryOperatorContractTests
         Signal.FromEnumerable([FirstValue, SecondValue, RetrySuccessAttempt]).Any(value => value == SecondValue).Subscribe(any.Add);
         Signal.FromEnumerable([SecondValue, FourthValue, SixthValue]).All(value => value % SecondValue == 0).Subscribe(all.Add);
         Signal.FromEnumerable([SecondValue, FourthValue, SixthValue]).Contains(FourthValue).Subscribe(contains.Add);
-        Signal.Empty<int>().IsEmpty().Subscribe(isEmpty.Add);
+        Signal.None<int>().IsEmpty().Subscribe(isEmpty.Add);
 
         Assert.Equal(new[] { RetrySuccessAttempt }, count);
         Assert.Equal(TrueExpected, any);
@@ -783,7 +783,7 @@ public class FactoryOperatorContractTests
     {
         var selected = new List<int>();
 
-        Signal.FromEnumerable(TakeWhileExpected).Bind(value => Signal.Range(value * ProjectionMultiplier, SecondValue)).Subscribe(selected.Add);
+        Signal.FromEnumerable(TakeWhileExpected).Bind(value => Signal.Sequence(value * ProjectionMultiplier, SecondValue)).Subscribe(selected.Add);
 
         Assert.Equal(SelectedProjectionExpected, selected);
     }
@@ -797,12 +797,12 @@ public class FactoryOperatorContractTests
         var converted = new[] { 4, AfterTicks }.ToObservable();
         var last = await converted.ToTask();
         var lastAlias = await converted.LastAsync();
-        var lastDefault = await Signal.Empty<int>().LastOrDefaultAsync(RetryResult);
-        var array = await Signal.Range(FirstValue, FourthValue).ToArrayAsync();
-        var list = await Signal.Range(FirstValue, FourthValue).ToListAsync();
+        var lastDefault = await Signal.None<int>().LastOrDefaultAsync(RetryResult);
+        var array = await Signal.Sequence(FirstValue, FourthValue).ToArrayAsync();
+        var list = await Signal.Sequence(FirstValue, FourthValue).ToListAsync();
 #pragma warning disable S6966 // This verifies the observable ToArray/ToList aliases, not async enumerable materialization.
-        var observedArray = await Signal.Range(FirstValue, SecondValue).ToArray().ToTask();
-        var observedList = await Signal.Range(FirstValue, SecondValue).ToList().ToTask();
+        var observedArray = await Signal.Sequence(FirstValue, SecondValue).ToArray().ToTask();
+        var observedList = await Signal.Sequence(FirstValue, SecondValue).ToList().ToTask();
 #pragma warning restore S6966
         var first = await Signal.FromEnumerable([RepeatValue, ProjectionMultiplier]).FirstAsync().ToTask();
         var started = await Signal.Start(() => ProjectedSecondValue, Sequencer.CurrentThread).ToTask();

--- a/src/tests/ReactiveUI.Primitives.Tests/OperatorCoverageExpansionTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/OperatorCoverageExpansionTests.cs
@@ -50,7 +50,7 @@ public class OperatorCoverageExpansionTests
     private const int DistinctErrorIndex = 3;
 
     /// <summary>
-    /// Observed error index for the outer SelectMany error.
+    /// Observed error index for the outer FlatMap error.
     /// </summary>
     private const int OuterErrorIndex = 2;
 
@@ -100,7 +100,7 @@ public class OperatorCoverageExpansionTests
     private static readonly int[] SingleFirstSource = [First];
 
     /// <summary>
-    /// Two-value source for SelectMany projection.
+    /// Two-value source for FlatMap projection.
     /// </summary>
     private static readonly int[] FirstSecondSource = [First, Second];
 
@@ -145,14 +145,14 @@ public class OperatorCoverageExpansionTests
     private static readonly bool[] FalseExpected = [false];
 
     /// <summary>
-    /// Expected queued SelectMany values.
+    /// Expected queued FlatMap values.
     /// </summary>
-    private static readonly int[] QueuedSelectManyExpected = [FirstInner, SecondInner];
+    private static readonly int[] QueuedFlatMapExpected = [FirstInner, SecondInner];
 
     /// <summary>
-    /// Expected result-selector SelectMany values.
+    /// Expected result-selector FlatMap values.
     /// </summary>
-    private static readonly int[] ResultSelectManyExpected = [First + FirstInner, Second + FirstInner];
+    private static readonly int[] ResultFlatMapExpected = [First + FirstInner, Second + FirstInner];
 
     /// <summary>
     /// Covers count, long-count, distinct fast count, and any helper branches.
@@ -182,15 +182,15 @@ public class OperatorCoverageExpansionTests
         Signal.FromEnumerable(AggregateSource).LongCount(value => value > Second).Subscribe(longCountPredicate.Add);
         Signal.FromEnumerable(DuplicateKeySource).DistinctBy(value => value).LongCount().Subscribe(distinctLongCount.Add);
         Signal.FromEnumerable(AggregateSource).Any().Subscribe(anyTrue.Add);
-        Signal.Empty<int>().Any().Subscribe(anyFalse.Add);
-        Signal.Range(First, Fourth).DistinctBy(value => value / Second).Count().Subscribe(rangeDistinctCount.Add);
-        Signal.Range(First, Fourth).DistinctBy(value => value / Second).LongCount().Subscribe(rangeDistinctLongCount.Add);
-        Signal.Range(First, Fourth).Any(value => value == Third).Subscribe(rangeAnyTrue.Add);
-        Signal.Range(First, Fourth).Any(value => value == MissingRangeValue).Subscribe(rangeAnyFalse.Add);
-        Signal.Range(First, Fourth).All(value => value > 0).Subscribe(rangeAllTrue.Add);
-        Signal.Range(First, Fourth).All(value => value < Fourth).Subscribe(rangeAllFalse.Add);
-        Signal.Range(First, Fourth).Contains(Third).Subscribe(rangeContainsTrue.Add);
-        Signal.Range(First, Fourth).Contains(MissingRangeValue).Subscribe(rangeContainsFalse.Add);
+        Signal.None<int>().Any().Subscribe(anyFalse.Add);
+        Signal.Sequence(First, Fourth).DistinctBy(value => value / Second).Count().Subscribe(rangeDistinctCount.Add);
+        Signal.Sequence(First, Fourth).DistinctBy(value => value / Second).LongCount().Subscribe(rangeDistinctLongCount.Add);
+        Signal.Sequence(First, Fourth).Any(value => value == Third).Subscribe(rangeAnyTrue.Add);
+        Signal.Sequence(First, Fourth).Any(value => value == MissingRangeValue).Subscribe(rangeAnyFalse.Add);
+        Signal.Sequence(First, Fourth).All(value => value > 0).Subscribe(rangeAllTrue.Add);
+        Signal.Sequence(First, Fourth).All(value => value < Fourth).Subscribe(rangeAllFalse.Add);
+        Signal.Sequence(First, Fourth).Contains(Third).Subscribe(rangeContainsTrue.Add);
+        Signal.Sequence(First, Fourth).Contains(MissingRangeValue).Subscribe(rangeContainsFalse.Add);
 
         Assert.Equal(CountTwoExpected, countPredicate);
         Assert.Equal(DistinctCountExpected, distinctCount);
@@ -221,10 +221,10 @@ public class OperatorCoverageExpansionTests
         var distinctError = new InvalidOperationException("distinct");
         var observed = new List<Exception>();
 
-        Signal.Throw<int>(countError).Count().Subscribe(_ => { }, observed.Add, () => { });
-        Signal.Throw<int>(longCountError).LongCount().Subscribe(_ => { }, observed.Add, () => { });
-        Signal.Throw<int>(anyError).Any().Subscribe(_ => { }, observed.Add, () => { });
-        Signal.Throw<int>(distinctError).DistinctBy(value => value).Count().Subscribe(_ => { }, observed.Add, () => { });
+        Signal.Fail<int>(countError).Count().Subscribe(_ => { }, observed.Add, () => { });
+        Signal.Fail<int>(longCountError).LongCount().Subscribe(_ => { }, observed.Add, () => { });
+        Signal.Fail<int>(anyError).Any().Subscribe(_ => { }, observed.Add, () => { });
+        Signal.Fail<int>(distinctError).DistinctBy(value => value).Count().Subscribe(_ => { }, observed.Add, () => { });
 
         Assert.Same(countError, observed[0]);
         Assert.Same(longCountError, observed[1]);
@@ -241,42 +241,42 @@ public class OperatorCoverageExpansionTests
         var allError = new InvalidOperationException(AllMessage);
         var observed = new List<Exception>();
 
-        Signal.Range(First, Fourth).All(_ => throw allError).Subscribe(_ => { }, observed.Add, () => { });
+        Signal.Sequence(First, Fourth).All(_ => throw allError).Subscribe(_ => { }, observed.Add, () => { });
 
         Assert.Same(allError, observed[0]);
     }
 
     /// <summary>
-    /// Covers fused prepend/default-if-empty/append and empty StartWith helpers.
+    /// Covers fused prepend/default-if-empty/append and empty Prepend helpers.
     /// </summary>
     [Test]
-    public void StartWithAppendDefaultIfEmptyFusionPreservesOrderingAndTerminals()
+    public void PrependAppendDefaultIfEmptyFusionPreservesOrderingAndTerminals()
     {
         var values = new List<int>();
-        var emptyStartWithValues = new List<int>();
+        var emptyPrependValues = new List<int>();
         var completed = 0;
 
-        Signal.Empty<int>()
+        Signal.None<int>()
             .DefaultIfEmpty(Second)
-            .StartWith(First)
+            .Prepend(First)
             .Append(Third)
             .Subscribe(values.Add, ex => throw ex, () => completed++);
 
         Signal.FromEnumerable(AggregateSource)
-            .StartWith()
+            .Prepend()
             .Append(Fourth)
-            .Subscribe(emptyStartWithValues.Add);
+            .Subscribe(emptyPrependValues.Add);
 
         Assert.Equal(new[] { First, Second, Third }, values);
         Assert.Equal(1, completed);
-        Assert.Equal(new[] { First, Second, Third, Fourth, Fourth }, emptyStartWithValues);
+        Assert.Equal(new[] { First, Second, Third, Fourth, Fourth }, emptyPrependValues);
     }
 
     /// <summary>
-    /// Covers SelectMany queuing while an inner signal is active.
+    /// Covers FlatMap queuing while an inner signal is active.
     /// </summary>
     [Test]
-    public void SelectManyQueuesInnerSignalsUntilActiveInnerCompletes()
+    public void FlatMapQueuesInnerSignalsUntilActiveInnerCompletes()
     {
         var outer = new Signal<int>();
         var firstInner = new Signal<int>();
@@ -284,7 +284,7 @@ public class OperatorCoverageExpansionTests
         var values = new List<int>();
         var completed = 0;
 
-        using var subscription = outer.SelectMany(value => value == First ? firstInner : secondInner)
+        using var subscription = outer.FlatMap(value => value == First ? firstInner : secondInner)
             .Subscribe(values.Add, ex => throw ex, () => completed++);
 
         outer.OnNext(First);
@@ -295,39 +295,39 @@ public class OperatorCoverageExpansionTests
         secondInner.OnNext(SecondInner);
         secondInner.OnCompleted();
 
-        Assert.Equal(QueuedSelectManyExpected, values);
+        Assert.Equal(QueuedFlatMapExpected, values);
         Assert.Equal(1, completed);
     }
 
     /// <summary>
-    /// Covers the SelectMany overload with an outer and inner result selector.
+    /// Covers the FlatMap overload with an outer and inner result selector.
     /// </summary>
     [Test]
-    public void SelectManyResultSelectorProjectsOuterAndInnerValues()
+    public void FlatMapResultSelectorProjectsOuterAndInnerValues()
     {
         var values = new List<int>();
 
         Signal.FromEnumerable(FirstSecondSource)
-            .SelectMany(value => Signal.FromEnumerable(SingleInnerSource), (outer, inner) => outer + inner)
+            .FlatMap(value => Signal.FromEnumerable(SingleInnerSource), (outer, inner) => outer + inner)
             .Subscribe(values.Add);
 
-        Assert.Equal(ResultSelectManyExpected, values);
+        Assert.Equal(ResultFlatMapExpected, values);
     }
 
     /// <summary>
-    /// Covers SelectMany selector, inner, and outer error forwarding.
+    /// Covers FlatMap selector, inner, and outer error forwarding.
     /// </summary>
     [Test]
-    public void SelectManyForwardsSelectorInnerAndOuterErrors()
+    public void FlatMapForwardsSelectorInnerAndOuterErrors()
     {
         var selectorError = new InvalidOperationException(SelectorMessage);
         var innerError = new InvalidOperationException(InnerMessage);
         var outerError = new InvalidOperationException(OuterMessage);
         var observed = new List<Exception>();
 
-        Signal.FromEnumerable(SingleFirstSource).SelectMany<int, int>(_ => throw selectorError).Subscribe(_ => { }, observed.Add, () => { });
-        Signal.FromEnumerable(SingleFirstSource).SelectMany(_ => Signal.Throw<int>(innerError)).Subscribe(_ => { }, observed.Add, () => { });
-        Signal.Throw<int>(outerError).SelectMany(ReturnValue).Subscribe(_ => { }, observed.Add, () => { });
+        Signal.FromEnumerable(SingleFirstSource).FlatMap<int, int>(_ => throw selectorError).Subscribe(_ => { }, observed.Add, () => { });
+        Signal.FromEnumerable(SingleFirstSource).FlatMap(_ => Signal.Fail<int>(innerError)).Subscribe(_ => { }, observed.Add, () => { });
+        Signal.Fail<int>(outerError).FlatMap(ReturnValue).Subscribe(_ => { }, observed.Add, () => { });
 
         Assert.Same(selectorError, observed[0]);
         Assert.Same(innerError, observed[1]);
@@ -339,5 +339,5 @@ public class OperatorCoverageExpansionTests
     /// </summary>
     /// <param name="value">The value to emit.</param>
     /// <returns>A scalar signal.</returns>
-    private static IObservable<int> ReturnValue(int value) => Signal.Return(value);
+    private static IObservable<int> ReturnValue(int value) => Signal.Emit(value);
 }

--- a/src/tests/ReactiveUI.Primitives.Tests/RealWorldReactiveScenarioTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/RealWorldReactiveScenarioTests.cs
@@ -178,7 +178,7 @@ public sealed class RealWorldReactiveScenarioTests
 
         var collectedArray = await source.CollectArrayAsync();
         var collectedList = await source.CollectListAsync();
-        var firstDefault = await Signal.Empty<Contact>().FirstOrDefaultAsync(new Contact("empty", null));
+        var firstDefault = await Signal.None<Contact>().FirstOrDefaultAsync(new Contact("empty", null));
         var last = await source.LastAsync();
         var anyNullLastName = await source.AnyAsync(contact => contact.LastName is null);
         var countWithLastName = await source.CountAsync(contact => contact.LastName is not null);

--- a/src/tests/ReactiveUI.Primitives.Tests/ReplaySignalTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/ReplaySignalTests.cs
@@ -47,6 +47,15 @@ public class ReplaySignalTests
         CreateAndDispose(() => new ReplaySignal<int>(0, EmptySequencer.Instance));
         CreateAndDispose(() => new ReplaySignal<int>(TimeSpan.Zero, EmptySequencer.Instance));
         CreateAndDispose(() => new ReplaySignal<int>(0, TimeSpan.Zero, EmptySequencer.Instance));
+
+        CreateAndDispose(() => new HistorySignal<int>());
+        CreateAndDispose(() => new HistorySignal<int>(EmptySequencer.Instance));
+        CreateAndDispose(() => new HistorySignal<int>(0));
+        CreateAndDispose(() => new HistorySignal<int>(0, EmptySequencer.Instance));
+        CreateAndDispose(() => new HistorySignal<int>(TimeSpan.Zero));
+        CreateAndDispose(() => new HistorySignal<int>(TimeSpan.Zero, EmptySequencer.Instance));
+        CreateAndDispose(() => new HistorySignal<int>(0, TimeSpan.Zero));
+        CreateAndDispose(() => new HistorySignal<int>(0, TimeSpan.Zero, EmptySequencer.Instance));
     }
 
     /// <summary>

--- a/src/tests/ReactiveUI.Primitives.Tests/SignalFromTaskTest.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/SignalFromTaskTest.cs
@@ -109,12 +109,12 @@ public class SignalFromTaskTest
                  }
 
                  throw new InvalidOperationException(BreakExecutionMessage);
-             }).Catch<RxVoid, Exception>(
+             }).Recover<RxVoid, Exception>(
             ex =>
             {
                 RecordStatus(statusTrail, ref position, ExceptionShouldBeHere);
-                return Signal.Throw<RxVoid>(ex);
-            }).Finally(() => RecordStatus(statusTrail, ref position, ShouldAlwaysComeHere));
+                return Signal.Fail<RxVoid>(ex);
+            }).OnCleanup(() => RecordStatus(statusTrail, ref position, ShouldAlwaysComeHere));
 
         var result = false;
         using var subscription = fixture.Subscribe(_ => result = true);
@@ -158,12 +158,12 @@ public class SignalFromTaskTest
                  }
 
                  return RxVoid.Default;
-             }).Catch<RxVoid, Exception>(
+             }).Recover<RxVoid, Exception>(
             ex =>
             {
                 RecordStatus(statusTrail, ref position, ExceptionShouldBeHere);
-                return Signal.Throw<RxVoid>(ex);
-            }).Finally(() => RecordStatus(statusTrail, ref position, ShouldAlwaysComeHere));
+                return Signal.Fail<RxVoid>(ex);
+            }).OnCleanup(() => RecordStatus(statusTrail, ref position, ShouldAlwaysComeHere));
 
         var result = false;
         using var subscription = fixture.Subscribe(_ => result = true);
@@ -214,12 +214,12 @@ public class SignalFromTaskTest
                  }
 
                  return RxVoid.Default;
-             }).Catch<RxVoid, Exception>(
+             }).Recover<RxVoid, Exception>(
             ex =>
             {
                 RecordStatus(statusTrail, ref position, ExceptionShouldBeHere);
-                return Signal.Throw<RxVoid>(ex);
-            }).Finally(() =>
+                return Signal.Fail<RxVoid>(ex);
+            }).OnCleanup(() =>
             {
                 RecordStatus(statusTrail, ref position, ShouldAlwaysComeHere);
                 finallyCompleted.TrySetResult();
@@ -262,12 +262,12 @@ public class SignalFromTaskTest
                  }
 
                  return RxVoid.Default;
-             }).Catch<RxVoid, Exception>(
+             }).Recover<RxVoid, Exception>(
             ex =>
             {
                 RecordStatus(statusTrail, ref position, ExceptionShouldBeHere);
-                return Signal.Throw<RxVoid>(ex);
-            }).Finally(() => RecordStatus(statusTrail, ref position, ShouldAlwaysComeHere));
+                return Signal.Fail<RxVoid>(ex);
+            }).OnCleanup(() => RecordStatus(statusTrail, ref position, ShouldAlwaysComeHere));
 
         using var subscription = fixture.Subscribe();
         await Task.Delay(InitialDelayMilliseconds).ConfigureAwait(true);
@@ -303,12 +303,12 @@ public class SignalFromTaskTest
                  }
 
                  return RxVoid.Default;
-             }).Catch<RxVoid, Exception>(
+             }).Recover<RxVoid, Exception>(
             ex =>
             {
                 RecordStatus(statusTrail, ref position, ExceptionShouldBeHere);
-                return Signal.Throw<RxVoid>(ex);
-            }).Finally(() => RecordStatus(statusTrail, ref position, ShouldAlwaysComeHere));
+                return Signal.Fail<RxVoid>(ex);
+            }).OnCleanup(() => RecordStatus(statusTrail, ref position, ShouldAlwaysComeHere));
 
         var result = false;
         using var subscription = fixture.Subscribe(_ => result = true);
@@ -348,12 +348,12 @@ public class SignalFromTaskTest
                  }
 
                  throw new InvalidOperationException(BreakExecutionMessage);
-             }).Catch<RxVoid, Exception>(
+             }).Recover<RxVoid, Exception>(
             ex =>
             {
                 RecordStatus(statusTrail, ref position, ExceptionShouldBeHere);
-                return Signal.Throw<RxVoid>(ex);
-            }).Finally(() => RecordStatus(statusTrail, ref position, ShouldAlwaysComeHere));
+                return Signal.Fail<RxVoid>(ex);
+            }).OnCleanup(() => RecordStatus(statusTrail, ref position, ShouldAlwaysComeHere));
 
         var result = false;
         using var subscription = fixture.Subscribe(_ => result = true);
@@ -397,12 +397,12 @@ public class SignalFromTaskTest
                  }
 
                  return RxVoid.Default;
-             }).Catch<RxVoid, Exception>(
+             }).Recover<RxVoid, Exception>(
             ex =>
             {
                 RecordStatus(statusTrail, ref position, ExceptionShouldBeHere);
-                return Signal.Throw<RxVoid>(ex);
-            }).Finally(() => RecordStatus(statusTrail, ref position, ShouldAlwaysComeHere));
+                return Signal.Fail<RxVoid>(ex);
+            }).OnCleanup(() => RecordStatus(statusTrail, ref position, ShouldAlwaysComeHere));
 
         var result = false;
         using var subscription = fixture.Subscribe(_ => result = true);
@@ -453,12 +453,12 @@ public class SignalFromTaskTest
                  }
 
                  return RxVoid.Default;
-             }).Catch<RxVoid, Exception>(
+             }).Recover<RxVoid, Exception>(
             ex =>
             {
                 RecordStatus(statusTrail, ref position, ExceptionShouldBeHere);
-                return Signal.Throw<RxVoid>(ex);
-            }).Finally(() =>
+                return Signal.Fail<RxVoid>(ex);
+            }).OnCleanup(() =>
             {
                 RecordStatus(statusTrail, ref position, ShouldAlwaysComeHere);
                 finallyCompleted.TrySetResult();
@@ -501,12 +501,12 @@ public class SignalFromTaskTest
                  }
 
                  return RxVoid.Default;
-             }).Catch<RxVoid, Exception>(
+             }).Recover<RxVoid, Exception>(
             ex =>
             {
                 RecordStatus(statusTrail, ref position, ExceptionShouldBeHere);
-                return Signal.Throw<RxVoid>(ex);
-            }).Finally(() => RecordStatus(statusTrail, ref position, ShouldAlwaysComeHere));
+                return Signal.Fail<RxVoid>(ex);
+            }).OnCleanup(() => RecordStatus(statusTrail, ref position, ShouldAlwaysComeHere));
 
         using var subscription = fixture.Subscribe();
         await Task.Delay(InitialDelayMilliseconds).ConfigureAwait(true);
@@ -542,12 +542,12 @@ public class SignalFromTaskTest
                  }
 
                  return RxVoid.Default;
-             }).Catch<RxVoid, Exception>(
+             }).Recover<RxVoid, Exception>(
             ex =>
             {
                 RecordStatus(statusTrail, ref position, ExceptionShouldBeHere);
-                return Signal.Throw<RxVoid>(ex);
-            }).Finally(() => RecordStatus(statusTrail, ref position, ShouldAlwaysComeHere));
+                return Signal.Fail<RxVoid>(ex);
+            }).OnCleanup(() => RecordStatus(statusTrail, ref position, ShouldAlwaysComeHere));
 
         var result = false;
         using var subscription = fixture.Subscribe(_ => result = true);

--- a/src/tests/ReactiveUI.Primitives.Tests/SignalTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/SignalTests.cs
@@ -430,7 +430,7 @@ public class SignalTests
     public void SubjectWhere()
     {
         var subject = new Signal<int>();
-        subject.Where(i => i % EvenDivisor == 0).Subscribe(i => Assert.Equal(ValueTwo, i));
+        subject.Keep(i => i % EvenDivisor == 0).Subscribe(i => Assert.Equal(ValueTwo, i));
         subject.OnNext(1);
         subject.OnNext(ValueTwo);
         subject.OnNext(ValueThree);
@@ -444,7 +444,7 @@ public class SignalTests
     public void SubjectSelect()
     {
         var subject = new Signal<int>();
-        subject.Select(i => i * SelectMultiplier).Subscribe(i => Assert.Equal(ValueFour, i));
+        subject.Map(i => i * SelectMultiplier).Subscribe(i => Assert.Equal(ValueFour, i));
         subject.OnNext(ValueTwo);
         subject.Dispose();
     }

--- a/src/tests/ReactiveUI.Primitives.Tests/StatefulSharingAndBridgeContractTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/StatefulSharingAndBridgeContractTests.cs
@@ -148,7 +148,7 @@ public class StatefulSharingAndBridgeContractTests
             return source.Subscribe(observer);
         });
 
-        var shared = cold.ShareLive();
+        var shared = cold.ShareLatest();
         var first = new List<int>();
         var second = new List<int>();
 
@@ -233,7 +233,7 @@ public class StatefulSharingAndBridgeContractTests
             return source.Subscribe(observer);
         });
 
-        var auto = cold.Publish().AutoConnect(2);
+        var auto = cold.Share().AutoConnect(2);
         var first = new List<int>();
         var second = new List<int>();
         using var firstSubscription = auto.Subscribe(first.Add);
@@ -245,10 +245,10 @@ public class StatefulSharingAndBridgeContractTests
         Assert.Equal(ExpectedSecondSharedValues[1..], first);
         Assert.Equal(ExpectedSecondSharedValues[1..], second);
         Assert.Throws<ArgumentNullException>(() => ConnectableSignalMixins.Multicast(null!, new Signal<int>()));
-        Assert.Throws<ArgumentNullException>(() => Signal.Never<int>().Multicast(null!));
-        Assert.Throws<ArgumentNullException>(() => ConnectableSignalMixins.RefCount<int>(null!));
+        Assert.Throws<ArgumentNullException>(() => Signal.Silent<int>().Multicast(null!));
+        Assert.Throws<ArgumentNullException>(() => ConnectableSignalMixins.AutoShare<int>(null!));
         Assert.Throws<ArgumentNullException>(() => ConnectableSignalMixins.AutoConnect<int>(null!));
-        Assert.Throws<ArgumentOutOfRangeException>(() => cold.PublishLive().AutoConnect(-1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => cold.ShareLive().AutoConnect(-1));
 
         var replayed = cold.Replay(1, TimeSpan.FromSeconds(1));
         using var connection = replayed.Connect();
@@ -410,7 +410,7 @@ using ReactiveUI.Primitives.Signals;
 
 public static class CoreOnlySmoke
 {
-    public static IObservable<int> Use() => Signal.Return(1);
+    public static IObservable<int> Use() => Signal.Emit(1);
 }
 """;
 


### PR DESCRIPTION
Rename and standardize core ReactiveUI.Primitives API surface and docs; add FinalSignal and HistorySignal implementations. 
Key changes: factory renames (Return->Emit, Empty->None, Never->Silent, Throw->Fail, Range->Sequence, Defer->Lazy, Repeat->Loop, etc.), subject/replay changes (ReplaySignal -> HistorySignal, AsyncSignal -> FinalSignal), many operator name adjustments (Select->Map, Where->Keep, SelectMany->FlatMap/Bind, Aggregate->Reduce, Scan->Fold, DistinctUntilChanged->Unique, Merge/Concat/Zip/etc. -> Blend/Chain/Pair/etc.), and related helper renames (Timer->After/Pulse, Timeout->Expire, Throttle->Calm, Sample->Probe, Delay->Shift). 
README updated to reflect the new vocabulary and migration guidance. Code, benchmarks, and tests updated across the project to use the new names, and two new source files (FinalSignal{T}.cs, HistorySignal{T}.cs) were added.