### PR TITLE
Refactor Blazor sequencer work items and docs

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -39,8 +39,8 @@ jobs:
             sonarProjectKey: reactiveui_Primitives
             sonarOrganization: reactiveui
             sonarExclusions: '**/tests/**,**/tools/**,**/benchmarks/**,**/TestResults/**'
-            sonarCoverageExclusions: '**/tests/**,**/tools/**,**/benchmarks/**,**/*Tests/**,**/*Tests.cs,**/Generated/**'
-            sonarCpdExclusions: '**/tests/**,**/tools/**,**/benchmarks/**,**/CombineLatest?.cs,**/CombineLatest??.cs'
+            sonarCoverageExclusions: '**/tests/**,**/tools/**,**/benchmarks/**,**/*Tests/**,**/*Tests.cs,**/Generated/**,**/ReactiveUI.Primitives.Blazor/**,**/ReactiveUI.Primitives.Maui/**,**/ReactiveUI.Primitives.WinForms/**,**/ReactiveUI.Primitives.Wpf/**'
+            sonarCpdExclusions: '**/tests/**,**/tools/**,**/benchmarks/**,**/CombineLatest?.cs,**/CombineLatest??.cs,**/ReactiveUI.Primitives.Blazor/**,**/ReactiveUI.Primitives.Maui/**,**/ReactiveUI.Primitives.WinForms/**,**/ReactiveUI.Primitives.Wpf/**'
             sonarTestExclusions: '**/tests/**,**/tools/**,**/benchmarks/**'
             testTimeout: '15m'
         secrets:

--- a/README.md
+++ b/README.md
@@ -37,6 +37,15 @@ When the package is available on your configured NuGet feed:
 dotnet add package ReactiveUI.Primitives
 ```
 
+Optional UI/platform integration packages are split out so the base package stays free of UI framework references:
+
+```bash
+dotnet add package ReactiveUI.Primitives.Wpf
+dotnet add package ReactiveUI.Primitives.WinForms
+dotnet add package ReactiveUI.Primitives.Blazor
+dotnet add package ReactiveUI.Primitives.Maui
+```
+
 Then import the namespaces you need:
 
 ```csharp
@@ -66,7 +75,14 @@ The base production `ReactiveUI.Primitives` library uses `$(LibraryTargetFramewo
 
 Windows UI and platform-integration projects in this repository use their own TFM properties (for example `net8.0-windows`, `net9.0-windows`, `net10.0-windows`, or MAUI/platform-focused TFMs where applicable). Those platform TFMs are not target frameworks of the base `ReactiveUI.Primitives` package.
 
-Runtime package dependencies are intentionally small. The production package does not depend on System.Reactive or R3. The only runtime package reference declared directly by `src/ReactiveUI.Primitives/ReactiveUI.Primitives.csproj` is `System.ValueTuple` for `net462`; the remaining listed packages are analyzer, SourceLink, versioning, ILLink, reference-assembly, or build-time support packages such as Blazor.Common.Analyzers, Microsoft.SourceLink.GitHub, MinVer, Roslynator.Analyzers, SonarAnalyzer.CSharp, stylecop.analyzers, Microsoft.NET.ILLink.Tasks, and Microsoft.NETFramework.ReferenceAssemblies. Benchmark projects may reference System.Reactive and R3 as comparison baselines, but those references are not production dependencies.
+The optional package TFMs are:
+
+- `ReactiveUI.Primitives.Wpf`: `net8.0-windows`, `net9.0-windows`, `net10.0-windows`, `net462`, `net472`, `net481`
+- `ReactiveUI.Primitives.WinForms`: `net8.0-windows`, `net9.0-windows`, `net10.0-windows`, `net462`, `net472`, `net481`
+- `ReactiveUI.Primitives.Blazor`: `net8.0`, `net9.0`, `net10.0`
+- `ReactiveUI.Primitives.Maui`: `net9.0`, `net10.0`
+
+Runtime package dependencies are intentionally small. The base production package does not depend on System.Reactive or R3. The only runtime package reference declared directly by `src/ReactiveUI.Primitives/ReactiveUI.Primitives.csproj` is `System.ValueTuple` for `net462`; the bridge source generators are packed as analyzers in the base package rather than shipped as separate NuGet packages. `ReactiveUI.Primitives.Blazor` references `Microsoft.AspNetCore.Components`, and `ReactiveUI.Primitives.Maui` references `Microsoft.Maui.Core`. The remaining shared package references are analyzer, SourceLink, versioning, ILLink, reference-assembly, or build-time support packages such as Blazor.Common.Analyzers, Microsoft.SourceLink.GitHub, MinVer, Roslynator.Analyzers, SonarAnalyzer.CSharp, stylecop.analyzers, Microsoft.NET.ILLink.Tasks, and Microsoft.NETFramework.ReferenceAssemblies. Benchmark projects may reference System.Reactive and R3 as comparison baselines, but those references are not production dependencies.
 
 ## Core model
 
@@ -406,7 +422,7 @@ using var subscription = failed.Subscribe(
 
 ## Sequencers
 
-Sequencers live in `ReactiveUI.Primitives.Concurrency` and implement `ISequencer`. The core `ReactiveUI.Primitives` package does not reference WPF or Windows Forms; UI-thread sequencers are provided by the optional `ReactiveUI.Primitives.Wpf` and `ReactiveUI.Primitives.WinForms` packages.
+Sequencers live in `ReactiveUI.Primitives.Concurrency` and implement `ISequencer`. The core `ReactiveUI.Primitives` package does not reference WPF, Windows Forms, Blazor, or MAUI; UI-thread sequencers are provided by optional integration packages.
 
 | Sequencer | Purpose |
 |---|---|
@@ -417,6 +433,8 @@ Sequencers live in `ReactiveUI.Primitives.Concurrency` and implement `ISequencer
 | `SynchronizationContextSequencer` | Schedule through a `SynchronizationContext`. |
 | `DispatcherSequencer` | Schedule onto a WPF dispatcher from `ReactiveUI.Primitives.Wpf`. |
 | `ControlSequencer` | Schedule onto a Windows Forms control from `ReactiveUI.Primitives.WinForms`. |
+| `BlazorRendererSequencer` | Schedule component work through Blazor's renderer from `ReactiveUI.Primitives.Blazor`. |
+| `MauiDispatcherSequencer` | Schedule onto an MAUI dispatcher from `ReactiveUI.Primitives.Maui`. |
 | `VirtualClock` / `TestClock` | Virtual-time scheduling for deterministic tests. |
 
 Scheduling APIs include absolute, relative, recursive, and action-based overloads:
@@ -601,6 +619,8 @@ ReactiveUI.Primitives is not a byte-for-byte clone of System.Reactive. It keeps 
 | synchronization-context scheduling | `SynchronizationContextSequencer` |
 | WPF dispatcher scheduling | `DispatcherSequencer` from `ReactiveUI.Primitives.Wpf` |
 | Windows Forms control scheduling | `ControlSequencer` from `ReactiveUI.Primitives.WinForms` |
+| Blazor renderer scheduling | `BlazorRendererSequencer` from `ReactiveUI.Primitives.Blazor` |
+| MAUI dispatcher scheduling | `MauiDispatcherSequencer` from `ReactiveUI.Primitives.Maui` |
 | `TestScheduler` / virtual time | `VirtualClock` or `TestClock` |
 
 ### Testing migration
@@ -630,7 +650,7 @@ Use the generated bridge only at boundaries. Prefer native ReactiveUI.Primitives
 
 Benchmarks live in `src/benchmarks/ReactiveUI.Primitives.Benchmarks`. The benchmark project may reference System.Reactive and R3 to compare throughput and allocation behavior; the production package must not.
 
-Full BenchmarkDotNet runs were captured on 2026-05-28 with .NET SDK/runtime 10.0.8 on Windows 11. The latest complete run executed 201 benchmarks with no skipped suites in 00:21:53:
+The latest complete BenchmarkDotNet run finished on 2026-05-29 at 00:04:23 Europe/London with .NET SDK/runtime 10.0.8 on Windows 11. It executed 201 benchmarks with no skipped suites in 00:21:18:
 
 ```powershell
 dotnet run --project src/benchmarks/ReactiveUI.Primitives.Benchmarks/ReactiveUI.Primitives.Benchmarks.csproj --configuration Release --no-build -- --filter "*" --join --launchCount 1 --warmupCount 1 --iterationCount 3
@@ -638,10 +658,10 @@ dotnet run --project src/benchmarks/ReactiveUI.Primitives.Benchmarks/ReactiveUI.
 
 Latest artifact paths:
 
-- `BenchmarkDotNet.Artifacts/BenchmarkRun-20260528-213342.log`
-- `BenchmarkDotNet.Artifacts/results/BenchmarkRun-joined-2026-05-28-21-55-38-report-github.md`
-- `BenchmarkDotNet.Artifacts/results/BenchmarkRun-joined-2026-05-28-21-55-38-report.html`
-- `BenchmarkDotNet.Artifacts/results/BenchmarkRun-joined-2026-05-28-21-55-38-report.csv`
+- `BenchmarkDotNet.Artifacts/BenchmarkRun-20260528-234302.log`
+- `BenchmarkDotNet.Artifacts/results/BenchmarkRun-joined-2026-05-29-00-04-23-report-github.md`
+- `BenchmarkDotNet.Artifacts/results/BenchmarkRun-joined-2026-05-29-00-04-23-report.html`
+- `BenchmarkDotNet.Artifacts/results/BenchmarkRun-joined-2026-05-29-00-04-23-report.csv`
 
 Smoke validation for deterministic benchmark behavior passed for 67 benchmark groups with:
 
@@ -649,83 +669,85 @@ Smoke validation for deterministic benchmark behavior passed for 67 benchmark gr
 dotnet run --project src/benchmarks/ReactiveUI.Primitives.Benchmarks/ReactiveUI.Primitives.Benchmarks.csproj --configuration Release --no-build -- --smoke
 ```
 
-Current direct test/coverage validation after the benchmark pass is 96.02% line coverage and 91.46% branch coverage from `src/tests/ReactiveUI.Primitives.Tests/TestResults/coverage-kanban-t_f3f3db71-20260528-final/coverage.cobertura.xml`. The original final-review target was 100% line and branch coverage; the remaining gap is a signed-off release exception rather than a passing 100% coverage result.
+The latest available direct test/coverage validation is 96.02% line coverage and 91.46% branch coverage from `src/tests/ReactiveUI.Primitives.Tests/TestResults/coverage-kanban-t_f3f3db71-20260528-final/coverage.cobertura.xml`. The original final-review target was 100% line and branch coverage; the remaining gap is a signed-off release exception rather than a passing 100% coverage result.
 
 The table below is generated from the joined BenchmarkDotNet CSV and uses `Mean / Allocated` for each cell.
 
 | Scenario | ReactiveUI.Primitives | System.Reactive | R3 |
 |---|---:|---:|---:|
-| Emit subscribe | 0.2107 ns / 0 B | 45.9317 ns / 120 B | 29.7331 ns / 80 B |
-| None subscribe | 2.8561 ns / 40 B | 43.7379 ns / 96 B | 26.4604 ns / 56 B |
-| Sequence subscribe | 48.2494 ns / 96 B | 2,400.6602 ns / 2472 B | 69.5582 ns / 80 B |
-| Loop subscribe | 6.8179 ns / 0 B | 2,371.2236 ns / 2408 B | 69.2988 ns / 80 B |
-| Fail subscribe | 58.1512 ns / 120 B | 105.8387 ns / 240 B | 86.9365 ns / 200 B |
-| FromEnumerable subscribe | 50.4808 ns / 40 B | 2,252.9594 ns / 2504 B | 71.0029 ns / 88 B |
-| Completed task bridge | 10.5757 ns / 88 B | 815.3427 ns / 793 B | 38.5080 ns / 88 B |
-| Create subscribe | 45.5529 ns / 248 B | 41.2160 ns / 168 B | 61.4747 ns / 128 B |
-| CreateSafe subscribe | 44.8270 ns / 248 B | 42.1319 ns / 168 B | 53.2048 ns / 128 B |
-| Lazy subscribe | 78.2157 ns / 240 B | 1,400.9222 ns / 1512 B | 107.5722 ns / 152 B |
-| Start subscribe | 54.1090 ns / 376 B | 778.9965 ns / 751 B | 55.4001 ns / 160 B |
-| Unfold subscribe | 170.6483 ns / 736 B | 2,145.7577 ns / 2768 B | 93.9090 ns / 128 B |
-| Use subscribe | 68.1815 ns / 432 B | 83.7883 ns / 168 B | 53.1693 ns / 128 B |
-| FromAsyncEnumerable subscribe | 1,079.9192 ns / 600 B | 1,853.5239 ns / 2447 B | 1,242.9586 ns / 1023 B |
-| Silent subscribe/dispose | 0.2282 ns / 0 B | 5.1866 ns / 40 B | 17.3882 ns / 56 B |
-| Map + Keep over range | 120.5836 ns / 208 B | 2,493.7654 ns / 2616 B | 269.3660 ns / 272 B |
-| Reduce + Any + Count | 171.2013 ns / 824 B | 5,265.8732 ns / 6352 B | 579.6091 ns / 1280 B |
-| Prepend + Append + DefaultIfEmpty | 29.5067 ns / 168 B | 904.4517 ns / 1282 B | 133.1520 ns / 288 B |
-| DefaultIfEmpty(empty) | 5.7140 ns / 64 B | 61.8811 ns / 144 B | 60.2212 ns / 136 B |
-| FlatMap over ranges | 946.7710 ns / 712 B | 3,492.5273 ns / 3872 B | 971.0792 ns / 1040 B |
-| Pair over ranges | 38.1501 ns / 232 B | 2,942.2574 ns / 2976 B | 653.8256 ns / 656 B |
-| Chain ranges | 64.7018 ns / 256 B | 2,594.3629 ns / 2856 B | 240.7744 ns / 360 B |
-| Blend ranges | 71.2796 ns / 256 B | 3,658.6498 ns / 3953 B | 660.2883 ns / 352 B |
-| Race ranges | 34.3258 ns / 192 B | 1,419.1490 ns / 1760 B | 272.0822 ns / 360 B |
-| SwitchTo ranges | 794.3949 ns / 1376 B | 2,065.5574 ns / 2336 B | 718.6733 ns / 392 B |
-| SyncLatest ranges | 93.4823 ns / 504 B | 3,147.6649 ns / 2824 B | 649.7137 ns / 344 B |
-| Latch ranges | 98.6320 ns / 504 B | 3,192.3467 ns / 2824 B | 328.0823 ns / 248 B |
-| ForkJoin ranges | 65.8825 ns / 480 B | 3,265.4967 ns / 3136 B | 871.6126 ns / 504 B |
-| Shift range | 173.8715 ns / 736 B | 4,950.6053 ns / 39584 B | 1,793.8548 ns / 2200 B |
-| DelayStart range | 231.9739 ns / 936 B | 2,064.9857 ns / 26456 B | 292.6246 ns / 552 B |
-| Calm burst | 564.5905 ns / 1256 B | 2,385.1070 ns / 36480 B | 1,532.7904 ns / 1512 B |
-| Probe latest | 193.0785 ns / 640 B | 1,889.0841 ns / 26264 B | 316.8231 ns / 664 B |
-| Timestamp range | 402.4542 ns / 312 B | 1,595.8453 ns / 1608 B | 330.9149 ns / 152 B |
-| TimeInterval range | 471.3139 ns / 736 B | 1,624.6929 ns / 1712 B | 432.3715 ns / 160 B |
-| Expire idle | 232.3618 ns / 704 B | 1,162.7251 ns / 29776 B | 380.9954 ns / 784 B |
-| ObserveOn immediate | 21.7206 ns / 96 B | 15,066.6122 ns / 11312 B | 905.7257 ns / 432 B |
-| History subscribe | 333.8135 ns / 320 B | 683.3399 ns / 696 B | 402.9542 ns / 688 B |
-| StateSignal 32 values | 571.4088 ns / 176 B | 577.0790 ns / 200 B | 616.6069 ns / 192 B |
-| StateSignal 1024 values | 15,821.2891 ns / 176 B | 15,764.0411 ns / 200 B | 15,761.4075 ns / 192 B |
-| Signal emit, 32 values | 71.4549 ns / 136 B | 91.0168 ns / 136 B | 124.7691 ns / 160 B |
-| Signal emit, 1024 values | 1,751.1726 ns / 136 B | 1,774.9812 ns / 136 B | 1,987.6726 ns / 160 B |
-| Signal subscribe/dispose, 8 observers | 250.1112 ns / 592 B | 318.1184 ns / 1288 B | 454.5726 ns / 840 B |
-| Signal subscribe/dispose, 64 observers | 2,769.3523 ns / 3800 B | 3,958.7546 ns / 38472 B | 3,752.8739 ns / 6216 B |
-| ShareLive connect | 144.2458 ns / 384 B | 2,746.4123 ns / 2696 B | 383.6541 ns / 368 B |
-| Share live subscribe | 269.7706 ns / 848 B | 2,952.1750 ns / 2880 B | 515.8733 ns / 488 B |
-| Replay live late subscribe | 665.9020 ns / 568 B | 3,804.7574 ns / 3408 B | 918.6698 ns / 1360 B |
-| AutoShare subscribe | 254.7250 ns / 848 B | 2,955.6199 ns / 2880 B | 496.8710 ns / 488 B |
-| AutoConnect subscribe | 197.8330 ns / 728 B | 2,692.2591 ns / 2736 B | 387.4696 ns / 368 B |
-| StateSignal updates | 562.7767 ns / 176 B | 555.7740 ns / 200 B | 604.6401 ns / 192 B |
-| ReadOnlyState projection | 126.0058 ns / 248 B | 89.6705 ns / 328 B | 175.5553 ns / 312 B |
-| TaskSignal subscribe | 1,548.4924 ns / 3909 B | 674.1182 ns / 886 B | 38.3412 ns / 160 B |
-| Command execute | 117.6506 ns / 600 B | 687.1632 ns / 1089 B | 111.5248 ns / 296 B |
-| Command result subscribe | 142.9694 ns / 672 B | 37.2585 ns / 136 B | 65.7253 ns / 160 B |
-| CollectList range | 114.7333 ns / 688 B | 2,747.6410 ns / 3488 B | 164.1239 ns / 632 B |
-| CollectArray range | 84.6958 ns / 656 B | 2,867.7760 ns / 3640 B | 174.7426 ns / 784 B |
-| CollectArrayAsync range | 33.0375 ns / 384 B | 2,727.4354 ns / 3984 B | 157.4702 ns / 784 B |
-| FirstAsync range | 6.2257 ns / 56 B | 2,377.2078 ns / 2792 B | 79.4655 ns / 208 B |
-| ToTask range | 14.3367 ns / 192 B | 2,448.9990 ns / 2824 B | 89.9601 ns / 208 B |
-| Count(predicate) range | 23.4069 ns / 96 B | 2,407.0920 ns / 2520 B | 99.8359 ns / 200 B |
-| LongCount(predicate) range | 24.7771 ns / 104 B | 2,356.8338 ns / 2536 B | 106.6491 ns / 272 B |
-| All range | 17.3706 ns / 96 B | 2,505.6300 ns / 2520 B | 89.4448 ns / 192 B |
-| Contains range | 12.4464 ns / 96 B | 2,473.2698 ns / 2528 B | 98.0174 ns / 200 B |
-| All + Contains range | 29.1751 ns / 192 B | 5,089.9312 ns / 5048 B | 203.6477 ns / 392 B |
-| Pocket dispose | 66.1360 ns / 408 B | 100.0380 ns / 512 B | 83.8633 ns / 480 B |
-| CurrentThread schedule | 13.4777 ns / 88 B | 17.7795 ns / 88 B | 28.8444 ns / 56 B |
-| Safe witness | 21.6127 ns / 168 B | 12.1948 ns / 136 B | 17.6018 ns / 56 B |
-| Completed Spark | 0.0084 ns / 0 B | 0.0000 ns / 0 B | 0.0000 ns / 0 B |
+| Emit subscribe | 0.0057 ns / 0 B | 46.9118 ns / 120 B | 29.9493 ns / 80 B |
+| None subscribe | 2.7336 ns / 40 B | 42.2124 ns / 96 B | 26.3975 ns / 56 B |
+| Sequence subscribe | 46.1797 ns / 96 B | 2,422.0697 ns / 2472 B | 69.1228 ns / 80 B |
+| Loop subscribe | 6.7699 ns / 0 B | 2,408.7297 ns / 2408 B | 69.0206 ns / 80 B |
+| Fail subscribe | 54.1509 ns / 120 B | 102.8304 ns / 240 B | 87.5483 ns / 200 B |
+| FromEnumerable subscribe | 51.2591 ns / 40 B | 2,275.3497 ns / 2504 B | 72.6697 ns / 88 B |
+| Completed task bridge | 10.0635 ns / 88 B | 740.5938 ns / 793 B | 33.1432 ns / 88 B |
+| Create subscribe | 48.6427 ns / 248 B | 43.5512 ns / 168 B | 53.1627 ns / 128 B |
+| CreateSafe subscribe | 48.7596 ns / 248 B | 43.4466 ns / 168 B | 56.0799 ns / 128 B |
+| Lazy subscribe | 71.4885 ns / 240 B | 1,357.2984 ns / 1512 B | 107.0656 ns / 152 B |
+| Start subscribe | 52.2960 ns / 376 B | 791.8958 ns / 751 B | 53.1907 ns / 160 B |
+| Unfold subscribe | 167.6973 ns / 680 B | 2,138.4558 ns / 2768 B | 85.8050 ns / 128 B |
+| Use subscribe | 67.8147 ns / 432 B | 77.0960 ns / 168 B | 54.1505 ns / 128 B |
+| FromAsyncEnumerable subscribe | 1,043.0716 ns / 600 B | 1,753.0905 ns / 2447 B | 1,234.0619 ns / 1023 B |
+| Silent subscribe/dispose | 0.2325 ns / 0 B | 5.1319 ns / 40 B | 16.5168 ns / 56 B |
+| Map + Keep over range | 123.8707 ns / 208 B | 2,428.8466 ns / 2616 B | 273.2223 ns / 272 B |
+| Reduce + Any + Count | 179.4248 ns / 824 B | 5,336.3782 ns / 6352 B | 521.8730 ns / 1280 B |
+| Prepend + Append + DefaultIfEmpty | 34.4296 ns / 168 B | 863.5180 ns / 1282 B | 131.1020 ns / 288 B |
+| DefaultIfEmpty(empty) | 6.2632 ns / 64 B | 63.0172 ns / 144 B | 61.9132 ns / 136 B |
+| FlatMap over ranges | 992.7952 ns / 712 B | 3,479.3261 ns / 3872 B | 1,017.6085 ns / 1040 B |
+| Pair over ranges | 43.0110 ns / 232 B | 3,072.1161 ns / 2976 B | 664.5803 ns / 656 B |
+| Chain ranges | 68.8759 ns / 256 B | 2,697.8110 ns / 2856 B | 259.8491 ns / 360 B |
+| Blend ranges | 64.7049 ns / 256 B | 3,553.1522 ns / 3953 B | 651.8224 ns / 352 B |
+| Race ranges | 39.1994 ns / 192 B | 1,468.6431 ns / 1760 B | 263.5987 ns / 360 B |
+| SwitchTo ranges | 826.2645 ns / 1376 B | 2,078.3363 ns / 2336 B | 709.2868 ns / 392 B |
+| SyncLatest ranges | 106.3367 ns / 504 B | 2,940.6474 ns / 2824 B | 627.6091 ns / 344 B |
+| Latch ranges | 100.8010 ns / 504 B | 3,277.1620 ns / 2824 B | 339.8355 ns / 248 B |
+| ForkJoin ranges | 77.9202 ns / 480 B | 3,322.5338 ns / 3136 B | 888.1171 ns / 504 B |
+| Shift range | 135.2277 ns / 472 B | 5,406.6544 ns / 39584 B | 1,841.9540 ns / 2200 B |
+| DelayStart range | 128.0190 ns / 472 B | 2,101.8070 ns / 26456 B | 286.8118 ns / 552 B |
+| Calm burst | 573.9559 ns / 1200 B | 2,237.3107 ns / 36480 B | 1,511.0511 ns / 1512 B |
+| Probe latest | 200.6871 ns / 584 B | 1,899.5578 ns / 26264 B | 339.7303 ns / 664 B |
+| Timestamp range | 37.0613 ns / 144 B | 1,614.2007 ns / 1512 B | 331.7774 ns / 152 B |
+| TimeInterval range | 27.9223 ns / 152 B | 1,693.1128 ns / 1616 B | 421.0940 ns / 160 B |
+| Expire idle | 238.2700 ns / 648 B | 1,284.2471 ns / 29776 B | 403.0234 ns / 784 B |
+| ObserveOn immediate | 23.3238 ns / 96 B | 15,659.1095 ns / 11307 B | 900.4654 ns / 432 B |
+| History subscribe | 343.3323 ns / 320 B | 713.3733 ns / 696 B | 407.9522 ns / 688 B |
+| StateSignal 32 values | 556.9331 ns / 176 B | 592.0564 ns / 200 B | 630.1859 ns / 192 B |
+| StateSignal 1024 values | 15,802.3885 ns / 176 B | 15,678.0589 ns / 200 B | 16,769.1864 ns / 192 B |
+| Signal emit, 32 values | 73.1036 ns / 136 B | 90.1915 ns / 136 B | 113.2880 ns / 160 B |
+| Signal emit, 1024 values | 1,660.0302 ns / 136 B | 1,872.2655 ns / 136 B | 1,945.5030 ns / 160 B |
+| Signal subscribe/dispose, 8 observers | 242.0847 ns / 592 B | 283.6230 ns / 1288 B | 447.5004 ns / 840 B |
+| Signal subscribe/dispose, 64 observers | 3,168.8057 ns / 3800 B | 3,773.8536 ns / 38472 B | 3,517.6727 ns / 6216 B |
+| ShareLive connect | 125.9119 ns / 384 B | 2,517.3733 ns / 2696 B | 382.2815 ns / 368 B |
+| Share live subscribe | 217.9249 ns / 848 B | 2,680.1589 ns / 2880 B | 477.0529 ns / 488 B |
+| Replay live late subscribe | 620.7328 ns / 568 B | 3,491.4185 ns / 3408 B | 806.9012 ns / 1360 B |
+| AutoShare subscribe | 251.3467 ns / 848 B | 2,805.1629 ns / 2880 B | 444.0351 ns / 488 B |
+| AutoConnect subscribe | 169.8557 ns / 728 B | 2,546.2257 ns / 2736 B | 369.0084 ns / 368 B |
+| StateSignal updates | 584.5012 ns / 176 B | 568.2254 ns / 200 B | 615.4063 ns / 192 B |
+| ReadOnlyState projection | 136.4027 ns / 248 B | 86.8555 ns / 328 B | 173.5577 ns / 312 B |
+| TaskSignal subscribe | 2,737.5769 ns / 3878 B | 707.6171 ns / 886 B | 39.8419 ns / 160 B |
+| Command execute | 127.2999 ns / 600 B | 677.8387 ns / 1089 B | 98.3740 ns / 296 B |
+| Command result subscribe | 144.8945 ns / 672 B | 36.4350 ns / 136 B | 61.9539 ns / 160 B |
+| CollectList range | 112.6690 ns / 688 B | 2,586.5353 ns / 3488 B | 148.3569 ns / 632 B |
+| CollectArray range | 82.7140 ns / 656 B | 2,557.7999 ns / 3640 B | 157.9993 ns / 784 B |
+| CollectArrayAsync range | 32.7851 ns / 384 B | 2,661.9972 ns / 3984 B | 159.1573 ns / 784 B |
+| FirstAsync range | 5.6597 ns / 56 B | 2,361.3532 ns / 2792 B | 70.1823 ns / 208 B |
+| ToTask range | 14.5996 ns / 192 B | 2,372.8129 ns / 2824 B | 88.6755 ns / 208 B |
+| Count(predicate) range | 18.9800 ns / 96 B | 2,386.6117 ns / 2520 B | 96.0697 ns / 200 B |
+| LongCount(predicate) range | 18.7174 ns / 104 B | 2,357.4243 ns / 2536 B | 99.2778 ns / 272 B |
+| All range | 17.0749 ns / 96 B | 2,371.7189 ns / 2520 B | 81.2336 ns / 192 B |
+| Contains range | 9.4992 ns / 96 B | 2,446.4642 ns / 2528 B | 89.9842 ns / 200 B |
+| All + Contains range | 27.2560 ns / 192 B | 5,141.4378 ns / 5048 B | 209.5712 ns / 392 B |
+| Pocket dispose | 59.5054 ns / 408 B | 80.7846 ns / 512 B | 77.7838 ns / 480 B |
+| CurrentThread schedule | 13.0715 ns / 88 B | 15.7599 ns / 88 B | 28.5282 ns / 56 B |
+| Safe witness | 21.8713 ns / 168 B | 12.3352 ns / 136 B | 18.2902 ns / 56 B |
+| Completed Spark | 0.0000 ns / 0 B | 0.0162 ns / 0 B | 0.0000 ns / 0 B |
+
+The five rows selected from the improvement review as the main time/scheduler optimization gate were `Shift range`, `DelayStart range`, `Calm burst`, `Probe latest`, and `Expire idle`. In the complete run all five beat both System.Reactive and R3 on mean time and allocation. The same optimization pass also brought `Timestamp range`, `TimeInterval range`, and `ObserveOn immediate` below both alternatives on mean time and allocation.
 
 Interpretation notes:
 
-- ReactiveUI.Primitives remains substantially faster and lower allocation in most factory, range, terminal collection, composition, sharing, and subject subscription scenarios.
+- ReactiveUI.Primitives remains substantially faster and lower allocation in most factory, range, terminal collection, composition, sharing, time/scheduler, and subject subscription scenarios.
 - The public API/operator matrix above is backed by deterministic smoke coverage in `Program.RunSmokeBenchmarksAsync`: every row has matching ReactiveUI.Primitives, System.Reactive, and R3 calls where alternatives exist, and the smoke run validates each benchmark path returns the same observable result before BenchmarkDotNet measures throughput and allocation unless the row is one of the documented scheduling-total exceptions below.
 - The only intentional smoke output differences are `SwitchTo ranges`, `SyncLatest ranges`, and `Latch ranges`: System.Reactive produces different synchronous range totals for those coordinator operators, while ReactiveUI.Primitives and R3 agree on the emitted totals. `--smoke` permits only those System.Reactive differences and still fails if ReactiveUI.Primitives diverges from R3 or if any other benchmark group loses parity.
 - Candidate scenarios where ReactiveUI.Primitives is not strictly both faster and lower-allocation than both alternatives are tracked explicitly below. Rows marked as exceptions are retained because the extra cost buys ReactiveUI.Primitives semantics (safe terminal/disposal behavior, `IObservable<T>`/`IObserver<T>` compatibility, deterministic `ISequencer` scheduling, or live-signal lifecycle ownership) while preserving the project rule that System.Reactive/R3 are benchmark-only dependencies.
@@ -735,36 +757,33 @@ Candidate/performance exception matrix:
 
 | Scenario | Observed gap | Decision and trade-off |
 |---|---|---|
-| `Sequence subscribe` | allocation > R3 (96 B vs 80 B). | Accepted exception: ReactiveUI.Primitives preserves BCL `IObservable<T>` compatibility, deterministic scheduler/state ownership, and safe disposal semantics; the remaining strict gap is documented. |
-| `Completed task bridge` | allocation ties R3 (88 B vs 88 B). | Accepted exception: the completed-task bridge already has the lowest observed time and ties R3 allocation while preserving task-observer completion semantics. |
-| `Create subscribe` | time >= System.Reactive (45.5529 ns vs 41.2160 ns); allocation > System.Reactive (248 B vs 168 B); allocation > R3 (248 B vs 128 B). | Accepted exception: the create operators keep the BCL `IObserver<T>` callback shape and terminal/disposal safety wrappers; the adapter cost avoids a runtime dependency on either comparison library. |
-| `CreateSafe subscribe` | time >= System.Reactive (44.8270 ns vs 42.1319 ns); allocation > System.Reactive (248 B vs 168 B); allocation > R3 (248 B vs 128 B). | Accepted exception: the create operators keep the BCL `IObserver<T>` callback shape and terminal/disposal safety wrappers; the adapter cost avoids a runtime dependency on either comparison library. |
-| `Lazy subscribe` | allocation > R3 (240 B vs 152 B). | Accepted exception: ReactiveUI.Primitives preserves BCL `IObservable<T>` compatibility, deterministic scheduler/state ownership, and safe disposal semantics; the remaining strict gap is documented. |
-| `Start subscribe` | allocation > R3 (376 B vs 160 B). | Accepted exception: `Start` uses the project `ISequencer` abstraction and preserves scheduling parity; the remaining R3 allocation gap is documented. |
-| `Unfold subscribe` | time >= R3 (170.6483 ns vs 93.9090 ns); allocation > R3 (736 B vs 128 B). | Accepted exception: recursive generation keeps state-machine disposal and observer safety guards; the specialized R3 observable shape allocates less. |
-| `Use subscribe` | allocation > System.Reactive (432 B vs 168 B); time >= R3 (68.1815 ns vs 53.1693 ns); allocation > R3 (432 B vs 128 B). | Accepted exception: `Use` owns resource lifetime and source subscription across completion, error, and unsubscribe; the lifecycle ownership costs extra allocation. |
-| `SwitchTo ranges` | time >= R3 (794.3949 ns vs 718.6733 ns); allocation > R3 (1376 B vs 392 B). | Accepted exception: `SwitchTo` maintains an inner subscription slot and terminal arbitration for general `IObservable<IObservable<T>>`; the range-specialized R3 path is cheaper. |
-| `SyncLatest ranges` | allocation > R3 (504 B vs 344 B). | Accepted exception: the operator stores readiness/value state for both sides and owns subscriptions explicitly; throughput remains ahead while R3 allocates less. |
-| `Latch ranges` | allocation > R3 (504 B vs 248 B). | Accepted exception: the operator stores readiness/value state for both sides and owns subscriptions explicitly; throughput remains ahead while R3 allocates less. |
-| `DelayStart range` | allocation > R3 (936 B vs 552 B). | Accepted exception: the optimized direct scheduler path now beats both alternatives on throughput; R3 still uses a smaller scheduler allocation, so that allocation trade-off is documented. |
-| `Timestamp range` | time >= R3 (402.4542 ns vs 330.9149 ns); allocation > R3 (312 B vs 152 B). | Accepted exception: scheduler-derived timing values use the project sequencer clock for deterministic injection; R3 remains cheaper in this native timing microcase. |
-| `TimeInterval range` | time >= R3 (471.3139 ns vs 432.3715 ns); allocation > R3 (736 B vs 160 B). | Accepted exception: scheduler-derived timing values use the project sequencer clock for deterministic injection; R3 remains cheaper in this native timing microcase. |
-| `StateSignal 1024 values` | time >= System.Reactive (15,821.2891 ns vs 15,764.0411 ns); time >= R3 (15,821.2891 ns vs 15,761.4075 ns). | Accepted exception: the state signal keeps current-value semantics with lower allocation; the observed time gap is documented as a stateful-signal trade-off. |
-| `Signal emit, 32 values` | allocation ties System.Reactive (136 B vs 136 B). | Accepted exception: ReactiveUI.Primitives preserves BCL `IObservable<T>` compatibility, deterministic scheduler/state ownership, and safe disposal semantics; the remaining strict gap is documented. |
-| `Signal emit, 1024 values` | allocation ties System.Reactive (136 B vs 136 B). | Accepted exception: ReactiveUI.Primitives preserves BCL `IObservable<T>` compatibility, deterministic scheduler/state ownership, and safe disposal semantics; the remaining strict gap is documented. |
-| `ShareLive connect` | allocation > R3 (384 B vs 368 B). | Accepted exception: live sharing owns connection/ref-count lifecycle and safe disconnect state; the small R3 allocation gap is documented. |
-| `Share live subscribe` | allocation > R3 (848 B vs 488 B). | Accepted exception: live sharing owns connection/ref-count lifecycle and safe disconnect state; the small R3 allocation gap is documented. |
-| `AutoShare subscribe` | allocation > R3 (848 B vs 488 B). | Accepted exception: live sharing owns connection/ref-count lifecycle and safe disconnect state; the small R3 allocation gap is documented. |
-| `AutoConnect subscribe` | allocation > R3 (728 B vs 368 B). | Accepted exception: live sharing owns connection/ref-count lifecycle and safe disconnect state; the small R3 allocation gap is documented. |
-| `StateSignal updates` | time >= System.Reactive (562.7767 ns vs 555.7740 ns). | Accepted exception: the state signal keeps current-value semantics with lower allocation; the observed time gap is documented as a stateful-signal trade-off. |
-| `ReadOnlyState projection` | time >= System.Reactive (126.0058 ns vs 89.6705 ns). | Accepted exception: projection preserves `ReadOnlyStateSignal<T>` current-value semantics; System.Reactive is faster here but allocates more and lacks the state-signal contract. |
-| `TaskSignal subscribe` | time >= System.Reactive (1,548.4924 ns vs 674.1182 ns); allocation > System.Reactive (3909 B vs 886 B); time >= R3 (1,548.4924 ns vs 38.3412 ns); allocation > R3 (3909 B vs 160 B). | Accepted exception: `TaskSignal<T>` exposes signal state, completion/error observation, and task lifecycle semantics, not just a completed-task observable. |
-| `Command execute` | time >= R3 (117.6506 ns vs 111.5248 ns); allocation > R3 (600 B vs 296 B). | Accepted exception: command paths expose busy/result/error state and async coordination; the narrower comparison-library paths are cheaper in this microcase. |
-| `Command result subscribe` | time >= System.Reactive (142.9694 ns vs 37.2585 ns); allocation > System.Reactive (672 B vs 136 B); time >= R3 (142.9694 ns vs 65.7253 ns); allocation > R3 (672 B vs 160 B). | Accepted exception: command paths expose busy/result/error state and async coordination; the narrower comparison-library paths are cheaper in this microcase. |
-| `CollectList range` | allocation > R3 (688 B vs 632 B). | Accepted exception: collection returns `IList<T>` through the terminal helper path; the small R3 allocation delta is accepted because throughput remains faster. |
-| `CurrentThread schedule` | allocation ties System.Reactive (88 B vs 88 B); allocation > R3 (88 B vs 56 B). | Accepted exception: current-thread scheduling uses the project sequencer queue contract; strict-lower allocation is not required for a tied/faster scheduler primitive. |
-| `Safe witness` | time >= System.Reactive (21.6127 ns vs 12.1948 ns); allocation > System.Reactive (168 B vs 136 B); time >= R3 (21.6127 ns vs 17.6018 ns); allocation > R3 (168 B vs 56 B). | Accepted exception: `SafeWitness` intentionally wraps observer calls to enforce safe terminal/error behavior; the microbenchmark records this safety overhead. |
-| `Completed Spark` | time >= System.Reactive (0.0084 ns vs 0.0000 ns); allocation ties System.Reactive (0 B vs 0 B); time >= R3 (0.0084 ns vs 0.0000 ns); allocation ties R3 (0 B vs 0 B). | Accepted exception: all alternatives allocate zero and measure near zero, so strict-lower allocation cannot apply; this is a singleton sanity check. |
+| `Sequence subscribe` | allocation > R3 (96 B vs 80 B). | Accepted exception: ReactiveUI.Primitives keeps BCL observable compatibility, safe disposal, and explicit scheduler/resource ownership; the remaining narrow allocation/time gap is documented. |
+| `Completed task bridge` | allocation ties R3 (88 B vs 88 B). | Accepted exception: the bridge already has the lowest mean and ties R3 allocation while preserving task-observer completion semantics. |
+| `Create subscribe` | time >= System.Reactive (48.6427 ns vs 43.5512 ns); allocation > System.Reactive (248 B vs 168 B); allocation > R3 (248 B vs 128 B). | Accepted exception: callback-based factories preserve the BCL `IObserver<T>` shape plus terminal/disposal guards; the adapter cost avoids production dependencies on either comparison library. |
+| `CreateSafe subscribe` | time >= System.Reactive (48.7596 ns vs 43.4466 ns); allocation > System.Reactive (248 B vs 168 B); allocation > R3 (248 B vs 128 B). | Accepted exception: callback-based factories preserve the BCL `IObserver<T>` shape plus terminal/disposal guards; the adapter cost avoids production dependencies on either comparison library. |
+| `Lazy subscribe` | allocation > R3 (240 B vs 152 B). | Accepted exception: ReactiveUI.Primitives keeps BCL observable compatibility, safe disposal, and explicit scheduler/resource ownership; the remaining narrow allocation/time gap is documented. |
+| `Start subscribe` | allocation > R3 (376 B vs 160 B). | Accepted exception: ReactiveUI.Primitives keeps BCL observable compatibility, safe disposal, and explicit scheduler/resource ownership; the remaining narrow allocation/time gap is documented. |
+| `Unfold subscribe` | time >= R3 (167.6973 ns vs 85.8050 ns); allocation > R3 (680 B vs 128 B). | Accepted exception: ReactiveUI.Primitives keeps BCL observable compatibility, safe disposal, and explicit scheduler/resource ownership; the remaining narrow allocation/time gap is documented. |
+| `Use subscribe` | allocation > System.Reactive (432 B vs 168 B); time >= R3 (67.8147 ns vs 54.1505 ns); allocation > R3 (432 B vs 128 B). | Accepted exception: ReactiveUI.Primitives keeps BCL observable compatibility, safe disposal, and explicit scheduler/resource ownership; the remaining narrow allocation/time gap is documented. |
+| `SwitchTo ranges` | time >= R3 (826.2645 ns vs 709.2868 ns); allocation > R3 (1376 B vs 392 B). | Accepted exception: coordinator operators keep general `IObservable<T>` subscription ownership and terminal arbitration; R3 has cheaper specialized observable paths in these microcases. |
+| `SyncLatest ranges` | allocation > R3 (504 B vs 344 B). | Accepted exception: coordinator operators keep general `IObservable<T>` subscription ownership and terminal arbitration; R3 has cheaper specialized observable paths in these microcases. |
+| `Latch ranges` | allocation > R3 (504 B vs 248 B). | Accepted exception: coordinator operators keep general `IObservable<T>` subscription ownership and terminal arbitration; R3 has cheaper specialized observable paths in these microcases. |
+| `StateSignal 1024 values` | time >= System.Reactive (15,802.3885 ns vs 15,678.0589 ns). | Accepted exception: state primitives preserve current-value/state-signal semantics; the row records the small remaining gap against narrower comparison paths. |
+| `Signal emit, 32 values` | allocation ties System.Reactive (136 B vs 136 B). | Accepted exception: emit loops now lead on throughput and tie System.Reactive allocation; strict lower allocation is not possible for this BCL-compatible shape in the measured path. |
+| `Signal emit, 1024 values` | allocation ties System.Reactive (136 B vs 136 B). | Accepted exception: emit loops now lead on throughput and tie System.Reactive allocation; strict lower allocation is not possible for this BCL-compatible shape in the measured path. |
+| `ShareLive connect` | allocation > R3 (384 B vs 368 B). | Accepted exception: live sharing owns connection/ref-count lifecycle and safe disconnect state; R3 remains lower allocation in this microcase. |
+| `Share live subscribe` | allocation > R3 (848 B vs 488 B). | Accepted exception: live sharing owns connection/ref-count lifecycle and safe disconnect state; R3 remains lower allocation in this microcase. |
+| `AutoShare subscribe` | allocation > R3 (848 B vs 488 B). | Accepted exception: live sharing owns connection/ref-count lifecycle and safe disconnect state; R3 remains lower allocation in this microcase. |
+| `AutoConnect subscribe` | allocation > R3 (728 B vs 368 B). | Accepted exception: live sharing owns connection/ref-count lifecycle and safe disconnect state; R3 remains lower allocation in this microcase. |
+| `StateSignal updates` | time >= System.Reactive (584.5012 ns vs 568.2254 ns). | Accepted exception: state primitives preserve current-value/state-signal semantics; the row records the small remaining gap against narrower comparison paths. |
+| `ReadOnlyState projection` | time >= System.Reactive (136.4027 ns vs 86.8555 ns). | Accepted exception: state primitives preserve current-value/state-signal semantics; the row records the small remaining gap against narrower comparison paths. |
+| `TaskSignal subscribe` | time >= System.Reactive (2,737.5769 ns vs 707.6171 ns); allocation > System.Reactive (3878 B vs 886 B); time >= R3 (2,737.5769 ns vs 39.8419 ns); allocation > R3 (3878 B vs 160 B). | Accepted exception: these primitives expose signal state, busy/result/error state, and async lifecycle coordination rather than only adapting a completed observable path. |
+| `Command execute` | time >= R3 (127.2999 ns vs 98.3740 ns); allocation > R3 (600 B vs 296 B). | Accepted exception: these primitives expose signal state, busy/result/error state, and async lifecycle coordination rather than only adapting a completed observable path. |
+| `Command result subscribe` | time >= System.Reactive (144.8945 ns vs 36.4350 ns); allocation > System.Reactive (672 B vs 136 B); time >= R3 (144.8945 ns vs 61.9539 ns); allocation > R3 (672 B vs 160 B). | Accepted exception: these primitives expose signal state, busy/result/error state, and async lifecycle coordination rather than only adapting a completed observable path. |
+| `CollectList range` | allocation > R3 (688 B vs 632 B). | Accepted exception: the terminal collection helper returns through the BCL-compatible result path; throughput is ahead while R3 allocates slightly less. |
+| `CurrentThread schedule` | allocation ties System.Reactive (88 B vs 88 B); allocation > R3 (88 B vs 56 B). | Accepted exception: current-thread scheduling uses the project sequencer queue contract; throughput is ahead of System.Reactive while R3 allocates less. |
+| `Safe witness` | time >= System.Reactive (21.8713 ns vs 12.3352 ns); allocation > System.Reactive (168 B vs 136 B); time >= R3 (21.8713 ns vs 18.2902 ns); allocation > R3 (168 B vs 56 B). | Accepted exception: the wrapper enforces safe observer/terminal behavior; the row records that deliberate safety overhead. |
+| `Completed Spark` | allocation ties System.Reactive (0 B vs 0 B); time >= R3 (0.0000 ns vs 0.0000 ns); allocation ties R3 (0 B vs 0 B). | Accepted exception: all implementations allocate zero and measure at empty-method scale, so a strict lower-allocation win is not meaningful. |
 
 Performance constraints used by the project:
 
@@ -781,6 +800,8 @@ Performance constraints used by the project:
 | `src/ReactiveUI.Primitives` | Production runtime library. |
 | `src/ReactiveUI.Primitives.Wpf` | Optional WPF dispatcher integration library. |
 | `src/ReactiveUI.Primitives.WinForms` | Optional Windows Forms control integration library. |
+| `src/ReactiveUI.Primitives.Blazor` | Optional Blazor renderer integration library. |
+| `src/ReactiveUI.Primitives.Maui` | Optional MAUI dispatcher integration library. |
 | `src/ReactiveUI.Primitives.SystemReactiveBridge.Generator` | Source generator for System.Reactive bridge adapters. |
 | `src/ReactiveUI.Primitives.R3Bridge.Generator` | Source generator for R3 bridge adapters. |
 | `src/ReactiveUI.Primitives.Tests` | Test project using Microsoft Testing Platform/TUnit-style validation. |
@@ -792,15 +813,18 @@ Performance constraints used by the project:
 
 ```powershell
 # Build solution
-dotnet build src/ReactiveUI.Primitives.slnx --no-restore -v:minimal
+dotnet build src/ReactiveUI.Primitives.slnx --no-restore -c Release -v:minimal
 
 # Test with the Microsoft Testing Platform runner from the src directory.
 Push-Location src
-dotnet test .\ReactiveUI.Primitives.slnx --no-build -v:minimal
+dotnet test .\ReactiveUI.Primitives.slnx --no-build -c Release -v:minimal
 Pop-Location
+
+# Pack NuGet packages.
+dotnet pack src\ReactiveUI.Primitives.slnx --no-build -c Release -v:minimal
 ```
 
-Results: build passed with 0 warnings/0 errors; `dotnet test` passed 537/537 tests across net8.0, net9.0, and net10.0. The latest coverage snapshot passed tests and reported 96.02% line (5285/5504) and 91.46% branch (1820/1990) coverage. That coverage remains below the original 100% line/branch final-review target and is documented as a signed-off release exception rather than represented as a 100% gate pass.
+Results: build passed with 0 warnings/0 errors; `dotnet test` passed 540/540 tests across net8.0, net9.0, and net10.0; `dotnet pack` produced `ReactiveUI.Primitives`, `ReactiveUI.Primitives.Wpf`, `ReactiveUI.Primitives.WinForms`, `ReactiveUI.Primitives.Blazor`, and `ReactiveUI.Primitives.Maui` packages. The latest coverage snapshot passed tests and reported 96.02% line (5285/5504) and 91.46% branch (1820/1990) coverage. That coverage remains below the original 100% line/branch final-review target and is documented as a signed-off release exception rather than represented as a 100% gate pass.
 
 ### Package verification
 
@@ -810,7 +834,7 @@ For NuGet package verification, inspect the generated `.nupkg` and confirm:
 - The nuspec contains `<readme>README.md</readme>`.
 - Bridge generator DLLs are present under `analyzers/dotnet/cs`.
 - Production runtime dependencies do not include System.Reactive or R3.
-- The core `ReactiveUI.Primitives` package does not reference WPF or Windows Forms assemblies; those integrations ship from `ReactiveUI.Primitives.Wpf` and `ReactiveUI.Primitives.WinForms`.
+- The core `ReactiveUI.Primitives` package does not reference WPF, Windows Forms, Blazor, or MAUI assemblies; those integrations ship from `ReactiveUI.Primitives.Wpf`, `ReactiveUI.Primitives.WinForms`, `ReactiveUI.Primitives.Blazor`, and `ReactiveUI.Primitives.Maui`.
 
 ## Practical migration checklist
 

--- a/src/ReactiveUI.Primitives.Blazor/Concurrency/BlazorRendererSequencer.cs
+++ b/src/ReactiveUI.Primitives.Blazor/Concurrency/BlazorRendererSequencer.cs
@@ -2,8 +2,8 @@
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.Threading;
 using ReactiveUI.Primitives.Concurrency;
-using ReactiveUI.Primitives.Disposables;
 
 namespace ReactiveUI.Primitives.Blazor.Concurrency;
 
@@ -53,17 +53,9 @@ public sealed class BlazorRendererSequencer : ISequencer
             throw new ArgumentNullException(nameof(action));
         }
 
-        var cancelable = new BooleanDisposable();
-        _ = _invokeAsync(() =>
-        {
-            if (cancelable.IsDisposed)
-            {
-                return;
-            }
-
-            action(this, state);
-        });
-        return cancelable;
+        var workItem = new RendererWorkItem<TState>(this, state, action);
+        _ = _invokeAsync(workItem.Invoke);
+        return workItem;
     }
 
     /// <summary>
@@ -82,9 +74,15 @@ public sealed class BlazorRendererSequencer : ISequencer
             throw new ArgumentNullException(nameof(action));
         }
 
-        var cancellation = new CancellationDisposable();
-        _ = DelayThenDispatchAsync(state, Sequencer.Normalize(dueTime), action, cancellation.Token);
-        return cancellation;
+        var normalized = Sequencer.Normalize(dueTime);
+        if (normalized == TimeSpan.Zero)
+        {
+            return Schedule(state, action);
+        }
+
+        var workItem = new DelayedRendererWorkItem<TState>(this, state, action, normalized);
+        _ = workItem.DelayThenDispatchAsync();
+        return workItem;
     }
 
     /// <summary>
@@ -99,41 +97,167 @@ public sealed class BlazorRendererSequencer : ISequencer
         Schedule(state, Sequencer.Normalize(dueTime - Now), action);
 
     /// <summary>
-    /// Delays work and then dispatches it through the renderer.
+    /// Disposable renderer work item.
     /// </summary>
     /// <typeparam name="TState">The type of the state passed to the scheduled action.</typeparam>
-    /// <param name="state">State passed to the action to be executed.</param>
-    /// <param name="dueTime">The normalized due time.</param>
-    /// <param name="action">Action to be executed.</param>
-    /// <param name="cancellationToken">Token used to cancel delayed work.</param>
-    /// <returns>A task representing the asynchronous delay and dispatch.</returns>
-    private async Task DelayThenDispatchAsync<TState>(
-        TState state,
-        TimeSpan dueTime,
-        Func<ISequencer, TState, IDisposable> action,
-        CancellationToken cancellationToken)
+    private sealed class RendererWorkItem<TState> : IDisposable
     {
-        try
+        /// <summary>
+        /// Sequencer passed to the scheduled action.
+        /// </summary>
+        private readonly BlazorRendererSequencer _sequencer;
+
+        /// <summary>
+        /// State passed to the scheduled action.
+        /// </summary>
+        private readonly TState _state;
+
+        /// <summary>
+        /// Action invoked when the scheduled item runs.
+        /// </summary>
+        private readonly Func<ISequencer, TState, IDisposable> _action;
+
+        /// <summary>
+        /// Tracks cancellation.
+        /// </summary>
+        private int _isDisposed;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RendererWorkItem{TState}"/> class.
+        /// </summary>
+        /// <param name="sequencer">Sequencer passed to the action.</param>
+        /// <param name="state">State passed to the action.</param>
+        /// <param name="action">Action to invoke.</param>
+        public RendererWorkItem(BlazorRendererSequencer sequencer, TState state, Func<ISequencer, TState, IDisposable> action)
         {
-            await Task.Delay(dueTime, cancellationToken).ConfigureAwait(false);
-            if (cancellationToken.IsCancellationRequested)
+            _sequencer = sequencer;
+            _state = state;
+            _action = action;
+        }
+
+        /// <summary>
+        /// Cancels the work item.
+        /// </summary>
+        public void Dispose() => Interlocked.Exchange(ref _isDisposed, 1);
+
+        /// <summary>
+        /// Invokes the scheduled action if it has not been cancelled.
+        /// </summary>
+        public void Invoke()
+        {
+            if (Volatile.Read(ref _isDisposed) != 0)
             {
                 return;
             }
 
-            await _invokeAsync(() =>
+            _action(_sequencer, _state);
+        }
+    }
+
+    /// <summary>
+    /// Disposable delayed renderer work item.
+    /// </summary>
+    /// <typeparam name="TState">The type of the state passed to the scheduled action.</typeparam>
+    private sealed class DelayedRendererWorkItem<TState> : IDisposable
+    {
+        /// <summary>
+        /// Sequencer passed to the scheduled action.
+        /// </summary>
+        private readonly BlazorRendererSequencer _sequencer;
+
+        /// <summary>
+        /// State passed to the scheduled action.
+        /// </summary>
+        private readonly TState _state;
+
+        /// <summary>
+        /// Action invoked when the scheduled item runs.
+        /// </summary>
+        private readonly Func<ISequencer, TState, IDisposable> _action;
+
+        /// <summary>
+        /// Relative time after which to dispatch the action.
+        /// </summary>
+        private readonly TimeSpan _dueTime;
+
+        /// <summary>
+        /// Cancellation source for the delayed work.
+        /// </summary>
+        private readonly CancellationTokenSource _cancellation = new();
+
+        /// <summary>
+        /// Cancellation token for the delayed work.
+        /// </summary>
+        private readonly CancellationToken _token;
+
+        /// <summary>
+        /// Tracks cancellation.
+        /// </summary>
+        private int _isDisposed;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DelayedRendererWorkItem{TState}"/> class.
+        /// </summary>
+        /// <param name="sequencer">Sequencer passed to the action.</param>
+        /// <param name="state">State passed to the action.</param>
+        /// <param name="action">Action to invoke.</param>
+        /// <param name="dueTime">Relative time after which to execute the action.</param>
+        public DelayedRendererWorkItem(BlazorRendererSequencer sequencer, TState state, Func<ISequencer, TState, IDisposable> action, TimeSpan dueTime)
+        {
+            _sequencer = sequencer;
+            _state = state;
+            _action = action;
+            _dueTime = dueTime;
+            _token = _cancellation.Token;
+        }
+
+        /// <summary>
+        /// Cancels the delayed work item.
+        /// </summary>
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _isDisposed, 1) != 0)
             {
-                if (cancellationToken.IsCancellationRequested)
+                return;
+            }
+
+            _cancellation.Cancel();
+            _cancellation.Dispose();
+        }
+
+        /// <summary>
+        /// Delays work and then dispatches it through the renderer.
+        /// </summary>
+        /// <returns>A task representing the asynchronous delay and dispatch.</returns>
+        public async Task DelayThenDispatchAsync()
+        {
+            try
+            {
+                await Task.Delay(_dueTime, _token).ConfigureAwait(false);
+                if (Volatile.Read(ref _isDisposed) != 0)
                 {
                     return;
                 }
 
-                action(this, state);
-            }).ConfigureAwait(false);
+                await _sequencer._invokeAsync(Invoke).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (_token.IsCancellationRequested)
+            {
+                // Cancellation is the expected disposal path for delayed renderer work.
+            }
         }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+
+        /// <summary>
+        /// Invokes the scheduled action if it has not been cancelled.
+        /// </summary>
+        private void Invoke()
         {
-            // Cancellation is the expected disposal path for delayed renderer work.
+            if (Volatile.Read(ref _isDisposed) != 0)
+            {
+                return;
+            }
+
+            _action(_sequencer, _state);
         }
     }
 }

--- a/src/ReactiveUI.Primitives.Blazor/Concurrency/BlazorRendererSequencer.cs
+++ b/src/ReactiveUI.Primitives.Blazor/Concurrency/BlazorRendererSequencer.cs
@@ -53,7 +53,7 @@ public sealed class BlazorRendererSequencer : ISequencer
             throw new ArgumentNullException(nameof(action));
         }
 
-        var workItem = new RendererWorkItem<TState>(this, state, action);
+        var workItem = new SequencerWorkItem<BlazorRendererSequencer, TState>(this, state, action);
         _ = _invokeAsync(workItem.Invoke);
         return workItem;
     }
@@ -95,64 +95,6 @@ public sealed class BlazorRendererSequencer : ISequencer
     /// <returns>The disposable object used to cancel the scheduled action on a best-effort basis.</returns>
     public IDisposable Schedule<TState>(TState state, DateTimeOffset dueTime, Func<ISequencer, TState, IDisposable> action) =>
         Schedule(state, Sequencer.Normalize(dueTime - Now), action);
-
-    /// <summary>
-    /// Disposable renderer work item.
-    /// </summary>
-    /// <typeparam name="TState">The type of the state passed to the scheduled action.</typeparam>
-    private sealed class RendererWorkItem<TState> : IDisposable
-    {
-        /// <summary>
-        /// Sequencer passed to the scheduled action.
-        /// </summary>
-        private readonly BlazorRendererSequencer _sequencer;
-
-        /// <summary>
-        /// State passed to the scheduled action.
-        /// </summary>
-        private readonly TState _state;
-
-        /// <summary>
-        /// Action invoked when the scheduled item runs.
-        /// </summary>
-        private readonly Func<ISequencer, TState, IDisposable> _action;
-
-        /// <summary>
-        /// Tracks cancellation.
-        /// </summary>
-        private int _isDisposed;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="RendererWorkItem{TState}"/> class.
-        /// </summary>
-        /// <param name="sequencer">Sequencer passed to the action.</param>
-        /// <param name="state">State passed to the action.</param>
-        /// <param name="action">Action to invoke.</param>
-        public RendererWorkItem(BlazorRendererSequencer sequencer, TState state, Func<ISequencer, TState, IDisposable> action)
-        {
-            _sequencer = sequencer;
-            _state = state;
-            _action = action;
-        }
-
-        /// <summary>
-        /// Cancels the work item.
-        /// </summary>
-        public void Dispose() => Interlocked.Exchange(ref _isDisposed, 1);
-
-        /// <summary>
-        /// Invokes the scheduled action if it has not been cancelled.
-        /// </summary>
-        public void Invoke()
-        {
-            if (Volatile.Read(ref _isDisposed) != 0)
-            {
-                return;
-            }
-
-            _action(_sequencer, _state);
-        }
-    }
 
     /// <summary>
     /// Disposable delayed renderer work item.

--- a/src/ReactiveUI.Primitives.Maui/Concurrency/MauiDispatcherSequencer.cs
+++ b/src/ReactiveUI.Primitives.Maui/Concurrency/MauiDispatcherSequencer.cs
@@ -53,7 +53,7 @@ public sealed class MauiDispatcherSequencer : ISequencer
             throw new ArgumentNullException(nameof(action));
         }
 
-        var workItem = new DispatcherWorkItem<TState>(this, state, action);
+        var workItem = new SequencerWorkItem<MauiDispatcherSequencer, TState>(this, state, action);
         _ = Dispatcher.Dispatch(workItem.Invoke);
         return workItem;
     }
@@ -95,64 +95,6 @@ public sealed class MauiDispatcherSequencer : ISequencer
     /// <returns>The disposable object used to cancel the scheduled action on a best-effort basis.</returns>
     public IDisposable Schedule<TState>(TState state, DateTimeOffset dueTime, Func<ISequencer, TState, IDisposable> action) =>
         Schedule(state, Sequencer.Normalize(dueTime - Now), action);
-
-    /// <summary>
-    /// Disposable dispatcher work item.
-    /// </summary>
-    /// <typeparam name="TState">The type of the state passed to the scheduled action.</typeparam>
-    private sealed class DispatcherWorkItem<TState> : IDisposable
-    {
-        /// <summary>
-        /// Sequencer passed to the scheduled action.
-        /// </summary>
-        private readonly MauiDispatcherSequencer _sequencer;
-
-        /// <summary>
-        /// State passed to the scheduled action.
-        /// </summary>
-        private readonly TState _state;
-
-        /// <summary>
-        /// Action invoked when the scheduled item runs.
-        /// </summary>
-        private readonly Func<ISequencer, TState, IDisposable> _action;
-
-        /// <summary>
-        /// Tracks cancellation.
-        /// </summary>
-        private int _isDisposed;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="DispatcherWorkItem{TState}"/> class.
-        /// </summary>
-        /// <param name="sequencer">Sequencer passed to the action.</param>
-        /// <param name="state">State passed to the action.</param>
-        /// <param name="action">Action to invoke.</param>
-        public DispatcherWorkItem(MauiDispatcherSequencer sequencer, TState state, Func<ISequencer, TState, IDisposable> action)
-        {
-            _sequencer = sequencer;
-            _state = state;
-            _action = action;
-        }
-
-        /// <summary>
-        /// Cancels the work item.
-        /// </summary>
-        public void Dispose() => Interlocked.Exchange(ref _isDisposed, 1);
-
-        /// <summary>
-        /// Invokes the scheduled action if it has not been cancelled.
-        /// </summary>
-        public void Invoke()
-        {
-            if (Volatile.Read(ref _isDisposed) != 0)
-            {
-                return;
-            }
-
-            _action(_sequencer, _state);
-        }
-    }
 
     /// <summary>
     /// Disposable dispatcher timer work item.

--- a/src/ReactiveUI.Primitives.Maui/Concurrency/MauiDispatcherSequencer.cs
+++ b/src/ReactiveUI.Primitives.Maui/Concurrency/MauiDispatcherSequencer.cs
@@ -2,8 +2,8 @@
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.Threading;
 using Microsoft.Maui.Dispatching;
-using ReactiveUI.Primitives.Disposables;
 
 namespace ReactiveUI.Primitives.Concurrency;
 
@@ -53,18 +53,9 @@ public sealed class MauiDispatcherSequencer : ISequencer
             throw new ArgumentNullException(nameof(action));
         }
 
-        var cancelable = new BooleanDisposable();
-        Dispatcher.Dispatch(() =>
-        {
-            if (cancelable.IsDisposed)
-            {
-                return;
-            }
-
-            action(this, state);
-        });
-
-        return cancelable;
+        var workItem = new DispatcherWorkItem<TState>(this, state, action);
+        _ = Dispatcher.Dispatch(workItem.Invoke);
+        return workItem;
     }
 
     /// <summary>
@@ -83,31 +74,15 @@ public sealed class MauiDispatcherSequencer : ISequencer
             throw new ArgumentNullException(nameof(action));
         }
 
-        var cancelable = new BooleanDisposable();
-        var timer = Dispatcher.CreateTimer();
-        timer.Interval = Sequencer.Normalize(dueTime);
-        timer.IsRepeating = false;
-        timer.Tick += OnTick;
-        timer.Start();
-
-        return Disposable.Create(() =>
+        var normalized = Sequencer.Normalize(dueTime);
+        if (normalized == TimeSpan.Zero)
         {
-            cancelable.Dispose();
-            timer.Stop();
-            timer.Tick -= OnTick;
-        });
-
-        void OnTick(object? sender, EventArgs eventArgs)
-        {
-            timer.Stop();
-            timer.Tick -= OnTick;
-            if (cancelable.IsDisposed)
-            {
-                return;
-            }
-
-            action(this, state);
+            return Schedule(state, action);
         }
+
+        var workItem = new DispatcherTimerWorkItem<TState>(this, state, action, normalized);
+        workItem.Start();
+        return workItem;
     }
 
     /// <summary>
@@ -120,4 +95,148 @@ public sealed class MauiDispatcherSequencer : ISequencer
     /// <returns>The disposable object used to cancel the scheduled action on a best-effort basis.</returns>
     public IDisposable Schedule<TState>(TState state, DateTimeOffset dueTime, Func<ISequencer, TState, IDisposable> action) =>
         Schedule(state, Sequencer.Normalize(dueTime - Now), action);
+
+    /// <summary>
+    /// Disposable dispatcher work item.
+    /// </summary>
+    /// <typeparam name="TState">The type of the state passed to the scheduled action.</typeparam>
+    private sealed class DispatcherWorkItem<TState> : IDisposable
+    {
+        /// <summary>
+        /// Sequencer passed to the scheduled action.
+        /// </summary>
+        private readonly MauiDispatcherSequencer _sequencer;
+
+        /// <summary>
+        /// State passed to the scheduled action.
+        /// </summary>
+        private readonly TState _state;
+
+        /// <summary>
+        /// Action invoked when the scheduled item runs.
+        /// </summary>
+        private readonly Func<ISequencer, TState, IDisposable> _action;
+
+        /// <summary>
+        /// Tracks cancellation.
+        /// </summary>
+        private int _isDisposed;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DispatcherWorkItem{TState}"/> class.
+        /// </summary>
+        /// <param name="sequencer">Sequencer passed to the action.</param>
+        /// <param name="state">State passed to the action.</param>
+        /// <param name="action">Action to invoke.</param>
+        public DispatcherWorkItem(MauiDispatcherSequencer sequencer, TState state, Func<ISequencer, TState, IDisposable> action)
+        {
+            _sequencer = sequencer;
+            _state = state;
+            _action = action;
+        }
+
+        /// <summary>
+        /// Cancels the work item.
+        /// </summary>
+        public void Dispose() => Interlocked.Exchange(ref _isDisposed, 1);
+
+        /// <summary>
+        /// Invokes the scheduled action if it has not been cancelled.
+        /// </summary>
+        public void Invoke()
+        {
+            if (Volatile.Read(ref _isDisposed) != 0)
+            {
+                return;
+            }
+
+            _action(_sequencer, _state);
+        }
+    }
+
+    /// <summary>
+    /// Disposable dispatcher timer work item.
+    /// </summary>
+    /// <typeparam name="TState">The type of the state passed to the scheduled action.</typeparam>
+    private sealed class DispatcherTimerWorkItem<TState> : IDisposable
+    {
+        /// <summary>
+        /// Sequencer passed to the scheduled action.
+        /// </summary>
+        private readonly MauiDispatcherSequencer _sequencer;
+
+        /// <summary>
+        /// State passed to the scheduled action.
+        /// </summary>
+        private readonly TState _state;
+
+        /// <summary>
+        /// Action invoked when the scheduled item runs.
+        /// </summary>
+        private readonly Func<ISequencer, TState, IDisposable> _action;
+
+        /// <summary>
+        /// MAUI timer used for delayed execution.
+        /// </summary>
+        private readonly IDispatcherTimer _timer;
+
+        /// <summary>
+        /// Tracks cancellation.
+        /// </summary>
+        private int _isDisposed;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DispatcherTimerWorkItem{TState}"/> class.
+        /// </summary>
+        /// <param name="sequencer">Sequencer passed to the action.</param>
+        /// <param name="state">State passed to the action.</param>
+        /// <param name="action">Action to invoke.</param>
+        /// <param name="dueTime">Relative time after which to execute the action.</param>
+        public DispatcherTimerWorkItem(MauiDispatcherSequencer sequencer, TState state, Func<ISequencer, TState, IDisposable> action, TimeSpan dueTime)
+        {
+            _sequencer = sequencer;
+            _state = state;
+            _action = action;
+            _timer = sequencer.Dispatcher.CreateTimer();
+            _timer.Interval = dueTime;
+            _timer.IsRepeating = false;
+            _timer.Tick += OnTick;
+        }
+
+        /// <summary>
+        /// Cancels the timer work item.
+        /// </summary>
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _isDisposed, 1) != 0)
+            {
+                return;
+            }
+
+            _timer.Stop();
+            _timer.Tick -= OnTick;
+        }
+
+        /// <summary>
+        /// Starts the MAUI dispatcher timer.
+        /// </summary>
+        public void Start() => _timer.Start();
+
+        /// <summary>
+        /// Handles the timer tick.
+        /// </summary>
+        /// <param name="sender">The event source.</param>
+        /// <param name="e">The event arguments.</param>
+        private void OnTick(object? sender, EventArgs e)
+        {
+            if (Interlocked.Exchange(ref _isDisposed, 1) != 0)
+            {
+                return;
+            }
+
+            _timer.Stop();
+            _timer.Tick -= OnTick;
+            _action(_sequencer, _state);
+        }
+    }
 }

--- a/src/ReactiveUI.Primitives.WinForms/Concurrency/ControlSequencer.cs
+++ b/src/ReactiveUI.Primitives.WinForms/Concurrency/ControlSequencer.cs
@@ -66,7 +66,7 @@ public sealed class ControlSequencer : ISequencer
             throw new ArgumentNullException(nameof(action));
         }
 
-        var workItem = new ControlWorkItem<TState>(this, state, action);
+        var workItem = new SequencerWorkItem<ControlSequencer, TState>(this, state, action);
         Control.BeginInvoke((MethodInvoker)workItem.Invoke);
         return workItem;
     }
@@ -108,64 +108,6 @@ public sealed class ControlSequencer : ISequencer
     /// <returns>The disposable object used to cancel the scheduled action on a best-effort basis.</returns>
     public IDisposable Schedule<TState>(TState state, DateTimeOffset dueTime, Func<ISequencer, TState, IDisposable> action) =>
         Schedule(state, Sequencer.Normalize(dueTime - Now), action);
-
-    /// <summary>
-    /// Disposable control work item.
-    /// </summary>
-    /// <typeparam name="TState">The type of the state passed to the scheduled action.</typeparam>
-    private sealed class ControlWorkItem<TState> : IDisposable
-    {
-        /// <summary>
-        /// Sequencer passed to the scheduled action.
-        /// </summary>
-        private readonly ControlSequencer _sequencer;
-
-        /// <summary>
-        /// State passed to the scheduled action.
-        /// </summary>
-        private readonly TState _state;
-
-        /// <summary>
-        /// Action invoked when the scheduled item runs.
-        /// </summary>
-        private readonly Func<ISequencer, TState, IDisposable> _action;
-
-        /// <summary>
-        /// Tracks cancellation.
-        /// </summary>
-        private int _isDisposed;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ControlWorkItem{TState}"/> class.
-        /// </summary>
-        /// <param name="sequencer">Sequencer passed to the action.</param>
-        /// <param name="state">State passed to the action.</param>
-        /// <param name="action">Action to invoke.</param>
-        public ControlWorkItem(ControlSequencer sequencer, TState state, Func<ISequencer, TState, IDisposable> action)
-        {
-            _sequencer = sequencer;
-            _state = state;
-            _action = action;
-        }
-
-        /// <summary>
-        /// Cancels the work item.
-        /// </summary>
-        public void Dispose() => Interlocked.Exchange(ref _isDisposed, 1);
-
-        /// <summary>
-        /// Invokes the scheduled action if it has not been cancelled.
-        /// </summary>
-        public void Invoke()
-        {
-            if (Volatile.Read(ref _isDisposed) != 0)
-            {
-                return;
-            }
-
-            _action(_sequencer, _state);
-        }
-    }
 
     /// <summary>
     /// Disposable Windows Forms timer work item.

--- a/src/ReactiveUI.Primitives.WinForms/Concurrency/ControlSequencer.cs
+++ b/src/ReactiveUI.Primitives.WinForms/Concurrency/ControlSequencer.cs
@@ -2,8 +2,8 @@
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.Threading;
 using System.Windows.Forms;
-using ReactiveUI.Primitives.Disposables;
 using FormsTimer = System.Windows.Forms.Timer;
 
 namespace ReactiveUI.Primitives.Concurrency;
@@ -66,18 +66,9 @@ public sealed class ControlSequencer : ISequencer
             throw new ArgumentNullException(nameof(action));
         }
 
-        var cancelable = new BooleanDisposable();
-        Control.BeginInvoke((MethodInvoker)(() =>
-        {
-            if (cancelable.IsDisposed)
-            {
-                return;
-            }
-
-            action(this, state);
-        }));
-
-        return cancelable;
+        var workItem = new ControlWorkItem<TState>(this, state, action);
+        Control.BeginInvoke((MethodInvoker)workItem.Invoke);
+        return workItem;
     }
 
     /// <summary>
@@ -96,24 +87,15 @@ public sealed class ControlSequencer : ISequencer
             throw new ArgumentNullException(nameof(action));
         }
 
-        var timer = new FormsTimer
+        var normalized = Sequencer.Normalize(dueTime);
+        if (normalized == TimeSpan.Zero)
         {
-            Interval = ToTimerInterval(Sequencer.Normalize(dueTime)),
-        };
+            return Schedule(state, action);
+        }
 
-        timer.Tick += (_, _) =>
-        {
-            timer.Stop();
-            timer.Dispose();
-            action(this, state);
-        };
-        timer.Start();
-
-        return Disposable.Create(() =>
-        {
-            timer.Stop();
-            timer.Dispose();
-        });
+        var workItem = new ControlTimerWorkItem<TState>(this, state, action, normalized);
+        workItem.Start();
+        return workItem;
     }
 
     /// <summary>
@@ -128,23 +110,166 @@ public sealed class ControlSequencer : ISequencer
         Schedule(state, Sequencer.Normalize(dueTime - Now), action);
 
     /// <summary>
-    /// Converts the due time to a Windows Forms timer interval.
+    /// Disposable control work item.
     /// </summary>
-    /// <param name="dueTime">The normalized due time.</param>
-    /// <returns>The timer interval in milliseconds.</returns>
-    private static int ToTimerInterval(TimeSpan dueTime)
+    /// <typeparam name="TState">The type of the state passed to the scheduled action.</typeparam>
+    private sealed class ControlWorkItem<TState> : IDisposable
     {
-        var totalMilliseconds = dueTime.TotalMilliseconds;
-        if (totalMilliseconds <= 1)
+        /// <summary>
+        /// Sequencer passed to the scheduled action.
+        /// </summary>
+        private readonly ControlSequencer _sequencer;
+
+        /// <summary>
+        /// State passed to the scheduled action.
+        /// </summary>
+        private readonly TState _state;
+
+        /// <summary>
+        /// Action invoked when the scheduled item runs.
+        /// </summary>
+        private readonly Func<ISequencer, TState, IDisposable> _action;
+
+        /// <summary>
+        /// Tracks cancellation.
+        /// </summary>
+        private int _isDisposed;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ControlWorkItem{TState}"/> class.
+        /// </summary>
+        /// <param name="sequencer">Sequencer passed to the action.</param>
+        /// <param name="state">State passed to the action.</param>
+        /// <param name="action">Action to invoke.</param>
+        public ControlWorkItem(ControlSequencer sequencer, TState state, Func<ISequencer, TState, IDisposable> action)
         {
-            return 1;
+            _sequencer = sequencer;
+            _state = state;
+            _action = action;
         }
 
-        if (totalMilliseconds >= int.MaxValue)
+        /// <summary>
+        /// Cancels the work item.
+        /// </summary>
+        public void Dispose() => Interlocked.Exchange(ref _isDisposed, 1);
+
+        /// <summary>
+        /// Invokes the scheduled action if it has not been cancelled.
+        /// </summary>
+        public void Invoke()
         {
-            return int.MaxValue;
+            if (Volatile.Read(ref _isDisposed) != 0)
+            {
+                return;
+            }
+
+            _action(_sequencer, _state);
+        }
+    }
+
+    /// <summary>
+    /// Disposable Windows Forms timer work item.
+    /// </summary>
+    /// <typeparam name="TState">The type of the state passed to the scheduled action.</typeparam>
+    private sealed class ControlTimerWorkItem<TState> : IDisposable
+    {
+        /// <summary>
+        /// Sequencer passed to the scheduled action.
+        /// </summary>
+        private readonly ControlSequencer _sequencer;
+
+        /// <summary>
+        /// State passed to the scheduled action.
+        /// </summary>
+        private readonly TState _state;
+
+        /// <summary>
+        /// Action invoked when the scheduled item runs.
+        /// </summary>
+        private readonly Func<ISequencer, TState, IDisposable> _action;
+
+        /// <summary>
+        /// Windows Forms timer used for delayed execution.
+        /// </summary>
+        private readonly FormsTimer _timer;
+
+        /// <summary>
+        /// Tracks cancellation.
+        /// </summary>
+        private int _isDisposed;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ControlTimerWorkItem{TState}"/> class.
+        /// </summary>
+        /// <param name="sequencer">Sequencer passed to the action.</param>
+        /// <param name="state">State passed to the action.</param>
+        /// <param name="action">Action to invoke.</param>
+        /// <param name="dueTime">Relative time after which to execute the action.</param>
+        public ControlTimerWorkItem(ControlSequencer sequencer, TState state, Func<ISequencer, TState, IDisposable> action, TimeSpan dueTime)
+        {
+            _sequencer = sequencer;
+            _state = state;
+            _action = action;
+            _timer = new FormsTimer
+            {
+                Interval = ToTimerInterval(dueTime),
+            };
+
+            _timer.Tick += OnTick;
+
+            static int ToTimerInterval(TimeSpan normalizedDueTime)
+            {
+                var totalMilliseconds = normalizedDueTime.TotalMilliseconds;
+                if (totalMilliseconds <= 1)
+                {
+                    return 1;
+                }
+
+                if (totalMilliseconds >= int.MaxValue)
+                {
+                    return int.MaxValue;
+                }
+
+                return (int)Math.Ceiling(totalMilliseconds);
+            }
         }
 
-        return (int)Math.Ceiling(totalMilliseconds);
+        /// <summary>
+        /// Cancels the timer work item.
+        /// </summary>
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _isDisposed, 1) != 0)
+            {
+                return;
+            }
+
+            _timer.Stop();
+            _timer.Tick -= OnTick;
+            _timer.Dispose();
+        }
+
+        /// <summary>
+        /// Starts the Windows Forms timer.
+        /// </summary>
+        public void Start() => _timer.Start();
+
+        /// <summary>
+        /// Handles the timer tick.
+        /// </summary>
+        /// <param name="sender">The event source.</param>
+        /// <param name="e">The event arguments.</param>
+        private void OnTick(object? sender, EventArgs e)
+        {
+            if (Interlocked.Exchange(ref _isDisposed, 1) != 0)
+            {
+                return;
+            }
+
+            _timer.Stop();
+            _timer.Tick -= OnTick;
+            _timer.Dispose();
+            _action(_sequencer, _state);
+        }
     }
 }

--- a/src/ReactiveUI.Primitives.Wpf/Concurrency/DispatcherSequencer.cs
+++ b/src/ReactiveUI.Primitives.Wpf/Concurrency/DispatcherSequencer.cs
@@ -71,7 +71,7 @@ public class DispatcherSequencer : ISequencer
             throw new ArgumentNullException(nameof(action));
         }
 
-        var workItem = new DispatcherWorkItem<TState>(this, state, action);
+        var workItem = new SequencerWorkItem<DispatcherSequencer, TState>(this, state, action);
         Dispatcher.BeginInvoke((Action)workItem.Invoke);
         return workItem;
     }
@@ -117,64 +117,6 @@ public class DispatcherSequencer : ISequencer
     /// </returns>
     public IDisposable Schedule<TState>(TState state, DateTimeOffset dueTime, Func<ISequencer, TState, IDisposable> action) =>
         Schedule(state, Sequencer.Normalize(dueTime - Now), action);
-
-    /// <summary>
-    /// Disposable dispatcher work item.
-    /// </summary>
-    /// <typeparam name="TState">The type of the state passed to the scheduled action.</typeparam>
-    private sealed class DispatcherWorkItem<TState> : IDisposable
-    {
-        /// <summary>
-        /// Sequencer passed to the scheduled action.
-        /// </summary>
-        private readonly DispatcherSequencer _sequencer;
-
-        /// <summary>
-        /// State passed to the scheduled action.
-        /// </summary>
-        private readonly TState _state;
-
-        /// <summary>
-        /// Action invoked when the scheduled item runs.
-        /// </summary>
-        private readonly Func<ISequencer, TState, IDisposable> _action;
-
-        /// <summary>
-        /// Tracks cancellation.
-        /// </summary>
-        private int _isDisposed;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="DispatcherWorkItem{TState}"/> class.
-        /// </summary>
-        /// <param name="sequencer">Sequencer passed to the action.</param>
-        /// <param name="state">State passed to the action.</param>
-        /// <param name="action">Action to invoke.</param>
-        public DispatcherWorkItem(DispatcherSequencer sequencer, TState state, Func<ISequencer, TState, IDisposable> action)
-        {
-            _sequencer = sequencer;
-            _state = state;
-            _action = action;
-        }
-
-        /// <summary>
-        /// Cancels the work item.
-        /// </summary>
-        public void Dispose() => Interlocked.Exchange(ref _isDisposed, 1);
-
-        /// <summary>
-        /// Invokes the scheduled action if it has not been cancelled.
-        /// </summary>
-        public void Invoke()
-        {
-            if (Volatile.Read(ref _isDisposed) != 0)
-            {
-                return;
-            }
-
-            _action(_sequencer, _state);
-        }
-    }
 
     /// <summary>
     /// Disposable dispatcher timer work item.

--- a/src/ReactiveUI.Primitives.Wpf/Concurrency/DispatcherSequencer.cs
+++ b/src/ReactiveUI.Primitives.Wpf/Concurrency/DispatcherSequencer.cs
@@ -3,8 +3,8 @@
 // See the LICENSE file in the project root for full license information.
 
 using System;
+using System.Threading;
 using System.Windows.Threading;
-using ReactiveUI.Primitives.Disposables;
 
 namespace ReactiveUI.Primitives.Concurrency;
 
@@ -71,17 +71,9 @@ public class DispatcherSequencer : ISequencer
             throw new ArgumentNullException(nameof(action));
         }
 
-        var cancelable = new BooleanDisposable();
-        Dispatcher.BeginInvoke(() =>
-        {
-            if (cancelable.IsDisposed)
-            {
-                return;
-            }
-
-            action(this, state);
-        });
-        return cancelable;
+        var workItem = new DispatcherWorkItem<TState>(this, state, action);
+        Dispatcher.BeginInvoke((Action)workItem.Invoke);
+        return workItem;
     }
 
     /// <summary>
@@ -103,20 +95,14 @@ public class DispatcherSequencer : ISequencer
         }
 
         var timeSpan = Sequencer.Normalize(dueTime);
-        var timer = new DispatcherTimer();
-        timer.Tick += (_, _) =>
+        if (timeSpan == TimeSpan.Zero)
         {
-            timer?.Stop();
-            timer = null;
-            action(this, state);
-        };
-        timer.Interval = timeSpan;
-        timer.Start();
-        return Disposable.Create(() =>
-        {
-            timer?.Stop();
-            timer = null;
-        });
+            return Schedule(state, action);
+        }
+
+        var workItem = new DispatcherTimerWorkItem<TState>(this, state, action, timeSpan);
+        workItem.Start();
+        return workItem;
     }
 
     /// <summary>
@@ -131,4 +117,146 @@ public class DispatcherSequencer : ISequencer
     /// </returns>
     public IDisposable Schedule<TState>(TState state, DateTimeOffset dueTime, Func<ISequencer, TState, IDisposable> action) =>
         Schedule(state, Sequencer.Normalize(dueTime - Now), action);
+
+    /// <summary>
+    /// Disposable dispatcher work item.
+    /// </summary>
+    /// <typeparam name="TState">The type of the state passed to the scheduled action.</typeparam>
+    private sealed class DispatcherWorkItem<TState> : IDisposable
+    {
+        /// <summary>
+        /// Sequencer passed to the scheduled action.
+        /// </summary>
+        private readonly DispatcherSequencer _sequencer;
+
+        /// <summary>
+        /// State passed to the scheduled action.
+        /// </summary>
+        private readonly TState _state;
+
+        /// <summary>
+        /// Action invoked when the scheduled item runs.
+        /// </summary>
+        private readonly Func<ISequencer, TState, IDisposable> _action;
+
+        /// <summary>
+        /// Tracks cancellation.
+        /// </summary>
+        private int _isDisposed;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DispatcherWorkItem{TState}"/> class.
+        /// </summary>
+        /// <param name="sequencer">Sequencer passed to the action.</param>
+        /// <param name="state">State passed to the action.</param>
+        /// <param name="action">Action to invoke.</param>
+        public DispatcherWorkItem(DispatcherSequencer sequencer, TState state, Func<ISequencer, TState, IDisposable> action)
+        {
+            _sequencer = sequencer;
+            _state = state;
+            _action = action;
+        }
+
+        /// <summary>
+        /// Cancels the work item.
+        /// </summary>
+        public void Dispose() => Interlocked.Exchange(ref _isDisposed, 1);
+
+        /// <summary>
+        /// Invokes the scheduled action if it has not been cancelled.
+        /// </summary>
+        public void Invoke()
+        {
+            if (Volatile.Read(ref _isDisposed) != 0)
+            {
+                return;
+            }
+
+            _action(_sequencer, _state);
+        }
+    }
+
+    /// <summary>
+    /// Disposable dispatcher timer work item.
+    /// </summary>
+    /// <typeparam name="TState">The type of the state passed to the scheduled action.</typeparam>
+    private sealed class DispatcherTimerWorkItem<TState> : IDisposable
+    {
+        /// <summary>
+        /// Sequencer passed to the scheduled action.
+        /// </summary>
+        private readonly DispatcherSequencer _sequencer;
+
+        /// <summary>
+        /// State passed to the scheduled action.
+        /// </summary>
+        private readonly TState _state;
+
+        /// <summary>
+        /// Action invoked when the scheduled item runs.
+        /// </summary>
+        private readonly Func<ISequencer, TState, IDisposable> _action;
+
+        /// <summary>
+        /// Dispatcher timer used for delayed execution.
+        /// </summary>
+        private readonly DispatcherTimer _timer;
+
+        /// <summary>
+        /// Tracks cancellation.
+        /// </summary>
+        private int _isDisposed;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DispatcherTimerWorkItem{TState}"/> class.
+        /// </summary>
+        /// <param name="sequencer">Sequencer passed to the action.</param>
+        /// <param name="state">State passed to the action.</param>
+        /// <param name="action">Action to invoke.</param>
+        /// <param name="dueTime">Relative time after which to execute the action.</param>
+        public DispatcherTimerWorkItem(DispatcherSequencer sequencer, TState state, Func<ISequencer, TState, IDisposable> action, TimeSpan dueTime)
+        {
+            _sequencer = sequencer;
+            _state = state;
+            _action = action;
+            _timer = new DispatcherTimer { Interval = dueTime };
+            _timer.Tick += OnTick;
+        }
+
+        /// <summary>
+        /// Cancels the timer work item.
+        /// </summary>
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _isDisposed, 1) != 0)
+            {
+                return;
+            }
+
+            _timer.Stop();
+            _timer.Tick -= OnTick;
+        }
+
+        /// <summary>
+        /// Starts the dispatcher timer.
+        /// </summary>
+        public void Start() => _timer.Start();
+
+        /// <summary>
+        /// Handles the timer tick.
+        /// </summary>
+        /// <param name="sender">The event source.</param>
+        /// <param name="e">The event arguments.</param>
+        private void OnTick(object? sender, EventArgs e)
+        {
+            if (Interlocked.Exchange(ref _isDisposed, 1) != 0)
+            {
+                return;
+            }
+
+            _timer.Stop();
+            _timer.Tick -= OnTick;
+            _action(_sequencer, _state);
+        }
+    }
 }

--- a/src/ReactiveUI.Primitives/Concurrency/SequencerQueue.cs
+++ b/src/ReactiveUI.Primitives/Concurrency/SequencerQueue.cs
@@ -66,7 +66,21 @@ public partial class SequencerQueue<TAbsolute>
     /// </summary>
     /// <param name="scheduledItem">Work item to be removed from the scheduler queue.</param>
     /// <returns><c>true</c> if the item was found; <c>false</c> otherwise.</returns>
-    public bool Remove(ScheduledItem<TAbsolute> scheduledItem) => _queue.Remove(scheduledItem);
+    public bool Remove(ScheduledItem<TAbsolute> scheduledItem)
+    {
+        if (_queue.Count == 0)
+        {
+            return false;
+        }
+
+        if (ReferenceEquals(_queue.Peek(), scheduledItem))
+        {
+            _queue.Dequeue();
+            return true;
+        }
+
+        return _queue.Remove(scheduledItem);
+    }
 
     /// <summary>
     /// Dequeues the next work item from the scheduler queue.

--- a/src/ReactiveUI.Primitives/Concurrency/SequencerWorkItem.cs
+++ b/src/ReactiveUI.Primitives/Concurrency/SequencerWorkItem.cs
@@ -1,0 +1,67 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Threading;
+
+namespace ReactiveUI.Primitives.Concurrency;
+
+/// <summary>
+/// Disposable scheduled work item used by UI-backed sequencers.
+/// </summary>
+/// <typeparam name="TSequencer">The sequencer type passed to the scheduled action.</typeparam>
+/// <typeparam name="TState">The scheduled state type.</typeparam>
+internal sealed class SequencerWorkItem<TSequencer, TState> : IDisposable
+    where TSequencer : ISequencer
+{
+    /// <summary>
+    /// Sequencer passed to the scheduled action.
+    /// </summary>
+    private readonly TSequencer _sequencer;
+
+    /// <summary>
+    /// State passed to the scheduled action.
+    /// </summary>
+    private readonly TState _state;
+
+    /// <summary>
+    /// Action invoked when the scheduled item runs.
+    /// </summary>
+    private readonly Func<ISequencer, TState, IDisposable> _action;
+
+    /// <summary>
+    /// Tracks cancellation.
+    /// </summary>
+    private int _isDisposed;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SequencerWorkItem{TSequencer, TState}"/> class.
+    /// </summary>
+    /// <param name="sequencer">Sequencer passed to the action.</param>
+    /// <param name="state">State passed to the action.</param>
+    /// <param name="action">Action to invoke.</param>
+    public SequencerWorkItem(TSequencer sequencer, TState state, Func<ISequencer, TState, IDisposable> action)
+    {
+        _sequencer = sequencer;
+        _state = state;
+        _action = action;
+    }
+
+    /// <summary>
+    /// Cancels the work item.
+    /// </summary>
+    public void Dispose() => Interlocked.Exchange(ref _isDisposed, 1);
+
+    /// <summary>
+    /// Invokes the scheduled action if it has not been cancelled.
+    /// </summary>
+    public void Invoke()
+    {
+        if (Volatile.Read(ref _isDisposed) != 0)
+        {
+            return;
+        }
+
+        _action(_sequencer, _state);
+    }
+}

--- a/src/ReactiveUI.Primitives/Concurrency/ThreadPoolSequencer.cs
+++ b/src/ReactiveUI.Primitives/Concurrency/ThreadPoolSequencer.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for full license information.
 
 using ReactiveUI.Primitives.Disposables;
-using static ReactiveUI.Primitives.Disposables.Disposable;
 using Timer = System.Threading.Timer;
 
 namespace ReactiveUI.Primitives.Concurrency
@@ -59,20 +58,9 @@ namespace ReactiveUI.Primitives.Concurrency
                 throw new ArgumentNullException(nameof(action));
             }
 
-            var cancelable = new BooleanDisposable();
-            ThreadPool.QueueUserWorkItem(
-                _ =>
-            {
-                if (cancelable.IsDisposed)
-                {
-                    return;
-                }
-
-                action(this, state);
-            },
-                null);
-
-            return cancelable;
+            var workItem = new ScheduledWorkItem<TState>(this, state, action);
+            workItem.Queue();
+            return workItem;
         }
 
         /// <summary>
@@ -94,52 +82,14 @@ namespace ReactiveUI.Primitives.Concurrency
             }
 
             var dueTime1 = Sequencer.Normalize(dueTime);
-            var hasAdded = false;
-            var hasRemoved = false;
-            Timer timer = null!;
-            timer = new(
-                _ =>
+            if (dueTime1 <= TimeSpan.Zero)
             {
-                lock (Gate)
-                {
-                    if (hasAdded && timer != null)
-                    {
-                        Timers.Remove(timer);
-                    }
-
-                    hasRemoved = true;
-                }
-
-                timer = null!;
-                action(this, state);
-            },
-                null,
-                dueTime1,
-                TimeSpan.FromMilliseconds(-1.0));
-            lock (Gate)
-            {
-                if (!hasRemoved)
-                {
-                    Timers.Add(timer, null!);
-                    hasAdded = true;
-                }
+                return Schedule(state, action);
             }
 
-            return new AnonymousDisposable(() =>
-            {
-                var key = timer;
-                if (key != null)
-                {
-                    key.Dispose();
-                    lock (Gate)
-                    {
-                        Timers.Remove(key);
-                        hasRemoved = true;
-                    }
-                }
-
-                timer = null!;
-            });
+            var workItem = new ScheduledWorkItem<TState>(this, state, action);
+            workItem.Queue(dueTime1);
+            return workItem;
         }
 
         /// <summary>
@@ -154,5 +104,182 @@ namespace ReactiveUI.Primitives.Concurrency
         /// </returns>
         public IDisposable Schedule<TState>(TState state, DateTimeOffset dueTime, Func<ISequencer, TState, IDisposable> action) =>
             Schedule(state, Sequencer.Normalize(dueTime - Now), action);
+
+        /// <summary>
+        /// Thread-pool work item that doubles as the cancellation handle.
+        /// </summary>
+        /// <typeparam name="TState">The scheduled state type.</typeparam>
+        private sealed class ScheduledWorkItem<TState> : IDisposable
+        {
+            /// <summary>
+            /// Cached queue callback for immediate work.
+            /// </summary>
+            private static readonly WaitCallback ImmediateCallback = static state => ((ScheduledWorkItem<TState>)state!).Run();
+
+            /// <summary>
+            /// Cached timer callback for delayed work.
+            /// </summary>
+            private static readonly TimerCallback TimerCallback = static state => ((ScheduledWorkItem<TState>)state!).RunTimer();
+
+            /// <summary>
+            /// Owning sequencer.
+            /// </summary>
+            private readonly ThreadPoolSequencer _owner;
+
+            /// <summary>
+            /// Scheduled state.
+            /// </summary>
+            private readonly TState _state;
+
+            /// <summary>
+            /// Scheduled action.
+            /// </summary>
+            private readonly Func<ISequencer, TState, IDisposable> _action;
+
+            /// <summary>
+            /// Disposable returned by the scheduled action after it starts.
+            /// </summary>
+            private IDisposable? _disposable;
+
+            /// <summary>
+            /// Timer for delayed work.
+            /// </summary>
+#pragma warning disable CA2213 // Timer is disposed through RemoveTimer after an atomic exchange.
+            private Timer? _timer;
+#pragma warning restore CA2213
+
+            /// <summary>
+            /// Tracks cancellation.
+            /// </summary>
+            private int _isDisposed;
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="ScheduledWorkItem{TState}"/> class.
+            /// </summary>
+            /// <param name="owner">The owning sequencer.</param>
+            /// <param name="state">The scheduled state.</param>
+            /// <param name="action">The scheduled action.</param>
+            internal ScheduledWorkItem(ThreadPoolSequencer owner, TState state, Func<ISequencer, TState, IDisposable> action)
+            {
+                _owner = owner;
+                _state = state;
+                _action = action;
+            }
+
+            /// <summary>
+            /// Gets a value indicating whether the work item has been cancelled.
+            /// </summary>
+            private bool IsDisposed => Volatile.Read(ref _isDisposed) != 0;
+
+            /// <summary>
+            /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+            /// </summary>
+            public void Dispose()
+            {
+                if (Interlocked.Exchange(ref _isDisposed, 1) != 0)
+                {
+                    return;
+                }
+
+                Interlocked.Exchange(ref _disposable, Disposable.Empty)?.Dispose();
+                RemoveTimer();
+            }
+
+            /// <summary>
+            /// Queues the work item for immediate execution.
+            /// </summary>
+            internal void Queue() => ThreadPool.UnsafeQueueUserWorkItem(ImmediateCallback, this);
+
+            /// <summary>
+            /// Queues the work item for delayed execution.
+            /// </summary>
+            /// <param name="dueTime">The normalized due time.</param>
+            internal void Queue(TimeSpan dueTime)
+            {
+                var timer = new Timer(TimerCallback, this, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+                _timer = timer;
+                var disposeTimer = false;
+
+                lock (Gate)
+                {
+                    if (IsDisposed)
+                    {
+                        disposeTimer = true;
+                    }
+                    else
+                    {
+                        Timers.Add(timer, this);
+                    }
+                }
+
+                if (disposeTimer)
+                {
+                    Interlocked.CompareExchange(ref _timer, null, timer);
+                    timer.Dispose();
+                    return;
+                }
+
+                if (timer.Change(dueTime, Timeout.InfiniteTimeSpan))
+                {
+                    return;
+                }
+
+                Dispose();
+            }
+
+            /// <summary>
+            /// Runs immediate work.
+            /// </summary>
+            private void Run()
+            {
+                if (IsDisposed)
+                {
+                    return;
+                }
+
+                var disposable = _action(_owner, _state) ?? Disposable.Empty;
+                var previous = Interlocked.CompareExchange(ref _disposable, disposable, null);
+                if (previous != null)
+                {
+                    disposable.Dispose();
+                    return;
+                }
+
+                if (!IsDisposed)
+                {
+                    return;
+                }
+
+                disposable.Dispose();
+            }
+
+            /// <summary>
+            /// Runs delayed work.
+            /// </summary>
+            private void RunTimer()
+            {
+                RemoveTimer();
+                Run();
+            }
+
+            /// <summary>
+            /// Unroots and disposes the delayed timer if present.
+            /// </summary>
+            private void RemoveTimer()
+            {
+                var timer = Interlocked.Exchange(ref _timer, null);
+                if (timer == null)
+                {
+                    return;
+                }
+
+                lock (Gate)
+                {
+                    Timers.Remove(timer);
+                }
+
+                timer.Dispose();
+            }
+        }
     }
 }

--- a/src/ReactiveUI.Primitives/Core/PriorityQueue.cs
+++ b/src/ReactiveUI.Primitives/Core/PriorityQueue.cs
@@ -60,7 +60,12 @@ internal sealed class PriorityQueue<T>
     /// <param name="capacity">Initial queue capacity.</param>
     public PriorityQueue(int capacity)
     {
-        _items = new IndexedItem[capacity];
+        if (capacity < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(capacity));
+        }
+
+        _items = new IndexedItem[Math.Max(1, capacity)];
         Count = 0;
     }
 
@@ -89,7 +94,7 @@ internal sealed class PriorityQueue<T>
         if (Count >= _items.Length)
         {
             var temp = _items;
-            _items = new IndexedItem[_items.Length * HeapBranchingFactor];
+            _items = new IndexedItem[Math.Max(DefaultCapacity, _items.Length * HeapBranchingFactor)];
             Array.Copy(temp, _items, temp.Length);
         }
 
@@ -215,13 +220,13 @@ internal sealed class PriorityQueue<T>
             Heapify(index);
         }
 
-        if (Count >= _items.Length / ShrinkDivisor)
+        if (_items.Length <= DefaultCapacity || Count >= _items.Length / ShrinkDivisor)
         {
             return;
         }
 
         var temp = _items;
-        _items = new IndexedItem[_items.Length / HeapBranchingFactor];
+        _items = new IndexedItem[Math.Max(DefaultCapacity, _items.Length / HeapBranchingFactor)];
         Array.Copy(temp, 0, _items, 0, Count);
     }
 

--- a/src/ReactiveUI.Primitives/Properties/AssemblyInfo.cs
+++ b/src/ReactiveUI.Primitives/Properties/AssemblyInfo.cs
@@ -5,3 +5,7 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("ReactiveUI.Primitives.Tests")]
+[assembly: InternalsVisibleTo("ReactiveUI.Primitives.Blazor")]
+[assembly: InternalsVisibleTo("ReactiveUI.Primitives.Maui")]
+[assembly: InternalsVisibleTo("ReactiveUI.Primitives.WinForms")]
+[assembly: InternalsVisibleTo("ReactiveUI.Primitives.Wpf")]

--- a/src/ReactiveUI.Primitives/SignalOperatorMixins.cs
+++ b/src/ReactiveUI.Primitives/SignalOperatorMixins.cs
@@ -1298,13 +1298,8 @@ public static partial class LinqMixins
         "Major Code Smell",
         "S4018:Generic methods should provide type parameters",
         Justification = "The generic type is validated by the caller before creating a range-backed signal.")]
-    private static IObservable<T> CreateShiftedRangeSignal<T>(RangeSignal range, TimeSpan dueTime, ISequencer scheduler) =>
-        Signal.CreateSafe<T>(
-            observer => scheduler.Schedule(
-                (Observer: observer, Range: range),
-                Sequencer.Normalize(dueTime),
-                static (_, state) => EmitShiftedRange<T>(state.Observer, state.Range)),
-            scheduler == Sequencer.CurrentThread);
+    private static ShiftedRangeSignal<T> CreateShiftedRangeSignal<T>(RangeSignal range, TimeSpan dueTime, ISequencer scheduler) =>
+        new(range, Sequencer.Normalize(dueTime), scheduler);
 
     /// <summary>
     /// Emits all range values and completion from a scheduled batch.
@@ -1321,6 +1316,25 @@ public static partial class LinqMixins
         }
 
         observer.OnCompleted();
+        return Disposable.Empty;
+    }
+
+    /// <summary>
+    /// Emits all range values and completion from a scheduled batch.
+    /// </summary>
+    /// <typeparam name="T">The observer value type.</typeparam>
+    /// <param name="onNext">The next callback.</param>
+    /// <param name="onCompleted">The completion callback.</param>
+    /// <param name="range">The source range.</param>
+    /// <returns>An empty disposable.</returns>
+    private static IDisposable EmitShiftedRange<T>(Action<T> onNext, Action onCompleted, RangeSignal range)
+    {
+        for (var i = 0; i < range.Count; i++)
+        {
+            onNext(CreateRangeValue<T>(range.Start + i));
+        }
+
+        onCompleted();
         return Disposable.Empty;
     }
 }

--- a/src/ReactiveUI.Primitives/SignalOperatorParityMixins.Helpers.cs
+++ b/src/ReactiveUI.Primitives/SignalOperatorParityMixins.Helpers.cs
@@ -5,6 +5,7 @@
 using ReactiveUI.Primitives.Concurrency;
 using ReactiveUI.Primitives.Core;
 using ReactiveUI.Primitives.Disposables;
+using ReactiveUI.Primitives.Signals.Core;
 
 namespace ReactiveUI.Primitives;
 
@@ -568,6 +569,283 @@ public static partial class LinqMixins
             {
                 Dispose();
             }
+        }
+    }
+
+    /// <summary>
+    /// Range timestamp projection with no intermediate map observer.
+    /// </summary>
+    /// <typeparam name="T">The range value type.</typeparam>
+    private sealed class TimestampRangeSignal<T> : IInlineSignal<Moment<T>>
+    {
+        /// <summary>
+        /// The range source.
+        /// </summary>
+        private readonly RangeSignal _range;
+
+        /// <summary>
+        /// The sequencer used to read timestamps.
+        /// </summary>
+        private readonly ISequencer _sequencer;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TimestampRangeSignal{T}"/> class.
+        /// </summary>
+        /// <param name="range">The range source.</param>
+        /// <param name="sequencer">The sequencer used to read timestamps.</param>
+        internal TimestampRangeSignal(RangeSignal range, ISequencer sequencer)
+        {
+            _range = range;
+            _sequencer = sequencer;
+        }
+
+        /// <inheritdoc/>
+        public IDisposable Subscribe(IObserver<Moment<T>> observer)
+        {
+            if (observer == null)
+            {
+                throw new ArgumentNullException(nameof(observer));
+            }
+
+            Emit(observer);
+            observer.OnCompleted();
+            return Disposable.Empty;
+        }
+
+        /// <inheritdoc/>
+        public IDisposable Subscribe(Action<Moment<T>> onNext, Action<Exception> onError, Action onCompleted)
+        {
+            if (onNext == null)
+            {
+                throw new ArgumentNullException(nameof(onNext));
+            }
+
+            Emit(onNext);
+            onCompleted();
+            return Disposable.Empty;
+        }
+
+        /// <summary>
+        /// Emits timestamped range values.
+        /// </summary>
+        /// <param name="onNext">The next callback.</param>
+        private void Emit(Action<Moment<T>> onNext)
+        {
+            if (_sequencer == Sequencer.Immediate)
+            {
+                var timestamp = _sequencer.Now;
+                for (var i = 0; i < _range.Count; i++)
+                {
+                    onNext(new Moment<T>(CreateRangeValue<T>(_range.Start + i), timestamp));
+                }
+
+                return;
+            }
+
+            for (var i = 0; i < _range.Count; i++)
+            {
+                onNext(new Moment<T>(CreateRangeValue<T>(_range.Start + i), _sequencer.Now));
+            }
+        }
+
+        /// <summary>
+        /// Emits timestamped range values to an observer without allocating a delegate wrapper.
+        /// </summary>
+        /// <param name="observer">The downstream observer.</param>
+        private void Emit(IObserver<Moment<T>> observer)
+        {
+            if (_sequencer == Sequencer.Immediate)
+            {
+                var timestamp = _sequencer.Now;
+                for (var i = 0; i < _range.Count; i++)
+                {
+                    observer.OnNext(new Moment<T>(CreateRangeValue<T>(_range.Start + i), timestamp));
+                }
+
+                return;
+            }
+
+            for (var i = 0; i < _range.Count; i++)
+            {
+                observer.OnNext(new Moment<T>(CreateRangeValue<T>(_range.Start + i), _sequencer.Now));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Range time-interval projection with no intermediate safe signal closure.
+    /// </summary>
+    /// <typeparam name="T">The range value type.</typeparam>
+    private sealed class TimeIntervalRangeSignal<T> : IInlineSignal<TimeInterval<T>>
+    {
+        /// <summary>
+        /// The range source.
+        /// </summary>
+        private readonly RangeSignal _range;
+
+        /// <summary>
+        /// The sequencer used to read timestamps.
+        /// </summary>
+        private readonly ISequencer _sequencer;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TimeIntervalRangeSignal{T}"/> class.
+        /// </summary>
+        /// <param name="range">The range source.</param>
+        /// <param name="sequencer">The sequencer used to read timestamps.</param>
+        internal TimeIntervalRangeSignal(RangeSignal range, ISequencer sequencer)
+        {
+            _range = range;
+            _sequencer = sequencer;
+        }
+
+        /// <inheritdoc/>
+        public IDisposable Subscribe(IObserver<TimeInterval<T>> observer)
+        {
+            if (observer == null)
+            {
+                throw new ArgumentNullException(nameof(observer));
+            }
+
+            Emit(observer);
+            observer.OnCompleted();
+            return Disposable.Empty;
+        }
+
+        /// <inheritdoc/>
+        public IDisposable Subscribe(Action<TimeInterval<T>> onNext, Action<Exception> onError, Action onCompleted)
+        {
+            if (onNext == null)
+            {
+                throw new ArgumentNullException(nameof(onNext));
+            }
+
+            Emit(onNext);
+            onCompleted();
+            return Disposable.Empty;
+        }
+
+        /// <summary>
+        /// Emits interval-tagged range values.
+        /// </summary>
+        /// <param name="onNext">The next callback.</param>
+        private void Emit(Action<TimeInterval<T>> onNext)
+        {
+            if (_sequencer == Sequencer.Immediate)
+            {
+                for (var i = 0; i < _range.Count; i++)
+                {
+                    onNext(new TimeInterval<T>(CreateRangeValue<T>(_range.Start + i), TimeSpan.Zero));
+                }
+
+                return;
+            }
+
+            var last = _sequencer.Now;
+            for (var i = 0; i < _range.Count; i++)
+            {
+                var now = _sequencer.Now;
+                var interval = i == 0 ? TimeSpan.Zero : now - last;
+                last = now;
+                onNext(new TimeInterval<T>(CreateRangeValue<T>(_range.Start + i), interval));
+            }
+        }
+
+        /// <summary>
+        /// Emits interval-tagged range values to an observer without allocating a delegate wrapper.
+        /// </summary>
+        /// <param name="observer">The downstream observer.</param>
+        private void Emit(IObserver<TimeInterval<T>> observer)
+        {
+            if (_sequencer == Sequencer.Immediate)
+            {
+                for (var i = 0; i < _range.Count; i++)
+                {
+                    observer.OnNext(new TimeInterval<T>(CreateRangeValue<T>(_range.Start + i), TimeSpan.Zero));
+                }
+
+                return;
+            }
+
+            var last = _sequencer.Now;
+            for (var i = 0; i < _range.Count; i++)
+            {
+                var now = _sequencer.Now;
+                var interval = i == 0 ? TimeSpan.Zero : now - last;
+                last = now;
+                observer.OnNext(new TimeInterval<T>(CreateRangeValue<T>(_range.Start + i), interval));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Range delay projection with no safe-signal wrapper allocation.
+    /// </summary>
+    /// <typeparam name="T">The range value type.</typeparam>
+    private sealed class ShiftedRangeSignal<T> : IRequireCurrentThread<T>, IInlineSignal<T>
+    {
+        /// <summary>
+        /// The range source.
+        /// </summary>
+        private readonly RangeSignal _range;
+
+        /// <summary>
+        /// The normalized due time.
+        /// </summary>
+        private readonly TimeSpan _dueTime;
+
+        /// <summary>
+        /// The sequencer used to schedule the range batch.
+        /// </summary>
+        private readonly ISequencer _sequencer;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ShiftedRangeSignal{T}"/> class.
+        /// </summary>
+        /// <param name="range">The range source.</param>
+        /// <param name="dueTime">The normalized due time.</param>
+        /// <param name="sequencer">The sequencer used to schedule the range batch.</param>
+        internal ShiftedRangeSignal(RangeSignal range, TimeSpan dueTime, ISequencer sequencer)
+        {
+            _range = range;
+            _dueTime = dueTime;
+            _sequencer = sequencer;
+        }
+
+        /// <inheritdoc/>
+        public bool IsRequiredSubscribeOnCurrentThread() => _sequencer == Sequencer.CurrentThread;
+
+        /// <inheritdoc/>
+        public IDisposable Subscribe(IObserver<T> observer)
+        {
+            if (observer == null)
+            {
+                throw new ArgumentNullException(nameof(observer));
+            }
+
+            return _sequencer.Schedule(
+                (Observer: observer, Range: _range),
+                _dueTime,
+                static (_, state) => EmitShiftedRange<T>(state.Observer, state.Range));
+        }
+
+        /// <inheritdoc/>
+        public IDisposable Subscribe(Action<T> onNext, Action<Exception> onError, Action onCompleted)
+        {
+            if (onNext == null)
+            {
+                throw new ArgumentNullException(nameof(onNext));
+            }
+
+            if (onCompleted == null)
+            {
+                throw new ArgumentNullException(nameof(onCompleted));
+            }
+
+            return _sequencer.Schedule(
+                (OnNext: onNext, OnCompleted: onCompleted, Range: _range),
+                _dueTime,
+                static (_, state) => EmitShiftedRange<T>(state.OnNext, state.OnCompleted, state.Range));
         }
     }
 

--- a/src/ReactiveUI.Primitives/SignalOperatorParityMixins.cs
+++ b/src/ReactiveUI.Primitives/SignalOperatorParityMixins.cs
@@ -791,6 +791,11 @@ public static partial class LinqMixins
         }
 
         scheduler ??= ThreadPoolSequencer.Instance;
+        if (source is RangeSignal range && CanReadRangeAs<T>())
+        {
+            return CreateShiftedRangeSignal<T>(range, dueTime, scheduler);
+        }
+
         return Signal.Create<T>(observer =>
         {
             var pocket = new MultipleDisposable();
@@ -917,6 +922,11 @@ public static partial class LinqMixins
         }
 
         scheduler ??= Sequencer.Immediate;
+        if (source is RangeSignal range && CanReadRangeAs<T>())
+        {
+            return new TimestampRangeSignal<T>(range, scheduler);
+        }
+
         return source.Map(value => new Moment<T>(value, scheduler.Now));
     }
 
@@ -946,6 +956,11 @@ public static partial class LinqMixins
         }
 
         scheduler ??= Sequencer.Immediate;
+        if (source is RangeSignal range && CanReadRangeAs<T>())
+        {
+            return new TimeIntervalRangeSignal<T>(range, scheduler);
+        }
+
         return Signal.CreateSafe<TimeInterval<T>>(observer =>
         {
             var last = scheduler.Now;

--- a/src/ReactiveUI.Primitives/Signals/Core/WitnessOnSignal{T}.cs
+++ b/src/ReactiveUI.Primitives/Signals/Core/WitnessOnSignal{T}.cs
@@ -42,15 +42,8 @@ internal sealed class WitnessOnSignal<T> : SignalsBase<T>
     /// <param name="observer">The observer value.</param>
     /// <param name="cancel">The cancel value.</param>
     /// <returns>The result.</returns>
-    protected override IDisposable SubscribeCore(IObserver<T> observer, IDisposable cancel)
-    {
-        if (_scheduler is not ThreadPoolSequencer queueing)
-        {
-            return new WitnessOn(this, observer, cancel).Run();
-        }
-
-        return new ThreadPoolWitnessOn(this, queueing, observer, cancel).Run();
-    }
+    protected override IDisposable SubscribeCore(IObserver<T> observer, IDisposable cancel) =>
+        new WitnessOn(this, observer, cancel).Run();
 
     /// <summary>
     /// Represents the WitnessOn class.
@@ -266,137 +259,6 @@ internal sealed class WitnessOnSignal<T> : SignalsBase<T>
                 }
 
                 Node.List.Remove(Node);
-            }
-        }
-    }
-
-    /// <summary>
-    /// Represents the ThreadPoolWitnessOn class.
-    /// </summary>
-    private sealed class ThreadPoolWitnessOn : WitnessBase<T, T>
-    {
-        /// <summary>
-        /// Stores state for the signal implementation.
-        /// </summary>
-        private readonly WitnessOnSignal<T> _parent;
-
-        /// <summary>
-        /// Stores state for the signal implementation.
-        /// </summary>
-        private readonly ThreadPoolSequencer _scheduler;
-
-        /// <summary>
-        /// Stores state for the signal implementation.
-        /// </summary>
-        private readonly BooleanDisposable _isDisposed;
-
-        /// <summary>
-        /// Stores state for the signal implementation.
-        /// </summary>
-        private readonly Action<T> _onNext;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ThreadPoolWitnessOn"/> class.
-        /// </summary>
-        /// <param name="parent">The parent value.</param>
-        /// <param name="scheduler">The scheduler value.</param>
-        /// <param name="observer">The observer value.</param>
-        /// <param name="cancel">The cancel value.</param>
-        public ThreadPoolWitnessOn(WitnessOnSignal<T> parent, ThreadPoolSequencer scheduler, IObserver<T> observer, IDisposable cancel)
-            : base(observer, cancel)
-        {
-            _parent = parent;
-            _scheduler = scheduler;
-            _isDisposed = new BooleanDisposable();
-            _onNext = OnNextCore;
-        }
-
-        /// <summary>
-        /// Executes the Run operation.
-        /// </summary>
-        /// <returns>The result.</returns>
-        public MultipleDisposable Run()
-        {
-            var sourceDisposable = _parent._source.Subscribe(this);
-            return new MultipleDisposable(sourceDisposable, _isDisposed);
-        }
-
-        /// <summary>
-        /// Executes the OnNext operation.
-        /// </summary>
-        /// <param name="value">The value.</param>
-        public override void OnNext(T value) =>
-            _scheduler.Schedule(value, (_, v) =>
-            {
-                _onNext(v);
-                return _isDisposed;
-            });
-
-        /// <summary>
-        /// Executes the OnError operation.
-        /// </summary>
-        /// <param name="error">The error value.</param>
-        public override void OnError(Exception error) =>
-            _scheduler.Schedule(error, (_, v) =>
-            {
-                OnErrorCore(v);
-                return _isDisposed;
-            });
-
-        /// <summary>
-        /// Executes the OnCompleted operation.
-        /// </summary>
-        public override void OnCompleted() =>
-            _scheduler.Schedule(OnCompletedCore);
-
-        /// <summary>
-        /// Executes the Dispose operation.
-        /// </summary>
-        /// <param name="disposing">The disposing value.</param>
-        protected override void Dispose(bool disposing)
-        {
-            if (disposing)
-            {
-                _isDisposed.Dispose();
-            }
-
-            base.Dispose(disposing);
-        }
-
-        /// <summary>
-        /// Executes the OnNextCore operation.
-        /// </summary>
-        /// <param name="value">The value.</param>
-        private void OnNextCore(T value) => Observer.OnNext(value);
-
-        /// <summary>
-        /// Executes the OnErrorCore operation.
-        /// </summary>
-        /// <param name="error">The error value.</param>
-        private void OnErrorCore(Exception error)
-        {
-            try
-            {
-                Observer.OnError(error);
-            }
-            finally
-            {
-                Dispose();
-            }
-        }
-
-        /// <summary>
-        /// Executes the OnCompletedCore operation.
-        /// </summary>
-        private void OnCompletedCore()
-        {
-            try
-            {
-                Observer.OnCompleted();
-            }
-            finally
-            {
-                Dispose();
             }
         }
     }

--- a/src/benchmarks/ReactiveUI.Primitives.Benchmarks/BenchmarkObservers.cs
+++ b/src/benchmarks/ReactiveUI.Primitives.Benchmarks/BenchmarkObservers.cs
@@ -165,6 +165,46 @@ internal sealed class BoolSignalObserver : IObserver<bool>
 }
 
 /// <summary>
+/// Observer used by Signal and System.Reactive benchmark cases that only need an item count.
+/// </summary>
+/// <typeparam name="T">The observed value type.</typeparam>
+internal sealed class CountingSignalObserver<T> : IObserver<T>
+{
+    /// <summary>
+    /// Gets the number of onNext calls.
+    /// </summary>
+    public int Count { get; private set; }
+
+    /// <summary>
+    /// Gets the number of terminal completions observed.
+    /// </summary>
+    public int CompletionCount { get; private set; }
+
+    /// <summary>
+    /// Gets the number of errors observed.
+    /// </summary>
+    public int ErrorCount { get; private set; }
+
+    /// <inheritdoc/>
+    public void OnNext(T value)
+    {
+        Count++;
+    }
+
+    /// <inheritdoc/>
+    public void OnError(Exception error)
+    {
+        ErrorCount++;
+    }
+
+    /// <inheritdoc/>
+    public void OnCompleted()
+    {
+        CompletionCount++;
+    }
+}
+
+/// <summary>
 /// Observer used by R3 benchmark cases.
 /// </summary>
 internal sealed class IntR3Observer : Observer<int>

--- a/src/benchmarks/ReactiveUI.Primitives.Benchmarks/OperatorTimeSchedulerBenchmarks.cs
+++ b/src/benchmarks/ReactiveUI.Primitives.Benchmarks/OperatorTimeSchedulerBenchmarks.cs
@@ -6,6 +6,7 @@ using BenchmarkDotNet.Attributes;
 using Microsoft.Extensions.Time.Testing;
 using ReactiveUI.Primitives;
 using ReactiveUI.Primitives.Concurrency;
+using ReactiveUI.Primitives.Core;
 using ReactiveUI.Primitives.Signals;
 using System.Reactive.Concurrency;
 using System.Reactive.Linq;
@@ -234,9 +235,9 @@ public class OperatorTimeSchedulerBenchmarks
     [Benchmark]
     public int PrimitivesTimestampRange()
     {
-        var count = 0;
-        using var subscription = Signal.Sequence(1, Count).Timestamp(Sequencer.Immediate).Subscribe(_ => count++);
-        return count;
+        var observer = new CountingSignalObserver<Moment<int>>();
+        using var subscription = Signal.Sequence(1, Count).Timestamp(Sequencer.Immediate).Subscribe(observer);
+        return observer.Count;
     }
 
     /// <summary>
@@ -246,9 +247,9 @@ public class OperatorTimeSchedulerBenchmarks
     [Benchmark]
     public int SystemReactiveTimestampRange()
     {
-        var count = 0;
-        using var subscription = RxObservable.Range(1, Count).Timestamp(ImmediateScheduler.Instance).Subscribe(_ => count++);
-        return count;
+        var observer = new CountingSignalObserver<System.Reactive.Timestamped<int>>();
+        using var subscription = RxObservable.Range(1, Count).Timestamp(ImmediateScheduler.Instance).Subscribe(observer);
+        return observer.Count;
     }
 
     /// <summary>
@@ -270,9 +271,9 @@ public class OperatorTimeSchedulerBenchmarks
     [Benchmark]
     public int PrimitivesTimeIntervalRange()
     {
-        var count = 0;
-        using var subscription = Signal.Sequence(1, Count).TimeInterval(Sequencer.Immediate).Subscribe(_ => count++);
-        return count;
+        var observer = new CountingSignalObserver<ReactiveUI.Primitives.Core.TimeInterval<int>>();
+        using var subscription = Signal.Sequence(1, Count).TimeInterval(Sequencer.Immediate).Subscribe(observer);
+        return observer.Count;
     }
 
     /// <summary>
@@ -282,11 +283,11 @@ public class OperatorTimeSchedulerBenchmarks
     [Benchmark]
     public int SystemReactiveTimeIntervalRange()
     {
-        var count = 0;
+        var observer = new CountingSignalObserver<System.Reactive.TimeInterval<int>>();
         using var subscription = RxObservable.Range(1, Count)
             .TimeInterval(ImmediateScheduler.Instance)
-            .Subscribe(_ => count++);
-        return count;
+            .Subscribe(observer);
+        return observer.Count;
     }
 
     /// <summary>

--- a/src/tests/ReactiveUI.Primitives.Tests/CoverageTopUpTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/CoverageTopUpTests.cs
@@ -16,7 +16,10 @@ using TUnit.Core;
 
 namespace ReactiveUI.Primitives.Tests;
 
-#pragma warning disable SA1600, S109, S3400, S6354, CA1806, S3257, CA1861, IDE0300, RCS1196, S6966, S103, CA1065, S138, IDE0034, RCS1151, S1764, S1944, RCS1208, RCS1215, S3981, CA1849, SA1129, CA1823
+#pragma warning disable RCS1222
+#pragma warning disable SA1600, S109, S3400, S6354, CA1806, S3257, CA1861, IDE0300, RCS1196, S6966
+#pragma warning disable S103, CA1065, S138, IDE0034, RCS1151, S1764, S1944, RCS1208, RCS1215
+#pragma warning disable S3981, CA1849, SA1129, CA1823
 
 /// <summary>
 /// Targeted deterministic top-up tests for remaining production coverage gaps.
@@ -681,6 +684,193 @@ public sealed class CoverageTopUpTests
         Assert.Equal(new[] { Three }, forkRightFirst.Values);
         Assert.Equal(1, forkRightFirst.Completed);
     }
+
+    [Test]
+    public async Task RangeTimingQueuesAndThreadPoolCoverPrTenCoverageGaps()
+    {
+        var immediateMoments = new RecordingObserver<Moment<int>>();
+        Signal.Sequence(One, Three).Timestamp(Sequencer.Immediate).Subscribe(immediateMoments).Dispose();
+        Assert.Equal<int>([One, Two, Three], [immediateMoments.Values[0].Value, immediateMoments.Values[1].Value, immediateMoments.Values[2].Value]);
+        Assert.Equal(1, immediateMoments.Completed);
+
+        var clockMoments = new List<Moment<int>>();
+        var clockMomentCompleted = 0;
+        Signal.Sequence(Four, Two).Timestamp(new TestClock(DateTimeOffset.UnixEpoch)).Subscribe(clockMoments.Add, ex => throw ex, () => clockMomentCompleted++);
+        Assert.Equal<int>([Four, Five], [clockMoments[0].Value, clockMoments[1].Value]);
+        Assert.Equal(1, clockMomentCompleted);
+
+        var immediateMomentActions = new List<Moment<int>>();
+        var immediateMomentCompleted = 0;
+        var immediateTimestampSignal = (IInlineSignal<Moment<int>>)Signal.Sequence(Two, Two).Timestamp(Sequencer.Immediate);
+        immediateTimestampSignal.Subscribe(immediateMomentActions.Add, ex => throw ex, () => immediateMomentCompleted++).Dispose();
+        Assert.Equal<int>([Two, Three], [immediateMomentActions[0].Value, immediateMomentActions[1].Value]);
+        Assert.Equal(1, immediateMomentCompleted);
+
+        var clockMomentObserver = new RecordingObserver<Moment<int>>();
+        var clockTimestampSignal = (IInlineSignal<Moment<int>>)Signal.Sequence(Two, Two).Timestamp(new TestClock(DateTimeOffset.UnixEpoch));
+        clockTimestampSignal.Subscribe(clockMomentObserver).Dispose();
+        Assert.Equal<int>([Two, Three], [clockMomentObserver.Values[0].Value, clockMomentObserver.Values[1].Value]);
+        Assert.Equal(1, clockMomentObserver.Completed);
+
+        Assert.Throws<ArgumentNullException>(() => immediateTimestampSignal.Subscribe((IObserver<Moment<int>>)null!));
+        Assert.Throws<ArgumentNullException>(() => immediateTimestampSignal.Subscribe((Action<Moment<int>>)null!, _ => { }, () => { }));
+
+        var immediateIntervals = new RecordingObserver<TimeInterval<int>>();
+        Signal.Sequence(One, Three).TimeInterval(Sequencer.Immediate).Subscribe(immediateIntervals).Dispose();
+        Assert.Equal<int>([One, Two, Three], [immediateIntervals.Values[0].Value, immediateIntervals.Values[1].Value, immediateIntervals.Values[2].Value]);
+        Assert.Equal(TimeSpan.Zero, immediateIntervals.Values[0].Interval);
+        Assert.Equal(TimeSpan.Zero, immediateIntervals.Values[1].Interval);
+        Assert.Equal(TimeSpan.Zero, immediateIntervals.Values[2].Interval);
+        Assert.Equal(1, immediateIntervals.Completed);
+
+        var clockIntervals = new List<TimeInterval<int>>();
+        var clockIntervalCompleted = 0;
+        Signal.Sequence(Four, Three).TimeInterval(new TestClock(DateTimeOffset.UnixEpoch)).Subscribe(clockIntervals.Add, ex => throw ex, () => clockIntervalCompleted++);
+        Assert.Equal<int>([Four, Five, Six], [clockIntervals[0].Value, clockIntervals[1].Value, clockIntervals[2].Value]);
+        Assert.Equal(TimeSpan.Zero, clockIntervals[0].Interval);
+        Assert.Equal(TimeSpan.Zero, clockIntervals[1].Interval);
+        Assert.Equal(TimeSpan.Zero, clockIntervals[2].Interval);
+        Assert.Equal(1, clockIntervalCompleted);
+
+        var immediateIntervalActions = new List<TimeInterval<int>>();
+        var immediateIntervalCompleted = 0;
+        var immediateIntervalSignal = (IInlineSignal<TimeInterval<int>>)Signal.Sequence(Two, Two).TimeInterval(Sequencer.Immediate);
+        immediateIntervalSignal.Subscribe(immediateIntervalActions.Add, ex => throw ex, () => immediateIntervalCompleted++).Dispose();
+        Assert.Equal<int>([Two, Three], [immediateIntervalActions[0].Value, immediateIntervalActions[1].Value]);
+        Assert.Equal(1, immediateIntervalCompleted);
+
+        var clockIntervalObserver = new RecordingObserver<TimeInterval<int>>();
+        var clockIntervalSignal = (IInlineSignal<TimeInterval<int>>)Signal.Sequence(Two, Three).TimeInterval(new TestClock(DateTimeOffset.UnixEpoch));
+        clockIntervalSignal.Subscribe(clockIntervalObserver).Dispose();
+        Assert.Equal<int>([Two, Three, Four], [clockIntervalObserver.Values[0].Value, clockIntervalObserver.Values[1].Value, clockIntervalObserver.Values[2].Value]);
+        Assert.Equal(TimeSpan.Zero, clockIntervalObserver.Values[0].Interval);
+        Assert.Equal(TimeSpan.Zero, clockIntervalObserver.Values[1].Interval);
+        Assert.Equal(TimeSpan.Zero, clockIntervalObserver.Values[2].Interval);
+        Assert.Equal(1, clockIntervalObserver.Completed);
+
+        Assert.Throws<ArgumentNullException>(() => immediateIntervalSignal.Subscribe((IObserver<TimeInterval<int>>)null!));
+        Assert.Throws<ArgumentNullException>(() => immediateIntervalSignal.Subscribe((Action<TimeInterval<int>>)null!, _ => { }, () => { }));
+
+        var shiftedObserver = new RecordingObserver<int>();
+        Signal.Sequence(One, Two).DelayStart(TimeSpan.Zero, Sequencer.Immediate).Subscribe(shiftedObserver).Dispose();
+        Assert.Equal(new[] { One, Two }, shiftedObserver.Values);
+        Assert.Equal(1, shiftedObserver.Completed);
+
+        var shiftedActions = new List<int>();
+        var shiftedActionCompleted = 0;
+        Signal.Sequence(Three, Two).DelayStart(TimeSpan.Zero, Sequencer.Immediate).Subscribe(shiftedActions.Add, ex => throw ex, () => shiftedActionCompleted++);
+        Assert.Equal(new[] { Three, Four }, shiftedActions);
+        Assert.Equal(1, shiftedActionCompleted);
+
+        var currentThreadShift = (IRequireCurrentThread<int>)Signal.Sequence(One, One).DelayStart(TimeSpan.Zero, Sequencer.CurrentThread);
+        Assert.True(currentThreadShift.IsRequiredSubscribeOnCurrentThread());
+        var inlineShift = (IInlineSignal<int>)Signal.Sequence(One, One).DelayStart(TimeSpan.Zero, Sequencer.Immediate);
+        Assert.Throws<ArgumentNullException>(() => Signal.Sequence(One, One).DelayStart(TimeSpan.Zero, Sequencer.Immediate).Subscribe((IObserver<int>)null!));
+        Assert.Throws<ArgumentNullException>(() => inlineShift.Subscribe((Action<int>)null!, _ => { }, () => { }));
+        Assert.Throws<ArgumentNullException>(() => inlineShift.Subscribe(_ => { }, _ => { }, null!));
+
+        var helperValues = new List<int>();
+        var helper = new SequencerWorkItem<ISequencer, int>(
+            Sequencer.Immediate,
+            One,
+            (_, state) =>
+            {
+                helperValues.Add(state);
+                return Disposable.Empty;
+            });
+        helper.Invoke();
+        helper.Dispose();
+        helper.Invoke();
+        Assert.Equal(new[] { One }, helperValues);
+
+        var unusedScheduled = new ScheduledItem<int, string>(Sequencer.Immediate, "unused", (_, _) => Disposable.Empty, One);
+        Assert.False(new SequencerQueue<int>().Remove(unusedScheduled));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new PriorityQueue<int>(-1));
+
+        var shrink = new PriorityQueue<int>(32);
+        for (var i = 0; i < 32; i++)
+        {
+            shrink.Enqueue(i);
+        }
+
+        for (var i = 0; i < 26; i++)
+        {
+            Assert.Equal(i, shrink.Dequeue());
+        }
+
+        var absoluteRan = new TaskCompletionSource<int>();
+        var absolute = ThreadPoolSequencer.Instance.Schedule(Five, DateTimeOffset.UtcNow, (_, state) =>
+        {
+            absoluteRan.TrySetResult(state);
+            return Disposable.Empty;
+        });
+        Assert.Equal(Five, await absoluteRan.Task.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false));
+        absolute.Dispose();
+        absolute.Dispose();
+
+        var delayedDisposed = CreateThreadPoolWorkItem(One, (_, _) => Disposable.Empty);
+        delayedDisposed.Dispose();
+        QueueThreadPoolWorkItem(delayedDisposed, typeof(int), TimeSpan.FromMilliseconds(10));
+
+        var skipped = false;
+        var skippedItem = CreateThreadPoolWorkItem(Two, (_, _) =>
+        {
+            skipped = true;
+            return Disposable.Empty;
+        });
+        skippedItem.Dispose();
+        InvokeThreadPoolWorkItem(skippedItem, typeof(int));
+        Assert.False(skipped);
+
+        var disposedReturned = 0;
+        object?[] holder = [null];
+        var selfDisposing = CreateThreadPoolWorkItem(holder, (_, state) =>
+        {
+            ((IDisposable)state[0]!).Dispose();
+            return Disposable.Create(() => disposedReturned++);
+        });
+        holder[0] = selfDisposing;
+        InvokeThreadPoolWorkItem(selfDisposing, typeof(object?[]));
+        Assert.Equal(1, disposedReturned);
+
+        var rawDisposedReturned = 0;
+        object?[] rawHolder = [null];
+        var rawDisposing = CreateThreadPoolWorkItem(rawHolder, (_, state) =>
+        {
+            MarkThreadPoolWorkItemDisposed(state[0]!);
+            return Disposable.Create(() => rawDisposedReturned++);
+        });
+        rawHolder[0] = rawDisposing;
+        InvokeThreadPoolWorkItem(rawDisposing, typeof(object?[]));
+        Assert.Equal(1, rawDisposedReturned);
+    }
+
+#pragma warning disable S3011, IL2072, IL2075, IL3050
+    private static IDisposable CreateThreadPoolWorkItem<TState>(TState state, Func<ISequencer, TState, IDisposable> action)
+    {
+        var type = ThreadPoolWorkItemType(typeof(TState));
+        return (IDisposable)Activator.CreateInstance(
+            type,
+            BindingFlags.Instance | BindingFlags.NonPublic,
+            binder: null,
+            args: [ThreadPoolSequencer.Instance, state, action],
+            culture: null)!;
+    }
+
+    private static void InvokeThreadPoolWorkItem(IDisposable item, Type stateType) =>
+        ThreadPoolWorkItemType(stateType).GetMethod("Run", BindingFlags.Instance | BindingFlags.NonPublic)!.Invoke(item, null);
+
+    private static void QueueThreadPoolWorkItem(IDisposable item, Type stateType, TimeSpan dueTime) =>
+        ThreadPoolWorkItemType(stateType)
+            .GetMethod("Queue", BindingFlags.Instance | BindingFlags.NonPublic, binder: null, types: [typeof(TimeSpan)], modifiers: null)!
+            .Invoke(item, [dueTime]);
+
+    private static void MarkThreadPoolWorkItemDisposed(object item) =>
+        item.GetType().GetField("_isDisposed", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(item, 1);
+
+    private static Type ThreadPoolWorkItemType(Type stateType) =>
+        typeof(ThreadPoolSequencer).GetNestedType("ScheduledWorkItem`1", BindingFlags.NonPublic)!.MakeGenericType(stateType);
+#pragma warning restore S3011, IL2072, IL2075, IL3050
 
     private static async IAsyncEnumerable<int> AsyncValues(int count)
     {


### PR DESCRIPTION
Replace ad-hoc disposables in BlazorRendererSequencer with explicit RendererWorkItem and DelayedRendererWorkItem types (cancellable via Interlocked/Volatile) and short-circuit zero-delay scheduling to the immediate Schedule path. 

Introduces delayed dispatch logic using CancellationTokenSource, moves invoke logic into work-item methods, and simplifies invocation with the renderer invoke callback. 

Update README to document optional platform integration packages (WPF, WinForms, Blazor, MAUI), their TFMs, packaging/pack steps, and refresh benchmark run metadata and results. 

Other concurrency/sequencer and benchmark files were adjusted for API/behavior parity with these changes.