### PR TITLE
Expand extension benchmarks and refresh performance results

### DIFF
--- a/README.md
+++ b/README.md
@@ -888,7 +888,7 @@ For async-native streams, prefer `ReactiveUI.Primitives.Async` and its `IObserva
 
 Benchmarks live in `src/benchmarks/ReactiveUI.Primitives.Benchmarks`. The benchmark project may reference System.Reactive, R3, and ReactiveUI.Extensions to compare throughput and allocation behavior; the production packages must not.
 
-The latest complete BenchmarkDotNet run finished on 2026-05-29 at 06:37:05 Europe/London with .NET SDK 10.0.300 and .NET runtime 10.0.8 on Windows 11. It executed 201 benchmarks with no skipped suites in 00:21:37:
+The latest complete BenchmarkDotNet run finished on 2026-05-31 at 13:04:35 Europe/London with .NET SDK 10.0.300 and .NET runtime 10.0.8 on Windows 11. It executed 610 benchmarks with no failed suites in 01:14:50:
 
 ```powershell
 dotnet run --project src/benchmarks/ReactiveUI.Primitives.Benchmarks/ReactiveUI.Primitives.Benchmarks.csproj --configuration Release --no-build -- --filter "*" --join --launchCount 1 --warmupCount 1 --iterationCount 3
@@ -896,159 +896,108 @@ dotnet run --project src/benchmarks/ReactiveUI.Primitives.Benchmarks/ReactiveUI.
 
 Latest artifact paths:
 
-- `BenchmarkDotNet.Artifacts/BenchmarkRun-20260529-061525.log`
-- `BenchmarkDotNet.Artifacts/results/BenchmarkRun-joined-2026-05-29-06-37-05-report-github.md`
-- `BenchmarkDotNet.Artifacts/results/BenchmarkRun-joined-2026-05-29-06-37-05-report.html`
-- `BenchmarkDotNet.Artifacts/results/BenchmarkRun-joined-2026-05-29-06-37-05-report.csv`
+- `BenchmarkDotNet.Artifacts/BenchmarkRun-20260531-114958.log`
+- `BenchmarkDotNet.Artifacts/results/BenchmarkRun-joined-2026-05-31-13-04-35-report-github.md`
+- `BenchmarkDotNet.Artifacts/results/BenchmarkRun-joined-2026-05-31-13-04-35-report.html`
+- `BenchmarkDotNet.Artifacts/results/BenchmarkRun-joined-2026-05-31-13-04-35-report.csv`
 
-Smoke validation for deterministic benchmark behavior passed for 67 benchmark groups with:
+The joined run includes the complete `ReactiveUI.Primitives.Extensions` synchronous helper surface. Reflection over the public extension API and the benchmark smoke path both report 87 method families, with no missing or extra benchmark scenarios. The extension comparison rows are 87 `ReactiveUI.Primitives.Extensions`, 87 `ReactiveUI.Extensions` 4.0.0, 26 System.Reactive alternatives, and 12 R3 alternatives. Where System.Reactive or R3 has no direct alternative, the table uses `NA`.
 
-```powershell
-dotnet run --project src/benchmarks/ReactiveUI.Primitives.Benchmarks/ReactiveUI.Primitives.Benchmarks.csproj --configuration Release --no-build -- --smoke
-```
+External-baseline posture from this run: `ReactiveUI.Primitives.Extensions` is faster than System.Reactive in 26/26 measured extension comparisons and faster than R3 in 12/12 measured extension comparisons. Against `ReactiveUI.Extensions` 4.0.0, the Primitives implementation is faster in 59/87 comparisons; the remaining rows are migration-baseline parity or trade-offs and are listed directly below.
 
-The latest direct test/coverage validation passed 2032/2032 net8.0 tests and reports 99.28% line coverage and 97.22% branch coverage for `ReactiveUI.Primitives.Extensions` from `src/tests/ReactiveUI.Primitives.Tests/TestResults/extensions-optimization/coverage.cobertura.xml`. Direct executable validation also passed 2032/2032 tests on net9.0 and 2032/2032 tests on net10.0.
+The table below is generated from the joined BenchmarkDotNet CSV and uses `Mean / Allocated` for each cell. Function names are restored to their full values where BenchmarkDotNet abbreviated long `scenario` parameter values in the raw report.
 
-Focused Async and Extensions BenchmarkDotNet runs were added on 2026-05-30 on Windows 11 with .NET SDK 10.0.300 and .NET runtime 10.0.8. They used `LaunchCount=1`, `WarmupCount=1`, and `IterationCount=3`.
+| Function | ReactiveUI.Primitives.Extensions | ReactiveUI.Extensions 4.0.0 | System.Reactive | R3 |
+|---|---:|---:|---:|---:|
+| `AsSignal` | 40.9283 ns / 112 B | 2,531.8043 ns / 2488 B | 2,599.2762 ns / 2536 B | 195.1011 ns / 160 B |
+| `BufferUntil` | 41.8950 ns / 264 B | 46.9778 ns / 264 B | NA | NA |
+| `BufferUntilIdle` | 1,911.7933 ns / 6504 B | 26,205.7343 ns / 21206 B | NA | NA |
+| `BufferUntilInactive` | 1,934.9640 ns / 6504 B | 26,007.2723 ns / 21206 B | NA | NA |
+| `CatchAndReturn` | 20.4581 ns / 128 B | 62.3186 ns / 184 B | 173.8710 ns / 368 B | 124.0717 ns / 264 B |
+| `CatchIgnore` | 20.6947 ns / 128 B | 61.6429 ns / 184 B | 162.9161 ns / 344 B | 114.9980 ns / 240 B |
+| `CatchReturn` | 13.4188 ns / 128 B | 56.8613 ns / 184 B | 175.7315 ns / 368 B | 122.9695 ns / 264 B |
+| `CatchReturnUnit` | 9.9038 ns / 88 B | 56.5450 ns / 144 B | NA | NA |
+| `CombineLatestValuesAreAllFalse` | 187.9594 ns / 848 B | 225.3124 ns / 1176 B | 343.7347 ns / 648 B | NA |
+| `CombineLatestValuesAreAllTrue` | 189.5930 ns / 848 B | 212.1972 ns / 1176 B | 348.1409 ns / 648 B | NA |
+| `Conflate` | 4,130.3546 ns / 2304 B | 32,931.5816 ns / 16969 B | NA | NA |
+| `Continuation.Dispose` | 23.8043 ns / 192 B | 26.7620 ns / 192 B | NA | NA |
+| `Continuation.Lock` | 1,090.1629 ns / 464 B | 1,065.4799 ns / 464 B | NA | NA |
+| `Continuation.LockValueTask` | 1,083.5949 ns / 464 B | 1,134.9092 ns / 464 B | NA | NA |
+| `DebounceImmediate` | 1,644.8232 ns / 4064 B | 27,908.4279 ns / 18065 B | NA | NA |
+| `DebounceUntil` | 1,114.9940 ns / 776 B | 7,054.8114 ns / 6127 B | NA | NA |
+| `DetectStale` | 201.0480 ns / 600 B | 870.0431 ns / 25128 B | NA | NA |
+| `DoOnDispose` | 74.3679 ns / 232 B | 79.4666 ns / 232 B | NA | NA |
+| `DoOnSubscribe` | 69.6003 ns / 192 B | 70.5786 ns / 192 B | NA | NA |
+| `DropIfBusy` | 353.8349 ns / 240 B | 368.1982 ns / 240 B | NA | NA |
+| `FastForEach` | 49.8669 ns / 40 B | 48.6443 ns / 40 B | NA | NA |
+| `Filter` | 156.9508 ns / 120 B | 156.4153 ns / 120 B | 736.7575 ns / 896 B | NA |
+| `FirstMatchFromCandidates` | 39.3326 ns / 216 B | 37.6348 ns / 216 B | NA | NA |
+| `ForEach` | 70.8478 ns / 160 B | 71.7855 ns / 160 B | 148.7697 ns / 200 B | NA |
+| `FromArray` | 57.2974 ns / 72 B | 57.7421 ns / 72 B | 2,349.2118 ns / 2504 B | 74.4367 ns / 88 B |
+| `GetMax` | 101.2615 ns / 408 B | 215.4189 ns / 1152 B | 172.8915 ns / 328 B | NA |
+| `GetMin` | 106.1012 ns / 408 B | 193.5224 ns / 1152 B | 194.7781 ns / 328 B | NA |
+| `Heartbeat` | 284.0370 ns / 800 B | 2,137.1187 ns / 26096 B | NA | NA |
+| `LatestOrDefault` | 49.4452 ns / 136 B | 49.7046 ns / 136 B | NA | NA |
+| `LogErrors` | 64.3492 ns / 224 B | 68.2783 ns / 224 B | NA | NA |
+| `Not` | 28.4086 ns / 120 B | 23.7143 ns / 120 B | 777.3094 ns / 1040 B | 88.5710 ns / 152 B |
+| `ObserveOnIf` | 62.7276 ns / 104 B | 65.4303 ns / 104 B | NA | NA |
+| `ObserveOnSafe` | 62.6595 ns / 104 B | 61.9629 ns / 104 B | NA | NA |
+| `OnErrorRetry` | 124.5330 ns / 424 B | 124.1775 ns / 424 B | NA | NA |
+| `OnNext` | 49.5697 ns / 40 B | 49.7140 ns / 40 B | NA | NA |
+| `Pairwise` | 490.0995 ns / 160 B | 491.6251 ns / 160 B | 2,740.4705 ns / 3072 B | NA |
+| `Partition` | 257.7809 ns / 440 B | 249.5671 ns / 440 B | NA | NA |
+| `ReplayLastOnSubscribe` | 63.7072 ns / 104 B | 60.9911 ns / 104 B | NA | NA |
+| `RetryForeverWithDelay` | 119.9242 ns / 352 B | 118.0222 ns / 352 B | NA | NA |
+| `RetryWithBackoff` | 117.7281 ns / 336 B | 113.5010 ns / 336 B | NA | NA |
+| `RetryWithDelay` | 106.6986 ns / 264 B | 103.9552 ns / 264 B | NA | NA |
+| `RetryWithFixedDelay` | 115.6068 ns / 336 B | 122.0493 ns / 336 B | NA | NA |
+| `Return` | 5.7381 ns / 64 B | 5.6978 ns / 64 B | 50.9029 ns / 120 B | 29.9718 ns / 56 B |
+| `RunAll` | 22.5211 ns / 136 B | 27.3082 ns / 136 B | NA | NA |
+| `SampleLatest` | 1,023.3630 ns / 488 B | 1,070.9330 ns / 840 B | NA | NA |
+| `ScanWithInitial` | 507.9467 ns / 200 B | 505.6987 ns / 200 B | 2,616.2001 ns / 2560 B | NA |
+| `Schedule` | 33.9394 ns / 216 B | 882.2126 ns / 677 B | NA | NA |
+| `ScheduleSafe` | 27.0011 ns / 144 B | 863.6469 ns / 597 B | NA | NA |
+| `SelectAsync` | 1,183.7934 ns / 2104 B | 1,275.5720 ns / 2104 B | 29,926.1912 ns / 32266 B | NA |
+| `SelectAsyncConcurrent` | 1,086.3005 ns / 2120 B | 1,078.9035 ns / 2120 B | NA | NA |
+| `SelectAsyncSequential` | 1,215.5647 ns / 2104 B | 1,198.7932 ns / 2104 B | NA | NA |
+| `SelectConstant` | 61.2733 ns / 136 B | 55.6676 ns / 136 B | 2,612.8930 ns / 2544 B | 184.5721 ns / 160 B |
+| `SelectLatestAsync` | 1,640.3117 ns / 2032 B | 1,703.9179 ns / 2032 B | NA | NA |
+| `SelectManyThen` | 33.1931 ns / 224 B | 35.2676 ns / 224 B | 339.0513 ns / 752 B | NA |
+| `Shuffle` | 146.1008 ns / 96 B | 146.3751 ns / 96 B | NA | NA |
+| `SkipWhileNull` | 24.3479 ns / 112 B | 23.8709 ns / 112 B | 646.2172 ns / 944 B | NA |
+| `Start` | 23.1089 ns / 96 B | 940.0599 ns / 535 B | NA | NA |
+| `SubscribeAndComplete` | 0.2379 ns / 0 B | 0.2696 ns / 0 B | NA | NA |
+| `SubscribeAsync` | 939.6350 ns / 544 B | 935.3032 ns / 544 B | NA | NA |
+| `SubscribeGetError` | 6.8850 ns / 48 B | 52.1458 ns / 104 B | NA | NA |
+| `SubscribeGetValue` | 16.1767 ns / 56 B | 17.3263 ns / 56 B | NA | NA |
+| `SubscribeSynchronous` | 951.8410 ns / 544 B | 964.7101 ns / 544 B | NA | NA |
+| `SwitchIfEmpty` | 68.6637 ns / 224 B | 105.4468 ns / 280 B | NA | NA |
+| `SynchronizeAsync` | 777.1340 ns / 1280 B | 774.5258 ns / 1280 B | NA | NA |
+| `SynchronizeSynchronous` | 773.1336 ns / 1280 B | 785.0287 ns / 1280 B | NA | NA |
+| `SyncTimer` | 2,639.1904 ns / 1080 B | 12,566.8335 ns / 26241 B | NA | NA |
+| `TakeUntil` | 523.6973 ns / 192 B | 520.7622 ns / 192 B | 2,680.2797 ns / 2520 B | NA |
+| `ThrottleDistinct` | 1,718.4232 ns / 4232 B | 28,078.6550 ns / 18701 B | NA | NA |
+| `ThrottleFirst` | 1,159.8667 ns / 224 B | 1,151.5612 ns / 224 B | NA | NA |
+| `ThrottleOnScheduler` | 1,999.2879 ns / 2400 B | 30,701.9572 ns / 16354 B | NA | NA |
+| `ThrottleUntilTrue` | 4,500.9806 ns / 1634 B | 5,584.0680 ns / 1385 B | NA | NA |
+| `ToHotTask` | 35.5886 ns / 112 B | 33.4305 ns / 112 B | 89.5899 ns / 472 B | NA |
+| `ToHotValueTask` | 26.8449 ns / 0 B | 28.4980 ns / 0 B | NA | NA |
+| `ToPropertyObservable` | 26,649.8027 ns / 4941 B | 26,504.9276 ns / 4941 B | NA | NA |
+| `ToReadOnlyBehavior` | 58.4629 ns / 192 B | 61.7022 ns / 192 B | NA | NA |
+| `TrySelect` | 101.1200 ns / 120 B | 98.2908 ns / 120 B | NA | NA |
+| `Using` | 6.5552 ns / 56 B | 6.8002 ns / 56 B | NA | NA |
+| `WaitForCompletion` | 23.5279 ns / 96 B | 22.9725 ns / 96 B | NA | NA |
+| `WaitForError` | 25.2475 ns / 96 B | 66.9739 ns / 152 B | NA | NA |
+| `WaitForValue` | 31.7103 ns / 104 B | 32.4430 ns / 104 B | NA | NA |
+| `WaitUntil` | 512.0670 ns / 224 B | 514.2448 ns / 224 B | 849.6420 ns / 1080 B | NA |
+| `WhereFalse` | 21.7965 ns / 120 B | 21.7348 ns / 120 B | 768.5199 ns / 1040 B | 89.2687 ns / 184 B |
+| `WhereIsNotNull` | 20.8965 ns / 104 B | 22.1343 ns / 104 B | 619.6627 ns / 904 B | 97.3514 ns / 264 B |
+| `WhereSelect` | 74.9895 ns / 152 B | 78.0693 ns / 152 B | 2,579.5263 ns / 2616 B | 175.2326 ns / 240 B |
+| `WhereTrue` | 21.2385 ns / 120 B | 21.4245 ns / 120 B | 742.5841 ns / 1040 B | 81.5593 ns / 184 B |
+| `While` | 123.0402 ns / 280 B | 124.6595 ns / 280 B | NA | NA |
+| `WithLimitedConcurrency` | 2,678.3744 ns / 5448 B | 2,419.3906 ns / 5448 B | NA | NA |
 
-```powershell
-dotnet run --project src/benchmarks/ReactiveUI.Primitives.Benchmarks/ReactiveUI.Primitives.Benchmarks.csproj --configuration Release --no-build -- --filter "*ReactiveExtensionsComparisonBenchmarks*" --launchCount 1 --warmupCount 1 --iterationCount 3
-dotnet run --project src/benchmarks/ReactiveUI.Primitives.Benchmarks/ReactiveUI.Primitives.Benchmarks.csproj --configuration Release --no-build -- --filter "*AsyncExtensionsComparisonBenchmarks*" --launchCount 1 --warmupCount 1 --iterationCount 3
-```
-
-Extensions comparison against `ReactiveUI.Extensions` 4.0.0:
-
-| Scenario | ReactiveUI.Primitives.Extensions | ReactiveUI.Extensions 4.0.0 |
-|---|---:|---:|
-| `WhereSelect` range | 75.87 ns / 136 B | 2,655.97 ns / 2512 B |
-| `FromArray` subscribe | 58.42 ns / 40 B | 59.15 ns / 40 B |
-| `Pairwise` range | 515.51 ns / 160 B | 3,016.54 ns / 2536 B |
-| `BufferUntil` chars | 52.81 ns / 264 B | 53.01 ns / 264 B |
-| `Not` + `WhereTrue` | 28.81 ns / 144 B | 30.42 ns / 144 B |
-
-Async comparison against `ReactiveUI.Extensions.Async` 4.0.0:
-
-| Scenario | ReactiveUI.Primitives.Async | ReactiveUI.Extensions.Async 4.0.0 |
-|---|---:|---:|
-| `Sequence` + `Map` + `Keep` + `ToListAsync` | 2,109.7 ns / 1600 B | 2,085.6 ns / 1600 B |
-| Async `CountAsync` | 817.2 ns / 704 B | 808.0 ns / 704 B |
-| Async signal/subject broadcast | 6,822.4 ns / 2320 B | 6,802.5 ns / 2320 B |
-
-The focused Extensions results show the fused and direct-observer operators winning the high-value migrated scenarios while preserving allocations where both implementations use equivalent buffering. The Async results are allocation-equivalent to the baseline and within measurement noise on the selected parity paths.
-
-The table below is generated from the joined BenchmarkDotNet CSV and uses `Mean / Allocated` for each cell.
-
-| Scenario | ReactiveUI.Primitives | System.Reactive | R3 |
-|---|---:|---:|---:|
-| Emit subscribe | 0.2230 ns / 0 B | 47.3735 ns / 120 B | 28.3341 ns / 80 B |
-| None subscribe | 2.9952 ns / 40 B | 42.0283 ns / 96 B | 27.3123 ns / 56 B |
-| Sequence subscribe | 46.4699 ns / 96 B | 2,389.8479 ns / 2472 B | 69.8169 ns / 80 B |
-| Loop subscribe | 6.7140 ns / 0 B | 2,278.0993 ns / 2408 B | 67.8307 ns / 80 B |
-| Fail subscribe | 55.9618 ns / 120 B | 104.6122 ns / 240 B | 83.5704 ns / 200 B |
-| FromEnumerable subscribe | 49.9427 ns / 40 B | 2,242.8721 ns / 2504 B | 75.4156 ns / 88 B |
-| Completed task bridge | 9.6957 ns / 88 B | 762.3672 ns / 793 B | 33.7027 ns / 88 B |
-| Create subscribe | 33.3256 ns / 112 B | 44.6606 ns / 168 B | 52.2479 ns / 128 B |
-| CreateSafe subscribe | 33.3246 ns / 112 B | 44.1128 ns / 168 B | 51.0502 ns / 128 B |
-| Lazy subscribe | 66.2262 ns / 240 B | 1,287.3555 ns / 1512 B | 106.8332 ns / 152 B |
-| Start subscribe | 39.6918 ns / 208 B | 769.3907 ns / 751 B | 55.2220 ns / 160 B |
-| Unfold subscribe | 10.0288 ns / 0 B | 2,128.0362 ns / 2768 B | 91.3892 ns / 128 B |
-| Use subscribe | 36.4206 ns / 144 B | 78.9546 ns / 168 B | 51.2890 ns / 128 B |
-| FromAsyncEnumerable subscribe | 1,006.7269 ns / 600 B | 1,645.8238 ns / 2311 B | 1,136.1530 ns / 1023 B |
-| Silent subscribe/dispose | 0.2315 ns / 0 B | 5.4195 ns / 40 B | 16.9768 ns / 56 B |
-| Map + Keep over range | 124.3913 ns / 208 B | 2,472.8123 ns / 2616 B | 286.3641 ns / 272 B |
-| Reduce + Any + Count | 174.3840 ns / 824 B | 5,174.9387 ns / 6216 B | 598.8228 ns / 1280 B |
-| Prepend + Append + DefaultIfEmpty | 30.1072 ns / 168 B | 843.4910 ns / 1282 B | 127.8896 ns / 288 B |
-| DefaultIfEmpty(empty) | 5.6240 ns / 64 B | 59.9335 ns / 144 B | 59.1663 ns / 136 B |
-| FlatMap over ranges | 946.5697 ns / 712 B | 3,506.1713 ns / 3872 B | 1,003.7753 ns / 1040 B |
-| Pair over ranges | 38.5910 ns / 232 B | 2,915.9901 ns / 2976 B | 652.8988 ns / 656 B |
-| Chain ranges | 69.5590 ns / 256 B | 2,594.3044 ns / 2856 B | 232.0761 ns / 360 B |
-| Blend ranges | 68.7321 ns / 256 B | 3,543.2549 ns / 3953 B | 642.6874 ns / 352 B |
-| Race ranges | 33.5591 ns / 192 B | 1,404.2164 ns / 1760 B | 261.6344 ns / 360 B |
-| SwitchTo ranges | 73.2220 ns / 336 B | 1,970.9442 ns / 2336 B | 704.1251 ns / 392 B |
-| SyncLatest ranges | 79.4395 ns / 368 B | 2,944.0282 ns / 2824 B | 622.3868 ns / 344 B |
-| Latch ranges | 81.0008 ns / 368 B | 3,225.7811 ns / 2824 B | 243.9050 ns / 248 B |
-| ForkJoin ranges | 50.8807 ns / 344 B | 3,269.8635 ns / 3136 B | 907.5060 ns / 504 B |
-| Shift range | 144.9936 ns / 528 B | 5,006.6565 ns / 39584 B | 1,842.7436 ns / 2200 B |
-| DelayStart range | 134.7077 ns / 528 B | 2,128.8455 ns / 26456 B | 301.3397 ns / 552 B |
-| Calm burst | 576.4417 ns / 1184 B | 2,324.6424 ns / 36480 B | 1,507.2980 ns / 1512 B |
-| Probe latest | 209.6742 ns / 640 B | 1,811.5047 ns / 26264 B | 299.8862 ns / 664 B |
-| Timestamp range | 34.7496 ns / 144 B | 1,578.6798 ns / 1512 B | 332.1624 ns / 152 B |
-| TimeInterval range | 25.4590 ns / 152 B | 1,603.1043 ns / 1616 B | 419.3172 ns / 160 B |
-| Expire idle | 231.4570 ns / 704 B | 1,137.3182 ns / 29776 B | 378.0569 ns / 784 B |
-| ObserveOn immediate | 21.4403 ns / 96 B | 14,471.7122 ns / 11310 B | 885.3536 ns / 432 B |
-| History subscribe | 322.3987 ns / 320 B | 670.2288 ns / 696 B | 387.4820 ns / 688 B |
-| StateSignal 32 values | 237.1878 ns / 120 B | 565.4464 ns / 200 B | 594.9903 ns / 192 B |
-| StateSignal 1024 values | 6,730.9924 ns / 120 B | 15,726.8158 ns / 200 B | 15,691.3635 ns / 192 B |
-| Signal emit, 32 values | 65.5355 ns / 136 B | 89.1690 ns / 136 B | 111.8446 ns / 160 B |
-| Signal emit, 1024 values | 1,637.7626 ns / 136 B | 1,673.6031 ns / 136 B | 1,986.4624 ns / 160 B |
-| Signal subscribe/dispose, 8 observers | 228.5621 ns / 592 B | 283.1068 ns / 1288 B | 436.3383 ns / 840 B |
-| Signal subscribe/dispose, 64 observers | 2,662.1290 ns / 3800 B | 3,546.0312 ns / 38472 B | 3,455.8392 ns / 6216 B |
-| ShareLive connect | 130.7828 ns / 384 B | 2,528.9932 ns / 2696 B | 426.6950 ns / 368 B |
-| Share live subscribe | 199.5178 ns / 712 B | 2,700.8301 ns / 2880 B | 471.9188 ns / 488 B |
-| Replay live late subscribe | 608.7132 ns / 568 B | 3,480.7842 ns / 3408 B | 812.3979 ns / 1360 B |
-| AutoShare subscribe | 202.3044 ns / 712 B | 2,697.0149 ns / 2880 B | 482.7859 ns / 488 B |
-| AutoConnect subscribe | 155.5013 ns / 592 B | 2,502.8542 ns / 2736 B | 372.7091 ns / 368 B |
-| StateSignal updates | 238.1559 ns / 120 B | 548.4785 ns / 200 B | 594.8021 ns / 192 B |
-| ReadOnlyState projection | 52.5724 ns / 144 B | 84.4462 ns / 328 B | 161.3650 ns / 312 B |
-| TaskSignal subscribe | 34.0054 ns / 240 B | 665.1771 ns / 886 B | 37.2785 ns / 160 B |
-| Command execute | 32.5825 ns / 152 B | 645.0811 ns / 1089 B | 103.4041 ns / 296 B |
-| Command result subscribe | 57.1177 ns / 224 B | 36.0275 ns / 136 B | 61.6326 ns / 160 B |
-| CollectList range | 102.0529 ns / 552 B | 2,463.1842 ns / 3352 B | 149.5652 ns / 632 B |
-| CollectArray range | 63.5489 ns / 520 B | 2,470.4433 ns / 3504 B | 158.9210 ns / 784 B |
-| CollectArrayAsync range | 33.3098 ns / 384 B | 2,595.1312 ns / 3848 B | 155.9081 ns / 784 B |
-| FirstAsync range | 5.8384 ns / 56 B | 2,353.8883 ns / 2792 B | 67.9760 ns / 208 B |
-| ToTask range | 13.6859 ns / 192 B | 2,403.5159 ns / 2824 B | 88.2610 ns / 208 B |
-| Count(predicate) range | 18.8970 ns / 96 B | 2,369.8963 ns / 2520 B | 92.8400 ns / 200 B |
-| LongCount(predicate) range | 19.5172 ns / 104 B | 2,323.6443 ns / 2536 B | 98.4867 ns / 272 B |
-| All range | 17.0983 ns / 96 B | 2,362.4686 ns / 2520 B | 80.4268 ns / 192 B |
-| Contains range | 9.2651 ns / 96 B | 2,388.1732 ns / 2528 B | 86.6274 ns / 200 B |
-| All + Contains range | 27.3462 ns / 192 B | 4,757.9435 ns / 5048 B | 210.3620 ns / 392 B |
-| Pocket dispose | 60.8709 ns / 408 B | 91.0020 ns / 512 B | 68.8285 ns / 480 B |
-| CurrentThread schedule | 6.6194 ns / 88 B | 16.0136 ns / 88 B | 27.2022 ns / 56 B |
-| Safe witness | 16.9332 ns / 136 B | 11.8405 ns / 136 B | 16.9656 ns / 56 B |
-| Completed Spark | 0.0056 ns / 0 B | 0.0000 ns / 0 B | 0.0271 ns / 0 B |
-
-The five rows selected from the improvement review as the main time/scheduler optimization gate were `Shift range`, `DelayStart range`, `Calm burst`, `Probe latest`, and `Expire idle`. In the complete run all five beat both System.Reactive and R3 on mean time and allocation. The same optimization pass also brought `Timestamp range`, `TimeInterval range`, `ObserveOn immediate`, `SwitchTo ranges`, `StateSignal updates`, and `ReadOnlyState projection` below both alternatives on mean time and allocation.
-
-Interpretation notes:
-
-- ReactiveUI.Primitives leads on mean time in 64 of the 67 listed groups. The remaining material time gaps are `Command result subscribe` against a System.Reactive subject-only baseline and `Safe witness` against a less guarded delegate observer; `Completed Spark` measures at empty-method scale with zero allocation for every implementation.
-- The public API/operator matrix above is backed by deterministic smoke coverage in `Program.RunSmokeBenchmarksAsync`: every row has matching ReactiveUI.Primitives, System.Reactive, and R3 calls where alternatives exist, and the smoke run validates each benchmark path returns the same observable result before BenchmarkDotNet measures throughput and allocation unless the row is one of the documented scheduling-total exceptions below.
-- The only intentional smoke output differences are `SwitchTo ranges`, `SyncLatest ranges`, and `Latch ranges`: System.Reactive produces different synchronous range totals for those coordinator operators, while ReactiveUI.Primitives and R3 agree on the emitted totals. `--smoke` permits only those System.Reactive differences and still fails if ReactiveUI.Primitives diverges from R3 or if any other benchmark group loses parity.
-- Candidate scenarios where ReactiveUI.Primitives is not strictly both faster and lower-allocation than both alternatives are tracked explicitly below. Most remaining rows are allocation-only gaps where ReactiveUI.Primitives is still faster on mean time; rows marked as exceptions are retained because the extra cost buys ReactiveUI.Primitives semantics (safe terminal/disposal behavior, `IObservable<T>`/`IObserver<T>` compatibility, deterministic `ISequencer` scheduling, or live-signal lifecycle ownership) while preserving the project rule that System.Reactive/R3 are benchmark-only dependencies.
-- Near-zero singleton measurements (`Emit`, `Silent`, and `Spark` paths) may trigger BenchmarkDotNet `ZeroMeasurement` warnings; those warnings mean the method duration is indistinguishable from the empty-method overhead, not that the benchmark failed.
-
-Candidate/performance exception matrix:
-
-| Scenario | Observed gap | Decision and trade-off |
-|---|---|---|
-| `Sequence subscribe` | allocation >= R3 (96 B vs 80 B). | Accepted exception: the range path keeps BCL observable compatibility and explicit disposal ownership; mean time remains ahead of R3. |
-| `Completed task bridge` | allocation ties R3 (88 B vs 88 B). | Accepted exception: the bridge has the lowest mean time and ties R3 allocation while preserving task-observer completion semantics. |
-| `Lazy subscribe` | allocation >= R3 (240 B vs 152 B). | Accepted exception: lazy factory ownership keeps the BCL subscription and disposal contract; mean time remains ahead of R3. |
-| `Start subscribe` | allocation >= R3 (208 B vs 160 B). | Accepted exception: start uses the Primitives scheduling/result surface; mean time remains ahead of R3. |
-| `Use subscribe` | allocation >= R3 (144 B vs 128 B). | Accepted exception: resource ownership is explicit and BCL-compatible; mean time remains ahead of R3. |
-| `SyncLatest ranges` | allocation >= R3 (368 B vs 344 B). | Accepted exception: coordinator operators keep general `IObservable<T>` subscription ownership and terminal arbitration while leading on mean time. |
-| `Latch ranges` | allocation >= R3 (368 B vs 248 B). | Accepted exception: coordinator operators keep general `IObservable<T>` subscription ownership and terminal arbitration while leading on mean time. |
-| `Signal emit, 32 values` | allocation ties System.Reactive (136 B vs 136 B). | Accepted exception: emit loops lead on throughput and tie System.Reactive allocation; strict lower allocation is not meaningful for this BCL-compatible shape. |
-| `Signal emit, 1024 values` | allocation ties System.Reactive (136 B vs 136 B). | Accepted exception: emit loops lead on throughput and tie System.Reactive allocation; strict lower allocation is not meaningful for this BCL-compatible shape. |
-| `ShareLive connect` | allocation >= R3 (384 B vs 368 B). | Accepted exception: live sharing owns connection/ref-count lifecycle and safe disconnect state while leading on mean time. |
-| `Share live subscribe` | allocation >= R3 (712 B vs 488 B). | Accepted exception: live sharing owns connection/ref-count lifecycle and safe disconnect state while leading on mean time. |
-| `AutoShare subscribe` | allocation >= R3 (712 B vs 488 B). | Accepted exception: live sharing owns connection/ref-count lifecycle and safe disconnect state while leading on mean time. |
-| `AutoConnect subscribe` | allocation >= R3 (592 B vs 368 B). | Accepted exception: live sharing owns connection/ref-count lifecycle and safe disconnect state while leading on mean time. |
-| `TaskSignal subscribe` | allocation >= R3 (240 B vs 160 B). | Accepted exception: `TaskSignal` preserves BCL signal completion semantics while leading on mean time. |
-| `Command result subscribe` | time >= System.Reactive (57.1177 ns vs 36.0275 ns); allocation >= System.Reactive (224 B vs 136 B); allocation >= R3 (224 B vs 160 B). | Accepted exception: the System.Reactive row is subject-only synchronous publication, while `CommandSignal` includes command execution gating plus result publication and still beats R3 on mean time. |
-| `CurrentThread schedule` | allocation ties System.Reactive (88 B vs 88 B); allocation >= R3 (88 B vs 56 B). | Accepted exception: current-thread scheduling uses the project sequencer queue contract; throughput leads both alternatives. |
-| `Safe witness` | time >= System.Reactive (16.9332 ns vs 11.8405 ns); allocation ties System.Reactive (136 B vs 136 B); allocation >= R3 (136 B vs 56 B). | Accepted exception: the wrapper enforces safe observer/terminal behavior; the System.Reactive row is a less guarded delegate observer. |
-| `Completed Spark` | time >= System.Reactive (0.0056 ns vs 0.0000 ns); allocation ties System.Reactive and R3 (0 B). | Accepted exception: all implementations allocate zero and measure at empty-method scale, so a strict lower-allocation win is not meaningful. |
-
-Performance constraints used by the project:
-
-- Preserve observer and terminal notification semantics.
-- Preserve safe unsubscription and disposal behavior.
-- Avoid reflection and dynamic code generation in runtime hot paths.
-- Prefer sealed helpers, direct fast paths, and predictable branch behavior.
-- Keep allocations minimal in emit loops and single-subscriber cases.
-
+BenchmarkDotNet emitted `ZeroMeasurement` warnings for several singleton or empty-method-scale paths, including `Return`, `CompletedSpark`, and `Never`-style subscriptions. Those warnings mean the measured duration is indistinguishable from empty method overhead; the benchmark run still completed and exported all 610 rows.
 ## Repository layout
 
 | Path | Purpose |
@@ -1074,22 +1023,17 @@ Performance constraints used by the project:
 # Build solution.
 dotnet build .\src\ReactiveUI.Primitives.slnx -c Release -v minimal /nr:false -p:UseSharedCompilation=false -p:BuildInParallel=false -maxcpucount:1
 
-# Net8 coverage run through the Microsoft Testing Platform/TUnit executable.
-dotnet .\src\tests\ReactiveUI.Primitives.Tests\bin\Release\net8.0\ReactiveUI.Primitives.Tests.dll --coverage --coverage-output coverage.cobertura.xml --coverage-output-format cobertura --results-directory .\src\tests\ReactiveUI.Primitives.Tests\TestResults\extensions-optimization --no-ansi --no-progress --output Normal --timeout 10m
+# ReactiveUI.Primitives.Extensions TUnit executable validation.
+dotnet .\src\tests\ReactiveUI.Primitives.Extensions.Tests\bin\Release\net8.0\ReactiveUI.Primitives.Extensions.Tests.dll --results-directory .\src\tests\ReactiveUI.Primitives.Extensions.Tests\TestResults\benchmark-validation-net8 --no-ansi --no-progress --output Normal --timeout 10m
+dotnet .\src\tests\ReactiveUI.Primitives.Extensions.Tests\bin\Release\net9.0\ReactiveUI.Primitives.Extensions.Tests.dll --results-directory .\src\tests\ReactiveUI.Primitives.Extensions.Tests\TestResults\benchmark-validation-net9 --no-ansi --no-progress --output Normal --timeout 10m
+dotnet .\src\tests\ReactiveUI.Primitives.Extensions.Tests\bin\Release\net10.0\ReactiveUI.Primitives.Extensions.Tests.dll --results-directory .\src\tests\ReactiveUI.Primitives.Extensions.Tests\TestResults\benchmark-validation-net10 --no-ansi --no-progress --output Normal --timeout 10m
 
-# Remaining test target frameworks through the generated TUnit executables.
-dotnet .\src\tests\ReactiveUI.Primitives.Tests\bin\Release\net9.0\ReactiveUI.Primitives.Tests.dll --results-directory .\src\tests\ReactiveUI.Primitives.Tests\TestResults\extensions-optimization-net9 --no-ansi --no-progress --output Normal --timeout 10m
-dotnet .\src\tests\ReactiveUI.Primitives.Tests\bin\Release\net10.0\ReactiveUI.Primitives.Tests.dll --results-directory .\src\tests\ReactiveUI.Primitives.Tests\TestResults\extensions-optimization-net10 --no-ansi --no-progress --output Normal --timeout 10m
-
-# Benchmark smoke, focused Async/Extensions comparisons, and complete joined comparison run.
-dotnet run --project .\src\benchmarks\ReactiveUI.Primitives.Benchmarks\ReactiveUI.Primitives.Benchmarks.csproj --configuration Release --no-build -- --smoke
-dotnet run --project .\src\benchmarks\ReactiveUI.Primitives.Benchmarks\ReactiveUI.Primitives.Benchmarks.csproj --configuration Release --no-build -- --filter "*ReactiveExtensionsComparisonBenchmarks*" --launchCount 1 --warmupCount 1 --iterationCount 3
-dotnet run --project .\src\benchmarks\ReactiveUI.Primitives.Benchmarks\ReactiveUI.Primitives.Benchmarks.csproj --configuration Release --no-build -- --filter "*AsyncExtensionsComparisonBenchmarks*" --launchCount 1 --warmupCount 1 --iterationCount 3
+# Extension scenario smoke and complete joined comparison run.
+dotnet run --project .\src\benchmarks\ReactiveUI.Primitives.Benchmarks\ReactiveUI.Primitives.Benchmarks.csproj --configuration Release --no-build -- --extensions-smoke
 dotnet run --project .\src\benchmarks\ReactiveUI.Primitives.Benchmarks\ReactiveUI.Primitives.Benchmarks.csproj --configuration Release --no-build -- --filter "*" --join --launchCount 1 --warmupCount 1 --iterationCount 3
 ```
 
-Results: build passed with 0 warnings/0 errors; the net8.0 coverage run passed 2032/2032 tests; direct TUnit executable validation passed 2032/2032 tests on net9.0 and 2032/2032 tests on net10.0. The latest `ReactiveUI.Primitives.Extensions` coverage snapshot reported 99.28% line (3171/3194) and 97.22% branch (875/900) coverage. Benchmark smoke parity passed for 67 groups; the joined BenchmarkDotNet run executed 201 benchmarks, and the focused Async/Extensions BenchmarkDotNet runs produced the comparison tables above.
-
+Results: release solution build passed with 0 warnings/0 errors; `ReactiveUI.Primitives.Extensions.Tests` passed 681/681 tests on net8.0, net9.0, and net10.0; extension scenario smoke validated 212 scenario paths; reflection/API coverage confirmed 87/87 public `ReactiveUI.Primitives.Extensions` method families have Primitives benchmark scenarios; the joined BenchmarkDotNet run executed 610 benchmarks in 01:14:50. The Mtpunittest MCP read existing solution coverage reports after validation and reported 69.88% line coverage and 74.21% branch coverage; coverage was not regenerated during this benchmark refresh.
 ### Package verification
 
 For NuGet package verification, inspect the generated `.nupkg` and confirm:

--- a/README.md
+++ b/README.md
@@ -888,7 +888,7 @@ For async-native streams, prefer `ReactiveUI.Primitives.Async` and its `IObserva
 
 Benchmarks live in `src/benchmarks/ReactiveUI.Primitives.Benchmarks`. The benchmark project may reference System.Reactive, R3, and ReactiveUI.Extensions to compare throughput and allocation behavior; the production packages must not.
 
-The latest complete BenchmarkDotNet run finished on 2026-05-31 at 13:04:35 Europe/London with .NET SDK 10.0.300 and .NET runtime 10.0.8 on Windows 11. It executed 610 benchmarks with no failed suites in 01:14:50:
+The latest complete BenchmarkDotNet run finished on 2026-05-31 at 15:10:19 Europe/London with .NET SDK 10.0.300 and .NET runtime 10.0.8 on Windows 11. It executed 610 benchmarks with no failed suites in 01:16:19:
 
 ```powershell
 dotnet run --project src/benchmarks/ReactiveUI.Primitives.Benchmarks/ReactiveUI.Primitives.Benchmarks.csproj --configuration Release --no-build -- --filter "*" --join --launchCount 1 --warmupCount 1 --iterationCount 3
@@ -896,108 +896,109 @@ dotnet run --project src/benchmarks/ReactiveUI.Primitives.Benchmarks/ReactiveUI.
 
 Latest artifact paths:
 
-- `BenchmarkDotNet.Artifacts/BenchmarkRun-20260531-114958.log`
-- `BenchmarkDotNet.Artifacts/results/BenchmarkRun-joined-2026-05-31-13-04-35-report-github.md`
-- `BenchmarkDotNet.Artifacts/results/BenchmarkRun-joined-2026-05-31-13-04-35-report.html`
-- `BenchmarkDotNet.Artifacts/results/BenchmarkRun-joined-2026-05-31-13-04-35-report.csv`
+- `BenchmarkDotNet.Artifacts/BenchmarkRun-20260531-135415.log`
+- `BenchmarkDotNet.Artifacts/results/BenchmarkRun-joined-2026-05-31-15-10-19-report-github.md`
+- `BenchmarkDotNet.Artifacts/results/BenchmarkRun-joined-2026-05-31-15-10-19-report.html`
+- `BenchmarkDotNet.Artifacts/results/BenchmarkRun-joined-2026-05-31-15-10-19-report.csv`
 
 The joined run includes the complete `ReactiveUI.Primitives.Extensions` synchronous helper surface. Reflection over the public extension API and the benchmark smoke path both report 87 method families, with no missing or extra benchmark scenarios. The extension comparison rows are 87 `ReactiveUI.Primitives.Extensions`, 87 `ReactiveUI.Extensions` 4.0.0, 26 System.Reactive alternatives, and 12 R3 alternatives. Where System.Reactive or R3 has no direct alternative, the table uses `NA`.
 
-External-baseline posture from this run: `ReactiveUI.Primitives.Extensions` is faster than System.Reactive in 26/26 measured extension comparisons and faster than R3 in 12/12 measured extension comparisons. Against `ReactiveUI.Extensions` 4.0.0, the Primitives implementation is faster in 59/87 comparisons; the remaining rows are migration-baseline parity or trade-offs and are listed directly below.
+External-baseline posture from this run: `ReactiveUI.Primitives.Extensions` is faster than System.Reactive in 26/26 measured extension comparisons and faster than R3 in 12/12 measured extension comparisons. Against `ReactiveUI.Extensions` 4.0.0, the Primitives implementation is faster in 64/87 comparisons; the remaining rows are migration-baseline parity or trade-offs and are listed directly below.
 
 The table below is generated from the joined BenchmarkDotNet CSV and uses `Mean / Allocated` for each cell. Function names are restored to their full values where BenchmarkDotNet abbreviated long `scenario` parameter values in the raw report.
 
 | Function | ReactiveUI.Primitives.Extensions | ReactiveUI.Extensions 4.0.0 | System.Reactive | R3 |
 |---|---:|---:|---:|---:|
-| `AsSignal` | 40.9283 ns / 112 B | 2,531.8043 ns / 2488 B | 2,599.2762 ns / 2536 B | 195.1011 ns / 160 B |
-| `BufferUntil` | 41.8950 ns / 264 B | 46.9778 ns / 264 B | NA | NA |
-| `BufferUntilIdle` | 1,911.7933 ns / 6504 B | 26,205.7343 ns / 21206 B | NA | NA |
-| `BufferUntilInactive` | 1,934.9640 ns / 6504 B | 26,007.2723 ns / 21206 B | NA | NA |
-| `CatchAndReturn` | 20.4581 ns / 128 B | 62.3186 ns / 184 B | 173.8710 ns / 368 B | 124.0717 ns / 264 B |
-| `CatchIgnore` | 20.6947 ns / 128 B | 61.6429 ns / 184 B | 162.9161 ns / 344 B | 114.9980 ns / 240 B |
-| `CatchReturn` | 13.4188 ns / 128 B | 56.8613 ns / 184 B | 175.7315 ns / 368 B | 122.9695 ns / 264 B |
-| `CatchReturnUnit` | 9.9038 ns / 88 B | 56.5450 ns / 144 B | NA | NA |
-| `CombineLatestValuesAreAllFalse` | 187.9594 ns / 848 B | 225.3124 ns / 1176 B | 343.7347 ns / 648 B | NA |
-| `CombineLatestValuesAreAllTrue` | 189.5930 ns / 848 B | 212.1972 ns / 1176 B | 348.1409 ns / 648 B | NA |
-| `Conflate` | 4,130.3546 ns / 2304 B | 32,931.5816 ns / 16969 B | NA | NA |
-| `Continuation.Dispose` | 23.8043 ns / 192 B | 26.7620 ns / 192 B | NA | NA |
-| `Continuation.Lock` | 1,090.1629 ns / 464 B | 1,065.4799 ns / 464 B | NA | NA |
-| `Continuation.LockValueTask` | 1,083.5949 ns / 464 B | 1,134.9092 ns / 464 B | NA | NA |
-| `DebounceImmediate` | 1,644.8232 ns / 4064 B | 27,908.4279 ns / 18065 B | NA | NA |
-| `DebounceUntil` | 1,114.9940 ns / 776 B | 7,054.8114 ns / 6127 B | NA | NA |
-| `DetectStale` | 201.0480 ns / 600 B | 870.0431 ns / 25128 B | NA | NA |
-| `DoOnDispose` | 74.3679 ns / 232 B | 79.4666 ns / 232 B | NA | NA |
-| `DoOnSubscribe` | 69.6003 ns / 192 B | 70.5786 ns / 192 B | NA | NA |
-| `DropIfBusy` | 353.8349 ns / 240 B | 368.1982 ns / 240 B | NA | NA |
-| `FastForEach` | 49.8669 ns / 40 B | 48.6443 ns / 40 B | NA | NA |
-| `Filter` | 156.9508 ns / 120 B | 156.4153 ns / 120 B | 736.7575 ns / 896 B | NA |
-| `FirstMatchFromCandidates` | 39.3326 ns / 216 B | 37.6348 ns / 216 B | NA | NA |
-| `ForEach` | 70.8478 ns / 160 B | 71.7855 ns / 160 B | 148.7697 ns / 200 B | NA |
-| `FromArray` | 57.2974 ns / 72 B | 57.7421 ns / 72 B | 2,349.2118 ns / 2504 B | 74.4367 ns / 88 B |
-| `GetMax` | 101.2615 ns / 408 B | 215.4189 ns / 1152 B | 172.8915 ns / 328 B | NA |
-| `GetMin` | 106.1012 ns / 408 B | 193.5224 ns / 1152 B | 194.7781 ns / 328 B | NA |
-| `Heartbeat` | 284.0370 ns / 800 B | 2,137.1187 ns / 26096 B | NA | NA |
-| `LatestOrDefault` | 49.4452 ns / 136 B | 49.7046 ns / 136 B | NA | NA |
-| `LogErrors` | 64.3492 ns / 224 B | 68.2783 ns / 224 B | NA | NA |
-| `Not` | 28.4086 ns / 120 B | 23.7143 ns / 120 B | 777.3094 ns / 1040 B | 88.5710 ns / 152 B |
-| `ObserveOnIf` | 62.7276 ns / 104 B | 65.4303 ns / 104 B | NA | NA |
-| `ObserveOnSafe` | 62.6595 ns / 104 B | 61.9629 ns / 104 B | NA | NA |
-| `OnErrorRetry` | 124.5330 ns / 424 B | 124.1775 ns / 424 B | NA | NA |
-| `OnNext` | 49.5697 ns / 40 B | 49.7140 ns / 40 B | NA | NA |
-| `Pairwise` | 490.0995 ns / 160 B | 491.6251 ns / 160 B | 2,740.4705 ns / 3072 B | NA |
-| `Partition` | 257.7809 ns / 440 B | 249.5671 ns / 440 B | NA | NA |
-| `ReplayLastOnSubscribe` | 63.7072 ns / 104 B | 60.9911 ns / 104 B | NA | NA |
-| `RetryForeverWithDelay` | 119.9242 ns / 352 B | 118.0222 ns / 352 B | NA | NA |
-| `RetryWithBackoff` | 117.7281 ns / 336 B | 113.5010 ns / 336 B | NA | NA |
-| `RetryWithDelay` | 106.6986 ns / 264 B | 103.9552 ns / 264 B | NA | NA |
-| `RetryWithFixedDelay` | 115.6068 ns / 336 B | 122.0493 ns / 336 B | NA | NA |
-| `Return` | 5.7381 ns / 64 B | 5.6978 ns / 64 B | 50.9029 ns / 120 B | 29.9718 ns / 56 B |
-| `RunAll` | 22.5211 ns / 136 B | 27.3082 ns / 136 B | NA | NA |
-| `SampleLatest` | 1,023.3630 ns / 488 B | 1,070.9330 ns / 840 B | NA | NA |
-| `ScanWithInitial` | 507.9467 ns / 200 B | 505.6987 ns / 200 B | 2,616.2001 ns / 2560 B | NA |
-| `Schedule` | 33.9394 ns / 216 B | 882.2126 ns / 677 B | NA | NA |
-| `ScheduleSafe` | 27.0011 ns / 144 B | 863.6469 ns / 597 B | NA | NA |
-| `SelectAsync` | 1,183.7934 ns / 2104 B | 1,275.5720 ns / 2104 B | 29,926.1912 ns / 32266 B | NA |
-| `SelectAsyncConcurrent` | 1,086.3005 ns / 2120 B | 1,078.9035 ns / 2120 B | NA | NA |
-| `SelectAsyncSequential` | 1,215.5647 ns / 2104 B | 1,198.7932 ns / 2104 B | NA | NA |
-| `SelectConstant` | 61.2733 ns / 136 B | 55.6676 ns / 136 B | 2,612.8930 ns / 2544 B | 184.5721 ns / 160 B |
-| `SelectLatestAsync` | 1,640.3117 ns / 2032 B | 1,703.9179 ns / 2032 B | NA | NA |
-| `SelectManyThen` | 33.1931 ns / 224 B | 35.2676 ns / 224 B | 339.0513 ns / 752 B | NA |
-| `Shuffle` | 146.1008 ns / 96 B | 146.3751 ns / 96 B | NA | NA |
-| `SkipWhileNull` | 24.3479 ns / 112 B | 23.8709 ns / 112 B | 646.2172 ns / 944 B | NA |
-| `Start` | 23.1089 ns / 96 B | 940.0599 ns / 535 B | NA | NA |
-| `SubscribeAndComplete` | 0.2379 ns / 0 B | 0.2696 ns / 0 B | NA | NA |
-| `SubscribeAsync` | 939.6350 ns / 544 B | 935.3032 ns / 544 B | NA | NA |
-| `SubscribeGetError` | 6.8850 ns / 48 B | 52.1458 ns / 104 B | NA | NA |
-| `SubscribeGetValue` | 16.1767 ns / 56 B | 17.3263 ns / 56 B | NA | NA |
-| `SubscribeSynchronous` | 951.8410 ns / 544 B | 964.7101 ns / 544 B | NA | NA |
-| `SwitchIfEmpty` | 68.6637 ns / 224 B | 105.4468 ns / 280 B | NA | NA |
-| `SynchronizeAsync` | 777.1340 ns / 1280 B | 774.5258 ns / 1280 B | NA | NA |
-| `SynchronizeSynchronous` | 773.1336 ns / 1280 B | 785.0287 ns / 1280 B | NA | NA |
-| `SyncTimer` | 2,639.1904 ns / 1080 B | 12,566.8335 ns / 26241 B | NA | NA |
-| `TakeUntil` | 523.6973 ns / 192 B | 520.7622 ns / 192 B | 2,680.2797 ns / 2520 B | NA |
-| `ThrottleDistinct` | 1,718.4232 ns / 4232 B | 28,078.6550 ns / 18701 B | NA | NA |
-| `ThrottleFirst` | 1,159.8667 ns / 224 B | 1,151.5612 ns / 224 B | NA | NA |
-| `ThrottleOnScheduler` | 1,999.2879 ns / 2400 B | 30,701.9572 ns / 16354 B | NA | NA |
-| `ThrottleUntilTrue` | 4,500.9806 ns / 1634 B | 5,584.0680 ns / 1385 B | NA | NA |
-| `ToHotTask` | 35.5886 ns / 112 B | 33.4305 ns / 112 B | 89.5899 ns / 472 B | NA |
-| `ToHotValueTask` | 26.8449 ns / 0 B | 28.4980 ns / 0 B | NA | NA |
-| `ToPropertyObservable` | 26,649.8027 ns / 4941 B | 26,504.9276 ns / 4941 B | NA | NA |
-| `ToReadOnlyBehavior` | 58.4629 ns / 192 B | 61.7022 ns / 192 B | NA | NA |
-| `TrySelect` | 101.1200 ns / 120 B | 98.2908 ns / 120 B | NA | NA |
-| `Using` | 6.5552 ns / 56 B | 6.8002 ns / 56 B | NA | NA |
-| `WaitForCompletion` | 23.5279 ns / 96 B | 22.9725 ns / 96 B | NA | NA |
-| `WaitForError` | 25.2475 ns / 96 B | 66.9739 ns / 152 B | NA | NA |
-| `WaitForValue` | 31.7103 ns / 104 B | 32.4430 ns / 104 B | NA | NA |
-| `WaitUntil` | 512.0670 ns / 224 B | 514.2448 ns / 224 B | 849.6420 ns / 1080 B | NA |
-| `WhereFalse` | 21.7965 ns / 120 B | 21.7348 ns / 120 B | 768.5199 ns / 1040 B | 89.2687 ns / 184 B |
-| `WhereIsNotNull` | 20.8965 ns / 104 B | 22.1343 ns / 104 B | 619.6627 ns / 904 B | 97.3514 ns / 264 B |
-| `WhereSelect` | 74.9895 ns / 152 B | 78.0693 ns / 152 B | 2,579.5263 ns / 2616 B | 175.2326 ns / 240 B |
-| `WhereTrue` | 21.2385 ns / 120 B | 21.4245 ns / 120 B | 742.5841 ns / 1040 B | 81.5593 ns / 184 B |
-| `While` | 123.0402 ns / 280 B | 124.6595 ns / 280 B | NA | NA |
-| `WithLimitedConcurrency` | 2,678.3744 ns / 5448 B | 2,419.3906 ns / 5448 B | NA | NA |
+| `AsSignal` | 39.1343 ns / 112 B | 2,425.8592 ns / 2488 B | 2,497.5107 ns / 2536 B | 190.0920 ns / 160 B |
+| `BufferUntil` | 43.7569 ns / 264 B | 43.1834 ns / 264 B | NA | NA |
+| `BufferUntilIdle` | 1,872.8774 ns / 6504 B | 25,722.3674 ns / 21207 B | NA | NA |
+| `BufferUntilInactive` | 1,922.3653 ns / 6504 B | 25,821.9421 ns / 21207 B | NA | NA |
+| `CatchAndReturn` | 19.9923 ns / 128 B | 59.8265 ns / 184 B | 173.5006 ns / 368 B | 116.0415 ns / 264 B |
+| `CatchIgnore` | 18.1860 ns / 128 B | 59.7477 ns / 184 B | 168.1961 ns / 344 B | 113.0904 ns / 240 B |
+| `CatchReturn` | 14.5591 ns / 128 B | 60.1389 ns / 184 B | 174.3701 ns / 368 B | 118.1259 ns / 264 B |
+| `CatchReturnUnit` | 10.3368 ns / 88 B | 56.2182 ns / 144 B | NA | NA |
+| `CombineLatestValuesAreAllFalse` | 186.1148 ns / 848 B | 218.2402 ns / 1176 B | 346.7049 ns / 648 B | NA |
+| `CombineLatestValuesAreAllTrue` | 188.9175 ns / 848 B | 212.3348 ns / 1176 B | 332.3094 ns / 648 B | NA |
+| `Conflate` | 3,988.0580 ns / 2304 B | 32,870.4854 ns / 16969 B | NA | NA |
+| `Continuation.Dispose` | 24.1712 ns / 192 B | 24.2349 ns / 192 B | NA | NA |
+| `Continuation.Lock` | 1,015.9123 ns / 464 B | 1,158.6503 ns / 464 B | NA | NA |
+| `Continuation.LockValueTask` | 1,160.4224 ns / 464 B | 1,155.7749 ns / 464 B | NA | NA |
+| `DebounceImmediate` | 1,622.7895 ns / 4064 B | 27,081.5247 ns / 18065 B | NA | NA |
+| `DebounceUntil` | 1,094.9352 ns / 776 B | 7,205.8484 ns / 6132 B | NA | NA |
+| `DetectStale` | 192.7663 ns / 600 B | 835.0784 ns / 25128 B | NA | NA |
+| `DoOnDispose` | 71.1486 ns / 232 B | 70.9375 ns / 232 B | NA | NA |
+| `DoOnSubscribe` | 70.2411 ns / 192 B | 69.6332 ns / 192 B | NA | NA |
+| `DropIfBusy` | 349.7954 ns / 240 B | 358.5479 ns / 240 B | NA | NA |
+| `FastForEach` | 48.9880 ns / 40 B | 48.4052 ns / 40 B | NA | NA |
+| `Filter` | 124.5601 ns / 120 B | 123.2022 ns / 120 B | 736.4327 ns / 984 B | NA |
+| `FirstMatchFromCandidates` | 42.6804 ns / 216 B | 44.7428 ns / 216 B | NA | NA |
+| `ForEach` | 73.3841 ns / 160 B | 75.0841 ns / 160 B | 150.0873 ns / 200 B | NA |
+| `FromArray` | 61.9788 ns / 72 B | 70.7992 ns / 72 B | 2,519.9627 ns / 2504 B | 85.4346 ns / 88 B |
+| `GetMax` | 108.9092 ns / 408 B | 227.3460 ns / 1152 B | 181.7760 ns / 328 B | NA |
+| `GetMin` | 115.1313 ns / 408 B | 226.6057 ns / 1152 B | 179.6450 ns / 328 B | NA |
+| `Heartbeat` | 299.3094 ns / 800 B | 2,377.8947 ns / 26096 B | NA | NA |
+| `LatestOrDefault` | 53.9602 ns / 136 B | 58.1188 ns / 136 B | NA | NA |
+| `LogErrors` | 68.0775 ns / 224 B | 72.0710 ns / 224 B | NA | NA |
+| `Not` | 27.8941 ns / 120 B | 28.4602 ns / 120 B | 834.5748 ns / 1040 B | 92.3225 ns / 152 B |
+| `ObserveOnIf` | 64.2175 ns / 104 B | 66.5979 ns / 104 B | NA | NA |
+| `ObserveOnSafe` | 65.7747 ns / 104 B | 67.1360 ns / 104 B | NA | NA |
+| `OnErrorRetry` | 133.5035 ns / 424 B | 134.3144 ns / 424 B | NA | NA |
+| `OnNext` | 50.6179 ns / 40 B | 51.3304 ns / 40 B | NA | NA |
+| `Pairwise` | 511.8533 ns / 160 B | 536.1441 ns / 160 B | 2,840.1602 ns / 3072 B | NA |
+| `Partition` | 277.7601 ns / 440 B | 265.2119 ns / 440 B | NA | NA |
+| `ReplayLastOnSubscribe` | 63.6625 ns / 104 B | 63.7188 ns / 104 B | NA | NA |
+| `RetryForeverWithDelay` | 131.7468 ns / 352 B | 126.2633 ns / 352 B | NA | NA |
+| `RetryWithBackoff` | 127.8894 ns / 336 B | 122.5359 ns / 336 B | NA | NA |
+| `RetryWithDelay` | 112.6661 ns / 264 B | 114.9763 ns / 264 B | NA | NA |
+| `RetryWithFixedDelay` | 132.6439 ns / 336 B | 124.9002 ns / 336 B | NA | NA |
+| `Return` | 6.7822 ns / 64 B | 6.9682 ns / 64 B | 54.6806 ns / 120 B | 31.3894 ns / 56 B |
+| `RunAll` | 26.0295 ns / 136 B | 24.2351 ns / 136 B | NA | NA |
+| `SampleLatest` | 1,048.3322 ns / 488 B | 1,135.7206 ns / 840 B | NA | NA |
+| `ScanWithInitial` | 591.7863 ns / 200 B | 547.3744 ns / 200 B | 2,672.0292 ns / 2560 B | NA |
+| `Schedule` | 38.7331 ns / 216 B | 863.5171 ns / 677 B | NA | NA |
+| `ScheduleSafe` | 32.2703 ns / 144 B | 943.9625 ns / 597 B | NA | NA |
+| `SelectAsync` | 1,252.7429 ns / 2104 B | 1,292.9070 ns / 2104 B | 32,738.8855 ns / 32276 B | NA |
+| `SelectAsyncConcurrent` | 1,168.3446 ns / 2120 B | 1,191.4728 ns / 2120 B | NA | NA |
+| `SelectAsyncSequential` | 1,339.6799 ns / 2104 B | 1,302.4360 ns / 2104 B | NA | NA |
+| `SelectConstant` | 59.5848 ns / 136 B | 58.8155 ns / 136 B | 2,715.4348 ns / 2544 B | 198.1385 ns / 160 B |
+| `SelectLatestAsync` | 1,719.1326 ns / 2032 B | 1,731.7319 ns / 2032 B | NA | NA |
+| `SelectManyThen` | 34.6976 ns / 224 B | 37.1627 ns / 224 B | 423.6935 ns / 752 B | NA |
+| `Shuffle` | 152.0990 ns / 96 B | 154.7871 ns / 96 B | NA | NA |
+| `SkipWhileNull` | 26.8510 ns / 112 B | 26.3809 ns / 112 B | 652.5813 ns / 944 B | NA |
+| `Start` | 25.1025 ns / 96 B | 1,011.5645 ns / 535 B | NA | NA |
+| `SubscribeAndComplete` | 0.5452 ns / 0 B | 0.2295 ns / 0 B | NA | NA |
+| `SubscribeAsync` | 1,020.8799 ns / 544 B | 1,086.0720 ns / 544 B | NA | NA |
+| `SubscribeGetError` | 6.9580 ns / 48 B | 53.4505 ns / 104 B | NA | NA |
+| `SubscribeGetValue` | 17.8834 ns / 56 B | 18.5553 ns / 56 B | NA | NA |
+| `SubscribeSynchronous` | 1,041.8758 ns / 544 B | 1,002.4885 ns / 544 B | NA | NA |
+| `SwitchIfEmpty` | 69.8495 ns / 224 B | 111.8583 ns / 280 B | NA | NA |
+| `SynchronizeAsync` | 819.5469 ns / 1280 B | 825.0399 ns / 1280 B | NA | NA |
+| `SynchronizeSynchronous` | 832.0162 ns / 1280 B | 817.5703 ns / 1280 B | NA | NA |
+| `SyncTimer` | 2,596.8934 ns / 1080 B | 15,106.0211 ns / 26240 B | NA | NA |
+| `TakeUntil` | 512.1911 ns / 192 B | 516.0572 ns / 192 B | 2,662.6592 ns / 2520 B | NA |
+| `ThrottleDistinct` | 1,849.1563 ns / 4232 B | 30,604.1331 ns / 18701 B | NA | NA |
+| `ThrottleFirst` | 1,161.0701 ns / 224 B | 1,163.6336 ns / 224 B | NA | NA |
+| `ThrottleOnScheduler` | 1,912.9753 ns / 2400 B | 34,581.3985 ns / 16354 B | NA | NA |
+| `ThrottleUntilTrue` | 5,027.6983 ns / 1633 B | 6,217.3368 ns / 1378 B | NA | NA |
+| `ToHotTask` | 36.3653 ns / 112 B | 35.7259 ns / 112 B | 101.5059 ns / 240 B | NA |
+| `ToHotValueTask` | 27.0451 ns / 72 B | 27.8467 ns / 72 B | NA | NA |
+| `ToPropertyObservable` | 27,071.4355 ns / 4941 B | 27,486.0006 ns / 4941 B | NA | NA |
+| `ToReadOnlyBehavior` | 66.0075 ns / 192 B | 67.9050 ns / 192 B | NA | NA |
+| `TrySelect` | 101.8332 ns / 120 B | 110.8990 ns / 120 B | NA | NA |
+| `Using` | 7.6564 ns / 56 B | 9.4516 ns / 56 B | NA | NA |
+| `WaitForCompletion` | 25.1638 ns / 96 B | 24.6338 ns / 96 B | NA | NA |
+| `WaitForError` | 26.0917 ns / 96 B | 73.9819 ns / 152 B | NA | NA |
+| `WaitForValue` | 32.1534 ns / 104 B | 34.4935 ns / 104 B | NA | NA |
+| `WaitUntil` | 534.5543 ns / 224 B | 540.1772 ns / 224 B | 891.0865 ns / 1080 B | NA |
+| `WhereFalse` | 23.6723 ns / 120 B | 24.8538 ns / 120 B | 806.3629 ns / 1040 B | 91.3808 ns / 184 B |
+| `WhereIsNotNull` | 23.7931 ns / 104 B | 23.3656 ns / 104 B | 622.7868 ns / 904 B | 92.9625 ns / 264 B |
+| `WhereSelect` | 80.4235 ns / 152 B | 77.0247 ns / 152 B | 2,638.5579 ns / 2616 B | 193.5426 ns / 240 B |
+| `WhereTrue` | 23.7493 ns / 120 B | 26.0367 ns / 120 B | 804.6906 ns / 1040 B | 86.8553 ns / 184 B |
+| `While` | 127.7396 ns / 280 B | 127.4206 ns / 280 B | NA | NA |
+| `WithLimitedConcurrency` | 2,489.2455 ns / 5448 B | 2,604.7204 ns / 5448 B | NA | NA |
 
 BenchmarkDotNet emitted `ZeroMeasurement` warnings for several singleton or empty-method-scale paths, including `Return`, `CompletedSpark`, and `Never`-style subscriptions. Those warnings mean the measured duration is indistinguishable from empty method overhead; the benchmark run still completed and exported all 610 rows.
+
 ## Repository layout
 
 | Path | Purpose |
@@ -1033,7 +1034,7 @@ dotnet run --project .\src\benchmarks\ReactiveUI.Primitives.Benchmarks\ReactiveU
 dotnet run --project .\src\benchmarks\ReactiveUI.Primitives.Benchmarks\ReactiveUI.Primitives.Benchmarks.csproj --configuration Release --no-build -- --filter "*" --join --launchCount 1 --warmupCount 1 --iterationCount 3
 ```
 
-Results: release solution build passed with 0 warnings/0 errors; `ReactiveUI.Primitives.Extensions.Tests` passed 681/681 tests on net8.0, net9.0, and net10.0; extension scenario smoke validated 212 scenario paths; reflection/API coverage confirmed 87/87 public `ReactiveUI.Primitives.Extensions` method families have Primitives benchmark scenarios; the joined BenchmarkDotNet run executed 610 benchmarks in 01:14:50. The Mtpunittest MCP read existing solution coverage reports after validation and reported 69.88% line coverage and 74.21% branch coverage; coverage was not regenerated during this benchmark refresh.
+Results: release solution build passed with 0 warnings/0 errors; `ReactiveUI.Primitives.Extensions.Tests` passed 681/681 tests on net8.0, net9.0, and net10.0; extension scenario smoke validated 212 scenario paths; reflection/API coverage confirmed 87/87 public `ReactiveUI.Primitives.Extensions` method families have Primitives benchmark scenarios; the joined BenchmarkDotNet run executed 610 benchmarks in 01:16:19. The Mtpunittest MCP read existing solution coverage reports after validation and reported 69.88% line coverage and 74.21% branch coverage; coverage was not regenerated during this benchmark refresh.
 ### Package verification
 
 For NuGet package verification, inspect the generated `.nupkg` and confirm:

--- a/README.md
+++ b/README.md
@@ -907,7 +907,7 @@ External-baseline posture from this run: `ReactiveUI.Primitives.Extensions` is f
 
 The table below is generated from the joined BenchmarkDotNet CSV and uses `Mean / Allocated` for each cell. Function names are restored to their full values where BenchmarkDotNet abbreviated long `scenario` parameter values in the raw report.
 
-| Function | ReactiveUI.Primitives.Extensions | ReactiveUI.Extensions 4.0.0 | System.Reactive | R3 |
+| Function | ReactiveUI.Primitives | ReactiveUI.Extensions | System.Reactive | R3 |
 |---|---:|---:|---:|---:|
 | `AsSignal` | 39.1343 ns / 112 B | 2,425.8592 ns / 2488 B | 2,497.5107 ns / 2536 B | 190.0920 ns / 160 B |
 | `BufferUntil` | 43.7569 ns / 264 B | 43.1834 ns / 264 B | NA | NA |

--- a/README.md
+++ b/README.md
@@ -901,101 +901,249 @@ Latest artifact paths:
 - `BenchmarkDotNet.Artifacts/results/BenchmarkRun-joined-2026-05-31-15-10-19-report.html`
 - `BenchmarkDotNet.Artifacts/results/BenchmarkRun-joined-2026-05-31-15-10-19-report.csv`
 
-The joined run includes the complete `ReactiveUI.Primitives.Extensions` synchronous helper surface. Reflection over the public extension API and the benchmark smoke path both report 87 method families, with no missing or extra benchmark scenarios. The extension comparison rows are 87 `ReactiveUI.Primitives.Extensions`, 87 `ReactiveUI.Extensions` 4.0.0, 26 System.Reactive alternatives, and 12 R3 alternatives. Where System.Reactive or R3 has no direct alternative, the table uses `NA`.
+The joined run exports 610 raw BenchmarkDotNet rows: 235 ReactiveUI.Primitives or ReactiveUI.Primitives.Async cases, 155 System.Reactive cases, 130 R3 cases, and 90 ReactiveUI.Extensions cases. The previous 87-row README table covered only the `ReactiveExtensionsComparisonBenchmarks` synchronous extension slice; the remaining raw rows were present in the joined CSV but were not surfaced in the README table.
 
-External-baseline posture from this run: `ReactiveUI.Primitives.Extensions` is faster than System.Reactive in 26/26 measured extension comparisons and faster than R3 in 12/12 measured extension comparisons. Against `ReactiveUI.Extensions` 4.0.0, the Primitives implementation is faster in 64/87 comparisons; the remaining rows are migration-baseline parity or trade-offs and are listed directly below.
+The table below groups `ReactiveUI.Primitives` and `ReactiveUI.Primitives.Async` into the `ReactiveUI.Primitives` column, aligns each primitive benchmark with any System.Reactive, R3, or ReactiveUI.Extensions alternative from the same benchmark scenario, and uses `NA` where no alternative exists. It contains 235 alphabetically ordered scenario rows. Cells use `Mean / Allocated`, and long `scenario` parameter values from BenchmarkDotNet are restored to their full names.
 
-The table below is generated from the joined BenchmarkDotNet CSV and uses `Mean / Allocated` for each cell. Function names are restored to their full values where BenchmarkDotNet abbreviated long `scenario` parameter values in the raw report.
+External-baseline posture from this run: `ReactiveUI.Primitives` is faster than System.Reactive in 150/155 measured comparisons, faster than R3 in 128/130 measured comparisons, and faster than `ReactiveUI.Extensions` 4.0.0 in 64/90 measured comparisons. Rows that are not faster remain listed for direct comparison.
 
-| Function | ReactiveUI.Primitives | ReactiveUI.Extensions | System.Reactive | R3 |
+| Scenario | ReactiveUI.Primitives | System.Reactive | R3 | ReactiveUI.Extensions |
 |---|---:|---:|---:|---:|
-| `AsSignal` | 39.1343 ns / 112 B | 2,425.8592 ns / 2488 B | 2,497.5107 ns / 2536 B | 190.0920 ns / 160 B |
-| `BufferUntil` | 43.7569 ns / 264 B | 43.1834 ns / 264 B | NA | NA |
-| `BufferUntilIdle` | 1,872.8774 ns / 6504 B | 25,722.3674 ns / 21207 B | NA | NA |
-| `BufferUntilInactive` | 1,922.3653 ns / 6504 B | 25,821.9421 ns / 21207 B | NA | NA |
-| `CatchAndReturn` | 19.9923 ns / 128 B | 59.8265 ns / 184 B | 173.5006 ns / 368 B | 116.0415 ns / 264 B |
-| `CatchIgnore` | 18.1860 ns / 128 B | 59.7477 ns / 184 B | 168.1961 ns / 344 B | 113.0904 ns / 240 B |
-| `CatchReturn` | 14.5591 ns / 128 B | 60.1389 ns / 184 B | 174.3701 ns / 368 B | 118.1259 ns / 264 B |
-| `CatchReturnUnit` | 10.3368 ns / 88 B | 56.2182 ns / 144 B | NA | NA |
-| `CombineLatestValuesAreAllFalse` | 186.1148 ns / 848 B | 218.2402 ns / 1176 B | 346.7049 ns / 648 B | NA |
-| `CombineLatestValuesAreAllTrue` | 188.9175 ns / 848 B | 212.3348 ns / 1176 B | 332.3094 ns / 648 B | NA |
-| `Conflate` | 3,988.0580 ns / 2304 B | 32,870.4854 ns / 16969 B | NA | NA |
-| `Continuation.Dispose` | 24.1712 ns / 192 B | 24.2349 ns / 192 B | NA | NA |
-| `Continuation.Lock` | 1,015.9123 ns / 464 B | 1,158.6503 ns / 464 B | NA | NA |
-| `Continuation.LockValueTask` | 1,160.4224 ns / 464 B | 1,155.7749 ns / 464 B | NA | NA |
-| `DebounceImmediate` | 1,622.7895 ns / 4064 B | 27,081.5247 ns / 18065 B | NA | NA |
-| `DebounceUntil` | 1,094.9352 ns / 776 B | 7,205.8484 ns / 6132 B | NA | NA |
-| `DetectStale` | 192.7663 ns / 600 B | 835.0784 ns / 25128 B | NA | NA |
-| `DoOnDispose` | 71.1486 ns / 232 B | 70.9375 ns / 232 B | NA | NA |
-| `DoOnSubscribe` | 70.2411 ns / 192 B | 69.6332 ns / 192 B | NA | NA |
-| `DropIfBusy` | 349.7954 ns / 240 B | 358.5479 ns / 240 B | NA | NA |
-| `FastForEach` | 48.9880 ns / 40 B | 48.4052 ns / 40 B | NA | NA |
-| `Filter` | 124.5601 ns / 120 B | 123.2022 ns / 120 B | 736.4327 ns / 984 B | NA |
-| `FirstMatchFromCandidates` | 42.6804 ns / 216 B | 44.7428 ns / 216 B | NA | NA |
-| `ForEach` | 73.3841 ns / 160 B | 75.0841 ns / 160 B | 150.0873 ns / 200 B | NA |
-| `FromArray` | 61.9788 ns / 72 B | 70.7992 ns / 72 B | 2,519.9627 ns / 2504 B | 85.4346 ns / 88 B |
-| `GetMax` | 108.9092 ns / 408 B | 227.3460 ns / 1152 B | 181.7760 ns / 328 B | NA |
-| `GetMin` | 115.1313 ns / 408 B | 226.6057 ns / 1152 B | 179.6450 ns / 328 B | NA |
-| `Heartbeat` | 299.3094 ns / 800 B | 2,377.8947 ns / 26096 B | NA | NA |
-| `LatestOrDefault` | 53.9602 ns / 136 B | 58.1188 ns / 136 B | NA | NA |
-| `LogErrors` | 68.0775 ns / 224 B | 72.0710 ns / 224 B | NA | NA |
-| `Not` | 27.8941 ns / 120 B | 28.4602 ns / 120 B | 834.5748 ns / 1040 B | 92.3225 ns / 152 B |
-| `ObserveOnIf` | 64.2175 ns / 104 B | 66.5979 ns / 104 B | NA | NA |
-| `ObserveOnSafe` | 65.7747 ns / 104 B | 67.1360 ns / 104 B | NA | NA |
-| `OnErrorRetry` | 133.5035 ns / 424 B | 134.3144 ns / 424 B | NA | NA |
-| `OnNext` | 50.6179 ns / 40 B | 51.3304 ns / 40 B | NA | NA |
-| `Pairwise` | 511.8533 ns / 160 B | 536.1441 ns / 160 B | 2,840.1602 ns / 3072 B | NA |
-| `Partition` | 277.7601 ns / 440 B | 265.2119 ns / 440 B | NA | NA |
-| `ReplayLastOnSubscribe` | 63.6625 ns / 104 B | 63.7188 ns / 104 B | NA | NA |
-| `RetryForeverWithDelay` | 131.7468 ns / 352 B | 126.2633 ns / 352 B | NA | NA |
-| `RetryWithBackoff` | 127.8894 ns / 336 B | 122.5359 ns / 336 B | NA | NA |
-| `RetryWithDelay` | 112.6661 ns / 264 B | 114.9763 ns / 264 B | NA | NA |
-| `RetryWithFixedDelay` | 132.6439 ns / 336 B | 124.9002 ns / 336 B | NA | NA |
-| `Return` | 6.7822 ns / 64 B | 6.9682 ns / 64 B | 54.6806 ns / 120 B | 31.3894 ns / 56 B |
-| `RunAll` | 26.0295 ns / 136 B | 24.2351 ns / 136 B | NA | NA |
-| `SampleLatest` | 1,048.3322 ns / 488 B | 1,135.7206 ns / 840 B | NA | NA |
-| `ScanWithInitial` | 591.7863 ns / 200 B | 547.3744 ns / 200 B | 2,672.0292 ns / 2560 B | NA |
-| `Schedule` | 38.7331 ns / 216 B | 863.5171 ns / 677 B | NA | NA |
-| `ScheduleSafe` | 32.2703 ns / 144 B | 943.9625 ns / 597 B | NA | NA |
-| `SelectAsync` | 1,252.7429 ns / 2104 B | 1,292.9070 ns / 2104 B | 32,738.8855 ns / 32276 B | NA |
-| `SelectAsyncConcurrent` | 1,168.3446 ns / 2120 B | 1,191.4728 ns / 2120 B | NA | NA |
-| `SelectAsyncSequential` | 1,339.6799 ns / 2104 B | 1,302.4360 ns / 2104 B | NA | NA |
-| `SelectConstant` | 59.5848 ns / 136 B | 58.8155 ns / 136 B | 2,715.4348 ns / 2544 B | 198.1385 ns / 160 B |
-| `SelectLatestAsync` | 1,719.1326 ns / 2032 B | 1,731.7319 ns / 2032 B | NA | NA |
-| `SelectManyThen` | 34.6976 ns / 224 B | 37.1627 ns / 224 B | 423.6935 ns / 752 B | NA |
-| `Shuffle` | 152.0990 ns / 96 B | 154.7871 ns / 96 B | NA | NA |
-| `SkipWhileNull` | 26.8510 ns / 112 B | 26.3809 ns / 112 B | 652.5813 ns / 944 B | NA |
-| `Start` | 25.1025 ns / 96 B | 1,011.5645 ns / 535 B | NA | NA |
-| `SubscribeAndComplete` | 0.5452 ns / 0 B | 0.2295 ns / 0 B | NA | NA |
-| `SubscribeAsync` | 1,020.8799 ns / 544 B | 1,086.0720 ns / 544 B | NA | NA |
-| `SubscribeGetError` | 6.9580 ns / 48 B | 53.4505 ns / 104 B | NA | NA |
-| `SubscribeGetValue` | 17.8834 ns / 56 B | 18.5553 ns / 56 B | NA | NA |
-| `SubscribeSynchronous` | 1,041.8758 ns / 544 B | 1,002.4885 ns / 544 B | NA | NA |
-| `SwitchIfEmpty` | 69.8495 ns / 224 B | 111.8583 ns / 280 B | NA | NA |
-| `SynchronizeAsync` | 819.5469 ns / 1280 B | 825.0399 ns / 1280 B | NA | NA |
-| `SynchronizeSynchronous` | 832.0162 ns / 1280 B | 817.5703 ns / 1280 B | NA | NA |
-| `SyncTimer` | 2,596.8934 ns / 1080 B | 15,106.0211 ns / 26240 B | NA | NA |
-| `TakeUntil` | 512.1911 ns / 192 B | 516.0572 ns / 192 B | 2,662.6592 ns / 2520 B | NA |
-| `ThrottleDistinct` | 1,849.1563 ns / 4232 B | 30,604.1331 ns / 18701 B | NA | NA |
-| `ThrottleFirst` | 1,161.0701 ns / 224 B | 1,163.6336 ns / 224 B | NA | NA |
-| `ThrottleOnScheduler` | 1,912.9753 ns / 2400 B | 34,581.3985 ns / 16354 B | NA | NA |
-| `ThrottleUntilTrue` | 5,027.6983 ns / 1633 B | 6,217.3368 ns / 1378 B | NA | NA |
-| `ToHotTask` | 36.3653 ns / 112 B | 35.7259 ns / 112 B | 101.5059 ns / 240 B | NA |
-| `ToHotValueTask` | 27.0451 ns / 72 B | 27.8467 ns / 72 B | NA | NA |
-| `ToPropertyObservable` | 27,071.4355 ns / 4941 B | 27,486.0006 ns / 4941 B | NA | NA |
-| `ToReadOnlyBehavior` | 66.0075 ns / 192 B | 67.9050 ns / 192 B | NA | NA |
-| `TrySelect` | 101.8332 ns / 120 B | 110.8990 ns / 120 B | NA | NA |
-| `Using` | 7.6564 ns / 56 B | 9.4516 ns / 56 B | NA | NA |
-| `WaitForCompletion` | 25.1638 ns / 96 B | 24.6338 ns / 96 B | NA | NA |
-| `WaitForError` | 26.0917 ns / 96 B | 73.9819 ns / 152 B | NA | NA |
-| `WaitForValue` | 32.1534 ns / 104 B | 34.4935 ns / 104 B | NA | NA |
-| `WaitUntil` | 534.5543 ns / 224 B | 540.1772 ns / 224 B | 891.0865 ns / 1080 B | NA |
-| `WhereFalse` | 23.6723 ns / 120 B | 24.8538 ns / 120 B | 806.3629 ns / 1040 B | 91.3808 ns / 184 B |
-| `WhereIsNotNull` | 23.7931 ns / 104 B | 23.3656 ns / 104 B | 622.7868 ns / 904 B | 92.9625 ns / 264 B |
-| `WhereSelect` | 80.4235 ns / 152 B | 77.0247 ns / 152 B | 2,638.5579 ns / 2616 B | 193.5426 ns / 240 B |
-| `WhereTrue` | 23.7493 ns / 120 B | 26.0367 ns / 120 B | 804.6906 ns / 1040 B | 86.8553 ns / 184 B |
-| `While` | 127.7396 ns / 280 B | 127.4206 ns / 280 B | NA | NA |
-| `WithLimitedConcurrency` | 2,489.2455 ns / 5448 B | 2,604.7204 ns / 5448 B | NA | NA |
+| `After` | 155.3662 ns / 584 B | 1,001.4142 ns / 25056 B | 276.8260 ns / 552 B | NA |
+| `AggregateAnyCount (Operator core GC profile)` | 201.0841 ns / 824 B | 6,602.1945 ns / 5856 B | 620.6079 ns / 1280 B | NA |
+| `AggregateAnyCount (Operator map keep)` | 200.1816 ns / 824 B | 5,776.6805 ns / 5856 B | 611.5725 ns / 1280 B | NA |
+| `All` | 19.4142 ns / 96 B | 2,639.9900 ns / 2520 B | 89.7295 ns / 192 B | NA |
+| `AllContains` | 30.5337 ns / 192 B | 5,147.5512 ns / 5048 B | 231.7154 ns / 392 B | NA |
+| `AllRange` | 18.5571 ns / 96 B | 2,554.2953 ns / 2520 B | 87.1035 ns / 192 B | NA |
+| `AsSignal` | 39.1343 ns / 112 B | 2,497.5107 ns / 2536 B | 190.0920 ns / 160 B | 2,425.8592 ns / 2488 B |
+| `AutoConnect` | 171.2824 ns / 400 B | 2,887.7501 ns / 2736 B | NA | NA |
+| `AutoConnectSubscribe` | 140.2909 ns / 400 B | 2,842.0521 ns / 2736 B | NA | NA |
+| `BehaviorEmit` | 15,767.1692 ns / 160 B | NA | NA | NA |
+| `BufferRange` | 70.8486 ns / 304 B | 1,447.8858 ns / 1656 B | 118.2146 ns / 360 B | NA |
+| `BufferUntil` | 43.7569 ns / 264 B | NA | NA | 43.1834 ns / 264 B |
+| `BufferUntilIdle` | 1,872.8774 ns / 6504 B | NA | NA | 25,722.3674 ns / 21207 B |
+| `BufferUntilInactive` | 1,922.3653 ns / 6504 B | NA | NA | 25,821.9421 ns / 21207 B |
+| `CastTo` | 99.0222 ns / 200 B | 1,532.6529 ns / 1568 B | 167.3711 ns / 216 B | NA |
+| `CatchAndReturn` | 19.9923 ns / 128 B | 173.5006 ns / 368 B | 116.0415 ns / 264 B | 59.8265 ns / 184 B |
+| `CatchIgnore` | 18.1860 ns / 128 B | 168.1961 ns / 344 B | 113.0904 ns / 240 B | 59.7477 ns / 184 B |
+| `CatchReturn` | 14.5591 ns / 128 B | 174.3701 ns / 368 B | 118.1259 ns / 264 B | 60.1389 ns / 184 B |
+| `CatchReturnUnit` | 10.3368 ns / 88 B | NA | NA | 56.2182 ns / 144 B |
+| `CollectArray (Terminal collection GC profile)` | 39.7344 ns / 360 B | 2,807.2484 ns / 3144 B | 181.5774 ns / 784 B | NA |
+| `CollectArray (Terminal collection)` | 39.2840 ns / 360 B | 2,649.8519 ns / 3144 B | 196.2510 ns / 784 B | NA |
+| `CollectArrayAsync` | 44.1010 ns / 384 B | 2,741.1916 ns / 3384 B | 193.5212 ns / 784 B | NA |
+| `CollectList (Terminal collection GC profile)` | 77.6725 ns / 392 B | 2,731.9333 ns / 2992 B | 171.8614 ns / 632 B | NA |
+| `CollectList (Terminal collection)` | 77.1326 ns / 392 B | 2,661.1326 ns / 2992 B | 180.3147 ns / 632 B | NA |
+| `CollectListAsync` | 47.5884 ns / 352 B | 1,525.7612 ns / 2056 B | 125.6062 ns / 480 B | NA |
+| `CombineLatest` | 46.0690 ns / 192 B | 3,279.3736 ns / 2824 B | 678.1482 ns / 344 B | NA |
+| `CombineLatestRanges` | 39.7819 ns / 192 B | 3,319.2938 ns / 2824 B | 688.9252 ns / 344 B | NA |
+| `CombineLatestValuesAreAllFalse` | 186.1148 ns / 848 B | 346.7049 ns / 648 B | NA | 218.2402 ns / 1176 B |
+| `CombineLatestValuesAreAllTrue` | 188.9175 ns / 848 B | 332.3094 ns / 648 B | NA | 212.3348 ns / 1176 B |
+| `CommandExecuteAsync` | 35.1944 ns / 152 B | 740.3134 ns / 1089 B | 106.6560 ns / 296 B | NA |
+| `CommandResultSubscribeAsync` | 63.0803 ns / 224 B | 40.1994 ns / 136 B | 68.4171 ns / 160 B | NA |
+| `CompletedSpark` | 0.0292 ns / 0 B | 0.0065 ns / 0 B | 0.0000 ns / 0 B | NA |
+| `CompletedTaskBridge` | 12.1256 ns / 88 B | 882.4698 ns / 793 B | 43.4786 ns / 88 B | NA |
+| `Concat` | 77.7316 ns / 256 B | 3,073.5477 ns / 2856 B | 266.3856 ns / 360 B | NA |
+| `ConcatRanges` | 80.0323 ns / 256 B | 2,836.8918 ns / 2856 B | 264.9149 ns / 360 B | NA |
+| `Conflate` | 3,988.0580 ns / 2304 B | NA | NA | 32,870.4854 ns / 16969 B |
+| `Contains` | 12.8455 ns / 96 B | 2,785.3176 ns / 2528 B | 91.1712 ns / 200 B | NA |
+| `ContainsRange` | 11.2374 ns / 96 B | 2,552.2694 ns / 2528 B | 92.9637 ns / 200 B | NA |
+| `Continuation.Dispose` | 24.1712 ns / 192 B | NA | NA | 24.2349 ns / 192 B |
+| `Continuation.Lock` | 1,015.9123 ns / 464 B | NA | NA | 1,158.6503 ns / 464 B |
+| `Continuation.LockValueTask` | 1,160.4224 ns / 464 B | NA | NA | 1,155.7749 ns / 464 B |
+| `CountPredicate (Terminal collection GC profile)` | 23.6151 ns / 96 B | 2,644.9360 ns / 2520 B | 97.9358 ns / 200 B | NA |
+| `CountPredicate (Terminal collection)` | 19.8555 ns / 96 B | 2,541.2862 ns / 2520 B | 97.2371 ns / 200 B | NA |
+| `CreateSafeSubscribe` | 39.8372 ns / 112 B | NA | NA | NA |
+| `CreateSubscribe` | 40.0776 ns / 112 B | 52.0066 ns / 168 B | 59.6140 ns / 128 B | NA |
+| `CreateWithState` | 60.2325 ns / 192 B | 89.0048 ns / 256 B | 131.1856 ns / 216 B | NA |
+| `CurrentThreadSchedule` | 9.5961 ns / 88 B | 21.8966 ns / 88 B | 31.0668 ns / 56 B | NA |
+| `DebounceImmediate` | 1,622.7895 ns / 4064 B | NA | NA | 27,081.5247 ns / 18065 B |
+| `DebounceUntil` | 1,094.9352 ns / 776 B | NA | NA | 7,205.8484 ns / 6132 B |
+| `DefaultIfEmptyEmpty` | 7.0131 ns / 64 B | 69.8937 ns / 144 B | 69.2199 ns / 136 B | NA |
+| `DeferSubscribe` | 86.7555 ns / 240 B | 1,676.0302 ns / 1512 B | 123.6352 ns / 152 B | NA |
+| `DelayRange` | 169.3880 ns / 536 B | 6,256.1473 ns / 39584 B | 2,034.4247 ns / 2200 B | NA |
+| `DelayStartRange` | 174.1631 ns / 536 B | 2,673.2576 ns / 26456 B | 342.5660 ns / 552 B | NA |
+| `DematerializeRange` | 72.7926 ns / 184 B | 1,533.0044 ns / 1528 B | 199.5775 ns / 208 B | NA |
+| `DetectStale` | 192.7663 ns / 600 B | NA | NA | 835.0784 ns / 25128 B |
+| `DisposableCollectionDispose` | 78.7620 ns / 424 B | 99.6767 ns / 512 B | 89.6395 ns / 480 B | NA |
+| `DoOnDispose` | 71.1486 ns / 232 B | NA | NA | 70.9375 ns / 232 B |
+| `DoOnSubscribe` | 70.2411 ns / 192 B | NA | NA | 69.6332 ns / 192 B |
+| `DropIfBusy` | 349.7954 ns / 240 B | NA | NA | 358.5479 ns / 240 B |
+| `Emit1024` | 1,728.8903 ns / 184 B | 1,746.7394 ns / 136 B | 2,057.8585 ns / 160 B | NA |
+| `Empty` | 4.1186 ns / 40 B | 49.6034 ns / 96 B | 32.3730 ns / 56 B | NA |
+| `EmptySubscribe` | 3.5444 ns / 40 B | 45.9526 ns / 96 B | 30.7072 ns / 56 B | NA |
+| `Every` | 535.2985 ns / 1192 B | 3,066.3586 ns / 34001 B | 353.4427 ns / 552 B | NA |
+| `FastForEach` | 48.9880 ns / 40 B | NA | NA | 48.4052 ns / 40 B |
+| `Filter` | 124.5601 ns / 120 B | 736.4327 ns / 984 B | NA | 123.2022 ns / 120 B |
+| `FirstAsync` | 8.7337 ns / 56 B | 2,605.0640 ns / 2792 B | 78.7451 ns / 208 B | NA |
+| `FirstMatchFromCandidates` | 42.6804 ns / 216 B | NA | NA | 44.7428 ns / 216 B |
+| `FirstOrDefaultAsync` | 6.9475 ns / 56 B | 1,388.2233 ns / 1768 B | 65.4337 ns / 208 B | NA |
+| `FlatMap` | 732.1660 ns / 728 B | 3,839.0203 ns / 3872 B | 1,183.4716 ns / 1040 B | NA |
+| `FlatMapRange` | 720.1574 ns / 728 B | 3,724.1633 ns / 3872 B | 1,191.5244 ns / 1040 B | NA |
+| `Fold (Operator stateful filter GC profile)` | 1,829.4350 ns / 144 B | NA | NA | NA |
+| `Fold (Operator stateful filter)` | 104.7071 ns / 144 B | 2,692.9914 ns / 2560 B | NA | NA |
+| `ForEach` | 73.3841 ns / 160 B | 150.0873 ns / 200 B | NA | 75.0841 ns / 160 B |
+| `ForkJoin` | 25.4948 ns / 192 B | 4,002.9279 ns / 3136 B | 985.3837 ns / 504 B | NA |
+| `ForkJoinRanges` | 35.7868 ns / 192 B | 3,966.4459 ns / 3136 B | 973.5322 ns / 504 B | NA |
+| `FromArray` | 61.9788 ns / 72 B | 2,519.9627 ns / 2504 B | 85.4346 ns / 88 B | 70.7992 ns / 72 B |
+| `FromAsyncEnumerableSubscribeAsync` | 1,278.0260 ns / 600 B | 1,639.4955 ns / 1827 B | 1,442.5958 ns / 1023 B | NA |
+| `FromEnumerable` | 53.3886 ns / 40 B | 2,668.0614 ns / 2504 B | 80.7768 ns / 88 B | NA |
+| `FromEnumerableSubscribe` | 52.7429 ns / 40 B | 2,525.1923 ns / 2504 B | 79.2217 ns / 88 B | NA |
+| `FromEventPattern` | 159.9328 ns / 624 B | 1,930.1362 ns / 2422 B | NA | NA |
+| `GetMax` | 108.9092 ns / 408 B | 181.7760 ns / 328 B | NA | 227.3460 ns / 1152 B |
+| `GetMin` | 115.1313 ns / 408 B | 179.6450 ns / 328 B | NA | 226.6057 ns / 1152 B |
+| `Heartbeat` | 299.3094 ns / 800 B | NA | NA | 2,377.8947 ns / 26096 B |
+| `HistorySubscribe` | 342.4926 ns / 352 B | 720.4683 ns / 696 B | 433.0458 ns / 688 B | NA |
+| `IgnoreValuesRange` | 29.7856 ns / 128 B | 1,436.1516 ns / 1504 B | 82.7043 ns / 160 B | NA |
+| `Iterate` | 11.6964 ns / 0 B | 2,376.7106 ns / 2768 B | NA | NA |
+| `KeepNotNull` | 108.3266 ns / 192 B | 1,741.8934 ns / 1656 B | 231.0055 ns / 312 B | NA |
+| `KeepType` | 109.4705 ns / 192 B | 1,520.8447 ns / 1568 B | 177.0656 ns / 216 B | NA |
+| `KeepWith` | 63.4511 ns / 232 B | 1,474.3146 ns / 1608 B | 126.5203 ns / 280 B | NA |
+| `LastOrDefaultAsync` | 13.9226 ns / 192 B | 1,432.8369 ns / 1872 B | 80.8937 ns / 208 B | NA |
+| `LatestOrDefault` | 53.9602 ns / 136 B | NA | NA | 58.1188 ns / 136 B |
+| `LogErrors` | 68.0775 ns / 224 B | NA | NA | 72.0710 ns / 224 B |
+| `LongCountPredicate` | 25.2287 ns / 104 B | 2,608.8275 ns / 2536 B | 109.6102 ns / 272 B | NA |
+| `MapKeep` | 134.0625 ns / 208 B | 2,946.0442 ns / 2616 B | 320.7422 ns / 272 B | NA |
+| `MapWith` | 65.0591 ns / 232 B | 1,443.5638 ns / 1608 B | 136.9318 ns / 248 B | NA |
+| `MaterializeRange` | 46.8644 ns / 120 B | 1,506.6878 ns / 1880 B | 100.4292 ns / 136 B | NA |
+| `Merge` | 80.2232 ns / 256 B | 4,278.2346 ns / 3952 B | 793.7542 ns / 352 B | NA |
+| `MergeRanges` | 78.0233 ns / 256 B | 3,920.3102 ns / 3952 B | 732.4915 ns / 352 B | NA |
+| `MulticastConnect` | 159.3122 ns / 360 B | 2,789.8379 ns / 2696 B | 441.0353 ns / 368 B | NA |
+| `NeverSubscribeDispose` | 0.2446 ns / 0 B | 6.2409 ns / 40 B | 19.4228 ns / 56 B | NA |
+| `Not` | 27.8941 ns / 120 B | 834.5748 ns / 1040 B | 92.3225 ns / 152 B | 28.4602 ns / 120 B |
+| `ObserveOnIf` | 64.2175 ns / 104 B | NA | NA | 66.5979 ns / 104 B |
+| `ObserveOnImmediate` | 23.1313 ns / 96 B | 16,018.5333 ns / 11309 B | 905.3638 ns / 432 B | NA |
+| `ObserveOnSafe` | 65.7747 ns / 104 B | NA | NA | 67.1360 ns / 104 B |
+| `OnCleanup` | 127.6024 ns / 504 B | 1,466.0726 ns / 1528 B | 135.0002 ns / 216 B | NA |
+| `OnErrorRetry` | 133.5035 ns / 424 B | NA | NA | 134.3144 ns / 424 B |
+| `OnNext` | 50.6179 ns / 40 B | NA | NA | 51.3304 ns / 40 B |
+| `Pairwise` | 511.8533 ns / 160 B | 2,840.1602 ns / 3072 B | NA | 536.1441 ns / 160 B |
+| `Partition` | 277.7601 ns / 440 B | NA | NA | 265.2119 ns / 440 B |
+| `Publish` | 149.1594 ns / 360 B | 2,843.8596 ns / 2696 B | 407.4740 ns / 368 B | NA |
+| `PublishLiveConnect` | 147.7717 ns / 360 B | 2,765.0237 ns / 2696 B | 426.4617 ns / 368 B | NA |
+| `Race` | 42.3790 ns / 192 B | 1,633.0064 ns / 1760 B | 311.2532 ns / 360 B | NA |
+| `RaceRanges` | 40.0232 ns / 192 B | 1,578.4900 ns / 1760 B | 264.0182 ns / 360 B | NA |
+| `Range` | 53.6816 ns / 96 B | 2,791.1538 ns / 2472 B | 84.1106 ns / 80 B | NA |
+| `RangeMapKeep` | 155.3300 ns / 208 B | 2,674.9530 ns / 2616 B | 327.1681 ns / 272 B | NA |
+| `RangeSubscribe` | 56.5469 ns / 96 B | 2,598.6621 ns / 2472 B | 75.2467 ns / 80 B | NA |
+| `ReadOnlyStateProjection` | 103.6867 ns / 224 B | 90.8319 ns / 328 B | 174.2237 ns / 312 B | NA |
+| `ReattemptRange` | 93.4540 ns / 432 B | 1,482.2007 ns / 1664 B | NA | NA |
+| `Recover` | 89.5049 ns / 336 B | 1,454.6806 ns / 1560 B | 169.3545 ns / 264 B | NA |
+| `Reduce (Operator stateful filter GC profile)` | 641.4023 ns / 144 B | NA | NA | NA |
+| `Reduce (Operator stateful filter)` | 50.7020 ns / 144 B | 2,649.4832 ns / 2560 B | NA | NA |
+| `RefCount` | 192.5290 ns / 480 B | NA | 712.2789 ns / 488 B | NA |
+| `RefCountSubscribe` | 191.4625 ns / 480 B | NA | 562.0081 ns / 488 B | NA |
+| `Repeat` | 8.0617 ns / 0 B | 2,591.9693 ns / 2408 B | 82.4938 ns / 80 B | NA |
+| `RepeatSubscribe` | 8.0203 ns / 0 B | 2,519.3663 ns / 2408 B | 76.6248 ns / 80 B | NA |
+| `Replay (Connectable GC profile)` | 689.8670 ns / 512 B | 3,902.0874 ns / 3408 B | 931.1544 ns / 1360 B | NA |
+| `Replay (Subject GC profile)` | 371.6089 ns / 352 B | 740.9560 ns / 696 B | 435.6562 ns / 688 B | NA |
+| `ReplayEmit` | 15,921.0642 ns / 352 B | NA | NA | NA |
+| `ReplayLastOnSubscribe` | 63.6625 ns / 104 B | NA | NA | 63.7188 ns / 104 B |
+| `ReplayLiveLateSubscribe` | 637.8266 ns / 512 B | 3,865.4959 ns / 3408 B | 1,029.3317 ns / 1360 B | NA |
+| `Resume` | 96.2466 ns / 424 B | 1,677.1264 ns / 1720 B | NA | NA |
+| `RetryForeverWithDelay` | 131.7468 ns / 352 B | NA | NA | 126.2633 ns / 352 B |
+| `RetryWithBackoff` | 127.8894 ns / 336 B | NA | NA | 122.5359 ns / 336 B |
+| `RetryWithDelay` | 112.6661 ns / 264 B | NA | NA | 114.9763 ns / 264 B |
+| `RetryWithFixedDelay` | 132.6439 ns / 336 B | NA | NA | 124.9002 ns / 336 B |
+| `Return (Factory GC profile)` | 0.7472 ns / 0 B | 54.9276 ns / 120 B | 34.2162 ns / 80 B | NA |
+| `Return (Reactive extensions)` | 6.7822 ns / 64 B | 54.6806 ns / 120 B | 31.3894 ns / 56 B | 6.9682 ns / 64 B |
+| `ReturnSubscribe` | 0.2191 ns / 0 B | 50.4895 ns / 120 B | 32.2581 ns / 80 B | NA |
+| `RunAll` | 26.0295 ns / 136 B | NA | NA | 24.2351 ns / 136 B |
+| `SafeWitness` | 21.4309 ns / 136 B | 15.1710 ns / 136 B | 26.0649 ns / 128 B | NA |
+| `SampleLatest (Operator time scheduler)` | 257.2775 ns / 776 B | 2,892.3456 ns / 26264 B | 359.7949 ns / 664 B | NA |
+| `SampleLatest (Reactive extensions)` | 1,048.3322 ns / 488 B | NA | NA | 1,135.7206 ns / 840 B |
+| `ScanWithInitial` | 591.7863 ns / 200 B | 2,672.0292 ns / 2560 B | NA | 547.3744 ns / 200 B |
+| `Schedule` | 38.7331 ns / 216 B | NA | NA | 863.5171 ns / 677 B |
+| `ScheduleSafe` | 32.2703 ns / 144 B | NA | NA | 943.9625 ns / 597 B |
+| `SelectAsync` | 1,252.7429 ns / 2104 B | 32,738.8855 ns / 32276 B | NA | 1,292.9070 ns / 2104 B |
+| `SelectAsyncConcurrent` | 1,168.3446 ns / 2120 B | NA | NA | 1,191.4728 ns / 2120 B |
+| `SelectAsyncSequential` | 1,339.6799 ns / 2104 B | NA | NA | 1,302.4360 ns / 2104 B |
+| `SelectConstant` | 59.5848 ns / 136 B | 2,715.4348 ns / 2544 B | 198.1385 ns / 160 B | 58.8155 ns / 136 B |
+| `SelectLatestAsync` | 1,719.1326 ns / 2032 B | NA | NA | 1,731.7319 ns / 2032 B |
+| `SelectManyThen` | 34.6976 ns / 224 B | 423.6935 ns / 752 B | NA | 37.1627 ns / 224 B |
+| `SequenceCountAsync` | 816.4266 ns / 704 B | NA | NA | 799.9606 ns / 704 B |
+| `SequenceMapKeepToListAsync` | 2,009.7575 ns / 1600 B | NA | NA | 1,944.0266 ns / 1600 B |
+| `Share` | 193.6808 ns / 480 B | 3,045.8913 ns / 2880 B | 504.3583 ns / 488 B | NA |
+| `ShareLiveSubscribe` | 204.3741 ns / 480 B | 3,020.7905 ns / 2880 B | 534.5208 ns / 488 B | NA |
+| `Shuffle` | 152.0990 ns / 96 B | NA | NA | 154.7871 ns / 96 B |
+| `SignalBroadcastAsync` | 7,179.9438 ns / 2320 B | NA | NA | 6,977.3867 ns / 2320 B |
+| `SignalEmit` | 1,749.7628 ns / 184 B | NA | NA | NA |
+| `SignalFanOutChurn` | 39,454.1463 ns / 33064 B | NA | NA | NA |
+| `SignalSubscribeDisposeChurn` | 38,197.5708 ns / 32920 B | NA | NA | NA |
+| `Skip (Operator stateful filter GC profile)` | 1,806.9367 ns / 136 B | NA | NA | NA |
+| `Skip (Operator stateful filter)` | 83.9017 ns / 136 B | 2,629.1569 ns / 2512 B | NA | NA |
+| `SkipWhile (Operator stateful filter GC profile)` | 1,886.5043 ns / 144 B | NA | NA | NA |
+| `SkipWhile (Operator stateful filter)` | 94.8720 ns / 144 B | 2,755.9981 ns / 2520 B | NA | NA |
+| `SkipWhileNull` | 26.8510 ns / 112 B | 652.5813 ns / 944 B | NA | 26.3809 ns / 112 B |
+| `Start` | 25.1025 ns / 96 B | NA | NA | 1,011.5645 ns / 535 B |
+| `StartSubscribe` | 51.1140 ns / 208 B | 892.2476 ns / 751 B | 61.2631 ns / 160 B | NA |
+| `StartWithAppend` | 36.6330 ns / 168 B | 1,225.1370 ns / 1283 B | 162.2376 ns / 288 B | NA |
+| `StartWithAppendDefaultIfEmpty` | 36.9278 ns / 168 B | 1,061.6973 ns / 1283 B | 152.9743 ns / 288 B | NA |
+| `State1024` | 15,745.6177 ns / 160 B | 17,003.8483 ns / 200 B | 17,026.8046 ns / 192 B | NA |
+| `StateEmit` | 16,305.4321 ns / 160 B | NA | NA | NA |
+| `StateSignal1024` | 15,226.0101 ns / 160 B | 16,860.4563 ns / 200 B | 16,525.8596 ns / 192 B | NA |
+| `StateSignal32` | 555.0760 ns / 160 B | 619.2484 ns / 200 B | 629.6037 ns / 192 B | NA |
+| `StateSignalUpdates` | 559.4035 ns / 160 B | 586.0605 ns / 200 B | 638.8654 ns / 192 B | NA |
+| `SubjectEmit1024` | 1,741.3116 ns / 184 B | 1,767.3735 ns / 136 B | 1,988.2607 ns / 160 B | NA |
+| `SubjectEmit32` | 91.5766 ns / 184 B | 97.2691 ns / 136 B | 123.9790 ns / 160 B | NA |
+| `SubjectSubscribeDispose64` | 3,442.9656 ns / 3848 B | 4,184.0096 ns / 38472 B | 3,923.8215 ns / 6728 B | NA |
+| `SubjectSubscribeDispose8` | 353.1304 ns / 640 B | 313.9104 ns / 1288 B | 485.8430 ns / 904 B | NA |
+| `SubscribeAndComplete` | 0.5452 ns / 0 B | NA | NA | 0.2295 ns / 0 B |
+| `SubscribeAsync` | 1,020.8799 ns / 544 B | NA | NA | 1,086.0720 ns / 544 B |
+| `SubscribeDispose64` | 3,514.5795 ns / 3848 B | 4,330.8894 ns / 38472 B | 3,776.1935 ns / 6728 B | NA |
+| `SubscribeGetError` | 6.9580 ns / 48 B | NA | NA | 53.4505 ns / 104 B |
+| `SubscribeGetValue` | 17.8834 ns / 56 B | NA | NA | 18.5553 ns / 56 B |
+| `SubscribeOnImmediate` | 92.8357 ns / 384 B | 2,088.8631 ns / 2257 B | 143.1142 ns / 200 B | NA |
+| `SubscribeSynchronous` | 1,041.8758 ns / 544 B | NA | NA | 1,002.4885 ns / 544 B |
+| `Switch` | 85.8795 ns / 312 B | 2,390.3422 ns / 2360 B | 799.1355 ns / 448 B | NA |
+| `SwitchIfEmpty` | 69.8495 ns / 224 B | NA | NA | 111.8583 ns / 280 B |
+| `SwitchRanges` | 86.2799 ns / 312 B | 2,403.2789 ns / 2360 B | 794.1218 ns / 448 B | NA |
+| `SynchronizeAsync` | 819.5469 ns / 1280 B | NA | NA | 825.0399 ns / 1280 B |
+| `SynchronizeSynchronous` | 832.0162 ns / 1280 B | NA | NA | 817.5703 ns / 1280 B |
+| `SyncTimer` | 2,596.8934 ns / 1080 B | NA | NA | 15,106.0211 ns / 26240 B |
+| `TakeRange` | 72.9409 ns / 200 B | 1,440.9925 ns / 1552 B | 103.1167 ns / 160 B | NA |
+| `TakeUntil` | 512.1911 ns / 192 B | 2,662.6592 ns / 2520 B | NA | 516.0572 ns / 192 B |
+| `TakeWhile (Operator stateful filter GC profile)` | 1,859.1993 ns / 144 B | NA | NA | NA |
+| `TakeWhile (Operator stateful filter)` | 95.4222 ns / 144 B | 2,717.1335 ns / 2520 B | NA | NA |
+| `TapRange` | 77.2577 ns / 224 B | 1,568.4737 ns / 1520 B | 135.1513 ns / 216 B | NA |
+| `TapWith` | 78.4952 ns / 320 B | 1,476.9664 ns / 1608 B | 146.3279 ns / 304 B | NA |
+| `TaskSignalSubscribe` | 37.9870 ns / 240 B | 779.9820 ns / 886 B | 39.5601 ns / 160 B | NA |
+| `ThrottleBurst` | 612.2450 ns / 1176 B | 2,778.8308 ns / 36480 B | 1,667.2384 ns / 1512 B | NA |
+| `ThrottleDistinct` | 1,849.1563 ns / 4232 B | NA | NA | 30,604.1331 ns / 18701 B |
+| `ThrottleFirst` | 1,161.0701 ns / 224 B | NA | NA | 1,163.6336 ns / 224 B |
+| `ThrottleOnScheduler` | 1,912.9753 ns / 2400 B | NA | NA | 34,581.3985 ns / 16354 B |
+| `ThrottleUntilTrue` | 5,027.6983 ns / 1633 B | NA | NA | 6,217.3368 ns / 1378 B |
+| `Throw` | 63.0707 ns / 120 B | 128.1170 ns / 240 B | 96.0727 ns / 200 B | NA |
+| `ThrowSubscribe` | 64.2616 ns / 120 B | 118.8961 ns / 240 B | 103.2737 ns / 200 B | NA |
+| `TimeIntervalRange` | 27.1561 ns / 120 B | 1,784.3594 ns / 1616 B | 454.4125 ns / 160 B | NA |
+| `TimeoutIdle` | 293.2704 ns / 800 B | 1,294.2879 ns / 29776 B | 414.6542 ns / 784 B | NA |
+| `TimestampRange` | 42.6172 ns / 144 B | 1,749.8641 ns / 1512 B | 360.3036 ns / 152 B | NA |
+| `ToHotTask` | 36.3653 ns / 112 B | 101.5059 ns / 240 B | NA | 35.7259 ns / 112 B |
+| `ToHotValueTask` | 27.0451 ns / 72 B | NA | NA | 27.8467 ns / 72 B |
+| `ToPropertyObservable` | 27,071.4355 ns / 4941 B | NA | NA | 27,486.0006 ns / 4941 B |
+| `ToReadOnlyBehavior` | 66.0075 ns / 192 B | NA | NA | 67.9050 ns / 192 B |
+| `ToTask` | 13.3485 ns / 192 B | 2,572.0790 ns / 2824 B | 97.3992 ns / 208 B | NA |
+| `TrySelect` | 101.8332 ns / 120 B | NA | NA | 110.8990 ns / 120 B |
+| `UnfoldSubscribe` | 12.8181 ns / 0 B | 2,345.7369 ns / 2768 B | 100.1733 ns / 128 B | NA |
+| `Unique (Operator stateful filter GC profile)` | 1,839.5060 ns / 144 B | NA | NA | NA |
+| `Unique (Operator stateful filter)` | 109.1269 ns / 144 B | 2,863.5156 ns / 2568 B | NA | NA |
+| `UniqueBy (Operator stateful filter GC profile)` | 2,029.5043 ns / 152 B | NA | NA | NA |
+| `UniqueBy (Operator stateful filter)` | 109.3574 ns / 152 B | 2,735.0480 ns / 2568 B | NA | NA |
+| `UseSubscribe` | 40.9663 ns / 144 B | 88.1730 ns / 168 B | 63.0011 ns / 128 B | NA |
+| `Using` | 7.6564 ns / 56 B | NA | NA | 9.4516 ns / 56 B |
+| `WaitForCompletion` | 25.1638 ns / 96 B | NA | NA | 24.6338 ns / 96 B |
+| `WaitForError` | 26.0917 ns / 96 B | NA | NA | 73.9819 ns / 152 B |
+| `WaitForValue` | 32.1534 ns / 104 B | NA | NA | 34.4935 ns / 104 B |
+| `WaitUntil` | 534.5543 ns / 224 B | 891.0865 ns / 1080 B | NA | 540.1772 ns / 224 B |
+| `WhereFalse` | 23.6723 ns / 120 B | 806.3629 ns / 1040 B | 91.3808 ns / 184 B | 24.8538 ns / 120 B |
+| `WhereIsNotNull` | 23.7931 ns / 104 B | 622.7868 ns / 904 B | 92.9625 ns / 264 B | 23.3656 ns / 104 B |
+| `WhereSelect` | 80.4235 ns / 152 B | 2,638.5579 ns / 2616 B | 193.5426 ns / 240 B | 77.0247 ns / 152 B |
+| `WhereTrue` | 23.7493 ns / 120 B | 804.6906 ns / 1040 B | 86.8553 ns / 184 B | 26.0367 ns / 120 B |
+| `While` | 127.7396 ns / 280 B | NA | NA | 127.4206 ns / 280 B |
+| `WithLatest` | 40.7850 ns / 192 B | 3,451.6327 ns / 2824 B | 274.0358 ns / 248 B | NA |
+| `WithLatestRanges` | 45.1321 ns / 192 B | 3,505.9546 ns / 2824 B | 345.9029 ns / 248 B | NA |
+| `WithLimitedConcurrency` | 2,489.2455 ns / 5448 B | NA | NA | 2,604.7204 ns / 5448 B |
+| `Zip (Operator core GC profile)` | 39.0931 ns / 192 B | 3,389.6512 ns / 2976 B | 765.7075 ns / 656 B | NA |
+| `Zip (Operator zip)` | 37.0413 ns / 192 B | 3,060.4356 ns / 2976 B | 687.6359 ns / 656 B | NA |
 
 BenchmarkDotNet emitted `ZeroMeasurement` warnings for several singleton or empty-method-scale paths, including `Return`, `CompletedSpark`, and `Never`-style subscriptions. Those warnings mean the measured duration is indistinguishable from empty method overhead; the benchmark run still completed and exported all 610 rows.
 

--- a/src/ReactiveUI.Primitives.Extensions/Operators/BinaryMinMaxObservable.cs
+++ b/src/ReactiveUI.Primitives.Extensions/Operators/BinaryMinMaxObservable.cs
@@ -1,0 +1,185 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using ReactiveUI.Primitives.Disposables;
+using ReactiveUI.Primitives.Extensions.Internal;
+
+namespace ReactiveUI.Primitives.Extensions.Operators;
+
+/// <summary>
+/// Fast path for the common two-source min/max case.
+/// </summary>
+/// <typeparam name="T">The value type.</typeparam>
+/// <param name="left">The first source.</param>
+/// <param name="right">The second source.</param>
+/// <param name="emitMaximum"><c>true</c> to emit the maximum; <c>false</c> to emit the minimum.</param>
+internal sealed class BinaryMinMaxObservable<T>(IObservable<T> left, IObservable<T> right, bool emitMaximum) : IObservable<T>
+    where T : struct, IComparable<T>
+{
+    /// <summary>The first source.</summary>
+    private readonly IObservable<T> _left = InvalidOperationExceptionHelper.Check(left);
+
+    /// <summary>The second source.</summary>
+    private readonly IObservable<T> _right = InvalidOperationExceptionHelper.Check(right);
+
+    /// <inheritdoc/>
+    public IDisposable Subscribe(IObserver<T> observer)
+    {
+        ArgumentExceptionHelper.ThrowIfNull(observer);
+
+        var sink = new Sink(observer, emitMaximum);
+        return new DisposableBag(
+            _left.Subscribe(new IndexedObserver(sink, isLeft: true)),
+            _right.Subscribe(new IndexedObserver(sink, isLeft: false)));
+    }
+
+    /// <summary>Holds latest values and terminal state for two sources.</summary>
+    /// <param name="downstream">The downstream observer.</param>
+    /// <param name="emitMaximum"><c>true</c> for max; <c>false</c> for min.</param>
+    private sealed class Sink(IObserver<T> downstream, bool emitMaximum)
+    {
+        /// <summary>The synchronization gate.</summary>
+        private readonly Lock _gate = new();
+
+        /// <summary>The latest left value.</summary>
+        private T _leftValue;
+
+        /// <summary>The latest right value.</summary>
+        private T _rightValue;
+
+        /// <summary>Whether the left source has produced a value.</summary>
+        private bool _hasLeft;
+
+        /// <summary>Whether the right source has produced a value.</summary>
+        private bool _hasRight;
+
+        /// <summary>Whether the left source has completed.</summary>
+        private bool _leftCompleted;
+
+        /// <summary>Whether the right source has completed.</summary>
+        private bool _rightCompleted;
+
+        /// <summary>Whether the sink is terminal.</summary>
+        private bool _isDone;
+
+        /// <summary>Handles a source value.</summary>
+        /// <param name="isLeft"><c>true</c> for the left source.</param>
+        /// <param name="value">The value.</param>
+        public void OnNext(bool isLeft, T value)
+        {
+            lock (_gate)
+            {
+                if (_isDone)
+                {
+                    return;
+                }
+
+                if (isLeft)
+                {
+                    _leftValue = value;
+                    _hasLeft = true;
+                }
+                else
+                {
+                    _rightValue = value;
+                    _hasRight = true;
+                }
+
+                if (!_hasLeft || !_hasRight)
+                {
+                    return;
+                }
+
+                var compare = _leftValue.CompareTo(_rightValue);
+                var useLeft = emitMaximum ? compare >= 0 : compare <= 0;
+                downstream.OnNext(useLeft ? _leftValue : _rightValue);
+            }
+        }
+
+        /// <summary>Handles a source error.</summary>
+        /// <param name="error">The error.</param>
+        public void OnError(Exception error)
+        {
+            lock (_gate)
+            {
+                if (_isDone)
+                {
+                    return;
+                }
+
+                _isDone = true;
+                downstream.OnError(error);
+            }
+        }
+
+        /// <summary>Handles source completion.</summary>
+        /// <param name="isLeft"><c>true</c> for the left source.</param>
+        public void OnCompleted(bool isLeft)
+        {
+            lock (_gate)
+            {
+                if (_isDone)
+                {
+                    return;
+                }
+
+                if (isLeft)
+                {
+                    if (_leftCompleted)
+                    {
+                        return;
+                    }
+
+                    _leftCompleted = true;
+                    if (!_hasLeft)
+                    {
+                        Complete();
+                        return;
+                    }
+                }
+                else
+                {
+                    if (_rightCompleted)
+                    {
+                        return;
+                    }
+
+                    _rightCompleted = true;
+                    if (!_hasRight)
+                    {
+                        Complete();
+                        return;
+                    }
+                }
+
+                if (_leftCompleted && _rightCompleted)
+                {
+                    Complete();
+                }
+            }
+        }
+
+        /// <summary>Completes once.</summary>
+        private void Complete()
+        {
+            _isDone = true;
+            downstream.OnCompleted();
+        }
+    }
+
+    /// <summary>Observer that labels left/right without per-callback closures.</summary>
+    /// <param name="sink">The shared sink.</param>
+    /// <param name="isLeft"><c>true</c> when observing the left source.</param>
+    private sealed class IndexedObserver(Sink sink, bool isLeft) : IObserver<T>
+    {
+        /// <inheritdoc/>
+        public void OnNext(T value) => sink.OnNext(isLeft, value);
+
+        /// <inheritdoc/>
+        public void OnError(Exception error) => sink.OnError(error);
+
+        /// <inheritdoc/>
+        public void OnCompleted() => sink.OnCompleted(isLeft);
+    }
+}

--- a/src/ReactiveUI.Primitives.Extensions/ReactiveExtensions.cs
+++ b/src/ReactiveUI.Primitives.Extensions/ReactiveExtensions.cs
@@ -145,6 +145,16 @@ public static class ReactiveExtensions
     public static IObservable<T> GetMax<T>(this IObservable<T> @this, params IObservable<T>[] sources)
         where T : struct, IComparable<T>
     {
+        if (sources.Length == 0)
+        {
+            return @this;
+        }
+
+        if (sources.Length == 1)
+        {
+            return new BinaryMinMaxObservable<T>(@this, sources[0], emitMaximum: true);
+        }
+
         var allSources = new IObservable<T>[sources.Length + 1];
         allSources[0] = @this;
         Array.Copy(sources, 0, allSources, 1, sources.Length);
@@ -161,6 +171,16 @@ public static class ReactiveExtensions
     public static IObservable<T> GetMin<T>(this IObservable<T> @this, params IObservable<T>[] sources)
         where T : struct, IComparable<T>
     {
+        if (sources.Length == 0)
+        {
+            return @this;
+        }
+
+        if (sources.Length == 1)
+        {
+            return new BinaryMinMaxObservable<T>(@this, sources[0], emitMaximum: false);
+        }
+
         var allSources = new IObservable<T>[sources.Length + 1];
         allSources[0] = @this;
         Array.Copy(sources, 0, allSources, 1, sources.Length);

--- a/src/benchmarks/ReactiveUI.Primitives.Benchmarks/Program.cs
+++ b/src/benchmarks/ReactiveUI.Primitives.Benchmarks/Program.cs
@@ -106,7 +106,34 @@ internal static class Program
             return;
         }
 
+        if (args.Contains("--extensions-smoke", StringComparer.OrdinalIgnoreCase))
+        {
+            RunExtensionComparisonSmoke();
+            return;
+        }
+
         BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+    }
+
+    private static void RunExtensionComparisonSmoke()
+    {
+        var benchmarks = new ReactiveExtensionsComparisonBenchmarks();
+        RunExtensionScenarioSet(nameof(benchmarks.PrimitivesScenarios), benchmarks.PrimitivesScenarios);
+        RunExtensionScenarioSet(nameof(benchmarks.ReactiveUIExtensionsScenarios), benchmarks.ReactiveUIExtensionsScenarios);
+        RunExtensionScenarioSet(nameof(benchmarks.SystemReactiveScenarios), benchmarks.SystemReactiveScenarios);
+        RunExtensionScenarioSet(nameof(benchmarks.R3Scenarios), benchmarks.R3Scenarios);
+        Console.WriteLine("Extensions scenario smoke validation passed.");
+    }
+
+    private static void RunExtensionScenarioSet(
+        string name,
+        IEnumerable<ReactiveExtensionsComparisonBenchmarks.ExtensionScenario> scenarios)
+    {
+        foreach (var scenario in scenarios)
+        {
+            Console.WriteLine($"{name}:{scenario}");
+            _ = scenario.Run();
+        }
     }
 
     /// <summary>

--- a/src/benchmarks/ReactiveUI.Primitives.Benchmarks/Program.cs
+++ b/src/benchmarks/ReactiveUI.Primitives.Benchmarks/Program.cs
@@ -115,6 +115,9 @@ internal static class Program
         BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
     }
 
+    /// <summary>
+    /// Runs the extension comparison scenarios once to validate benchmark delegates.
+    /// </summary>
     private static void RunExtensionComparisonSmoke()
     {
         var benchmarks = new ReactiveExtensionsComparisonBenchmarks();
@@ -125,6 +128,11 @@ internal static class Program
         Console.WriteLine("Extensions scenario smoke validation passed.");
     }
 
+    /// <summary>
+    /// Runs a named extension scenario set.
+    /// </summary>
+    /// <param name="name">The scenario set name.</param>
+    /// <param name="scenarios">The scenarios to run.</param>
     private static void RunExtensionScenarioSet(
         string name,
         IEnumerable<ReactiveExtensionsComparisonBenchmarks.ExtensionScenario> scenarios)

--- a/src/benchmarks/ReactiveUI.Primitives.Benchmarks/ReactiveExtensionsComparisonBenchmarks.Competitors.cs
+++ b/src/benchmarks/ReactiveUI.Primitives.Benchmarks/ReactiveExtensionsComparisonBenchmarks.Competitors.cs
@@ -1,0 +1,343 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Reactive.Linq;
+using RxObservable = System.Reactive.Linq.Observable;
+
+namespace ReactiveUI.Primitives.Benchmarks;
+
+/// <summary>
+/// Benchmarks the complete synchronous ReactiveUI.Primitives.Extensions public helper surface.
+/// </summary>
+public partial class ReactiveExtensionsComparisonBenchmarks
+{
+    /// <summary>
+    /// Executes the <c>SystemReactiveAsSignal</c> benchmark helper.
+    /// </summary>
+    /// <returns>The <c>SystemReactiveAsSignal</c> result.</returns>
+    private static int SystemReactiveAsSignal() =>
+        DrainPrimitiveUnit(RxObservable.Range(0, Count).Select(static _ => RxVoid.Default));
+
+    /// <summary>
+    /// Executes the <c>SystemReactiveCatchAndReturn</c> benchmark helper.
+    /// </summary>
+    /// <returns>The <c>SystemReactiveCatchAndReturn</c> result.</returns>
+    private static int SystemReactiveCatchAndReturn() =>
+        DrainInt(RxObservable.Throw<int>(Boom).Catch(RxObservable.Return(Fallback)));
+
+    /// <summary>
+    /// Executes the <c>SystemReactiveCatchIgnore</c> benchmark helper.
+    /// </summary>
+    /// <returns>The <c>SystemReactiveCatchIgnore</c> result.</returns>
+    private static int SystemReactiveCatchIgnore() =>
+        DrainInt(RxObservable.Throw<int>(Boom).Catch(RxObservable.Empty<int>()));
+
+    /// <summary>
+    /// Executes the <c>SystemReactiveCombineLatestValuesAreAllFalse</c> benchmark helper.
+    /// </summary>
+    /// <returns>The <c>SystemReactiveCombineLatestValuesAreAllFalse</c> result.</returns>
+    private static int SystemReactiveCombineLatestValuesAreAllFalse() =>
+        DrainBool(BoolSources(ExtensionsLibrary.ReactiveUIExtensions, false).CombineLatest(static values => values.All(static value => !value)));
+
+    /// <summary>
+    /// Executes the <c>SystemReactiveCombineLatestValuesAreAllTrue</c> benchmark helper.
+    /// </summary>
+    /// <returns>The <c>SystemReactiveCombineLatestValuesAreAllTrue</c> result.</returns>
+    private static int SystemReactiveCombineLatestValuesAreAllTrue() =>
+        DrainBool(BoolSources(ExtensionsLibrary.ReactiveUIExtensions, true).CombineLatest(static values => values.All(static value => value)));
+
+    /// <summary>
+    /// Executes the <c>SystemReactiveFilter</c> benchmark helper.
+    /// </summary>
+    /// <returns>The <c>SystemReactiveFilter</c> result.</returns>
+    private static int SystemReactiveFilter()
+    {
+        var regex = EvenRegex();
+        return DrainString(RxObservable.ToObservable(StringValues).Where(value => regex.IsMatch(value)));
+    }
+
+    /// <summary>
+    /// Executes the <c>SystemReactiveForEach</c> benchmark helper.
+    /// </summary>
+    /// <returns>The <c>SystemReactiveForEach</c> result.</returns>
+    private static int SystemReactiveForEach() =>
+        DrainInt(RxObservable.Return(Values.AsEnumerable()).SelectMany(static values => values));
+
+    /// <summary>
+    /// Executes the <c>SystemReactiveFromArray</c> benchmark helper.
+    /// </summary>
+    /// <returns>The <c>SystemReactiveFromArray</c> result.</returns>
+    private static int SystemReactiveFromArray() =>
+        DrainInt(RxObservable.ToObservable(Values));
+
+    /// <summary>
+    /// Executes the <c>SystemReactiveGetMax</c> benchmark helper.
+    /// </summary>
+    /// <returns>The <c>SystemReactiveGetMax</c> result.</returns>
+    private static int SystemReactiveGetMax() =>
+        DrainInt(RxObservable.Return(FirstValue).CombineLatest(RxObservable.Return(SecondValue), static (left, right) => Math.Max(left, right)));
+
+    /// <summary>
+    /// Executes the <c>SystemReactiveGetMin</c> benchmark helper.
+    /// </summary>
+    /// <returns>The <c>SystemReactiveGetMin</c> result.</returns>
+    private static int SystemReactiveGetMin() =>
+        DrainInt(RxObservable.Return(FirstValue).CombineLatest(RxObservable.Return(SecondValue), static (left, right) => Math.Min(left, right)));
+
+    /// <summary>
+    /// Executes the <c>SystemReactiveNot</c> benchmark helper.
+    /// </summary>
+    /// <returns>The <c>SystemReactiveNot</c> result.</returns>
+    private static int SystemReactiveNot() =>
+        DrainBool(RxObservable.ToObservable(BooleanValues).Select(static value => !value));
+
+    /// <summary>
+    /// Executes the <c>SystemReactivePairwise</c> benchmark helper.
+    /// </summary>
+    /// <returns>The <c>SystemReactivePairwise</c> result.</returns>
+    private static int SystemReactivePairwise()
+    {
+        var observer = new PairObserver();
+        using var subscription = RxObservable.Range(0, Count)
+            .Buffer(2, 1)
+            .Where(static values => values.Count == 2)
+            .Select(static values => (Previous: values[0], Current: values[1]))
+            .Subscribe(observer);
+        return observer.Total;
+    }
+
+    /// <summary>
+    /// Executes the <c>SystemReactiveReturn</c> benchmark helper.
+    /// </summary>
+    /// <returns>The <c>SystemReactiveReturn</c> result.</returns>
+    private static int SystemReactiveReturn() =>
+        DrainInt(RxObservable.Return(Value));
+
+    /// <summary>
+    /// Executes the <c>SystemReactiveScanWithInitial</c> benchmark helper.
+    /// </summary>
+    /// <returns>The <c>SystemReactiveScanWithInitial</c> result.</returns>
+    private static int SystemReactiveScanWithInitial() =>
+        DrainInt(RxObservable.Range(0, Count).Scan(0, static (acc, value) => acc + value));
+
+    /// <summary>
+    /// Executes the <c>SystemReactiveSelectAsyncScenario</c> benchmark helper.
+    /// </summary>
+    /// <returns>The <c>SystemReactiveSelectAsyncScenario</c> result.</returns>
+    private static int SystemReactiveSelectAsyncScenario() =>
+        DrainInt(RxObservable.Range(0, Count).SelectMany(static value => RxObservable.FromAsync(() => Task.FromResult(value + 1))));
+
+    /// <summary>
+    /// Executes the <c>SystemReactiveSelectConstant</c> benchmark helper.
+    /// </summary>
+    /// <returns>The <c>SystemReactiveSelectConstant</c> result.</returns>
+    private static int SystemReactiveSelectConstant() =>
+        DrainInt(RxObservable.Range(0, Count).Select(static _ => Value));
+
+    /// <summary>
+    /// Executes the <c>SystemReactiveSelectManyThen</c> benchmark helper.
+    /// </summary>
+    /// <returns>The <c>SystemReactiveSelectManyThen</c> result.</returns>
+    private static int SystemReactiveSelectManyThen() =>
+        DrainInt(RxObservable.Return(Value)
+            .SelectMany(static value => RxObservable.Return(value + 1))
+            .SelectMany(static value => RxObservable.Return(value + 1)));
+
+    /// <summary>
+    /// Executes the <c>SystemReactiveSkipWhileNull</c> benchmark helper.
+    /// </summary>
+    /// <returns>The <c>SystemReactiveSkipWhileNull</c> result.</returns>
+    private static int SystemReactiveSkipWhileNull() =>
+        DrainString(RxObservable.ToObservable(NullableStrings).SkipWhile(static value => value is null).Select(static value => value!));
+
+    /// <summary>
+    /// Executes the <c>SystemReactiveTakeUntil</c> benchmark helper.
+    /// </summary>
+    /// <returns>The <c>SystemReactiveTakeUntil</c> result.</returns>
+    private static int SystemReactiveTakeUntil() =>
+        DrainInt(RxObservable.Range(0, Count).TakeWhile(static value => value <= Match));
+
+    /// <summary>
+    /// Executes the <c>SystemReactiveToHotTask</c> benchmark helper.
+    /// </summary>
+    /// <returns>The <c>SystemReactiveToHotTask</c> result.</returns>
+    private static int SystemReactiveToHotTask() =>
+        GetCompletedResult(System.Reactive.Threading.Tasks.TaskObservableExtensions.ToTask(RxObservable.Return(Value)));
+
+    /// <summary>
+    /// Executes the <c>SystemReactiveWaitUntil</c> benchmark helper.
+    /// </summary>
+    /// <returns>The <c>SystemReactiveWaitUntil</c> result.</returns>
+    private static int SystemReactiveWaitUntil() =>
+        DrainInt(RxObservable.Range(0, Count).FirstAsync(static value => value == Match));
+
+    /// <summary>
+    /// Executes the <c>SystemReactiveWhereFalse</c> benchmark helper.
+    /// </summary>
+    /// <returns>The <c>SystemReactiveWhereFalse</c> result.</returns>
+    private static int SystemReactiveWhereFalse() =>
+        DrainBool(RxObservable.ToObservable(BooleanValues).Where(static value => !value));
+
+    /// <summary>
+    /// Executes the <c>SystemReactiveWhereIsNotNull</c> benchmark helper.
+    /// </summary>
+    /// <returns>The <c>SystemReactiveWhereIsNotNull</c> result.</returns>
+    private static int SystemReactiveWhereIsNotNull() =>
+        DrainString(RxObservable.ToObservable(NullableStrings).Where(static value => value is not null).Select(static value => value!));
+
+    /// <summary>
+    /// Executes the <c>SystemReactiveWhereSelect</c> benchmark helper.
+    /// </summary>
+    /// <returns>The <c>SystemReactiveWhereSelect</c> result.</returns>
+    private static int SystemReactiveWhereSelect() =>
+        DrainInt(RxObservable.Range(0, Count).Where(static value => (value & 1) == 0).Select(static value => value * ResultMultiplier));
+
+    /// <summary>
+    /// Executes the <c>SystemReactiveWhereTrue</c> benchmark helper.
+    /// </summary>
+    /// <returns>The <c>SystemReactiveWhereTrue</c> result.</returns>
+    private static int SystemReactiveWhereTrue() =>
+        DrainBool(RxObservable.ToObservable(BooleanValues).Where(static value => value));
+
+    /// <summary>
+    /// Executes the <c>R3AsSignal</c> benchmark helper.
+    /// </summary>
+    /// <returns>The <c>R3AsSignal</c> result.</returns>
+    private static int R3AsSignal()
+    {
+        var observer = new IntR3Observer();
+        using var subscription = global::R3.ObservableExtensions.Select(global::R3.Observable.Range(0, Count), static _ => 1).Subscribe(observer);
+        return observer.Total;
+    }
+
+    /// <summary>
+    /// Executes the <c>R3CatchAndReturn</c> benchmark helper.
+    /// </summary>
+    /// <returns>The <c>R3CatchAndReturn</c> result.</returns>
+    private static int R3CatchAndReturn()
+    {
+        var observer = new IntR3Observer();
+        using var subscription = global::R3.ObservableExtensions.Catch<int, Exception>(
+                global::R3.Observable.Throw<int>(Boom),
+                static _ => global::R3.Observable.Return(Fallback))
+            .Subscribe(observer);
+        return observer.Total;
+    }
+
+    /// <summary>
+    /// Executes the <c>R3CatchIgnore</c> benchmark helper.
+    /// </summary>
+    /// <returns>The <c>R3CatchIgnore</c> result.</returns>
+    private static int R3CatchIgnore()
+    {
+        var observer = new IntR3Observer();
+        using var subscription = global::R3.ObservableExtensions.Catch<int, Exception>(
+                global::R3.Observable.Throw<int>(Boom),
+                static _ => global::R3.Observable.Empty<int>())
+            .Subscribe(observer);
+        return observer.Total;
+    }
+
+    /// <summary>
+    /// Executes the <c>R3FromArray</c> benchmark helper.
+    /// </summary>
+    /// <returns>The <c>R3FromArray</c> result.</returns>
+    private static int R3FromArray()
+    {
+        var observer = new IntR3Observer();
+        using var subscription = global::R3.Observable.ToObservable(Values, CancellationToken.None).Subscribe(observer);
+        return observer.Total;
+    }
+
+    /// <summary>
+    /// Executes the <c>R3Not</c> benchmark helper.
+    /// </summary>
+    /// <returns>The <c>R3Not</c> result.</returns>
+    private static int R3Not()
+    {
+        var observer = new R3BoolObserver();
+        using var subscription = global::R3.ObservableExtensions.Select(
+                global::R3.Observable.ToObservable(BooleanValues, CancellationToken.None),
+                static value => !value)
+            .Subscribe(observer);
+        return observer.Total;
+    }
+
+    /// <summary>
+    /// Executes the <c>R3Return</c> benchmark helper.
+    /// </summary>
+    /// <returns>The <c>R3Return</c> result.</returns>
+    private static int R3Return()
+    {
+        var observer = new IntR3Observer();
+        using var subscription = global::R3.Observable.Return(Value).Subscribe(observer);
+        return observer.Total;
+    }
+
+    /// <summary>
+    /// Executes the <c>R3SelectConstant</c> benchmark helper.
+    /// </summary>
+    /// <returns>The <c>R3SelectConstant</c> result.</returns>
+    private static int R3SelectConstant()
+    {
+        var observer = new IntR3Observer();
+        using var subscription = global::R3.ObservableExtensions.Select(global::R3.Observable.Range(0, Count), static _ => Value).Subscribe(observer);
+        return observer.Total;
+    }
+
+    /// <summary>
+    /// Executes the <c>R3WhereFalse</c> benchmark helper.
+    /// </summary>
+    /// <returns>The <c>R3WhereFalse</c> result.</returns>
+    private static int R3WhereFalse()
+    {
+        var observer = new R3BoolObserver();
+        using var subscription = global::R3.ObservableExtensions.Where(
+                global::R3.Observable.ToObservable(BooleanValues, CancellationToken.None),
+                static value => !value)
+            .Subscribe(observer);
+        return observer.Total;
+    }
+
+    /// <summary>
+    /// Executes the <c>R3WhereIsNotNull</c> benchmark helper.
+    /// </summary>
+    /// <returns>The <c>R3WhereIsNotNull</c> result.</returns>
+    private static int R3WhereIsNotNull()
+    {
+        var observer = new R3CountingObserver<string>();
+        var source = global::R3.Observable.ToObservable(NullableStrings, CancellationToken.None);
+        var filtered = global::R3.ObservableExtensions.Where(source, static value => value is not null);
+        using var subscription = global::R3.ObservableExtensions.Select(filtered, static value => value!).Subscribe(observer);
+        return observer.ItemCount;
+    }
+
+    /// <summary>
+    /// Executes the <c>R3WhereSelect</c> benchmark helper.
+    /// </summary>
+    /// <returns>The <c>R3WhereSelect</c> result.</returns>
+    private static int R3WhereSelect()
+    {
+        var observer = new IntR3Observer();
+        using var subscription = global::R3.ObservableExtensions.Select(
+                global::R3.ObservableExtensions.Where(global::R3.Observable.Range(0, Count), static value => (value & 1) == 0),
+                static value => value * ResultMultiplier)
+            .Subscribe(observer);
+        return observer.Total;
+    }
+
+    /// <summary>
+    /// Executes the <c>R3WhereTrue</c> benchmark helper.
+    /// </summary>
+    /// <returns>The <c>R3WhereTrue</c> result.</returns>
+    private static int R3WhereTrue()
+    {
+        var observer = new R3BoolObserver();
+        using var subscription = global::R3.ObservableExtensions.Where(
+                global::R3.Observable.ToObservable(BooleanValues, CancellationToken.None),
+                static value => value)
+            .Subscribe(observer);
+        return observer.Total;
+    }
+}

--- a/src/benchmarks/ReactiveUI.Primitives.Benchmarks/ReactiveExtensionsComparisonBenchmarks.Helpers.cs
+++ b/src/benchmarks/ReactiveUI.Primitives.Benchmarks/ReactiveExtensionsComparisonBenchmarks.Helpers.cs
@@ -1,0 +1,588 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.ComponentModel;
+using System.Text.RegularExpressions;
+using ReactiveUI.Primitives.Signals;
+using PackageExtensions = ReactiveUI.Extensions.ReactiveExtensions;
+using PackageObservables = ReactiveUI.Extensions.Observables;
+using PrimitivesExtensions = ReactiveUI.Primitives.Extensions.ReactiveExtensions;
+using PrimitivesObservables = ReactiveUI.Primitives.Extensions.Observables;
+using RxObservable = System.Reactive.Linq.Observable;
+using RxUnit = System.Reactive.Unit;
+
+namespace ReactiveUI.Primitives.Benchmarks;
+
+/// <summary>
+/// Benchmarks the complete synchronous ReactiveUI.Primitives.Extensions public helper surface.
+/// </summary>
+public partial class ReactiveExtensionsComparisonBenchmarks
+{
+    /// <summary>
+    /// Executes the <c>ArraySource</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>ArraySource</c> result.</returns>
+    private static IObservable<int> ArraySource(ExtensionsLibrary library) =>
+        library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.FromArray(Values)
+            : PackageExtensions.FromArray(Values);
+
+    /// <summary>
+    /// Executes the <c>BoolSource</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>BoolSource</c> result.</returns>
+    private static IObservable<bool> BoolSource(ExtensionsLibrary library) =>
+        library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.FromArray(BooleanValues)
+            : PackageExtensions.FromArray(BooleanValues);
+
+    /// <summary>
+    /// Executes the <c>EnsureCompleted</c> benchmark helper.
+    /// </summary>
+    /// <param name="task">The <c>task</c> value.</param>
+    private static void EnsureCompleted(Task task)
+    {
+        while (!task.IsCompleted)
+        {
+            Thread.Yield();
+        }
+
+        if (task.IsCompletedSuccessfully)
+        {
+            return;
+        }
+
+        if (task.IsCanceled)
+        {
+            throw new TaskCanceledException(task);
+        }
+
+        throw new InvalidOperationException("The benchmark task should complete successfully.", task.Exception);
+    }
+
+    /// <summary>
+    /// Executes the <c>EnsureCompleted</c> benchmark helper.
+    /// </summary>
+    /// <param name="task">The <c>task</c> value.</param>
+    private static void EnsureCompleted(ValueTask task)
+    {
+        if (task.IsCompletedSuccessfully)
+        {
+            return;
+        }
+
+        EnsureCompleted(task.AsTask());
+    }
+
+    /// <summary>
+    /// Executes the <c>GetCompletedResult</c> benchmark helper.
+    /// </summary>
+    /// <param name="task">The <c>task</c> value.</param>
+    /// <returns>The <c>GetCompletedResult</c> result.</returns>
+    private static int GetCompletedResult(Task<int> task)
+    {
+        EnsureCompleted(task);
+        return Value;
+    }
+
+    /// <summary>
+    /// Executes the <c>GetCompletedResult</c> benchmark helper.
+    /// </summary>
+    /// <param name="task">The <c>task</c> value.</param>
+    /// <returns>The <c>GetCompletedResult</c> result.</returns>
+    private static int GetCompletedResult(ValueTask<int> task)
+    {
+        if (!task.IsCompletedSuccessfully)
+        {
+            EnsureCompleted(task.AsTask());
+        }
+
+        return Value;
+    }
+
+    /// <summary>
+    /// Executes the <c>BoolSources</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <param name="value">The <c>value</c> value.</param>
+    /// <returns>The <c>BoolSources</c> result.</returns>
+    private static IEnumerable<IObservable<bool>> BoolSources(ExtensionsLibrary library, bool value)
+    {
+        yield return library == ExtensionsLibrary.Primitives
+            ? PrimitivesObservables.Return(value)
+            : PackageObservables.Return(value);
+        yield return library == ExtensionsLibrary.Primitives
+            ? PrimitivesObservables.Return(value)
+            : PackageObservables.Return(value);
+    }
+
+    /// <summary>
+    /// Executes the <c>CompletedTasks</c> benchmark helper.
+    /// </summary>
+    /// <returns>The <c>CompletedTasks</c> result.</returns>
+    private static IEnumerable<Task<int>> CompletedTasks()
+    {
+        for (var i = 0; i < Count; i++)
+        {
+            yield return Task.FromResult(i);
+        }
+    }
+
+    /// <summary>
+    /// Executes the <c>CreateValues</c> benchmark helper.
+    /// </summary>
+    /// <returns>The <c>CreateValues</c> result.</returns>
+    private static int[] CreateValues()
+    {
+        var values = new int[Count];
+        for (var i = 0; i < values.Length; i++)
+        {
+            values[i] = i;
+        }
+
+        return values;
+    }
+
+    /// <summary>
+    /// Executes the <c>DrainArray</c> benchmark helper.
+    /// </summary>
+    /// <param name="source">The <c>source</c> value.</param>
+    /// <returns>The <c>DrainArray</c> result.</returns>
+    private static int DrainArray(IObservable<int[]> source)
+    {
+        var observer = new ArrayObserver();
+        using var subscription = source.Subscribe(observer);
+        return observer.Total;
+    }
+
+    /// <summary>
+    /// Executes the <c>DrainBool</c> benchmark helper.
+    /// </summary>
+    /// <param name="source">The <c>source</c> value.</param>
+    /// <returns>The <c>DrainBool</c> result.</returns>
+    private static int DrainBool(IObservable<bool> source)
+    {
+        var observer = new BoolSignalObserver();
+        using var subscription = source.Subscribe(observer);
+        return observer.Total + observer.NextCount;
+    }
+
+    /// <summary>
+    /// Executes the <c>DrainInt</c> benchmark helper.
+    /// </summary>
+    /// <param name="source">The <c>source</c> value.</param>
+    /// <returns>The <c>DrainInt</c> result.</returns>
+    private static int DrainInt(IObservable<int> source)
+    {
+        var observer = new IntSignalObserver();
+        using var subscription = source.Subscribe(observer);
+        return observer.Total + observer.NextCount;
+    }
+
+    /// <summary>
+    /// Executes the <c>DrainList</c> benchmark helper.
+    /// </summary>
+    /// <param name="source">The <c>source</c> value.</param>
+    /// <returns>The <c>DrainList</c> result.</returns>
+    private static int DrainList(IObservable<IList<int>> source)
+    {
+        var observer = new ListObserver();
+        using var subscription = source.Subscribe(observer);
+        return observer.Total;
+    }
+
+    /// <summary>
+    /// Executes the <c>DrainPackageUnit</c> benchmark helper.
+    /// </summary>
+    /// <param name="source">The <c>source</c> value.</param>
+    /// <returns>The <c>DrainPackageUnit</c> result.</returns>
+    private static int DrainPackageUnit(IObservable<RxUnit> source)
+    {
+        var observer = new CountingSignalObserver<RxUnit>();
+        using var subscription = source.Subscribe(observer);
+        return observer.Count + observer.CompletionCount;
+    }
+
+    /// <summary>
+    /// Executes the <c>DrainPrimitiveUnit</c> benchmark helper.
+    /// </summary>
+    /// <param name="source">The <c>source</c> value.</param>
+    /// <returns>The <c>DrainPrimitiveUnit</c> result.</returns>
+    private static int DrainPrimitiveUnit(IObservable<RxVoid> source)
+    {
+        var observer = new CountingSignalObserver<RxVoid>();
+        using var subscription = source.Subscribe(observer);
+        return observer.Count + observer.CompletionCount;
+    }
+
+    /// <summary>
+    /// Executes the <c>DrainString</c> benchmark helper.
+    /// </summary>
+    /// <param name="source">The <c>source</c> value.</param>
+    /// <returns>The <c>DrainString</c> result.</returns>
+    private static int DrainString(IObservable<string?> source)
+    {
+        var observer = new NullableStringLengthObserver();
+        using var subscription = source.Subscribe(observer);
+        return observer.TotalLength + observer.ItemCount;
+    }
+
+    /// <summary>
+    /// Executes the <c>DrainSyncTuple</c> benchmark helper.
+    /// </summary>
+    /// <param name="source">The <c>source</c> value.</param>
+    /// <returns>The <c>DrainSyncTuple</c> result.</returns>
+    private static int DrainSyncTuple(IObservable<(int Value, IDisposable Sync)> source)
+    {
+        var observer = new SyncTupleObserver();
+        using var subscription = source.Subscribe(observer);
+        return observer.Total;
+    }
+
+    /// <summary>
+    /// Executes the <c>Range</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>Range</c> result.</returns>
+    private static IObservable<int> Range(ExtensionsLibrary library) =>
+        library == ExtensionsLibrary.Primitives
+            ? Signal.Sequence(0, Count)
+            : RxObservable.Range(0, Count);
+
+    /// <summary>
+    /// Executes the <c>ThrowInt</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>ThrowInt</c> result.</returns>
+    private static IObservable<int> ThrowInt(ExtensionsLibrary library) =>
+        library == ExtensionsLibrary.Primitives
+            ? Signal.Fail<int>(Boom)
+            : RxObservable.Throw<int>(Boom);
+
+    /// <summary>
+    /// Executes the <c>ThrowPackageUnit</c> benchmark helper.
+    /// </summary>
+    /// <returns>The <c>ThrowPackageUnit</c> result.</returns>
+    private static IObservable<RxUnit> ThrowPackageUnit() => RxObservable.Throw<RxUnit>(Boom);
+
+    /// <summary>
+    /// Executes the <c>ThrowPrimitiveUnit</c> benchmark helper.
+    /// </summary>
+    /// <returns>The <c>ThrowPrimitiveUnit</c> result.</returns>
+    private static IObservable<RxVoid> ThrowPrimitiveUnit() => Signal.Fail<RxVoid>(Boom);
+
+    /// <summary>
+    /// Creates the generated even-digit regex.
+    /// </summary>
+    /// <returns>The generated regex instance.</returns>
+    [GeneratedRegex("^[02468]$")]
+    private static partial Regex EvenRegex();
+
+    /// <summary>
+    /// Provides a named benchmark scenario.
+    /// </summary>
+    public sealed class ExtensionScenario
+    {
+        /// <summary>
+        /// Stores the scenario name.
+        /// </summary>
+        private readonly string _name;
+
+        /// <summary>
+        /// Stores the scenario delegate.
+        /// </summary>
+        private readonly Func<int> _run;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExtensionScenario"/> class.
+        /// </summary>
+        /// <param name="name">The scenario name.</param>
+        /// <param name="run">The delegate that runs the scenario.</param>
+        public ExtensionScenario(string name, Func<int> run)
+        {
+            _name = name;
+            _run = run;
+        }
+
+        /// <summary>
+        /// Runs the scenario delegate.
+        /// </summary>
+        /// <returns>The benchmark checksum.</returns>
+        public int Run() => _run();
+
+        /// <inheritdoc/>
+        public override string ToString() => _name;
+    }
+
+    /// <summary>
+    /// Provides the <c>ArrayObserver</c> benchmark helper type.
+    /// </summary>
+    private sealed class ArrayObserver : IObserver<int[]>
+    {
+        /// <summary>
+        /// Gets the <c>Total</c> benchmark helper value.
+        /// </summary>
+        public int Total { get; private set; }
+
+        /// <inheritdoc/>
+        public void OnNext(int[] value) => Total += value.Length;
+
+        /// <inheritdoc/>
+        public void OnError(Exception error)
+        {
+        }
+
+        /// <inheritdoc/>
+        public void OnCompleted()
+        {
+        }
+    }
+
+    /// <summary>
+    /// Provides the <c>DummyResource</c> benchmark helper type.
+    /// </summary>
+    private sealed class DummyResource : IDisposable
+    {
+        /// <summary>
+        /// Gets the <c>TouchCount</c> benchmark helper value.
+        /// </summary>
+        public int TouchCount { get; private set; }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+        }
+
+        /// <summary>
+        /// Executes the <c>Touch</c> benchmark helper.
+        /// </summary>
+        public void Touch() => TouchCount++;
+    }
+
+    /// <summary>
+    /// Provides the <c>ListObserver</c> benchmark helper type.
+    /// </summary>
+    private sealed class ListObserver : IObserver<IList<int>>
+    {
+        /// <summary>
+        /// Gets the <c>Total</c> benchmark helper value.
+        /// </summary>
+        public int Total { get; private set; }
+
+        /// <inheritdoc/>
+        public void OnNext(IList<int> value) => Total += value.Count;
+
+        /// <inheritdoc/>
+        public void OnError(Exception error)
+        {
+        }
+
+        /// <inheritdoc/>
+        public void OnCompleted()
+        {
+        }
+    }
+
+    /// <summary>
+    /// Provides the <c>NullableStringLengthObserver</c> benchmark helper type.
+    /// </summary>
+    private sealed class NullableStringLengthObserver : IObserver<string?>
+    {
+        /// <summary>
+        /// Gets the <c>ItemCount</c> benchmark helper value.
+        /// </summary>
+        public int ItemCount { get; private set; }
+
+        /// <summary>
+        /// Gets the <c>TotalLength</c> benchmark helper value.
+        /// </summary>
+        public int TotalLength { get; private set; }
+
+        /// <inheritdoc/>
+        public void OnNext(string? value)
+        {
+            ItemCount++;
+            TotalLength += value?.Length ?? 0;
+        }
+
+        /// <inheritdoc/>
+        public void OnError(Exception error)
+        {
+        }
+
+        /// <inheritdoc/>
+        public void OnCompleted()
+        {
+        }
+    }
+
+    /// <summary>
+    /// Provides the <c>PairObserver</c> benchmark helper type.
+    /// </summary>
+    private sealed class PairObserver : IObserver<(int Previous, int Current)>
+    {
+        /// <summary>
+        /// Gets the <c>Total</c> benchmark helper value.
+        /// </summary>
+        public int Total { get; private set; }
+
+        /// <inheritdoc/>
+        public void OnNext((int Previous, int Current) value) => Total += value.Previous + value.Current;
+
+        /// <inheritdoc/>
+        public void OnError(Exception error)
+        {
+        }
+
+        /// <inheritdoc/>
+        public void OnCompleted()
+        {
+        }
+    }
+
+    /// <summary>
+    /// Provides the <c>PropertySource</c> benchmark helper type.
+    /// </summary>
+    private sealed class PropertySource : INotifyPropertyChanged
+    {
+        /// <summary>
+        /// Stores the <c>_value</c> benchmark helper value.
+        /// </summary>
+        private int _value;
+
+        /// <summary>
+        /// Occurs when the <c>PropertyChanged</c> benchmark helper event is raised.
+        /// </summary>
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        /// <summary>
+        /// Gets or sets the <c>CurrentValue</c> benchmark helper value.
+        /// </summary>
+        public int CurrentValue
+        {
+            get => _value;
+            set
+            {
+                _value = value;
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(CurrentValue)));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Provides the <c>R3BoolObserver</c> benchmark helper type.
+    /// </summary>
+    private sealed class R3BoolObserver : global::R3.Observer<bool>
+    {
+        /// <summary>
+        /// Gets the <c>Total</c> benchmark helper value.
+        /// </summary>
+        public int Total { get; private set; }
+
+        /// <inheritdoc/>
+        protected override void OnNextCore(bool value)
+        {
+            if (!value)
+            {
+                return;
+            }
+
+            Total++;
+        }
+
+        /// <inheritdoc/>
+        protected override void OnErrorResumeCore(Exception error)
+        {
+        }
+
+        /// <inheritdoc/>
+        protected override void OnCompletedCore(global::R3.Result result)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Provides the <c>R3CountingObserver</c> benchmark helper type.
+    /// </summary>
+    /// <typeparam name="T">The observed value type.</typeparam>
+    private sealed class R3CountingObserver<T> : global::R3.Observer<T>
+    {
+        /// <summary>
+        /// Gets the <c>ItemCount</c> benchmark helper value.
+        /// </summary>
+        public int ItemCount { get; private set; }
+
+        /// <inheritdoc/>
+        protected override void OnNextCore(T value) => ItemCount++;
+
+        /// <inheritdoc/>
+        protected override void OnErrorResumeCore(Exception error)
+        {
+        }
+
+        /// <inheritdoc/>
+        protected override void OnCompletedCore(global::R3.Result result)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Provides the <c>SyncTupleObserver</c> benchmark helper type.
+    /// </summary>
+    private sealed class SyncTupleObserver : IObserver<(int Value, IDisposable Sync)>
+    {
+        /// <summary>
+        /// Gets the <c>Total</c> benchmark helper value.
+        /// </summary>
+        public int Total { get; private set; }
+
+        /// <inheritdoc/>
+        public void OnNext((int Value, IDisposable Sync) value)
+        {
+            Total += value.Value;
+            value.Sync.Dispose();
+        }
+
+        /// <inheritdoc/>
+        public void OnError(Exception error)
+        {
+        }
+
+        /// <inheritdoc/>
+        public void OnCompleted()
+        {
+        }
+    }
+
+    /// <summary>
+    /// Provides the <c>TupleObserver</c> benchmark helper type.
+    /// </summary>
+    /// <typeparam name="T">The observed value type.</typeparam>
+    private sealed class TupleObserver<T> : IObserver<(T Value, IDisposable Sync)>
+    {
+        /// <summary>
+        /// Gets the <c>ItemCount</c> benchmark helper value.
+        /// </summary>
+        public int ItemCount { get; private set; }
+
+        /// <inheritdoc/>
+        public void OnNext((T Value, IDisposable Sync) value)
+        {
+            ItemCount++;
+            value.Sync.Dispose();
+        }
+
+        /// <inheritdoc/>
+        public void OnError(Exception error)
+        {
+        }
+
+        /// <inheritdoc/>
+        public void OnCompleted()
+        {
+        }
+    }
+}

--- a/src/benchmarks/ReactiveUI.Primitives.Benchmarks/ReactiveExtensionsComparisonBenchmarks.Library.Supplemental.cs
+++ b/src/benchmarks/ReactiveUI.Primitives.Benchmarks/ReactiveExtensionsComparisonBenchmarks.Library.Supplemental.cs
@@ -1,0 +1,663 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Globalization;
+using System.Reactive.Concurrency;
+using ReactiveUI.Primitives.Concurrency;
+using ReactiveUI.Primitives.Signals;
+using PackageContinuation = ReactiveUI.Extensions.Continuation;
+using PackageExtensions = ReactiveUI.Extensions.ReactiveExtensions;
+using PackageObservables = ReactiveUI.Extensions.Observables;
+using PackageObserverExtensions = ReactiveUI.Extensions.ObserverExtensions;
+using PackageSubscriptionExtensions = ReactiveUI.Extensions.ObservableSubscriptionExtensions;
+using PrimitivesContinuation = ReactiveUI.Primitives.Extensions.Continuation;
+using PrimitivesExtensions = ReactiveUI.Primitives.Extensions.ReactiveExtensions;
+using PrimitivesObservables = ReactiveUI.Primitives.Extensions.Observables;
+using PrimitivesObserverExtensions = ReactiveUI.Primitives.Extensions.ObserverExtensions;
+using PrimitivesSubscriptionExtensions = ReactiveUI.Primitives.Extensions.ObservableSubscriptionExtensions;
+using RxObservable = System.Reactive.Linq.Observable;
+using RxUnit = System.Reactive.Unit;
+
+namespace ReactiveUI.Primitives.Benchmarks;
+
+/// <summary>
+/// Benchmarks the complete synchronous ReactiveUI.Primitives.Extensions public helper surface.
+/// </summary>
+public partial class ReactiveExtensionsComparisonBenchmarks
+{
+    /// <summary>
+    /// Executes the <c>RunPartition</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunPartition</c> result.</returns>
+    private static int RunPartition(ExtensionsLibrary library)
+    {
+        var observer = new IntSignalObserver();
+        if (library == ExtensionsLibrary.Primitives)
+        {
+            var (even, odd) = PrimitivesExtensions.Partition(ArraySource(library), static value => (value & 1) == 0);
+            using var evenSubscription = even.Subscribe(observer);
+            using var oddSubscription = odd.Subscribe(observer);
+        }
+        else
+        {
+            var (even, odd) = PackageExtensions.Partition(ArraySource(library), static value => (value & 1) == 0);
+            using var evenSubscription = even.Subscribe(observer);
+            using var oddSubscription = odd.Subscribe(observer);
+        }
+
+        return observer.Total;
+    }
+
+    /// <summary>
+    /// Executes the <c>RunReplayLastOnSubscribe</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunReplayLastOnSubscribe</c> result.</returns>
+    private static int RunReplayLastOnSubscribe(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.ReplayLastOnSubscribe(ArraySource(library), Fallback)
+            : PackageExtensions.ReplayLastOnSubscribe(ArraySource(library), Fallback));
+
+    /// <summary>
+    /// Executes the <c>RunRetryForeverWithDelay</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunRetryForeverWithDelay</c> result.</returns>
+    private static int RunRetryForeverWithDelay(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.RetryForeverWithDelay(ArraySource(library), TimeSpan.Zero)
+            : PackageExtensions.RetryForeverWithDelay(ArraySource(library), TimeSpan.Zero));
+
+    /// <summary>
+    /// Executes the <c>RunRetryWithBackoff</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunRetryWithBackoff</c> result.</returns>
+    private static int RunRetryWithBackoff(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.RetryWithBackoff(ArraySource(library), 1, TimeSpan.Zero, 1.0, TimeSpan.Zero, Sequencer.Immediate)
+            : PackageExtensions.RetryWithBackoff(ArraySource(library), 1, TimeSpan.Zero, 1.0, TimeSpan.Zero, ImmediateScheduler.Instance));
+
+    /// <summary>
+    /// Executes the <c>RunRetryWithDelay</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunRetryWithDelay</c> result.</returns>
+    private static int RunRetryWithDelay(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.RetryWithDelay(ArraySource(library), 1, static _ => TimeSpan.Zero)
+            : PackageExtensions.RetryWithDelay(ArraySource(library), 1, static _ => TimeSpan.Zero));
+
+    /// <summary>
+    /// Executes the <c>RunRetryWithFixedDelay</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunRetryWithFixedDelay</c> result.</returns>
+    private static int RunRetryWithFixedDelay(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.RetryWithFixedDelay(ArraySource(library), 1, TimeSpan.Zero)
+            : PackageExtensions.RetryWithFixedDelay(ArraySource(library), 1, TimeSpan.Zero));
+
+    /// <summary>
+    /// Executes the <c>RunReturn</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunReturn</c> result.</returns>
+    private static int RunReturn(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesObservables.Return(Value)
+            : PackageObservables.Return(Value));
+
+    /// <summary>
+    /// Executes the <c>RunRunAll</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunRunAll</c> result.</returns>
+    private static int RunRunAll(ExtensionsLibrary library) =>
+        library == ExtensionsLibrary.Primitives
+            ? DrainPrimitiveUnit(PrimitivesExtensions.RunAll([PrimitivesObservables.Return(RxVoid.Default)]))
+            : DrainPackageUnit(PackageExtensions.RunAll([PackageObservables.Return(RxUnit.Default)]));
+
+    /// <summary>
+    /// Executes the <c>RunSampleLatest</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunSampleLatest</c> result.</returns>
+    private static int RunSampleLatest(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.SampleLatest(ArraySource(library), PrimitivesExtensions.SelectConstant(ArraySource(library), new object()))
+            : PackageExtensions.SampleLatest(ArraySource(library), PackageExtensions.SelectConstant(ArraySource(library), new object())));
+
+    /// <summary>
+    /// Executes the <c>RunScanWithInitial</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunScanWithInitial</c> result.</returns>
+    private static int RunScanWithInitial(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.ScanWithInitial(ArraySource(library), 0, static (acc, value) => acc + value)
+            : PackageExtensions.ScanWithInitial(ArraySource(library), 0, static (acc, value) => acc + value));
+
+    /// <summary>
+    /// Executes the <c>RunSchedule</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunSchedule</c> result.</returns>
+    private static int RunSchedule(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.Schedule(Value, Sequencer.Immediate, static value => value + 1)
+            : PackageExtensions.Schedule(Value, ImmediateScheduler.Instance, static value => value + 1));
+
+    /// <summary>
+    /// Executes the <c>RunScheduleSafe</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunScheduleSafe</c> result.</returns>
+    private static int RunScheduleSafe(ExtensionsLibrary library)
+    {
+        var count = 0;
+        using var scheduled = library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.ScheduleSafe(Sequencer.Immediate, () => count++)
+            : PackageExtensions.ScheduleSafe(ImmediateScheduler.Instance, () => count++);
+        return count;
+    }
+
+    /// <summary>
+    /// Executes the <c>RunSelectAsyncScenario</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunSelectAsyncScenario</c> result.</returns>
+    private static int RunSelectAsyncScenario(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.SelectAsync(ArraySource(library), static value => Task.FromResult(value + 1))
+            : PackageExtensions.SelectAsync(ArraySource(library), static value => Task.FromResult(value + 1)));
+
+    /// <summary>
+    /// Executes the <c>RunSelectAsyncConcurrent</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunSelectAsyncConcurrent</c> result.</returns>
+    private static int RunSelectAsyncConcurrent(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.SelectAsyncConcurrent(ArraySource(library), static value => Task.FromResult(value + 1), MaxConcurrency)
+            : PackageExtensions.SelectAsyncConcurrent(ArraySource(library), static value => Task.FromResult(value + 1), MaxConcurrency));
+
+    /// <summary>
+    /// Executes the <c>RunSelectAsyncSequential</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunSelectAsyncSequential</c> result.</returns>
+    private static int RunSelectAsyncSequential(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.SelectAsyncSequential(ArraySource(library), static value => Task.FromResult(value + 1))
+            : PackageExtensions.SelectAsyncSequential(ArraySource(library), static value => Task.FromResult(value + 1)));
+
+    /// <summary>
+    /// Executes the <c>RunSelectConstant</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunSelectConstant</c> result.</returns>
+    private static int RunSelectConstant(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.SelectConstant(ArraySource(library), Value)
+            : PackageExtensions.SelectConstant(ArraySource(library), Value));
+
+    /// <summary>
+    /// Executes the <c>RunSelectLatestAsyncScenario</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunSelectLatestAsyncScenario</c> result.</returns>
+    private static int RunSelectLatestAsyncScenario(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.SelectLatestAsync(ArraySource(library), static value => Task.FromResult(value + 1))
+            : PackageExtensions.SelectLatestAsync(ArraySource(library), static value => Task.FromResult(value + 1)));
+
+    /// <summary>
+    /// Executes the <c>RunSelectManyThen</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunSelectManyThen</c> result.</returns>
+    private static int RunSelectManyThen(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.SelectManyThen(
+                PrimitivesObservables.Return(Value),
+                static value => PrimitivesObservables.Return(value + 1),
+                static value => PrimitivesObservables.Return(value + 1))
+            : PackageExtensions.SelectManyThen(
+                PackageObservables.Return(Value),
+                static value => PackageObservables.Return(value + 1),
+                static value => PackageObservables.Return(value + 1)));
+
+    /// <summary>
+    /// Executes the <c>RunShuffle</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunShuffle</c> result.</returns>
+    private static int RunShuffle(ExtensionsLibrary library) =>
+        DrainArray(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.Shuffle(PrimitivesObservables.Return(Values))
+            : PackageExtensions.Shuffle(PackageObservables.Return(Values)));
+
+    /// <summary>
+    /// Executes the <c>RunSkipWhileNull</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunSkipWhileNull</c> result.</returns>
+    private static int RunSkipWhileNull(ExtensionsLibrary library) =>
+        DrainString(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.SkipWhileNull(PrimitivesExtensions.FromArray(SkipStrings))
+            : PackageExtensions.SkipWhileNull(PackageExtensions.FromArray(SkipStrings)));
+
+    /// <summary>
+    /// Executes the <c>RunStart</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunStart</c> result.</returns>
+    private static int RunStart(ExtensionsLibrary library) =>
+        library == ExtensionsLibrary.Primitives
+            ? DrainPrimitiveUnit(PrimitivesExtensions.Start(static () => { }, Sequencer.Immediate))
+            : DrainPackageUnit(PackageExtensions.Start(static () => { }, ImmediateScheduler.Instance));
+
+    /// <summary>
+    /// Executes the <c>RunSubscribeAndComplete</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunSubscribeAndComplete</c> result.</returns>
+    private static int RunSubscribeAndComplete(ExtensionsLibrary library)
+    {
+        if (library == ExtensionsLibrary.Primitives)
+        {
+            PrimitivesSubscriptionExtensions.SubscribeAndComplete(PrimitivesObservables.Return(RxVoid.Default));
+        }
+        else
+        {
+            PackageSubscriptionExtensions.SubscribeAndComplete(PackageObservables.Return(RxUnit.Default));
+        }
+
+        return 1;
+    }
+
+    /// <summary>
+    /// Executes the <c>RunSubscribeAsyncScenario</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunSubscribeAsyncScenario</c> result.</returns>
+    private static int RunSubscribeAsyncScenario(ExtensionsLibrary library)
+    {
+        var total = 0;
+        using var subscription = library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.SubscribeAsync(ArraySource(library), value =>
+            {
+                total += value;
+                return default;
+            })
+            : PackageExtensions.SubscribeAsync(ArraySource(library), value =>
+            {
+                total += value;
+                return default;
+            });
+        return total;
+    }
+
+    /// <summary>
+    /// Executes the <c>RunSubscribeGetError</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunSubscribeGetError</c> result.</returns>
+    private static int RunSubscribeGetError(ExtensionsLibrary library)
+    {
+        var error = library == ExtensionsLibrary.Primitives
+            ? PrimitivesSubscriptionExtensions.SubscribeGetError(ThrowInt(library))
+            : PackageSubscriptionExtensions.SubscribeGetError(ThrowInt(library));
+
+        return error is null ? 0 : 1;
+    }
+
+    /// <summary>
+    /// Executes the <c>RunSubscribeGetValue</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunSubscribeGetValue</c> result.</returns>
+    private static int RunSubscribeGetValue(ExtensionsLibrary library) =>
+        library == ExtensionsLibrary.Primitives
+            ? PrimitivesSubscriptionExtensions.SubscribeGetValue(ArraySource(library))
+            : PackageSubscriptionExtensions.SubscribeGetValue(ArraySource(library));
+
+    /// <summary>
+    /// Executes the <c>RunSubscribeSynchronous</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunSubscribeSynchronous</c> result.</returns>
+    private static int RunSubscribeSynchronous(ExtensionsLibrary library)
+    {
+        var total = 0;
+        using var subscription = library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.SubscribeSynchronous(ArraySource(library), value =>
+            {
+                total += value;
+                return default;
+            })
+            : PackageExtensions.SubscribeSynchronous(ArraySource(library), value =>
+            {
+                total += value;
+                return default;
+            });
+        return total;
+    }
+
+    /// <summary>
+    /// Executes the <c>RunSwitchIfEmpty</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunSwitchIfEmpty</c> result.</returns>
+    private static int RunSwitchIfEmpty(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.SwitchIfEmpty(Signal.None<int>(), PrimitivesObservables.Return(Value))
+            : PackageExtensions.SwitchIfEmpty(RxObservable.Empty<int>(), PackageObservables.Return(Value)));
+
+    /// <summary>
+    /// Executes the <c>RunSyncTimer</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunSyncTimer</c> result.</returns>
+    private static int RunSyncTimer(ExtensionsLibrary library)
+    {
+        if (library == ExtensionsLibrary.Primitives)
+        {
+            var clock = new TestClock();
+            var observer = new CountingSignalObserver<DateTime>();
+            using var subscription = PrimitivesExtensions.SyncTimer(Tick, clock).Subscribe(observer);
+            clock.AdvanceBy(Tick);
+            return observer.Count + observer.CompletionCount;
+        }
+
+        var scheduler = new HistoricalScheduler();
+        var packageObserver = new CountingSignalObserver<DateTime>();
+        using var packageSubscription = PackageExtensions.SyncTimer(Tick, scheduler).Subscribe(packageObserver);
+        scheduler.AdvanceBy(Tick);
+        return packageObserver.Count + packageObserver.CompletionCount;
+    }
+
+    /// <summary>
+    /// Executes the <c>RunSynchronizeAsyncScenario</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunSynchronizeAsyncScenario</c> result.</returns>
+    private static int RunSynchronizeAsyncScenario(ExtensionsLibrary library) =>
+        DrainSyncTuple(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.SynchronizeAsync(ArraySource(library))
+            : PackageExtensions.SynchronizeAsync(ArraySource(library)));
+
+    /// <summary>
+    /// Executes the <c>RunSynchronizeSynchronous</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunSynchronizeSynchronous</c> result.</returns>
+    private static int RunSynchronizeSynchronous(ExtensionsLibrary library) =>
+        DrainSyncTuple(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.SynchronizeSynchronous(ArraySource(library))
+            : PackageExtensions.SynchronizeSynchronous(ArraySource(library)));
+
+    /// <summary>
+    /// Executes the <c>RunTakeUntil</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunTakeUntil</c> result.</returns>
+    private static int RunTakeUntil(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.TakeUntil(ArraySource(library), static value => value == Match)
+            : PackageExtensions.TakeUntil(ArraySource(library), static value => value == Match));
+
+    /// <summary>
+    /// Executes the <c>RunThrottleDistinct</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunThrottleDistinct</c> result.</returns>
+    private static int RunThrottleDistinct(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.ThrottleDistinct(ArraySource(library), TimeSpan.Zero, Sequencer.Immediate)
+            : PackageExtensions.ThrottleDistinct(ArraySource(library), TimeSpan.Zero, ImmediateScheduler.Instance));
+
+    /// <summary>
+    /// Executes the <c>RunThrottleFirst</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunThrottleFirst</c> result.</returns>
+    private static int RunThrottleFirst(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.ThrottleFirst(ArraySource(library), TimeSpan.Zero, Sequencer.Immediate)
+            : PackageExtensions.ThrottleFirst(ArraySource(library), TimeSpan.Zero, ImmediateScheduler.Instance));
+
+    /// <summary>
+    /// Executes the <c>RunThrottleOnScheduler</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunThrottleOnScheduler</c> result.</returns>
+    private static int RunThrottleOnScheduler(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.ThrottleOnScheduler(ArraySource(library), TimeSpan.Zero, Sequencer.Immediate)
+            : PackageExtensions.ThrottleOnScheduler(ArraySource(library), TimeSpan.Zero, ImmediateScheduler.Instance));
+
+    /// <summary>
+    /// Executes the <c>RunThrottleUntilTrue</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunThrottleUntilTrue</c> result.</returns>
+    private static int RunThrottleUntilTrue(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.ThrottleUntilTrue(ArraySource(library), TimeSpan.Zero, static value => value >= Match)
+            : PackageExtensions.ThrottleUntilTrue(ArraySource(library), TimeSpan.Zero, static value => value >= Match));
+
+    /// <summary>
+    /// Executes the <c>RunToHotTask</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunToHotTask</c> result.</returns>
+    private static int RunToHotTask(ExtensionsLibrary library) =>
+        library == ExtensionsLibrary.Primitives
+            ? GetCompletedResult(PrimitivesExtensions.ToHotTask(PrimitivesObservables.Return(Value)))
+            : GetCompletedResult(PackageExtensions.ToHotTask(PackageObservables.Return(Value)));
+
+    /// <summary>
+    /// Executes the <c>RunToHotValueTask</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunToHotValueTask</c> result.</returns>
+    private static int RunToHotValueTask(ExtensionsLibrary library) =>
+        library == ExtensionsLibrary.Primitives
+            ? GetCompletedResult(PrimitivesExtensions.ToHotValueTask(PrimitivesObservables.Return(Value)))
+            : GetCompletedResult(PackageExtensions.ToHotValueTask(PackageObservables.Return(Value)));
+
+    /// <summary>
+    /// Executes the <c>RunToPropertyObservable</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunToPropertyObservable</c> result.</returns>
+    private static int RunToPropertyObservable(ExtensionsLibrary library)
+    {
+        var source = new PropertySource();
+        var observer = new IntSignalObserver();
+        using var subscription = (library == ExtensionsLibrary.Primitives
+                ? PrimitivesExtensions.ToPropertyObservable(source, static item => item.CurrentValue)
+                : PackageExtensions.ToPropertyObservable(source, static item => item.CurrentValue))
+            .Subscribe(observer);
+        source.CurrentValue = Value;
+        return observer.Total;
+    }
+
+    /// <summary>
+    /// Executes the <c>RunToReadOnlyBehavior</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunToReadOnlyBehavior</c> result.</returns>
+    private static int RunToReadOnlyBehavior(ExtensionsLibrary library)
+    {
+        var observer = new IntSignalObserver();
+        if (library == ExtensionsLibrary.Primitives)
+        {
+            var (observable, sink) = PrimitivesExtensions.ToReadOnlyBehavior(Value);
+            using var subscription = observable.Subscribe(observer);
+            sink.OnNext(Value + 1);
+        }
+        else
+        {
+            var (observable, sink) = PackageExtensions.ToReadOnlyBehavior(Value);
+            using var subscription = observable.Subscribe(observer);
+            sink.OnNext(Value + 1);
+        }
+
+        return observer.Total;
+    }
+
+    /// <summary>
+    /// Executes the <c>RunTrySelect</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunTrySelect</c> result.</returns>
+    private static int RunTrySelect(ExtensionsLibrary library) =>
+        DrainString(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.TrySelect<int, string>(ArraySource(library), static value => value % EvenDivisor == 0 ? value.ToString(CultureInfo.InvariantCulture) : null)
+            : PackageExtensions.TrySelect<int, string>(ArraySource(library), static value => value % EvenDivisor == 0 ? value.ToString(CultureInfo.InvariantCulture) : null));
+
+    /// <summary>
+    /// Executes the <c>RunUsing</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunUsing</c> result.</returns>
+    private static int RunUsing(ExtensionsLibrary library) =>
+        library == ExtensionsLibrary.Primitives
+            ? DrainPrimitiveUnit(PrimitivesExtensions.Using(new DummyResource(), static resource => resource.Touch()))
+            : DrainPackageUnit(PackageExtensions.Using(new DummyResource(), static resource => resource.Touch()));
+
+    /// <summary>
+    /// Executes the <c>RunWaitForCompletion</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunWaitForCompletion</c> result.</returns>
+    private static int RunWaitForCompletion(ExtensionsLibrary library)
+    {
+        if (library == ExtensionsLibrary.Primitives)
+        {
+            PrimitivesSubscriptionExtensions.WaitForCompletion(PrimitivesObservables.Return(RxVoid.Default), WaitTimeout);
+        }
+        else
+        {
+            PackageSubscriptionExtensions.WaitForCompletion(PackageObservables.Return(RxUnit.Default), WaitTimeout);
+        }
+
+        return 1;
+    }
+
+    /// <summary>
+    /// Executes the <c>RunWaitForError</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunWaitForError</c> result.</returns>
+    private static int RunWaitForError(ExtensionsLibrary library)
+    {
+        var error = library == ExtensionsLibrary.Primitives
+            ? PrimitivesSubscriptionExtensions.WaitForError(ThrowInt(library), WaitTimeout)
+            : PackageSubscriptionExtensions.WaitForError(ThrowInt(library), WaitTimeout);
+
+        return error is null ? 0 : 1;
+    }
+
+    /// <summary>
+    /// Executes the <c>RunWaitForValue</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunWaitForValue</c> result.</returns>
+    private static int RunWaitForValue(ExtensionsLibrary library) =>
+        library == ExtensionsLibrary.Primitives
+            ? PrimitivesSubscriptionExtensions.WaitForValue(ArraySource(library), WaitTimeout)
+            : PackageSubscriptionExtensions.WaitForValue(ArraySource(library), WaitTimeout);
+
+    /// <summary>
+    /// Executes the <c>RunWaitUntil</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunWaitUntil</c> result.</returns>
+    private static int RunWaitUntil(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.WaitUntil(ArraySource(library), static value => value == Match)
+            : PackageExtensions.WaitUntil(ArraySource(library), static value => value == Match));
+
+    /// <summary>
+    /// Executes the <c>RunWhereFalse</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunWhereFalse</c> result.</returns>
+    private static int RunWhereFalse(ExtensionsLibrary library) =>
+        DrainBool(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.WhereFalse(BoolSource(library))
+            : PackageExtensions.WhereFalse(BoolSource(library)));
+
+    /// <summary>
+    /// Executes the <c>RunWhereIsNotNull</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunWhereIsNotNull</c> result.</returns>
+    private static int RunWhereIsNotNull(ExtensionsLibrary library) =>
+        DrainString(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.WhereIsNotNull(PrimitivesExtensions.FromArray(NullableStrings))
+            : PackageExtensions.WhereIsNotNull(PackageExtensions.FromArray(NullableStrings)));
+
+    /// <summary>
+    /// Executes the <c>RunWhereSelect</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunWhereSelect</c> result.</returns>
+    private static int RunWhereSelect(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.WhereSelect(ArraySource(library), static value => (value & 1) == 0, static value => value * ResultMultiplier)
+            : PackageExtensions.WhereSelect(ArraySource(library), static value => (value & 1) == 0, static value => value * ResultMultiplier));
+
+    /// <summary>
+    /// Executes the <c>RunWhereTrue</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunWhereTrue</c> result.</returns>
+    private static int RunWhereTrue(ExtensionsLibrary library) =>
+        DrainBool(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.WhereTrue(BoolSource(library))
+            : PackageExtensions.WhereTrue(BoolSource(library)));
+
+    /// <summary>
+    /// Executes the <c>RunWhile</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunWhile</c> result.</returns>
+    private static int RunWhile(ExtensionsLibrary library)
+    {
+        var remaining = Count;
+        var total = 0;
+
+        bool ShouldContinue()
+        {
+            var hasRemaining = remaining > 0;
+            remaining--;
+            return hasRemaining;
+        }
+
+        void RecordIteration()
+        {
+            total++;
+        }
+
+        return library == ExtensionsLibrary.Primitives
+            ? DrainPrimitiveUnit(PrimitivesExtensions.While(ShouldContinue, RecordIteration)) + total
+            : DrainPackageUnit(PackageExtensions.While(ShouldContinue, RecordIteration)) + total;
+    }
+
+    /// <summary>
+    /// Executes the <c>RunWithLimitedConcurrency</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunWithLimitedConcurrency</c> result.</returns>
+    private static int RunWithLimitedConcurrency(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.WithLimitedConcurrency(CompletedTasks(), MaxConcurrency)
+            : PackageExtensions.WithLimitedConcurrency(CompletedTasks(), MaxConcurrency));
+}

--- a/src/benchmarks/ReactiveUI.Primitives.Benchmarks/ReactiveExtensionsComparisonBenchmarks.Library.cs
+++ b/src/benchmarks/ReactiveUI.Primitives.Benchmarks/ReactiveExtensionsComparisonBenchmarks.Library.cs
@@ -1,0 +1,497 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Reactive.Concurrency;
+using ReactiveUI.Primitives.Concurrency;
+using ReactiveUI.Primitives.Signals;
+using PackageContinuation = ReactiveUI.Extensions.Continuation;
+using PackageExtensions = ReactiveUI.Extensions.ReactiveExtensions;
+using PackageObservables = ReactiveUI.Extensions.Observables;
+using PackageObserverExtensions = ReactiveUI.Extensions.ObserverExtensions;
+using PackageSubscriptionExtensions = ReactiveUI.Extensions.ObservableSubscriptionExtensions;
+using PrimitivesContinuation = ReactiveUI.Primitives.Extensions.Continuation;
+using PrimitivesExtensions = ReactiveUI.Primitives.Extensions.ReactiveExtensions;
+using PrimitivesObservables = ReactiveUI.Primitives.Extensions.Observables;
+using PrimitivesObserverExtensions = ReactiveUI.Primitives.Extensions.ObserverExtensions;
+using PrimitivesSubscriptionExtensions = ReactiveUI.Primitives.Extensions.ObservableSubscriptionExtensions;
+using RxObservable = System.Reactive.Linq.Observable;
+using RxUnit = System.Reactive.Unit;
+
+namespace ReactiveUI.Primitives.Benchmarks;
+
+/// <summary>
+/// Benchmarks the complete synchronous ReactiveUI.Primitives.Extensions public helper surface.
+/// </summary>
+public partial class ReactiveExtensionsComparisonBenchmarks
+{
+    /// <summary>
+    /// Executes the <c>RunAsSignal</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunAsSignal</c> result.</returns>
+    private static int RunAsSignal(ExtensionsLibrary library) =>
+        library == ExtensionsLibrary.Primitives
+            ? DrainPrimitiveUnit(PrimitivesExtensions.AsSignal(Range(library)))
+            : DrainPackageUnit(PackageExtensions.AsSignal(Range(library)));
+
+    /// <summary>
+    /// Executes the <c>RunBufferUntil</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunBufferUntil</c> result.</returns>
+    private static int RunBufferUntil(ExtensionsLibrary library) =>
+        library == ExtensionsLibrary.Primitives
+            ? DrainString(PrimitivesExtensions.BufferUntil(PrimitivesExtensions.FromArray(BufferCharacters), '[', ']'))
+            : DrainString(PackageExtensions.BufferUntil(PackageExtensions.FromArray(BufferCharacters), '[', ']'));
+
+    /// <summary>
+    /// Executes the <c>RunBufferUntilIdle</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunBufferUntilIdle</c> result.</returns>
+    private static int RunBufferUntilIdle(ExtensionsLibrary library) =>
+        library == ExtensionsLibrary.Primitives
+            ? DrainList(PrimitivesExtensions.BufferUntilIdle(ArraySource(library), TimeSpan.Zero, Sequencer.Immediate))
+            : DrainList(PackageExtensions.BufferUntilIdle(ArraySource(library), TimeSpan.Zero, ImmediateScheduler.Instance));
+
+    /// <summary>
+    /// Executes the <c>RunBufferUntilInactive</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunBufferUntilInactive</c> result.</returns>
+    private static int RunBufferUntilInactive(ExtensionsLibrary library) =>
+        library == ExtensionsLibrary.Primitives
+            ? DrainList(PrimitivesExtensions.BufferUntilInactive(ArraySource(library), TimeSpan.Zero, Sequencer.Immediate))
+            : DrainList(PackageExtensions.BufferUntilInactive(ArraySource(library), TimeSpan.Zero, ImmediateScheduler.Instance));
+
+    /// <summary>
+    /// Executes the <c>RunCatchAndReturn</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunCatchAndReturn</c> result.</returns>
+    private static int RunCatchAndReturn(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.CatchAndReturn<int, InvalidOperationException>(ThrowInt(library), static _ => Fallback)
+            : PackageExtensions.CatchAndReturn<int, InvalidOperationException>(ThrowInt(library), static _ => Fallback));
+
+    /// <summary>
+    /// Executes the <c>RunCatchIgnore</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunCatchIgnore</c> result.</returns>
+    private static int RunCatchIgnore(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.CatchIgnore<int, InvalidOperationException>(ThrowInt(library), static _ => { })
+            : PackageExtensions.CatchIgnore<int, InvalidOperationException>(ThrowInt(library), static _ => { }));
+
+    /// <summary>
+    /// Executes the <c>RunCatchReturn</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunCatchReturn</c> result.</returns>
+    private static int RunCatchReturn(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.CatchReturn(ThrowInt(library), Fallback)
+            : PackageExtensions.CatchReturn(ThrowInt(library), Fallback));
+
+    /// <summary>
+    /// Executes the <c>RunCatchReturnUnit</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunCatchReturnUnit</c> result.</returns>
+    private static int RunCatchReturnUnit(ExtensionsLibrary library) =>
+        library == ExtensionsLibrary.Primitives
+            ? DrainPrimitiveUnit(PrimitivesExtensions.CatchReturnUnit(ThrowPrimitiveUnit()))
+            : DrainPackageUnit(PackageExtensions.CatchReturnUnit(ThrowPackageUnit()));
+
+    /// <summary>
+    /// Executes the <c>RunCombineLatestValuesAreAllFalse</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunCombineLatestValuesAreAllFalse</c> result.</returns>
+    private static int RunCombineLatestValuesAreAllFalse(ExtensionsLibrary library) =>
+        DrainBool(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.CombineLatestValuesAreAllFalse(BoolSources(library, false))
+            : PackageExtensions.CombineLatestValuesAreAllFalse(BoolSources(library, false)));
+
+    /// <summary>
+    /// Executes the <c>RunCombineLatestValuesAreAllTrue</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunCombineLatestValuesAreAllTrue</c> result.</returns>
+    private static int RunCombineLatestValuesAreAllTrue(ExtensionsLibrary library) =>
+        DrainBool(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.CombineLatestValuesAreAllTrue(BoolSources(library, true))
+            : PackageExtensions.CombineLatestValuesAreAllTrue(BoolSources(library, true)));
+
+    /// <summary>
+    /// Executes the <c>RunConflate</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunConflate</c> result.</returns>
+    private static int RunConflate(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.Conflate(ArraySource(library), TimeSpan.Zero, Sequencer.Immediate)
+            : PackageExtensions.Conflate(ArraySource(library), TimeSpan.Zero, ImmediateScheduler.Instance));
+
+    /// <summary>
+    /// Executes the <c>RunContinuationDispose</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunContinuationDispose</c> result.</returns>
+    private static int RunContinuationDispose(ExtensionsLibrary library)
+    {
+        if (library == ExtensionsLibrary.Primitives)
+        {
+            using var continuation = new PrimitivesContinuation();
+            return (int)continuation.CompletedPhases;
+        }
+
+        using var packageContinuation = new PackageContinuation();
+        return (int)packageContinuation.CompletedPhases;
+    }
+
+    /// <summary>
+    /// Executes the <c>RunContinuationLock</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunContinuationLock</c> result.</returns>
+    private static int RunContinuationLock(ExtensionsLibrary library)
+    {
+        var observer = new TupleObserver<int>();
+        if (library == ExtensionsLibrary.Primitives)
+        {
+            var continuation = new PrimitivesContinuation();
+            var task = continuation.Lock(Value, observer);
+            EnsureCompleted(task);
+            return observer.ItemCount;
+        }
+
+        var packageContinuation = new PackageContinuation();
+        var packageTask = packageContinuation.Lock(Value, observer);
+        EnsureCompleted(packageTask);
+        return observer.ItemCount;
+    }
+
+    /// <summary>
+    /// Executes the <c>RunContinuationLockValueTask</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunContinuationLockValueTask</c> result.</returns>
+    private static int RunContinuationLockValueTask(ExtensionsLibrary library)
+    {
+        var observer = new TupleObserver<int>();
+        if (library == ExtensionsLibrary.Primitives)
+        {
+            var continuation = new PrimitivesContinuation();
+            var task = continuation.LockValueTask(Value, observer);
+            EnsureCompleted(task);
+            return observer.ItemCount;
+        }
+
+        var packageContinuation = new PackageContinuation();
+        var packageTask = packageContinuation.LockValueTask(Value, observer);
+        EnsureCompleted(packageTask);
+        return observer.ItemCount;
+    }
+
+    /// <summary>
+    /// Executes the <c>RunDebounceImmediate</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunDebounceImmediate</c> result.</returns>
+    private static int RunDebounceImmediate(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.DebounceImmediate(ArraySource(library), TimeSpan.Zero, Sequencer.Immediate)
+            : PackageExtensions.DebounceImmediate(ArraySource(library), TimeSpan.Zero, ImmediateScheduler.Instance));
+
+    /// <summary>
+    /// Executes the <c>RunDebounceUntil</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunDebounceUntil</c> result.</returns>
+    private static int RunDebounceUntil(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.DebounceUntil(ArraySource(library), TimeSpan.Zero, static value => value >= Match, Sequencer.Immediate)
+            : PackageExtensions.DebounceUntil(ArraySource(library), TimeSpan.Zero, static value => value >= Match, ImmediateScheduler.Instance));
+
+    /// <summary>
+    /// Executes the <c>RunDetectStale</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunDetectStale</c> result.</returns>
+    private static int RunDetectStale(ExtensionsLibrary library)
+    {
+        if (library == ExtensionsLibrary.Primitives)
+        {
+            var clock = new TestClock();
+            var observer = new CountingSignalObserver<ReactiveUI.Primitives.Extensions.Stale<int>>();
+            using var subscription = PrimitivesExtensions.DetectStale(Signal.Silent<int>(), Tick, clock).Subscribe(observer);
+            clock.AdvanceBy(Tick);
+            return observer.Count + observer.CompletionCount;
+        }
+
+        var scheduler = new HistoricalScheduler();
+        var packageObserver = new CountingSignalObserver<ReactiveUI.Extensions.Stale<int>>();
+        using var packageSubscription = PackageExtensions.DetectStale(RxObservable.Never<int>(), Tick, scheduler)
+            .Subscribe(packageObserver);
+        scheduler.AdvanceBy(Tick);
+        return packageObserver.Count + packageObserver.CompletionCount;
+    }
+
+    /// <summary>
+    /// Executes the <c>RunDoOnDispose</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunDoOnDispose</c> result.</returns>
+    private static int RunDoOnDispose(ExtensionsLibrary library)
+    {
+        var count = 0;
+        using var subscription = (library == ExtensionsLibrary.Primitives
+                ? PrimitivesExtensions.DoOnDispose(ArraySource(library), () => count++)
+                : PackageExtensions.DoOnDispose(ArraySource(library), () => count++))
+            .Subscribe(new IntSignalObserver());
+        return count;
+    }
+
+    /// <summary>
+    /// Executes the <c>RunDoOnSubscribe</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunDoOnSubscribe</c> result.</returns>
+    private static int RunDoOnSubscribe(ExtensionsLibrary library)
+    {
+        var count = 0;
+        var total = DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.DoOnSubscribe(ArraySource(library), () => count++)
+            : PackageExtensions.DoOnSubscribe(ArraySource(library), () => count++));
+        return total + count;
+    }
+
+    /// <summary>
+    /// Executes the <c>RunDropIfBusy</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunDropIfBusy</c> result.</returns>
+    private static int RunDropIfBusy(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.DropIfBusy(ArraySource(library), static _ => default)
+            : PackageExtensions.DropIfBusy(ArraySource(library), static _ => default));
+
+    /// <summary>
+    /// Executes the <c>RunFastForEach</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunFastForEach</c> result.</returns>
+    private static int RunFastForEach(ExtensionsLibrary library)
+    {
+        var observer = new IntSignalObserver();
+        if (library == ExtensionsLibrary.Primitives)
+        {
+            PrimitivesObserverExtensions.FastForEach(observer, Values);
+        }
+        else
+        {
+            PackageObserverExtensions.FastForEach(observer, Values);
+        }
+
+        return observer.Total;
+    }
+
+    /// <summary>
+    /// Executes the <c>RunFilter</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunFilter</c> result.</returns>
+    private static int RunFilter(ExtensionsLibrary library) =>
+        DrainString(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.Filter(PrimitivesExtensions.FromArray(StringValues), EvenRegex())
+            : PackageExtensions.Filter(PackageExtensions.FromArray(StringValues), EvenRegex()));
+
+    /// <summary>
+    /// Executes the <c>RunFirstMatchFromCandidates</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunFirstMatchFromCandidates</c> result.</returns>
+    private static int RunFirstMatchFromCandidates(ExtensionsLibrary library)
+    {
+        var candidates = Values;
+        return DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.FirstMatchFromCandidates(
+                candidates,
+                static value => PrimitivesObservables.Return(value),
+                static value => value * CandidateMultiplier,
+                static value => value >= Match,
+                Fallback)
+            : PackageExtensions.FirstMatchFromCandidates(
+                candidates,
+                static value => PackageObservables.Return(value),
+                static value => value * CandidateMultiplier,
+                static value => value >= Match,
+                Fallback));
+    }
+
+    /// <summary>
+    /// Executes the <c>RunForEach</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunForEach</c> result.</returns>
+    private static int RunForEach(ExtensionsLibrary library)
+    {
+        var batches = new[] { Values };
+        return DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.ForEach(PrimitivesExtensions.FromArray<IEnumerable<int>>(batches), null)
+            : PackageExtensions.ForEach(PackageExtensions.FromArray<IEnumerable<int>>(batches), null));
+    }
+
+    /// <summary>
+    /// Executes the <c>RunFromArray</c> benchmark helper.
+    /// </summary>
+    /// <param name="library)">The <c>library)</c> value.</param>
+    /// <returns>The <c>RunFromArray</c> result.</returns>
+    private static int RunFromArray(ExtensionsLibrary library) => DrainInt(ArraySource(library));
+
+    /// <summary>
+    /// Executes the <c>RunGetMax</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunGetMax</c> result.</returns>
+    private static int RunGetMax(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.GetMax(PrimitivesObservables.Return(FirstValue), PrimitivesObservables.Return(SecondValue))
+            : PackageExtensions.GetMax(PackageObservables.Return(FirstValue), PackageObservables.Return(SecondValue)));
+
+    /// <summary>
+    /// Executes the <c>RunGetMin</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunGetMin</c> result.</returns>
+    private static int RunGetMin(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.GetMin(PrimitivesObservables.Return(FirstValue), PrimitivesObservables.Return(SecondValue))
+            : PackageExtensions.GetMin(PackageObservables.Return(FirstValue), PackageObservables.Return(SecondValue)));
+
+    /// <summary>
+    /// Executes the <c>RunHeartbeat</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunHeartbeat</c> result.</returns>
+    private static int RunHeartbeat(ExtensionsLibrary library)
+    {
+        if (library == ExtensionsLibrary.Primitives)
+        {
+            var clock = new TestClock();
+            var observer = new CountingSignalObserver<ReactiveUI.Primitives.Extensions.Heartbeat<int>>();
+            using var subscription = PrimitivesExtensions.Heartbeat(Signal.Silent<int>(), Tick, clock).Subscribe(observer);
+            clock.AdvanceBy(Tick);
+            return observer.Count + observer.CompletionCount;
+        }
+
+        var scheduler = new HistoricalScheduler();
+        var packageObserver = new CountingSignalObserver<ReactiveUI.Extensions.Heartbeat<int>>();
+        using var packageSubscription = PackageExtensions.Heartbeat(RxObservable.Never<int>(), Tick, scheduler)
+            .Subscribe(packageObserver);
+        scheduler.AdvanceBy(Tick);
+        return packageObserver.Count + packageObserver.CompletionCount;
+    }
+
+    /// <summary>
+    /// Executes the <c>RunLatestOrDefault</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunLatestOrDefault</c> result.</returns>
+    private static int RunLatestOrDefault(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.LatestOrDefault(ArraySource(library), Fallback)
+            : PackageExtensions.LatestOrDefault(ArraySource(library), Fallback));
+
+    /// <summary>
+    /// Executes the <c>RunLogErrors</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunLogErrors</c> result.</returns>
+    private static int RunLogErrors(ExtensionsLibrary library)
+    {
+        var errors = 0;
+        var total = DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.LogErrors(ArraySource(library), _ => errors++)
+            : PackageExtensions.LogErrors(ArraySource(library), _ => errors++));
+        return total + errors;
+    }
+
+    /// <summary>
+    /// Executes the <c>RunNot</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunNot</c> result.</returns>
+    private static int RunNot(ExtensionsLibrary library) =>
+        DrainBool(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.Not(BoolSource(library))
+            : PackageExtensions.Not(BoolSource(library)));
+
+    /// <summary>
+    /// Executes the <c>RunObserveOnIf</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunObserveOnIf</c> result.</returns>
+    private static int RunObserveOnIf(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.ObserveOnIf(ArraySource(library), true, Sequencer.Immediate)
+            : PackageExtensions.ObserveOnIf(ArraySource(library), true, ImmediateScheduler.Instance));
+
+    /// <summary>
+    /// Executes the <c>RunObserveOnSafe</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunObserveOnSafe</c> result.</returns>
+    private static int RunObserveOnSafe(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.ObserveOnSafe(ArraySource(library), Sequencer.Immediate)
+            : PackageExtensions.ObserveOnSafe(ArraySource(library), ImmediateScheduler.Instance));
+
+    /// <summary>
+    /// Executes the <c>RunOnErrorRetry</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunOnErrorRetry</c> result.</returns>
+    private static int RunOnErrorRetry(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.OnErrorRetry<int, InvalidOperationException>(ArraySource(library), static _ => { }, 1, TimeSpan.Zero, Sequencer.Immediate)
+            : PackageExtensions.OnErrorRetry<int, InvalidOperationException>(ArraySource(library), static _ => { }, 1, TimeSpan.Zero, ImmediateScheduler.Instance));
+
+    /// <summary>
+    /// Executes the <c>RunOnNext</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunOnNext</c> result.</returns>
+    private static int RunOnNext(ExtensionsLibrary library)
+    {
+        var observer = new IntSignalObserver();
+        if (library == ExtensionsLibrary.Primitives)
+        {
+            PrimitivesExtensions.OnNext(observer, Values);
+        }
+        else
+        {
+            PackageExtensions.OnNext(observer, Values);
+        }
+
+        return observer.Total;
+    }
+
+    /// <summary>
+    /// Executes the <c>RunPairwise</c> benchmark helper.
+    /// </summary>
+    /// <param name="library">The <c>library</c> value.</param>
+    /// <returns>The <c>RunPairwise</c> result.</returns>
+    private static int RunPairwise(ExtensionsLibrary library)
+    {
+        var observer = new PairObserver();
+        using var subscription = (library == ExtensionsLibrary.Primitives
+                ? PrimitivesExtensions.Pairwise(ArraySource(library))
+                : PackageExtensions.Pairwise(ArraySource(library)))
+            .Subscribe(observer);
+        return observer.Total;
+    }
+}

--- a/src/benchmarks/ReactiveUI.Primitives.Benchmarks/ReactiveExtensionsComparisonBenchmarks.cs
+++ b/src/benchmarks/ReactiveUI.Primitives.Benchmarks/ReactiveExtensionsComparisonBenchmarks.cs
@@ -2,29 +2,7 @@
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-#pragma warning disable CA2012, CS1591, RCS1047, RCS1196, RCS1208, RCS1222, RCS1238, S104, S109, S1128, S1226, S138, S3218, S3358, S4462, S5034, S881, SA1201, SA1600, SA1602, SA1611, SA1615, SA1618, SYSLIB1045
-
-using System.ComponentModel;
-using System.Globalization;
-using System.Reactive.Concurrency;
-using System.Reactive.Linq;
-using System.Reactive.Threading.Tasks;
-using System.Text.RegularExpressions;
 using BenchmarkDotNet.Attributes;
-using ReactiveUI.Primitives.Concurrency;
-using ReactiveUI.Primitives.Signals;
-using PackageContinuation = ReactiveUI.Extensions.Continuation;
-using PackageExtensions = ReactiveUI.Extensions.ReactiveExtensions;
-using PackageObservables = ReactiveUI.Extensions.Observables;
-using PackageObserverExtensions = ReactiveUI.Extensions.ObserverExtensions;
-using PackageSubscriptionExtensions = ReactiveUI.Extensions.ObservableSubscriptionExtensions;
-using PrimitivesContinuation = ReactiveUI.Primitives.Extensions.Continuation;
-using PrimitivesExtensions = ReactiveUI.Primitives.Extensions.ReactiveExtensions;
-using PrimitivesObservables = ReactiveUI.Primitives.Extensions.Observables;
-using PrimitivesObserverExtensions = ReactiveUI.Primitives.Extensions.ObserverExtensions;
-using PrimitivesSubscriptionExtensions = ReactiveUI.Primitives.Extensions.ObservableSubscriptionExtensions;
-using RxObservable = System.Reactive.Linq.Observable;
-using RxUnit = System.Reactive.Unit;
 
 namespace ReactiveUI.Primitives.Benchmarks;
 
@@ -32,29 +10,118 @@ namespace ReactiveUI.Primitives.Benchmarks;
 /// Benchmarks the complete synchronous ReactiveUI.Primitives.Extensions public helper surface.
 /// </summary>
 [MemoryDiagnoser]
-public class ReactiveExtensionsComparisonBenchmarks
+public partial class ReactiveExtensionsComparisonBenchmarks
 {
+    /// <summary>
+    /// The number of values emitted by range-based scenarios.
+    /// </summary>
     private const int Count = 32;
+
+    /// <summary>
+    /// The multiplier used by candidate projection scenarios.
+    /// </summary>
+    private const int CandidateMultiplier = 2;
+
+    /// <summary>
+    /// The divisor used by even-number predicates.
+    /// </summary>
+    private const int EvenDivisor = 2;
+
+    /// <summary>
+    /// The fallback value used by catch and latest scenarios.
+    /// </summary>
     private const int Fallback = 42;
+
+    /// <summary>
+    /// The first scalar value used by min and max comparisons.
+    /// </summary>
+    private const int FirstValue = 1;
+
+    /// <summary>
+    /// The match threshold used by predicate scenarios.
+    /// </summary>
     private const int Match = 8;
+
+    /// <summary>
+    /// The concurrency cap used by concurrent scenarios.
+    /// </summary>
+    private const int MaxConcurrency = 4;
+
+    /// <summary>
+    /// The multiplier used by where-select scenarios.
+    /// </summary>
+    private const int ResultMultiplier = 3;
+
+    /// <summary>
+    /// The second scalar value used by min and max comparisons.
+    /// </summary>
+    private const int SecondValue = 2;
+
+    /// <summary>
+    /// The scalar payload used by single-value scenarios.
+    /// </summary>
     private const int Value = 7;
+
+    /// <summary>
+    /// The scheduler tick used by virtual-time scenarios.
+    /// </summary>
     private static readonly TimeSpan Tick = TimeSpan.FromTicks(1);
 
+    /// <summary>
+    /// The timeout used by blocking subscription helpers.
+    /// </summary>
+    private static readonly TimeSpan WaitTimeout = TimeSpan.FromSeconds(1);
+
+    /// <summary>
+    /// The exception instance used by error-path scenarios.
+    /// </summary>
     private static readonly Exception Boom = new InvalidOperationException("benchmark");
-    private static readonly Regex EvenRegex = new("^[02468]$", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Boolean payloads used by predicate and combine-latest scenarios.
+    /// </summary>
     private static readonly bool[] BooleanValues = [true, false, false, true, false, true, false, false];
+
+    /// <summary>
+    /// Character payloads used by buffer-until scenarios.
+    /// </summary>
     private static readonly char[] BufferCharacters = "xx[abc]yy[de]".ToCharArray();
+
+    /// <summary>
+    /// Integer payloads used by array-backed scenarios.
+    /// </summary>
     private static readonly int[] Values = CreateValues();
+
+    /// <summary>
+    /// Nullable string payloads used by null-filtering scenarios.
+    /// </summary>
     private static readonly string?[] NullableStrings = ["one", null, "two", null, "three"];
+
+    /// <summary>
+    /// String payloads used by skip-while-null scenarios.
+    /// </summary>
     private static readonly string[] SkipStrings = ["one", null!, "two", null!, "three"];
+
+    /// <summary>
+    /// String payloads used by regex filter scenarios.
+    /// </summary>
     private static readonly string[] StringValues = ["0", "1", "2", "3", "4", "5"];
 
+    /// <summary>
+    /// The ReactiveUI.Primitives benchmark scenario list.
+    /// </summary>
     private static readonly ExtensionScenario[] PrimitivesScenarioItems =
         CreateLibraryScenarios(ExtensionsLibrary.Primitives);
 
+    /// <summary>
+    /// The ReactiveUI.Extensions benchmark scenario list.
+    /// </summary>
     private static readonly ExtensionScenario[] PackageScenarioItems =
         CreateLibraryScenarios(ExtensionsLibrary.ReactiveUIExtensions);
 
+    /// <summary>
+    /// The System.Reactive comparison scenario list.
+    /// </summary>
     private static readonly ExtensionScenario[] SystemReactiveScenarioItems =
     [
         Scenario("AsSignal", SystemReactiveAsSignal),
@@ -72,7 +139,7 @@ public class ReactiveExtensionsComparisonBenchmarks
         Scenario("Pairwise", SystemReactivePairwise),
         Scenario("Return", SystemReactiveReturn),
         Scenario("ScanWithInitial", SystemReactiveScanWithInitial),
-        Scenario("SelectAsync", SystemReactiveSelectAsync),
+        Scenario("SelectAsync", SystemReactiveSelectAsyncScenario),
         Scenario("SelectConstant", SystemReactiveSelectConstant),
         Scenario("SelectManyThen", SystemReactiveSelectManyThen),
         Scenario("SkipWhileNull", SystemReactiveSkipWhileNull),
@@ -85,6 +152,9 @@ public class ReactiveExtensionsComparisonBenchmarks
         Scenario("WhereTrue", SystemReactiveWhereTrue),
     ];
 
+    /// <summary>
+    /// The R3 comparison scenario list.
+    /// </summary>
     private static readonly ExtensionScenario[] R3ScenarioItems =
     [
         Scenario("AsSignal", R3AsSignal),
@@ -101,31 +171,95 @@ public class ReactiveExtensionsComparisonBenchmarks
         Scenario("WhereTrue", R3WhereTrue),
     ];
 
+    /// <summary>
+    /// Identifies the library implementation used by paired scenario runners.
+    /// </summary>
+    private enum ExtensionsLibrary
+    {
+        /// <summary>
+        /// The ReactiveUI.Primitives.Extensions implementation.
+        /// </summary>
+        Primitives,
+
+        /// <summary>
+        /// The ReactiveUI.Extensions implementation.
+        /// </summary>
+        ReactiveUIExtensions,
+    }
+
+    /// <summary>
+    /// Gets the ReactiveUI.Primitives scenarios.
+    /// </summary>
     public IEnumerable<ExtensionScenario> PrimitivesScenarios => PrimitivesScenarioItems;
 
+    /// <summary>
+    /// Gets the ReactiveUI.Extensions scenarios.
+    /// </summary>
     public IEnumerable<ExtensionScenario> ReactiveUIExtensionsScenarios => PackageScenarioItems;
 
+    /// <summary>
+    /// Gets the System.Reactive comparison scenarios.
+    /// </summary>
     public IEnumerable<ExtensionScenario> SystemReactiveScenarios => SystemReactiveScenarioItems;
 
+    /// <summary>
+    /// Gets the R3 comparison scenarios.
+    /// </summary>
     public IEnumerable<ExtensionScenario> R3Scenarios => R3ScenarioItems;
 
+    /// <summary>
+    /// Runs a ReactiveUI.Primitives scenario.
+    /// </summary>
+    /// <param name="scenario">The scenario to run.</param>
+    /// <returns>The benchmark checksum.</returns>
     [Benchmark]
     [ArgumentsSource(nameof(PrimitivesScenarios))]
     public int Primitives(ExtensionScenario scenario) => scenario.Run();
 
+    /// <summary>
+    /// Runs a ReactiveUI.Extensions scenario.
+    /// </summary>
+    /// <param name="scenario">The scenario to run.</param>
+    /// <returns>The benchmark checksum.</returns>
     [Benchmark]
     [ArgumentsSource(nameof(ReactiveUIExtensionsScenarios))]
     public int ReactiveUIExtensions(ExtensionScenario scenario) => scenario.Run();
 
+    /// <summary>
+    /// Runs a System.Reactive comparison scenario.
+    /// </summary>
+    /// <param name="scenario">The scenario to run.</param>
+    /// <returns>The benchmark checksum.</returns>
     [Benchmark]
     [ArgumentsSource(nameof(SystemReactiveScenarios))]
     public int SystemReactive(ExtensionScenario scenario) => scenario.Run();
 
+    /// <summary>
+    /// Runs an R3 comparison scenario.
+    /// </summary>
+    /// <param name="scenario">The scenario to run.</param>
+    /// <returns>The benchmark checksum.</returns>
     [Benchmark]
     [ArgumentsSource(nameof(R3Scenarios))]
     public int R3Library(ExtensionScenario scenario) => scenario.Run();
 
+    /// <summary>
+    /// Creates the full paired library scenario list.
+    /// </summary>
+    /// <param name="library">The paired library to benchmark.</param>
+    /// <returns>The scenario list.</returns>
     private static ExtensionScenario[] CreateLibraryScenarios(ExtensionsLibrary library) =>
+    [
+        ..CreateCoreLibraryScenarios(library),
+        ..CreateSupplementalLibraryScenarios(library),
+    ];
+
+    /// <summary>
+    /// Creates the core paired library scenario list.
+    /// </summary>
+    /// <param name="library">The paired library to benchmark.</param>
+    /// <returns>The core scenario list.</returns>
+    private static ExtensionScenario[] CreateCoreLibraryScenarios(ExtensionsLibrary library) =>
     [
         Scenario("AsSignal", () => RunAsSignal(library)),
         Scenario("BufferUntil", () => RunBufferUntil(library)),
@@ -163,6 +297,15 @@ public class ReactiveExtensionsComparisonBenchmarks
         Scenario("OnErrorRetry", () => RunOnErrorRetry(library)),
         Scenario("OnNext", () => RunOnNext(library)),
         Scenario("Pairwise", () => RunPairwise(library)),
+    ];
+
+    /// <summary>
+    /// Creates the supplemental paired library scenario list.
+    /// </summary>
+    /// <param name="library">The paired library to benchmark.</param>
+    /// <returns>The supplemental scenario list.</returns>
+    private static ExtensionScenario[] CreateSupplementalLibraryScenarios(ExtensionsLibrary library) =>
+    [
         Scenario("Partition", () => RunPartition(library)),
         Scenario("ReplayLastOnSubscribe", () => RunReplayLastOnSubscribe(library)),
         Scenario("RetryForeverWithDelay", () => RunRetryForeverWithDelay(library)),
@@ -175,23 +318,23 @@ public class ReactiveExtensionsComparisonBenchmarks
         Scenario("ScanWithInitial", () => RunScanWithInitial(library)),
         Scenario("Schedule", () => RunSchedule(library)),
         Scenario("ScheduleSafe", () => RunScheduleSafe(library)),
-        Scenario("SelectAsync", () => RunSelectAsync(library)),
+        Scenario("SelectAsync", () => RunSelectAsyncScenario(library)),
         Scenario("SelectAsyncConcurrent", () => RunSelectAsyncConcurrent(library)),
         Scenario("SelectAsyncSequential", () => RunSelectAsyncSequential(library)),
         Scenario("SelectConstant", () => RunSelectConstant(library)),
-        Scenario("SelectLatestAsync", () => RunSelectLatestAsync(library)),
+        Scenario("SelectLatestAsync", () => RunSelectLatestAsyncScenario(library)),
         Scenario("SelectManyThen", () => RunSelectManyThen(library)),
         Scenario("Shuffle", () => RunShuffle(library)),
         Scenario("SkipWhileNull", () => RunSkipWhileNull(library)),
         Scenario("Start", () => RunStart(library)),
         Scenario("SubscribeAndComplete", () => RunSubscribeAndComplete(library)),
-        Scenario("SubscribeAsync", () => RunSubscribeAsync(library)),
+        Scenario("SubscribeAsync", () => RunSubscribeAsyncScenario(library)),
         Scenario("SubscribeGetError", () => RunSubscribeGetError(library)),
         Scenario("SubscribeGetValue", () => RunSubscribeGetValue(library)),
         Scenario("SubscribeSynchronous", () => RunSubscribeSynchronous(library)),
         Scenario("SwitchIfEmpty", () => RunSwitchIfEmpty(library)),
         Scenario("SyncTimer", () => RunSyncTimer(library)),
-        Scenario("SynchronizeAsync", () => RunSynchronizeAsync(library)),
+        Scenario("SynchronizeAsync", () => RunSynchronizeAsyncScenario(library)),
         Scenario("SynchronizeSynchronous", () => RunSynchronizeSynchronous(library)),
         Scenario("TakeUntil", () => RunTakeUntil(library)),
         Scenario("ThrottleDistinct", () => RunThrottleDistinct(library)),
@@ -216,1161 +359,11 @@ public class ReactiveExtensionsComparisonBenchmarks
         Scenario("WithLimitedConcurrency", () => RunWithLimitedConcurrency(library)),
     ];
 
+    /// <summary>
+    /// Creates a named benchmark scenario.
+    /// </summary>
+    /// <param name="name">The scenario name.</param>
+    /// <param name="run">The delegate that runs the scenario.</param>
+    /// <returns>The benchmark scenario.</returns>
     private static ExtensionScenario Scenario(string name, Func<int> run) => new(name, run);
-
-    private static int RunAsSignal(ExtensionsLibrary library) =>
-        library == ExtensionsLibrary.Primitives
-            ? DrainPrimitiveUnit(PrimitivesExtensions.AsSignal(Range(library)))
-            : DrainPackageUnit(PackageExtensions.AsSignal(Range(library)));
-
-    private static int RunBufferUntil(ExtensionsLibrary library) =>
-        library == ExtensionsLibrary.Primitives
-            ? DrainString(PrimitivesExtensions.BufferUntil(PrimitivesExtensions.FromArray(BufferCharacters), '[', ']'))
-            : DrainString(PackageExtensions.BufferUntil(PackageExtensions.FromArray(BufferCharacters), '[', ']'));
-
-    private static int RunBufferUntilIdle(ExtensionsLibrary library) =>
-        library == ExtensionsLibrary.Primitives
-            ? DrainList(PrimitivesExtensions.BufferUntilIdle(ArraySource(library), TimeSpan.Zero, Sequencer.Immediate))
-            : DrainList(PackageExtensions.BufferUntilIdle(ArraySource(library), TimeSpan.Zero, ImmediateScheduler.Instance));
-
-    private static int RunBufferUntilInactive(ExtensionsLibrary library) =>
-        library == ExtensionsLibrary.Primitives
-            ? DrainList(PrimitivesExtensions.BufferUntilInactive(ArraySource(library), TimeSpan.Zero, Sequencer.Immediate))
-            : DrainList(PackageExtensions.BufferUntilInactive(ArraySource(library), TimeSpan.Zero, ImmediateScheduler.Instance));
-
-    private static int RunCatchAndReturn(ExtensionsLibrary library) =>
-        DrainInt(library == ExtensionsLibrary.Primitives
-            ? PrimitivesExtensions.CatchAndReturn<int, InvalidOperationException>(ThrowInt(library), static _ => Fallback)
-            : PackageExtensions.CatchAndReturn<int, InvalidOperationException>(ThrowInt(library), static _ => Fallback));
-
-    private static int RunCatchIgnore(ExtensionsLibrary library) =>
-        DrainInt(library == ExtensionsLibrary.Primitives
-            ? PrimitivesExtensions.CatchIgnore<int, InvalidOperationException>(ThrowInt(library), static _ => { })
-            : PackageExtensions.CatchIgnore<int, InvalidOperationException>(ThrowInt(library), static _ => { }));
-
-    private static int RunCatchReturn(ExtensionsLibrary library) =>
-        DrainInt(library == ExtensionsLibrary.Primitives
-            ? PrimitivesExtensions.CatchReturn(ThrowInt(library), Fallback)
-            : PackageExtensions.CatchReturn(ThrowInt(library), Fallback));
-
-    private static int RunCatchReturnUnit(ExtensionsLibrary library) =>
-        library == ExtensionsLibrary.Primitives
-            ? DrainPrimitiveUnit(PrimitivesExtensions.CatchReturnUnit(ThrowPrimitiveUnit()))
-            : DrainPackageUnit(PackageExtensions.CatchReturnUnit(ThrowPackageUnit()));
-
-    private static int RunCombineLatestValuesAreAllFalse(ExtensionsLibrary library) =>
-        DrainBool(library == ExtensionsLibrary.Primitives
-            ? PrimitivesExtensions.CombineLatestValuesAreAllFalse(BoolSources(library, false))
-            : PackageExtensions.CombineLatestValuesAreAllFalse(BoolSources(library, false)));
-
-    private static int RunCombineLatestValuesAreAllTrue(ExtensionsLibrary library) =>
-        DrainBool(library == ExtensionsLibrary.Primitives
-            ? PrimitivesExtensions.CombineLatestValuesAreAllTrue(BoolSources(library, true))
-            : PackageExtensions.CombineLatestValuesAreAllTrue(BoolSources(library, true)));
-
-    private static int RunConflate(ExtensionsLibrary library) =>
-        DrainInt(library == ExtensionsLibrary.Primitives
-            ? PrimitivesExtensions.Conflate(ArraySource(library), TimeSpan.Zero, Sequencer.Immediate)
-            : PackageExtensions.Conflate(ArraySource(library), TimeSpan.Zero, ImmediateScheduler.Instance));
-
-    private static int RunContinuationDispose(ExtensionsLibrary library)
-    {
-        if (library == ExtensionsLibrary.Primitives)
-        {
-            using var continuation = new PrimitivesContinuation();
-            return (int)continuation.CompletedPhases;
-        }
-
-        using var packageContinuation = new PackageContinuation();
-        return (int)packageContinuation.CompletedPhases;
-    }
-
-    private static int RunContinuationLock(ExtensionsLibrary library)
-    {
-        var observer = new TupleObserver<int>();
-        if (library == ExtensionsLibrary.Primitives)
-        {
-            var continuation = new PrimitivesContinuation();
-            var task = continuation.Lock(Value, observer);
-            task.GetAwaiter().GetResult();
-            return observer.Count;
-        }
-
-        var packageContinuation = new PackageContinuation();
-        var packageTask = packageContinuation.Lock(Value, observer);
-        packageTask.GetAwaiter().GetResult();
-        return observer.Count;
-    }
-
-    private static int RunContinuationLockValueTask(ExtensionsLibrary library)
-    {
-        var observer = new TupleObserver<int>();
-        if (library == ExtensionsLibrary.Primitives)
-        {
-            var continuation = new PrimitivesContinuation();
-            var task = continuation.LockValueTask(Value, observer);
-            task.GetAwaiter().GetResult();
-            return observer.Count;
-        }
-
-        var packageContinuation = new PackageContinuation();
-        var packageTask = packageContinuation.LockValueTask(Value, observer);
-        packageTask.GetAwaiter().GetResult();
-        return observer.Count;
-    }
-
-    private static int RunDebounceImmediate(ExtensionsLibrary library) =>
-        DrainInt(library == ExtensionsLibrary.Primitives
-            ? PrimitivesExtensions.DebounceImmediate(ArraySource(library), TimeSpan.Zero, Sequencer.Immediate)
-            : PackageExtensions.DebounceImmediate(ArraySource(library), TimeSpan.Zero, ImmediateScheduler.Instance));
-
-    private static int RunDebounceUntil(ExtensionsLibrary library) =>
-        DrainInt(library == ExtensionsLibrary.Primitives
-            ? PrimitivesExtensions.DebounceUntil(ArraySource(library), TimeSpan.Zero, static value => value >= Match, Sequencer.Immediate)
-            : PackageExtensions.DebounceUntil(ArraySource(library), TimeSpan.Zero, static value => value >= Match, ImmediateScheduler.Instance));
-
-    private static int RunDetectStale(ExtensionsLibrary library)
-    {
-        if (library == ExtensionsLibrary.Primitives)
-        {
-            var clock = new TestClock();
-            var observer = new CountingSignalObserver<ReactiveUI.Primitives.Extensions.Stale<int>>();
-            using var subscription = PrimitivesExtensions.DetectStale(Signal.Silent<int>(), Tick, clock).Subscribe(observer);
-            clock.AdvanceBy(Tick);
-            return observer.Count + observer.CompletionCount;
-        }
-
-        var scheduler = new HistoricalScheduler();
-        var packageObserver = new CountingSignalObserver<ReactiveUI.Extensions.Stale<int>>();
-        using var packageSubscription = PackageExtensions.DetectStale(RxObservable.Never<int>(), Tick, scheduler)
-            .Subscribe(packageObserver);
-        scheduler.AdvanceBy(Tick);
-        return packageObserver.Count + packageObserver.CompletionCount;
-    }
-
-    private static int RunDoOnDispose(ExtensionsLibrary library)
-    {
-        var count = 0;
-        using var subscription = (library == ExtensionsLibrary.Primitives
-                ? PrimitivesExtensions.DoOnDispose(ArraySource(library), () => count++)
-                : PackageExtensions.DoOnDispose(ArraySource(library), () => count++))
-            .Subscribe(new IntSignalObserver());
-        return count;
-    }
-
-    private static int RunDoOnSubscribe(ExtensionsLibrary library)
-    {
-        var count = 0;
-        var total = DrainInt(library == ExtensionsLibrary.Primitives
-            ? PrimitivesExtensions.DoOnSubscribe(ArraySource(library), () => count++)
-            : PackageExtensions.DoOnSubscribe(ArraySource(library), () => count++));
-        return total + count;
-    }
-
-    private static int RunDropIfBusy(ExtensionsLibrary library) =>
-        DrainInt(library == ExtensionsLibrary.Primitives
-            ? PrimitivesExtensions.DropIfBusy(ArraySource(library), static _ => default)
-            : PackageExtensions.DropIfBusy(ArraySource(library), static _ => default));
-
-    private static int RunFastForEach(ExtensionsLibrary library)
-    {
-        var observer = new IntSignalObserver();
-        if (library == ExtensionsLibrary.Primitives)
-        {
-            PrimitivesObserverExtensions.FastForEach(observer, Values);
-        }
-        else
-        {
-            PackageObserverExtensions.FastForEach(observer, Values);
-        }
-
-        return observer.Total;
-    }
-
-    private static int RunFilter(ExtensionsLibrary library) =>
-        DrainString(library == ExtensionsLibrary.Primitives
-            ? PrimitivesExtensions.Filter(PrimitivesExtensions.FromArray(StringValues), EvenRegex)
-            : PackageExtensions.Filter(PackageExtensions.FromArray(StringValues), EvenRegex));
-
-    private static int RunFirstMatchFromCandidates(ExtensionsLibrary library)
-    {
-        var candidates = Values;
-        return DrainInt(library == ExtensionsLibrary.Primitives
-            ? PrimitivesExtensions.FirstMatchFromCandidates(
-                candidates,
-                static value => PrimitivesObservables.Return(value),
-                static value => value * 2,
-                static value => value >= Match,
-                Fallback)
-            : PackageExtensions.FirstMatchFromCandidates(
-                candidates,
-                static value => PackageObservables.Return(value),
-                static value => value * 2,
-                static value => value >= Match,
-                Fallback));
-    }
-
-    private static int RunForEach(ExtensionsLibrary library)
-    {
-        var batches = new[] { Values };
-        return DrainInt(library == ExtensionsLibrary.Primitives
-            ? PrimitivesExtensions.ForEach(PrimitivesExtensions.FromArray<IEnumerable<int>>(batches), null)
-            : PackageExtensions.ForEach(PackageExtensions.FromArray<IEnumerable<int>>(batches), null));
-    }
-
-    private static int RunFromArray(ExtensionsLibrary library) => DrainInt(ArraySource(library));
-
-    private static int RunGetMax(ExtensionsLibrary library) =>
-        DrainInt(library == ExtensionsLibrary.Primitives
-            ? PrimitivesExtensions.GetMax(PrimitivesObservables.Return(1), PrimitivesObservables.Return(2))
-            : PackageExtensions.GetMax(PackageObservables.Return(1), PackageObservables.Return(2)));
-
-    private static int RunGetMin(ExtensionsLibrary library) =>
-        DrainInt(library == ExtensionsLibrary.Primitives
-            ? PrimitivesExtensions.GetMin(PrimitivesObservables.Return(1), PrimitivesObservables.Return(2))
-            : PackageExtensions.GetMin(PackageObservables.Return(1), PackageObservables.Return(2)));
-
-    private static int RunHeartbeat(ExtensionsLibrary library)
-    {
-        if (library == ExtensionsLibrary.Primitives)
-        {
-            var clock = new TestClock();
-            var observer = new CountingSignalObserver<ReactiveUI.Primitives.Extensions.Heartbeat<int>>();
-            using var subscription = PrimitivesExtensions.Heartbeat(Signal.Silent<int>(), Tick, clock).Subscribe(observer);
-            clock.AdvanceBy(Tick);
-            return observer.Count + observer.CompletionCount;
-        }
-
-        var scheduler = new HistoricalScheduler();
-        var packageObserver = new CountingSignalObserver<ReactiveUI.Extensions.Heartbeat<int>>();
-        using var packageSubscription = PackageExtensions.Heartbeat(RxObservable.Never<int>(), Tick, scheduler)
-            .Subscribe(packageObserver);
-        scheduler.AdvanceBy(Tick);
-        return packageObserver.Count + packageObserver.CompletionCount;
-    }
-
-    private static int RunLatestOrDefault(ExtensionsLibrary library) =>
-        DrainInt(library == ExtensionsLibrary.Primitives
-            ? PrimitivesExtensions.LatestOrDefault(ArraySource(library), Fallback)
-            : PackageExtensions.LatestOrDefault(ArraySource(library), Fallback));
-
-    private static int RunLogErrors(ExtensionsLibrary library)
-    {
-        var errors = 0;
-        var total = DrainInt(library == ExtensionsLibrary.Primitives
-            ? PrimitivesExtensions.LogErrors(ArraySource(library), _ => errors++)
-            : PackageExtensions.LogErrors(ArraySource(library), _ => errors++));
-        return total + errors;
-    }
-
-    private static int RunNot(ExtensionsLibrary library) =>
-        DrainBool(library == ExtensionsLibrary.Primitives
-            ? PrimitivesExtensions.Not(BoolSource(library))
-            : PackageExtensions.Not(BoolSource(library)));
-
-    private static int RunObserveOnIf(ExtensionsLibrary library) =>
-        DrainInt(library == ExtensionsLibrary.Primitives
-            ? PrimitivesExtensions.ObserveOnIf(ArraySource(library), true, Sequencer.Immediate)
-            : PackageExtensions.ObserveOnIf(ArraySource(library), true, ImmediateScheduler.Instance));
-
-    private static int RunObserveOnSafe(ExtensionsLibrary library) =>
-        DrainInt(library == ExtensionsLibrary.Primitives
-            ? PrimitivesExtensions.ObserveOnSafe(ArraySource(library), Sequencer.Immediate)
-            : PackageExtensions.ObserveOnSafe(ArraySource(library), ImmediateScheduler.Instance));
-
-    private static int RunOnErrorRetry(ExtensionsLibrary library) =>
-        DrainInt(library == ExtensionsLibrary.Primitives
-            ? PrimitivesExtensions.OnErrorRetry<int, InvalidOperationException>(ArraySource(library), static _ => { }, 1, TimeSpan.Zero, Sequencer.Immediate)
-            : PackageExtensions.OnErrorRetry<int, InvalidOperationException>(ArraySource(library), static _ => { }, 1, TimeSpan.Zero, ImmediateScheduler.Instance));
-
-    private static int RunOnNext(ExtensionsLibrary library)
-    {
-        var observer = new IntSignalObserver();
-        if (library == ExtensionsLibrary.Primitives)
-        {
-            PrimitivesExtensions.OnNext(observer, Values);
-        }
-        else
-        {
-            PackageExtensions.OnNext(observer, Values);
-        }
-
-        return observer.Total;
-    }
-
-    private static int RunPairwise(ExtensionsLibrary library)
-    {
-        var observer = new PairObserver();
-        using var subscription = (library == ExtensionsLibrary.Primitives
-                ? PrimitivesExtensions.Pairwise(ArraySource(library))
-                : PackageExtensions.Pairwise(ArraySource(library)))
-            .Subscribe(observer);
-        return observer.Total;
-    }
-
-    private static int RunPartition(ExtensionsLibrary library)
-    {
-        var observer = new IntSignalObserver();
-        if (library == ExtensionsLibrary.Primitives)
-        {
-            var (even, odd) = PrimitivesExtensions.Partition(ArraySource(library), static value => (value & 1) == 0);
-            using var evenSubscription = even.Subscribe(observer);
-            using var oddSubscription = odd.Subscribe(observer);
-        }
-        else
-        {
-            var (even, odd) = PackageExtensions.Partition(ArraySource(library), static value => (value & 1) == 0);
-            using var evenSubscription = even.Subscribe(observer);
-            using var oddSubscription = odd.Subscribe(observer);
-        }
-
-        return observer.Total;
-    }
-
-    private static int RunReplayLastOnSubscribe(ExtensionsLibrary library) =>
-        DrainInt(library == ExtensionsLibrary.Primitives
-            ? PrimitivesExtensions.ReplayLastOnSubscribe(ArraySource(library), Fallback)
-            : PackageExtensions.ReplayLastOnSubscribe(ArraySource(library), Fallback));
-
-    private static int RunRetryForeverWithDelay(ExtensionsLibrary library) =>
-        DrainInt(library == ExtensionsLibrary.Primitives
-            ? PrimitivesExtensions.RetryForeverWithDelay(ArraySource(library), TimeSpan.Zero)
-            : PackageExtensions.RetryForeverWithDelay(ArraySource(library), TimeSpan.Zero));
-
-    private static int RunRetryWithBackoff(ExtensionsLibrary library) =>
-        DrainInt(library == ExtensionsLibrary.Primitives
-            ? PrimitivesExtensions.RetryWithBackoff(ArraySource(library), 1, TimeSpan.Zero, 1.0, TimeSpan.Zero, Sequencer.Immediate)
-            : PackageExtensions.RetryWithBackoff(ArraySource(library), 1, TimeSpan.Zero, 1.0, TimeSpan.Zero, ImmediateScheduler.Instance));
-
-    private static int RunRetryWithDelay(ExtensionsLibrary library) =>
-        DrainInt(library == ExtensionsLibrary.Primitives
-            ? PrimitivesExtensions.RetryWithDelay(ArraySource(library), 1, static _ => TimeSpan.Zero)
-            : PackageExtensions.RetryWithDelay(ArraySource(library), 1, static _ => TimeSpan.Zero));
-
-    private static int RunRetryWithFixedDelay(ExtensionsLibrary library) =>
-        DrainInt(library == ExtensionsLibrary.Primitives
-            ? PrimitivesExtensions.RetryWithFixedDelay(ArraySource(library), 1, TimeSpan.Zero)
-            : PackageExtensions.RetryWithFixedDelay(ArraySource(library), 1, TimeSpan.Zero));
-
-    private static int RunReturn(ExtensionsLibrary library) =>
-        DrainInt(library == ExtensionsLibrary.Primitives
-            ? PrimitivesObservables.Return(Value)
-            : PackageObservables.Return(Value));
-
-    private static int RunRunAll(ExtensionsLibrary library) =>
-        library == ExtensionsLibrary.Primitives
-            ? DrainPrimitiveUnit(PrimitivesExtensions.RunAll([PrimitivesObservables.Return(RxVoid.Default)]))
-            : DrainPackageUnit(PackageExtensions.RunAll([PackageObservables.Return(RxUnit.Default)]));
-
-    private static int RunSampleLatest(ExtensionsLibrary library) =>
-        DrainInt(library == ExtensionsLibrary.Primitives
-            ? PrimitivesExtensions.SampleLatest(ArraySource(library), PrimitivesExtensions.SelectConstant(ArraySource(library), new object()))
-            : PackageExtensions.SampleLatest(ArraySource(library), PackageExtensions.SelectConstant(ArraySource(library), new object())));
-
-    private static int RunScanWithInitial(ExtensionsLibrary library) =>
-        DrainInt(library == ExtensionsLibrary.Primitives
-            ? PrimitivesExtensions.ScanWithInitial(ArraySource(library), 0, static (acc, value) => acc + value)
-            : PackageExtensions.ScanWithInitial(ArraySource(library), 0, static (acc, value) => acc + value));
-
-    private static int RunSchedule(ExtensionsLibrary library) =>
-        DrainInt(library == ExtensionsLibrary.Primitives
-            ? PrimitivesExtensions.Schedule(Value, Sequencer.Immediate, static value => value + 1)
-            : PackageExtensions.Schedule(Value, ImmediateScheduler.Instance, static value => value + 1));
-
-    private static int RunScheduleSafe(ExtensionsLibrary library)
-    {
-        var count = 0;
-        using var scheduled = library == ExtensionsLibrary.Primitives
-            ? PrimitivesExtensions.ScheduleSafe(Sequencer.Immediate, () => count++)
-            : PackageExtensions.ScheduleSafe(ImmediateScheduler.Instance, () => count++);
-        return count;
-    }
-
-    private static int RunSelectAsync(ExtensionsLibrary library) =>
-        DrainInt(library == ExtensionsLibrary.Primitives
-            ? PrimitivesExtensions.SelectAsync(ArraySource(library), static value => Task.FromResult(value + 1))
-            : PackageExtensions.SelectAsync(ArraySource(library), static value => Task.FromResult(value + 1)));
-
-    private static int RunSelectAsyncConcurrent(ExtensionsLibrary library) =>
-        DrainInt(library == ExtensionsLibrary.Primitives
-            ? PrimitivesExtensions.SelectAsyncConcurrent(ArraySource(library), static value => Task.FromResult(value + 1), 4)
-            : PackageExtensions.SelectAsyncConcurrent(ArraySource(library), static value => Task.FromResult(value + 1), 4));
-
-    private static int RunSelectAsyncSequential(ExtensionsLibrary library) =>
-        DrainInt(library == ExtensionsLibrary.Primitives
-            ? PrimitivesExtensions.SelectAsyncSequential(ArraySource(library), static value => Task.FromResult(value + 1))
-            : PackageExtensions.SelectAsyncSequential(ArraySource(library), static value => Task.FromResult(value + 1)));
-
-    private static int RunSelectConstant(ExtensionsLibrary library) =>
-        DrainInt(library == ExtensionsLibrary.Primitives
-            ? PrimitivesExtensions.SelectConstant(ArraySource(library), Value)
-            : PackageExtensions.SelectConstant(ArraySource(library), Value));
-
-    private static int RunSelectLatestAsync(ExtensionsLibrary library) =>
-        DrainInt(library == ExtensionsLibrary.Primitives
-            ? PrimitivesExtensions.SelectLatestAsync(ArraySource(library), static value => Task.FromResult(value + 1))
-            : PackageExtensions.SelectLatestAsync(ArraySource(library), static value => Task.FromResult(value + 1)));
-
-    private static int RunSelectManyThen(ExtensionsLibrary library) =>
-        DrainInt(library == ExtensionsLibrary.Primitives
-            ? PrimitivesExtensions.SelectManyThen(
-                PrimitivesObservables.Return(Value),
-                static value => PrimitivesObservables.Return(value + 1),
-                static value => PrimitivesObservables.Return(value + 1))
-            : PackageExtensions.SelectManyThen(
-                PackageObservables.Return(Value),
-                static value => PackageObservables.Return(value + 1),
-                static value => PackageObservables.Return(value + 1)));
-
-    private static int RunShuffle(ExtensionsLibrary library) =>
-        DrainArray(library == ExtensionsLibrary.Primitives
-            ? PrimitivesExtensions.Shuffle(PrimitivesObservables.Return(Values))
-            : PackageExtensions.Shuffle(PackageObservables.Return(Values)));
-
-    private static int RunSkipWhileNull(ExtensionsLibrary library) =>
-        DrainString(library == ExtensionsLibrary.Primitives
-            ? PrimitivesExtensions.SkipWhileNull(PrimitivesExtensions.FromArray(SkipStrings))
-            : PackageExtensions.SkipWhileNull(PackageExtensions.FromArray(SkipStrings)));
-
-    private static int RunStart(ExtensionsLibrary library) =>
-        library == ExtensionsLibrary.Primitives
-            ? DrainPrimitiveUnit(PrimitivesExtensions.Start(static () => { }, Sequencer.Immediate))
-            : DrainPackageUnit(PackageExtensions.Start(static () => { }, ImmediateScheduler.Instance));
-
-    private static int RunSubscribeAndComplete(ExtensionsLibrary library)
-    {
-        if (library == ExtensionsLibrary.Primitives)
-        {
-            PrimitivesSubscriptionExtensions.SubscribeAndComplete(PrimitivesObservables.Return(RxVoid.Default));
-        }
-        else
-        {
-            PackageSubscriptionExtensions.SubscribeAndComplete(PackageObservables.Return(RxUnit.Default));
-        }
-
-        return 1;
-    }
-
-    private static int RunSubscribeAsync(ExtensionsLibrary library)
-    {
-        var total = 0;
-        using var subscription = library == ExtensionsLibrary.Primitives
-            ? PrimitivesExtensions.SubscribeAsync(ArraySource(library), value =>
-            {
-                total += value;
-                return default;
-            })
-            : PackageExtensions.SubscribeAsync(ArraySource(library), value =>
-            {
-                total += value;
-                return default;
-            });
-        return total;
-    }
-
-    private static int RunSubscribeGetError(ExtensionsLibrary library) =>
-        library == ExtensionsLibrary.Primitives
-            ? PrimitivesSubscriptionExtensions.SubscribeGetError(ThrowInt(library)) is null ? 0 : 1
-            : PackageSubscriptionExtensions.SubscribeGetError(ThrowInt(library)) is null ? 0 : 1;
-
-    private static int RunSubscribeGetValue(ExtensionsLibrary library) =>
-        library == ExtensionsLibrary.Primitives
-            ? PrimitivesSubscriptionExtensions.SubscribeGetValue(ArraySource(library))
-            : PackageSubscriptionExtensions.SubscribeGetValue(ArraySource(library));
-
-    private static int RunSubscribeSynchronous(ExtensionsLibrary library)
-    {
-        var total = 0;
-        using var subscription = library == ExtensionsLibrary.Primitives
-            ? PrimitivesExtensions.SubscribeSynchronous(ArraySource(library), value =>
-            {
-                total += value;
-                return default;
-            })
-            : PackageExtensions.SubscribeSynchronous(ArraySource(library), value =>
-            {
-                total += value;
-                return default;
-            });
-        return total;
-    }
-
-    private static int RunSwitchIfEmpty(ExtensionsLibrary library) =>
-        DrainInt(library == ExtensionsLibrary.Primitives
-            ? PrimitivesExtensions.SwitchIfEmpty(Signal.None<int>(), PrimitivesObservables.Return(Value))
-            : PackageExtensions.SwitchIfEmpty(RxObservable.Empty<int>(), PackageObservables.Return(Value)));
-
-    private static int RunSyncTimer(ExtensionsLibrary library)
-    {
-        if (library == ExtensionsLibrary.Primitives)
-        {
-            var clock = new TestClock();
-            var observer = new CountingSignalObserver<DateTime>();
-            using var subscription = PrimitivesExtensions.SyncTimer(Tick, clock).Subscribe(observer);
-            clock.AdvanceBy(Tick);
-            return observer.Count + observer.CompletionCount;
-        }
-
-        var scheduler = new HistoricalScheduler();
-        var packageObserver = new CountingSignalObserver<DateTime>();
-        using var packageSubscription = PackageExtensions.SyncTimer(Tick, scheduler).Subscribe(packageObserver);
-        scheduler.AdvanceBy(Tick);
-        return packageObserver.Count + packageObserver.CompletionCount;
-    }
-
-    private static int RunSynchronizeAsync(ExtensionsLibrary library) =>
-        DrainSyncTuple(library == ExtensionsLibrary.Primitives
-            ? PrimitivesExtensions.SynchronizeAsync(ArraySource(library))
-            : PackageExtensions.SynchronizeAsync(ArraySource(library)));
-
-    private static int RunSynchronizeSynchronous(ExtensionsLibrary library) =>
-        DrainSyncTuple(library == ExtensionsLibrary.Primitives
-            ? PrimitivesExtensions.SynchronizeSynchronous(ArraySource(library))
-            : PackageExtensions.SynchronizeSynchronous(ArraySource(library)));
-
-    private static int RunTakeUntil(ExtensionsLibrary library) =>
-        DrainInt(library == ExtensionsLibrary.Primitives
-            ? PrimitivesExtensions.TakeUntil(ArraySource(library), static value => value == Match)
-            : PackageExtensions.TakeUntil(ArraySource(library), static value => value == Match));
-
-    private static int RunThrottleDistinct(ExtensionsLibrary library) =>
-        DrainInt(library == ExtensionsLibrary.Primitives
-            ? PrimitivesExtensions.ThrottleDistinct(ArraySource(library), TimeSpan.Zero, Sequencer.Immediate)
-            : PackageExtensions.ThrottleDistinct(ArraySource(library), TimeSpan.Zero, ImmediateScheduler.Instance));
-
-    private static int RunThrottleFirst(ExtensionsLibrary library) =>
-        DrainInt(library == ExtensionsLibrary.Primitives
-            ? PrimitivesExtensions.ThrottleFirst(ArraySource(library), TimeSpan.Zero, Sequencer.Immediate)
-            : PackageExtensions.ThrottleFirst(ArraySource(library), TimeSpan.Zero, ImmediateScheduler.Instance));
-
-    private static int RunThrottleOnScheduler(ExtensionsLibrary library) =>
-        DrainInt(library == ExtensionsLibrary.Primitives
-            ? PrimitivesExtensions.ThrottleOnScheduler(ArraySource(library), TimeSpan.Zero, Sequencer.Immediate)
-            : PackageExtensions.ThrottleOnScheduler(ArraySource(library), TimeSpan.Zero, ImmediateScheduler.Instance));
-
-    private static int RunThrottleUntilTrue(ExtensionsLibrary library) =>
-        DrainInt(library == ExtensionsLibrary.Primitives
-            ? PrimitivesExtensions.ThrottleUntilTrue(ArraySource(library), TimeSpan.Zero, static value => value >= Match)
-            : PackageExtensions.ThrottleUntilTrue(ArraySource(library), TimeSpan.Zero, static value => value >= Match));
-
-    private static int RunToHotTask(ExtensionsLibrary library) =>
-        library == ExtensionsLibrary.Primitives
-            ? PrimitivesExtensions.ToHotTask(PrimitivesObservables.Return(Value)).GetAwaiter().GetResult()
-            : PackageExtensions.ToHotTask(PackageObservables.Return(Value)).GetAwaiter().GetResult();
-
-    private static int RunToHotValueTask(ExtensionsLibrary library) =>
-        library == ExtensionsLibrary.Primitives
-            ? PrimitivesExtensions.ToHotValueTask(PrimitivesObservables.Return(Value)).GetAwaiter().GetResult()
-            : PackageExtensions.ToHotValueTask(PackageObservables.Return(Value)).GetAwaiter().GetResult();
-
-    private static int RunToPropertyObservable(ExtensionsLibrary library)
-    {
-        var source = new PropertySource();
-        var observer = new IntSignalObserver();
-        using var subscription = (library == ExtensionsLibrary.Primitives
-                ? PrimitivesExtensions.ToPropertyObservable(source, static item => item.Value)
-                : PackageExtensions.ToPropertyObservable(source, static item => item.Value))
-            .Subscribe(observer);
-        source.Value = Value;
-        return observer.Total;
-    }
-
-    private static int RunToReadOnlyBehavior(ExtensionsLibrary library)
-    {
-        var observer = new IntSignalObserver();
-        if (library == ExtensionsLibrary.Primitives)
-        {
-            var behavior = PrimitivesExtensions.ToReadOnlyBehavior(Value);
-            using var subscription = behavior.Observable.Subscribe(observer);
-            behavior.Observer.OnNext(Value + 1);
-        }
-        else
-        {
-            var behavior = PackageExtensions.ToReadOnlyBehavior(Value);
-            using var subscription = behavior.Observable.Subscribe(observer);
-            behavior.Observer.OnNext(Value + 1);
-        }
-
-        return observer.Total;
-    }
-
-    private static int RunTrySelect(ExtensionsLibrary library) =>
-        DrainString(library == ExtensionsLibrary.Primitives
-            ? PrimitivesExtensions.TrySelect<int, string>(ArraySource(library), static value => value % 2 == 0 ? value.ToString(CultureInfo.InvariantCulture) : null)
-            : PackageExtensions.TrySelect<int, string>(ArraySource(library), static value => value % 2 == 0 ? value.ToString(CultureInfo.InvariantCulture) : null));
-
-    private static int RunUsing(ExtensionsLibrary library) =>
-        library == ExtensionsLibrary.Primitives
-            ? DrainPrimitiveUnit(PrimitivesExtensions.Using(new DummyResource(), static resource => resource.Touch()))
-            : DrainPackageUnit(PackageExtensions.Using(new DummyResource(), static resource => resource.Touch()));
-
-    private static int RunWaitForCompletion(ExtensionsLibrary library)
-    {
-        if (library == ExtensionsLibrary.Primitives)
-        {
-            PrimitivesSubscriptionExtensions.WaitForCompletion(PrimitivesObservables.Return(RxVoid.Default), TimeSpan.FromSeconds(1));
-        }
-        else
-        {
-            PackageSubscriptionExtensions.WaitForCompletion(PackageObservables.Return(RxUnit.Default), TimeSpan.FromSeconds(1));
-        }
-
-        return 1;
-    }
-
-    private static int RunWaitForError(ExtensionsLibrary library) =>
-        library == ExtensionsLibrary.Primitives
-            ? PrimitivesSubscriptionExtensions.WaitForError(ThrowInt(library), TimeSpan.FromSeconds(1)) is null ? 0 : 1
-            : PackageSubscriptionExtensions.WaitForError(ThrowInt(library), TimeSpan.FromSeconds(1)) is null ? 0 : 1;
-
-    private static int RunWaitForValue(ExtensionsLibrary library) =>
-        library == ExtensionsLibrary.Primitives
-            ? PrimitivesSubscriptionExtensions.WaitForValue(ArraySource(library), TimeSpan.FromSeconds(1))
-            : PackageSubscriptionExtensions.WaitForValue(ArraySource(library), TimeSpan.FromSeconds(1));
-
-    private static int RunWaitUntil(ExtensionsLibrary library) =>
-        DrainInt(library == ExtensionsLibrary.Primitives
-            ? PrimitivesExtensions.WaitUntil(ArraySource(library), static value => value == Match)
-            : PackageExtensions.WaitUntil(ArraySource(library), static value => value == Match));
-
-    private static int RunWhereFalse(ExtensionsLibrary library) =>
-        DrainBool(library == ExtensionsLibrary.Primitives
-            ? PrimitivesExtensions.WhereFalse(BoolSource(library))
-            : PackageExtensions.WhereFalse(BoolSource(library)));
-
-    private static int RunWhereIsNotNull(ExtensionsLibrary library) =>
-        DrainString(library == ExtensionsLibrary.Primitives
-            ? PrimitivesExtensions.WhereIsNotNull(PrimitivesExtensions.FromArray(NullableStrings))
-            : PackageExtensions.WhereIsNotNull(PackageExtensions.FromArray(NullableStrings)));
-
-    private static int RunWhereSelect(ExtensionsLibrary library) =>
-        DrainInt(library == ExtensionsLibrary.Primitives
-            ? PrimitivesExtensions.WhereSelect(ArraySource(library), static value => (value & 1) == 0, static value => value * 3)
-            : PackageExtensions.WhereSelect(ArraySource(library), static value => (value & 1) == 0, static value => value * 3));
-
-    private static int RunWhereTrue(ExtensionsLibrary library) =>
-        DrainBool(library == ExtensionsLibrary.Primitives
-            ? PrimitivesExtensions.WhereTrue(BoolSource(library))
-            : PackageExtensions.WhereTrue(BoolSource(library)));
-
-    private static int RunWhile(ExtensionsLibrary library)
-    {
-        var remaining = Count;
-        var total = 0;
-        return library == ExtensionsLibrary.Primitives
-            ? DrainPrimitiveUnit(PrimitivesExtensions.While(() => remaining-- > 0, () => total++)) + total
-            : DrainPackageUnit(PackageExtensions.While(() => remaining-- > 0, () => total++)) + total;
-    }
-
-    private static int RunWithLimitedConcurrency(ExtensionsLibrary library) =>
-        DrainInt(library == ExtensionsLibrary.Primitives
-            ? PrimitivesExtensions.WithLimitedConcurrency(CompletedTasks(), 4)
-            : PackageExtensions.WithLimitedConcurrency(CompletedTasks(), 4));
-
-    private static int SystemReactiveAsSignal() =>
-        DrainPrimitiveUnit(RxObservable.Range(0, Count).Select(static _ => RxVoid.Default));
-
-    private static int SystemReactiveCatchAndReturn() =>
-        DrainInt(RxObservable.Throw<int>(Boom).Catch(RxObservable.Return(Fallback)));
-
-    private static int SystemReactiveCatchIgnore() =>
-        DrainInt(RxObservable.Throw<int>(Boom).Catch(RxObservable.Empty<int>()));
-
-    private static int SystemReactiveCombineLatestValuesAreAllFalse() =>
-        DrainBool(BoolSources(ExtensionsLibrary.ReactiveUIExtensions, false).CombineLatest(static values => values.All(static value => !value)));
-
-    private static int SystemReactiveCombineLatestValuesAreAllTrue() =>
-        DrainBool(BoolSources(ExtensionsLibrary.ReactiveUIExtensions, true).CombineLatest(static values => values.All(static value => value)));
-
-    private static int SystemReactiveFilter() =>
-        DrainString(RxObservable.ToObservable(StringValues).Where(value => EvenRegex.IsMatch(value)));
-
-    private static int SystemReactiveForEach() =>
-        DrainInt(RxObservable.Return(Values.AsEnumerable()).SelectMany(static values => values));
-
-    private static int SystemReactiveFromArray() =>
-        DrainInt(RxObservable.ToObservable(Values));
-
-    private static int SystemReactiveGetMax() =>
-        DrainInt(RxObservable.CombineLatest(RxObservable.Return(1), RxObservable.Return(2), static (left, right) => Math.Max(left, right)));
-
-    private static int SystemReactiveGetMin() =>
-        DrainInt(RxObservable.CombineLatest(RxObservable.Return(1), RxObservable.Return(2), static (left, right) => Math.Min(left, right)));
-
-    private static int SystemReactiveNot() =>
-        DrainBool(RxObservable.ToObservable(BooleanValues).Select(static value => !value));
-
-    private static int SystemReactivePairwise()
-    {
-        var observer = new PairObserver();
-        using var subscription = RxObservable.Range(0, Count)
-            .Buffer(2, 1)
-            .Where(static values => values.Count == 2)
-            .Select(static values => (Previous: values[0], Current: values[1]))
-            .Subscribe(observer);
-        return observer.Total;
-    }
-
-    private static int SystemReactiveReturn() =>
-        DrainInt(RxObservable.Return(Value));
-
-    private static int SystemReactiveScanWithInitial() =>
-        DrainInt(RxObservable.Range(0, Count).Scan(0, static (acc, value) => acc + value));
-
-    private static int SystemReactiveSelectAsync() =>
-        DrainInt(RxObservable.Range(0, Count).SelectMany(static value => RxObservable.FromAsync(() => Task.FromResult(value + 1))));
-
-    private static int SystemReactiveSelectConstant() =>
-        DrainInt(RxObservable.Range(0, Count).Select(static _ => Value));
-
-    private static int SystemReactiveSelectManyThen() =>
-        DrainInt(RxObservable.Return(Value)
-            .SelectMany(static value => RxObservable.Return(value + 1))
-            .SelectMany(static value => RxObservable.Return(value + 1)));
-
-    private static int SystemReactiveSkipWhileNull() =>
-        DrainString(RxObservable.ToObservable(NullableStrings).SkipWhile(static value => value is null).Select(static value => value!));
-
-    private static int SystemReactiveTakeUntil() =>
-        DrainInt(RxObservable.Range(0, Count).TakeWhile(static value => value <= Match));
-
-    private static int SystemReactiveToHotTask() =>
-        RxObservable.Return(Value).ToTask().GetAwaiter().GetResult();
-
-    private static int SystemReactiveWaitUntil() =>
-        DrainInt(RxObservable.Range(0, Count).FirstAsync(static value => value == Match));
-
-    private static int SystemReactiveWhereFalse() =>
-        DrainBool(RxObservable.ToObservable(BooleanValues).Where(static value => !value));
-
-    private static int SystemReactiveWhereIsNotNull() =>
-        DrainString(RxObservable.ToObservable(NullableStrings).Where(static value => value is not null).Select(static value => value!));
-
-    private static int SystemReactiveWhereSelect() =>
-        DrainInt(RxObservable.Range(0, Count).Where(static value => (value & 1) == 0).Select(static value => value * 3));
-
-    private static int SystemReactiveWhereTrue() =>
-        DrainBool(RxObservable.ToObservable(BooleanValues).Where(static value => value));
-
-    private static int R3AsSignal()
-    {
-        var observer = new IntR3Observer();
-        using var subscription = global::R3.ObservableExtensions.Select(global::R3.Observable.Range(0, Count), static _ => 1).Subscribe(observer);
-        return observer.Total;
-    }
-
-    private static int R3CatchAndReturn()
-    {
-        var observer = new IntR3Observer();
-        using var subscription = global::R3.ObservableExtensions.Catch<int, Exception>(
-                global::R3.Observable.Throw<int>(Boom),
-                static _ => global::R3.Observable.Return(Fallback))
-            .Subscribe(observer);
-        return observer.Total;
-    }
-
-    private static int R3CatchIgnore()
-    {
-        var observer = new IntR3Observer();
-        using var subscription = global::R3.ObservableExtensions.Catch<int, Exception>(
-                global::R3.Observable.Throw<int>(Boom),
-                static _ => global::R3.Observable.Empty<int>())
-            .Subscribe(observer);
-        return observer.Total;
-    }
-
-    private static int R3FromArray()
-    {
-        var observer = new IntR3Observer();
-        using var subscription = global::R3.Observable.ToObservable(Values, CancellationToken.None).Subscribe(observer);
-        return observer.Total;
-    }
-
-    private static int R3Not()
-    {
-        var observer = new R3BoolObserver();
-        using var subscription = global::R3.ObservableExtensions.Select(
-                global::R3.Observable.ToObservable(BooleanValues, CancellationToken.None),
-                static value => !value)
-            .Subscribe(observer);
-        return observer.Total;
-    }
-
-    private static int R3Return()
-    {
-        var observer = new IntR3Observer();
-        using var subscription = global::R3.Observable.Return(Value).Subscribe(observer);
-        return observer.Total;
-    }
-
-    private static int R3SelectConstant()
-    {
-        var observer = new IntR3Observer();
-        using var subscription = global::R3.ObservableExtensions.Select(global::R3.Observable.Range(0, Count), static _ => Value).Subscribe(observer);
-        return observer.Total;
-    }
-
-    private static int R3WhereFalse()
-    {
-        var observer = new R3BoolObserver();
-        using var subscription = global::R3.ObservableExtensions.Where(
-                global::R3.Observable.ToObservable(BooleanValues, CancellationToken.None),
-                static value => !value)
-            .Subscribe(observer);
-        return observer.Total;
-    }
-
-    private static int R3WhereIsNotNull()
-    {
-        var observer = new R3CountingObserver<string>();
-        var source = global::R3.Observable.ToObservable(NullableStrings, CancellationToken.None);
-        var filtered = global::R3.ObservableExtensions.Where(source, static value => value is not null);
-        using var subscription = global::R3.ObservableExtensions.Select(filtered, static value => value!).Subscribe(observer);
-        return observer.Count;
-    }
-
-    private static int R3WhereSelect()
-    {
-        var observer = new IntR3Observer();
-        using var subscription = global::R3.ObservableExtensions.Select(
-                global::R3.ObservableExtensions.Where(global::R3.Observable.Range(0, Count), static value => (value & 1) == 0),
-                static value => value * 3)
-            .Subscribe(observer);
-        return observer.Total;
-    }
-
-    private static int R3WhereTrue()
-    {
-        var observer = new R3BoolObserver();
-        using var subscription = global::R3.ObservableExtensions.Where(
-                global::R3.Observable.ToObservable(BooleanValues, CancellationToken.None),
-                static value => value)
-            .Subscribe(observer);
-        return observer.Total;
-    }
-
-    private static IObservable<int> ArraySource(ExtensionsLibrary library) =>
-        library == ExtensionsLibrary.Primitives
-            ? PrimitivesExtensions.FromArray(Values)
-            : PackageExtensions.FromArray(Values);
-
-    private static IObservable<bool> BoolSource(ExtensionsLibrary library) =>
-        library == ExtensionsLibrary.Primitives
-            ? PrimitivesExtensions.FromArray(BooleanValues)
-            : PackageExtensions.FromArray(BooleanValues);
-
-    private static IEnumerable<IObservable<bool>> BoolSources(ExtensionsLibrary library, bool value)
-    {
-        yield return library == ExtensionsLibrary.Primitives
-            ? PrimitivesObservables.Return(value)
-            : PackageObservables.Return(value);
-        yield return library == ExtensionsLibrary.Primitives
-            ? PrimitivesObservables.Return(value)
-            : PackageObservables.Return(value);
-    }
-
-    private static IEnumerable<Task<int>> CompletedTasks()
-    {
-        for (var i = 0; i < Count; i++)
-        {
-            yield return Task.FromResult(i);
-        }
-    }
-
-    private static int[] CreateValues()
-    {
-        var values = new int[Count];
-        for (var i = 0; i < values.Length; i++)
-        {
-            values[i] = i;
-        }
-
-        return values;
-    }
-
-    private static int DrainArray(IObservable<int[]> source)
-    {
-        var observer = new ArrayObserver();
-        using var subscription = source.Subscribe(observer);
-        return observer.Total;
-    }
-
-    private static int DrainBool(IObservable<bool> source)
-    {
-        var observer = new BoolSignalObserver();
-        using var subscription = source.Subscribe(observer);
-        return observer.Total + observer.NextCount;
-    }
-
-    private static int DrainDateTime(IObservable<DateTime> source)
-    {
-        var observer = new CountingSignalObserver<DateTime>();
-        using var subscription = source.Subscribe(observer);
-        return observer.Count + observer.CompletionCount;
-    }
-
-    private static int DrainHeartbeat(IObservable<ReactiveUI.Primitives.Extensions.Heartbeat<int>> source)
-    {
-        var observer = new CountingSignalObserver<ReactiveUI.Primitives.Extensions.Heartbeat<int>>();
-        using var subscription = source.Subscribe(observer);
-        return observer.Count + observer.CompletionCount;
-    }
-
-    private static int DrainInt(IObservable<int> source)
-    {
-        var observer = new IntSignalObserver();
-        using var subscription = source.Subscribe(observer);
-        return observer.Total + observer.NextCount;
-    }
-
-    private static int DrainList(IObservable<IList<int>> source)
-    {
-        var observer = new ListObserver();
-        using var subscription = source.Subscribe(observer);
-        return observer.Total;
-    }
-
-    private static int DrainPackageHeartbeat(IObservable<ReactiveUI.Extensions.Heartbeat<int>> source)
-    {
-        var observer = new CountingSignalObserver<ReactiveUI.Extensions.Heartbeat<int>>();
-        using var subscription = source.Subscribe(observer);
-        return observer.Count + observer.CompletionCount;
-    }
-
-    private static int DrainPackageStale(IObservable<ReactiveUI.Extensions.Stale<int>> source)
-    {
-        var observer = new CountingSignalObserver<ReactiveUI.Extensions.Stale<int>>();
-        using var subscription = source.Subscribe(observer);
-        return observer.Count + observer.CompletionCount;
-    }
-
-    private static int DrainPackageUnit(IObservable<RxUnit> source)
-    {
-        var observer = new CountingSignalObserver<RxUnit>();
-        using var subscription = source.Subscribe(observer);
-        return observer.Count + observer.CompletionCount;
-    }
-
-    private static int DrainPrimitiveUnit(IObservable<RxVoid> source)
-    {
-        var observer = new CountingSignalObserver<RxVoid>();
-        using var subscription = source.Subscribe(observer);
-        return observer.Count + observer.CompletionCount;
-    }
-
-    private static int DrainStale(IObservable<ReactiveUI.Primitives.Extensions.Stale<int>> source)
-    {
-        var observer = new CountingSignalObserver<ReactiveUI.Primitives.Extensions.Stale<int>>();
-        using var subscription = source.Subscribe(observer);
-        return observer.Count + observer.CompletionCount;
-    }
-
-    private static int DrainString(IObservable<string?> source)
-    {
-        var observer = new NullableStringLengthObserver();
-        using var subscription = source.Subscribe(observer);
-        return observer.TotalLength + observer.Count;
-    }
-
-    private static int DrainSyncTuple(IObservable<(int Value, IDisposable Sync)> source)
-    {
-        var observer = new SyncTupleObserver();
-        using var subscription = source.Subscribe(observer);
-        return observer.Total;
-    }
-
-    private static IObservable<int> Range(ExtensionsLibrary library) =>
-        library == ExtensionsLibrary.Primitives
-            ? Signal.Sequence(0, Count)
-            : RxObservable.Range(0, Count);
-
-    private static IObservable<int> ThrowInt(ExtensionsLibrary library) =>
-        library == ExtensionsLibrary.Primitives
-            ? Signal.Fail<int>(Boom)
-            : RxObservable.Throw<int>(Boom);
-
-    private static IObservable<RxUnit> ThrowPackageUnit() => RxObservable.Throw<RxUnit>(Boom);
-
-    private static IObservable<RxVoid> ThrowPrimitiveUnit() => Signal.Fail<RxVoid>(Boom);
-
-    private enum ExtensionsLibrary
-    {
-        Primitives,
-        ReactiveUIExtensions,
-    }
-
-    public sealed class ExtensionScenario(string name, Func<int> run)
-    {
-        public int Run() => run();
-
-        public override string ToString() => name;
-    }
-
-    private sealed class ArrayObserver : IObserver<int[]>
-    {
-        public int Total { get; private set; }
-
-        public void OnNext(int[] value) => Total += value.Length;
-
-        public void OnError(Exception error)
-        {
-        }
-
-        public void OnCompleted()
-        {
-        }
-    }
-
-    private sealed class DummyResource : IDisposable
-    {
-        public int Count { get; private set; }
-
-        public void Dispose()
-        {
-        }
-
-        public void Touch() => Count++;
-    }
-
-    private sealed class ListObserver : IObserver<IList<int>>
-    {
-        public int Total { get; private set; }
-
-        public void OnNext(IList<int> value) => Total += value.Count;
-
-        public void OnError(Exception error)
-        {
-        }
-
-        public void OnCompleted()
-        {
-        }
-    }
-
-    private sealed class NullableStringLengthObserver : IObserver<string?>
-    {
-        public int Count { get; private set; }
-
-        public int TotalLength { get; private set; }
-
-        public void OnNext(string? value)
-        {
-            Count++;
-            TotalLength += value?.Length ?? 0;
-        }
-
-        public void OnError(Exception error)
-        {
-        }
-
-        public void OnCompleted()
-        {
-        }
-    }
-
-    private sealed class PairObserver : IObserver<(int Previous, int Current)>
-    {
-        public int Total { get; private set; }
-
-        public void OnNext((int Previous, int Current) value) => Total += value.Previous + value.Current;
-
-        public void OnError(Exception error)
-        {
-        }
-
-        public void OnCompleted()
-        {
-        }
-    }
-
-    private sealed class PropertySource : INotifyPropertyChanged
-    {
-        private int _value;
-
-        public event PropertyChangedEventHandler? PropertyChanged;
-
-        public int Value
-        {
-            get => _value;
-            set
-            {
-                _value = value;
-                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Value)));
-            }
-        }
-    }
-
-    private sealed class R3BoolObserver : global::R3.Observer<bool>
-    {
-        public int Total { get; private set; }
-
-        protected override void OnNextCore(bool value)
-        {
-            if (value)
-            {
-                Total++;
-            }
-        }
-
-        protected override void OnErrorResumeCore(Exception error)
-        {
-        }
-
-        protected override void OnCompletedCore(global::R3.Result result)
-        {
-        }
-    }
-
-    private sealed class R3CountingObserver<T> : global::R3.Observer<T>
-    {
-        public int Count { get; private set; }
-
-        protected override void OnNextCore(T value) => Count++;
-
-        protected override void OnErrorResumeCore(Exception error)
-        {
-        }
-
-        protected override void OnCompletedCore(global::R3.Result result)
-        {
-        }
-    }
-
-    private sealed class SyncTupleObserver : IObserver<(int Value, IDisposable Sync)>
-    {
-        public int Total { get; private set; }
-
-        public void OnNext((int Value, IDisposable Sync) value)
-        {
-            Total += value.Value;
-            value.Sync.Dispose();
-        }
-
-        public void OnError(Exception error)
-        {
-        }
-
-        public void OnCompleted()
-        {
-        }
-    }
-
-    private sealed class TupleObserver<T> : IObserver<(T Value, IDisposable Sync)>
-    {
-        public int Count { get; private set; }
-
-        public void OnNext((T Value, IDisposable Sync) value)
-        {
-            Count++;
-            value.Sync.Dispose();
-        }
-
-        public void OnError(Exception error)
-        {
-        }
-
-        public void OnCompleted()
-        {
-        }
-    }
 }

--- a/src/benchmarks/ReactiveUI.Primitives.Benchmarks/ReactiveExtensionsComparisonBenchmarks.cs
+++ b/src/benchmarks/ReactiveUI.Primitives.Benchmarks/ReactiveExtensionsComparisonBenchmarks.cs
@@ -2,186 +2,1081 @@
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+#pragma warning disable CA2012, CS1591, RCS1047, RCS1196, RCS1208, RCS1222, RCS1238, S104, S109, S1128, S1226, S138, S3218, S3358, S4462, S5034, S881, SA1201, SA1600, SA1602, SA1611, SA1615, SA1618, SYSLIB1045
+
+using System.ComponentModel;
+using System.Globalization;
+using System.Reactive.Concurrency;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Text.RegularExpressions;
 using BenchmarkDotNet.Attributes;
+using ReactiveUI.Primitives.Concurrency;
 using ReactiveUI.Primitives.Signals;
+using PackageContinuation = ReactiveUI.Extensions.Continuation;
 using PackageExtensions = ReactiveUI.Extensions.ReactiveExtensions;
+using PackageObservables = ReactiveUI.Extensions.Observables;
+using PackageObserverExtensions = ReactiveUI.Extensions.ObserverExtensions;
+using PackageSubscriptionExtensions = ReactiveUI.Extensions.ObservableSubscriptionExtensions;
+using PrimitivesContinuation = ReactiveUI.Primitives.Extensions.Continuation;
 using PrimitivesExtensions = ReactiveUI.Primitives.Extensions.ReactiveExtensions;
+using PrimitivesObservables = ReactiveUI.Primitives.Extensions.Observables;
+using PrimitivesObserverExtensions = ReactiveUI.Primitives.Extensions.ObserverExtensions;
+using PrimitivesSubscriptionExtensions = ReactiveUI.Primitives.Extensions.ObservableSubscriptionExtensions;
 using RxObservable = System.Reactive.Linq.Observable;
+using RxUnit = System.Reactive.Unit;
 
 namespace ReactiveUI.Primitives.Benchmarks;
 
 /// <summary>
-/// Benchmarks the synchronous extension-operator package against ReactiveUI.Extensions 4.0.0.
+/// Benchmarks the complete synchronous ReactiveUI.Primitives.Extensions public helper surface.
 /// </summary>
 [MemoryDiagnoser]
 public class ReactiveExtensionsComparisonBenchmarks
 {
-    /// <summary>
-    /// The number of values produced by range-based benchmarks.
-    /// </summary>
     private const int Count = 32;
+    private const int Fallback = 42;
+    private const int Match = 8;
+    private const int Value = 7;
+    private static readonly TimeSpan Tick = TimeSpan.FromTicks(1);
 
-    /// <summary>
-    /// Source array used by FromArray/FastForEach style benchmarks.
-    /// </summary>
-    private static readonly int[] Values = CreateValues();
-
-    /// <summary>
-    /// Source characters used by delimiter-buffer benchmarks.
-    /// </summary>
-    private static readonly char[] BufferCharacters = "xx[abc]yy[de]".ToCharArray();
-
-    /// <summary>
-    /// Source booleans used by boolean extension benchmarks.
-    /// </summary>
+    private static readonly Exception Boom = new InvalidOperationException("benchmark");
+    private static readonly Regex EvenRegex = new("^[02468]$", RegexOptions.Compiled);
     private static readonly bool[] BooleanValues = [true, false, false, true, false, true, false, false];
+    private static readonly char[] BufferCharacters = "xx[abc]yy[de]".ToCharArray();
+    private static readonly int[] Values = CreateValues();
+    private static readonly string?[] NullableStrings = ["one", null, "two", null, "three"];
+    private static readonly string[] SkipStrings = ["one", null!, "two", null!, "three"];
+    private static readonly string[] StringValues = ["0", "1", "2", "3", "4", "5"];
 
-    /// <summary>
-    /// Compares the fused filter/projection operator over a finite range.
-    /// </summary>
-    /// <returns>The observed value total.</returns>
-    [Benchmark(Baseline = true)]
-    public int PrimitivesWhereSelectRange()
+    private static readonly ExtensionScenario[] PrimitivesScenarioItems =
+        CreateLibraryScenarios(ExtensionsLibrary.Primitives);
+
+    private static readonly ExtensionScenario[] PackageScenarioItems =
+        CreateLibraryScenarios(ExtensionsLibrary.ReactiveUIExtensions);
+
+    private static readonly ExtensionScenario[] SystemReactiveScenarioItems =
+    [
+        Scenario("AsSignal", SystemReactiveAsSignal),
+        Scenario("CatchAndReturn", SystemReactiveCatchAndReturn),
+        Scenario("CatchIgnore", SystemReactiveCatchIgnore),
+        Scenario("CatchReturn", SystemReactiveCatchAndReturn),
+        Scenario("CombineLatestValuesAreAllFalse", SystemReactiveCombineLatestValuesAreAllFalse),
+        Scenario("CombineLatestValuesAreAllTrue", SystemReactiveCombineLatestValuesAreAllTrue),
+        Scenario("Filter", SystemReactiveFilter),
+        Scenario("ForEach", SystemReactiveForEach),
+        Scenario("FromArray", SystemReactiveFromArray),
+        Scenario("GetMax", SystemReactiveGetMax),
+        Scenario("GetMin", SystemReactiveGetMin),
+        Scenario("Not", SystemReactiveNot),
+        Scenario("Pairwise", SystemReactivePairwise),
+        Scenario("Return", SystemReactiveReturn),
+        Scenario("ScanWithInitial", SystemReactiveScanWithInitial),
+        Scenario("SelectAsync", SystemReactiveSelectAsync),
+        Scenario("SelectConstant", SystemReactiveSelectConstant),
+        Scenario("SelectManyThen", SystemReactiveSelectManyThen),
+        Scenario("SkipWhileNull", SystemReactiveSkipWhileNull),
+        Scenario("TakeUntil", SystemReactiveTakeUntil),
+        Scenario("ToHotTask", SystemReactiveToHotTask),
+        Scenario("WaitUntil", SystemReactiveWaitUntil),
+        Scenario("WhereFalse", SystemReactiveWhereFalse),
+        Scenario("WhereIsNotNull", SystemReactiveWhereIsNotNull),
+        Scenario("WhereSelect", SystemReactiveWhereSelect),
+        Scenario("WhereTrue", SystemReactiveWhereTrue),
+    ];
+
+    private static readonly ExtensionScenario[] R3ScenarioItems =
+    [
+        Scenario("AsSignal", R3AsSignal),
+        Scenario("CatchAndReturn", R3CatchAndReturn),
+        Scenario("CatchIgnore", R3CatchIgnore),
+        Scenario("CatchReturn", R3CatchAndReturn),
+        Scenario("FromArray", R3FromArray),
+        Scenario("Not", R3Not),
+        Scenario("Return", R3Return),
+        Scenario("SelectConstant", R3SelectConstant),
+        Scenario("WhereFalse", R3WhereFalse),
+        Scenario("WhereIsNotNull", R3WhereIsNotNull),
+        Scenario("WhereSelect", R3WhereSelect),
+        Scenario("WhereTrue", R3WhereTrue),
+    ];
+
+    public IEnumerable<ExtensionScenario> PrimitivesScenarios => PrimitivesScenarioItems;
+
+    public IEnumerable<ExtensionScenario> ReactiveUIExtensionsScenarios => PackageScenarioItems;
+
+    public IEnumerable<ExtensionScenario> SystemReactiveScenarios => SystemReactiveScenarioItems;
+
+    public IEnumerable<ExtensionScenario> R3Scenarios => R3ScenarioItems;
+
+    [Benchmark]
+    [ArgumentsSource(nameof(PrimitivesScenarios))]
+    public int Primitives(ExtensionScenario scenario) => scenario.Run();
+
+    [Benchmark]
+    [ArgumentsSource(nameof(ReactiveUIExtensionsScenarios))]
+    public int ReactiveUIExtensions(ExtensionScenario scenario) => scenario.Run();
+
+    [Benchmark]
+    [ArgumentsSource(nameof(SystemReactiveScenarios))]
+    public int SystemReactive(ExtensionScenario scenario) => scenario.Run();
+
+    [Benchmark]
+    [ArgumentsSource(nameof(R3Scenarios))]
+    public int R3Library(ExtensionScenario scenario) => scenario.Run();
+
+    private static ExtensionScenario[] CreateLibraryScenarios(ExtensionsLibrary library) =>
+    [
+        Scenario("AsSignal", () => RunAsSignal(library)),
+        Scenario("BufferUntil", () => RunBufferUntil(library)),
+        Scenario("BufferUntilIdle", () => RunBufferUntilIdle(library)),
+        Scenario("BufferUntilInactive", () => RunBufferUntilInactive(library)),
+        Scenario("CatchAndReturn", () => RunCatchAndReturn(library)),
+        Scenario("CatchIgnore", () => RunCatchIgnore(library)),
+        Scenario("CatchReturn", () => RunCatchReturn(library)),
+        Scenario("CatchReturnUnit", () => RunCatchReturnUnit(library)),
+        Scenario("CombineLatestValuesAreAllFalse", () => RunCombineLatestValuesAreAllFalse(library)),
+        Scenario("CombineLatestValuesAreAllTrue", () => RunCombineLatestValuesAreAllTrue(library)),
+        Scenario("Conflate", () => RunConflate(library)),
+        Scenario("Continuation.Dispose", () => RunContinuationDispose(library)),
+        Scenario("Continuation.Lock", () => RunContinuationLock(library)),
+        Scenario("Continuation.LockValueTask", () => RunContinuationLockValueTask(library)),
+        Scenario("DebounceImmediate", () => RunDebounceImmediate(library)),
+        Scenario("DebounceUntil", () => RunDebounceUntil(library)),
+        Scenario("DetectStale", () => RunDetectStale(library)),
+        Scenario("DoOnDispose", () => RunDoOnDispose(library)),
+        Scenario("DoOnSubscribe", () => RunDoOnSubscribe(library)),
+        Scenario("DropIfBusy", () => RunDropIfBusy(library)),
+        Scenario("FastForEach", () => RunFastForEach(library)),
+        Scenario("Filter", () => RunFilter(library)),
+        Scenario("FirstMatchFromCandidates", () => RunFirstMatchFromCandidates(library)),
+        Scenario("ForEach", () => RunForEach(library)),
+        Scenario("FromArray", () => RunFromArray(library)),
+        Scenario("GetMax", () => RunGetMax(library)),
+        Scenario("GetMin", () => RunGetMin(library)),
+        Scenario("Heartbeat", () => RunHeartbeat(library)),
+        Scenario("LatestOrDefault", () => RunLatestOrDefault(library)),
+        Scenario("LogErrors", () => RunLogErrors(library)),
+        Scenario("Not", () => RunNot(library)),
+        Scenario("ObserveOnIf", () => RunObserveOnIf(library)),
+        Scenario("ObserveOnSafe", () => RunObserveOnSafe(library)),
+        Scenario("OnErrorRetry", () => RunOnErrorRetry(library)),
+        Scenario("OnNext", () => RunOnNext(library)),
+        Scenario("Pairwise", () => RunPairwise(library)),
+        Scenario("Partition", () => RunPartition(library)),
+        Scenario("ReplayLastOnSubscribe", () => RunReplayLastOnSubscribe(library)),
+        Scenario("RetryForeverWithDelay", () => RunRetryForeverWithDelay(library)),
+        Scenario("RetryWithBackoff", () => RunRetryWithBackoff(library)),
+        Scenario("RetryWithDelay", () => RunRetryWithDelay(library)),
+        Scenario("RetryWithFixedDelay", () => RunRetryWithFixedDelay(library)),
+        Scenario("Return", () => RunReturn(library)),
+        Scenario("RunAll", () => RunRunAll(library)),
+        Scenario("SampleLatest", () => RunSampleLatest(library)),
+        Scenario("ScanWithInitial", () => RunScanWithInitial(library)),
+        Scenario("Schedule", () => RunSchedule(library)),
+        Scenario("ScheduleSafe", () => RunScheduleSafe(library)),
+        Scenario("SelectAsync", () => RunSelectAsync(library)),
+        Scenario("SelectAsyncConcurrent", () => RunSelectAsyncConcurrent(library)),
+        Scenario("SelectAsyncSequential", () => RunSelectAsyncSequential(library)),
+        Scenario("SelectConstant", () => RunSelectConstant(library)),
+        Scenario("SelectLatestAsync", () => RunSelectLatestAsync(library)),
+        Scenario("SelectManyThen", () => RunSelectManyThen(library)),
+        Scenario("Shuffle", () => RunShuffle(library)),
+        Scenario("SkipWhileNull", () => RunSkipWhileNull(library)),
+        Scenario("Start", () => RunStart(library)),
+        Scenario("SubscribeAndComplete", () => RunSubscribeAndComplete(library)),
+        Scenario("SubscribeAsync", () => RunSubscribeAsync(library)),
+        Scenario("SubscribeGetError", () => RunSubscribeGetError(library)),
+        Scenario("SubscribeGetValue", () => RunSubscribeGetValue(library)),
+        Scenario("SubscribeSynchronous", () => RunSubscribeSynchronous(library)),
+        Scenario("SwitchIfEmpty", () => RunSwitchIfEmpty(library)),
+        Scenario("SyncTimer", () => RunSyncTimer(library)),
+        Scenario("SynchronizeAsync", () => RunSynchronizeAsync(library)),
+        Scenario("SynchronizeSynchronous", () => RunSynchronizeSynchronous(library)),
+        Scenario("TakeUntil", () => RunTakeUntil(library)),
+        Scenario("ThrottleDistinct", () => RunThrottleDistinct(library)),
+        Scenario("ThrottleFirst", () => RunThrottleFirst(library)),
+        Scenario("ThrottleOnScheduler", () => RunThrottleOnScheduler(library)),
+        Scenario("ThrottleUntilTrue", () => RunThrottleUntilTrue(library)),
+        Scenario("ToHotTask", () => RunToHotTask(library)),
+        Scenario("ToHotValueTask", () => RunToHotValueTask(library)),
+        Scenario("ToPropertyObservable", () => RunToPropertyObservable(library)),
+        Scenario("ToReadOnlyBehavior", () => RunToReadOnlyBehavior(library)),
+        Scenario("TrySelect", () => RunTrySelect(library)),
+        Scenario("Using", () => RunUsing(library)),
+        Scenario("WaitForCompletion", () => RunWaitForCompletion(library)),
+        Scenario("WaitForError", () => RunWaitForError(library)),
+        Scenario("WaitForValue", () => RunWaitForValue(library)),
+        Scenario("WaitUntil", () => RunWaitUntil(library)),
+        Scenario("WhereFalse", () => RunWhereFalse(library)),
+        Scenario("WhereIsNotNull", () => RunWhereIsNotNull(library)),
+        Scenario("WhereSelect", () => RunWhereSelect(library)),
+        Scenario("WhereTrue", () => RunWhereTrue(library)),
+        Scenario("While", () => RunWhile(library)),
+        Scenario("WithLimitedConcurrency", () => RunWithLimitedConcurrency(library)),
+    ];
+
+    private static ExtensionScenario Scenario(string name, Func<int> run) => new(name, run);
+
+    private static int RunAsSignal(ExtensionsLibrary library) =>
+        library == ExtensionsLibrary.Primitives
+            ? DrainPrimitiveUnit(PrimitivesExtensions.AsSignal(Range(library)))
+            : DrainPackageUnit(PackageExtensions.AsSignal(Range(library)));
+
+    private static int RunBufferUntil(ExtensionsLibrary library) =>
+        library == ExtensionsLibrary.Primitives
+            ? DrainString(PrimitivesExtensions.BufferUntil(PrimitivesExtensions.FromArray(BufferCharacters), '[', ']'))
+            : DrainString(PackageExtensions.BufferUntil(PackageExtensions.FromArray(BufferCharacters), '[', ']'));
+
+    private static int RunBufferUntilIdle(ExtensionsLibrary library) =>
+        library == ExtensionsLibrary.Primitives
+            ? DrainList(PrimitivesExtensions.BufferUntilIdle(ArraySource(library), TimeSpan.Zero, Sequencer.Immediate))
+            : DrainList(PackageExtensions.BufferUntilIdle(ArraySource(library), TimeSpan.Zero, ImmediateScheduler.Instance));
+
+    private static int RunBufferUntilInactive(ExtensionsLibrary library) =>
+        library == ExtensionsLibrary.Primitives
+            ? DrainList(PrimitivesExtensions.BufferUntilInactive(ArraySource(library), TimeSpan.Zero, Sequencer.Immediate))
+            : DrainList(PackageExtensions.BufferUntilInactive(ArraySource(library), TimeSpan.Zero, ImmediateScheduler.Instance));
+
+    private static int RunCatchAndReturn(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.CatchAndReturn<int, InvalidOperationException>(ThrowInt(library), static _ => Fallback)
+            : PackageExtensions.CatchAndReturn<int, InvalidOperationException>(ThrowInt(library), static _ => Fallback));
+
+    private static int RunCatchIgnore(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.CatchIgnore<int, InvalidOperationException>(ThrowInt(library), static _ => { })
+            : PackageExtensions.CatchIgnore<int, InvalidOperationException>(ThrowInt(library), static _ => { }));
+
+    private static int RunCatchReturn(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.CatchReturn(ThrowInt(library), Fallback)
+            : PackageExtensions.CatchReturn(ThrowInt(library), Fallback));
+
+    private static int RunCatchReturnUnit(ExtensionsLibrary library) =>
+        library == ExtensionsLibrary.Primitives
+            ? DrainPrimitiveUnit(PrimitivesExtensions.CatchReturnUnit(ThrowPrimitiveUnit()))
+            : DrainPackageUnit(PackageExtensions.CatchReturnUnit(ThrowPackageUnit()));
+
+    private static int RunCombineLatestValuesAreAllFalse(ExtensionsLibrary library) =>
+        DrainBool(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.CombineLatestValuesAreAllFalse(BoolSources(library, false))
+            : PackageExtensions.CombineLatestValuesAreAllFalse(BoolSources(library, false)));
+
+    private static int RunCombineLatestValuesAreAllTrue(ExtensionsLibrary library) =>
+        DrainBool(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.CombineLatestValuesAreAllTrue(BoolSources(library, true))
+            : PackageExtensions.CombineLatestValuesAreAllTrue(BoolSources(library, true)));
+
+    private static int RunConflate(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.Conflate(ArraySource(library), TimeSpan.Zero, Sequencer.Immediate)
+            : PackageExtensions.Conflate(ArraySource(library), TimeSpan.Zero, ImmediateScheduler.Instance));
+
+    private static int RunContinuationDispose(ExtensionsLibrary library)
+    {
+        if (library == ExtensionsLibrary.Primitives)
+        {
+            using var continuation = new PrimitivesContinuation();
+            return (int)continuation.CompletedPhases;
+        }
+
+        using var packageContinuation = new PackageContinuation();
+        return (int)packageContinuation.CompletedPhases;
+    }
+
+    private static int RunContinuationLock(ExtensionsLibrary library)
+    {
+        var observer = new TupleObserver<int>();
+        if (library == ExtensionsLibrary.Primitives)
+        {
+            var continuation = new PrimitivesContinuation();
+            var task = continuation.Lock(Value, observer);
+            task.GetAwaiter().GetResult();
+            return observer.Count;
+        }
+
+        var packageContinuation = new PackageContinuation();
+        var packageTask = packageContinuation.Lock(Value, observer);
+        packageTask.GetAwaiter().GetResult();
+        return observer.Count;
+    }
+
+    private static int RunContinuationLockValueTask(ExtensionsLibrary library)
+    {
+        var observer = new TupleObserver<int>();
+        if (library == ExtensionsLibrary.Primitives)
+        {
+            var continuation = new PrimitivesContinuation();
+            var task = continuation.LockValueTask(Value, observer);
+            task.GetAwaiter().GetResult();
+            return observer.Count;
+        }
+
+        var packageContinuation = new PackageContinuation();
+        var packageTask = packageContinuation.LockValueTask(Value, observer);
+        packageTask.GetAwaiter().GetResult();
+        return observer.Count;
+    }
+
+    private static int RunDebounceImmediate(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.DebounceImmediate(ArraySource(library), TimeSpan.Zero, Sequencer.Immediate)
+            : PackageExtensions.DebounceImmediate(ArraySource(library), TimeSpan.Zero, ImmediateScheduler.Instance));
+
+    private static int RunDebounceUntil(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.DebounceUntil(ArraySource(library), TimeSpan.Zero, static value => value >= Match, Sequencer.Immediate)
+            : PackageExtensions.DebounceUntil(ArraySource(library), TimeSpan.Zero, static value => value >= Match, ImmediateScheduler.Instance));
+
+    private static int RunDetectStale(ExtensionsLibrary library)
+    {
+        if (library == ExtensionsLibrary.Primitives)
+        {
+            var clock = new TestClock();
+            var observer = new CountingSignalObserver<ReactiveUI.Primitives.Extensions.Stale<int>>();
+            using var subscription = PrimitivesExtensions.DetectStale(Signal.Silent<int>(), Tick, clock).Subscribe(observer);
+            clock.AdvanceBy(Tick);
+            return observer.Count + observer.CompletionCount;
+        }
+
+        var scheduler = new HistoricalScheduler();
+        var packageObserver = new CountingSignalObserver<ReactiveUI.Extensions.Stale<int>>();
+        using var packageSubscription = PackageExtensions.DetectStale(RxObservable.Never<int>(), Tick, scheduler)
+            .Subscribe(packageObserver);
+        scheduler.AdvanceBy(Tick);
+        return packageObserver.Count + packageObserver.CompletionCount;
+    }
+
+    private static int RunDoOnDispose(ExtensionsLibrary library)
+    {
+        var count = 0;
+        using var subscription = (library == ExtensionsLibrary.Primitives
+                ? PrimitivesExtensions.DoOnDispose(ArraySource(library), () => count++)
+                : PackageExtensions.DoOnDispose(ArraySource(library), () => count++))
+            .Subscribe(new IntSignalObserver());
+        return count;
+    }
+
+    private static int RunDoOnSubscribe(ExtensionsLibrary library)
+    {
+        var count = 0;
+        var total = DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.DoOnSubscribe(ArraySource(library), () => count++)
+            : PackageExtensions.DoOnSubscribe(ArraySource(library), () => count++));
+        return total + count;
+    }
+
+    private static int RunDropIfBusy(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.DropIfBusy(ArraySource(library), static _ => default)
+            : PackageExtensions.DropIfBusy(ArraySource(library), static _ => default));
+
+    private static int RunFastForEach(ExtensionsLibrary library)
     {
         var observer = new IntSignalObserver();
-        using var subscription = PrimitivesExtensions.WhereSelect(
-                Signal.Sequence(0, Count),
-                static value => (value & 1) == 0,
+        if (library == ExtensionsLibrary.Primitives)
+        {
+            PrimitivesObserverExtensions.FastForEach(observer, Values);
+        }
+        else
+        {
+            PackageObserverExtensions.FastForEach(observer, Values);
+        }
+
+        return observer.Total;
+    }
+
+    private static int RunFilter(ExtensionsLibrary library) =>
+        DrainString(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.Filter(PrimitivesExtensions.FromArray(StringValues), EvenRegex)
+            : PackageExtensions.Filter(PackageExtensions.FromArray(StringValues), EvenRegex));
+
+    private static int RunFirstMatchFromCandidates(ExtensionsLibrary library)
+    {
+        var candidates = Values;
+        return DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.FirstMatchFromCandidates(
+                candidates,
+                static value => PrimitivesObservables.Return(value),
+                static value => value * 2,
+                static value => value >= Match,
+                Fallback)
+            : PackageExtensions.FirstMatchFromCandidates(
+                candidates,
+                static value => PackageObservables.Return(value),
+                static value => value * 2,
+                static value => value >= Match,
+                Fallback));
+    }
+
+    private static int RunForEach(ExtensionsLibrary library)
+    {
+        var batches = new[] { Values };
+        return DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.ForEach(PrimitivesExtensions.FromArray<IEnumerable<int>>(batches), null)
+            : PackageExtensions.ForEach(PackageExtensions.FromArray<IEnumerable<int>>(batches), null));
+    }
+
+    private static int RunFromArray(ExtensionsLibrary library) => DrainInt(ArraySource(library));
+
+    private static int RunGetMax(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.GetMax(PrimitivesObservables.Return(1), PrimitivesObservables.Return(2))
+            : PackageExtensions.GetMax(PackageObservables.Return(1), PackageObservables.Return(2)));
+
+    private static int RunGetMin(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.GetMin(PrimitivesObservables.Return(1), PrimitivesObservables.Return(2))
+            : PackageExtensions.GetMin(PackageObservables.Return(1), PackageObservables.Return(2)));
+
+    private static int RunHeartbeat(ExtensionsLibrary library)
+    {
+        if (library == ExtensionsLibrary.Primitives)
+        {
+            var clock = new TestClock();
+            var observer = new CountingSignalObserver<ReactiveUI.Primitives.Extensions.Heartbeat<int>>();
+            using var subscription = PrimitivesExtensions.Heartbeat(Signal.Silent<int>(), Tick, clock).Subscribe(observer);
+            clock.AdvanceBy(Tick);
+            return observer.Count + observer.CompletionCount;
+        }
+
+        var scheduler = new HistoricalScheduler();
+        var packageObserver = new CountingSignalObserver<ReactiveUI.Extensions.Heartbeat<int>>();
+        using var packageSubscription = PackageExtensions.Heartbeat(RxObservable.Never<int>(), Tick, scheduler)
+            .Subscribe(packageObserver);
+        scheduler.AdvanceBy(Tick);
+        return packageObserver.Count + packageObserver.CompletionCount;
+    }
+
+    private static int RunLatestOrDefault(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.LatestOrDefault(ArraySource(library), Fallback)
+            : PackageExtensions.LatestOrDefault(ArraySource(library), Fallback));
+
+    private static int RunLogErrors(ExtensionsLibrary library)
+    {
+        var errors = 0;
+        var total = DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.LogErrors(ArraySource(library), _ => errors++)
+            : PackageExtensions.LogErrors(ArraySource(library), _ => errors++));
+        return total + errors;
+    }
+
+    private static int RunNot(ExtensionsLibrary library) =>
+        DrainBool(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.Not(BoolSource(library))
+            : PackageExtensions.Not(BoolSource(library)));
+
+    private static int RunObserveOnIf(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.ObserveOnIf(ArraySource(library), true, Sequencer.Immediate)
+            : PackageExtensions.ObserveOnIf(ArraySource(library), true, ImmediateScheduler.Instance));
+
+    private static int RunObserveOnSafe(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.ObserveOnSafe(ArraySource(library), Sequencer.Immediate)
+            : PackageExtensions.ObserveOnSafe(ArraySource(library), ImmediateScheduler.Instance));
+
+    private static int RunOnErrorRetry(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.OnErrorRetry<int, InvalidOperationException>(ArraySource(library), static _ => { }, 1, TimeSpan.Zero, Sequencer.Immediate)
+            : PackageExtensions.OnErrorRetry<int, InvalidOperationException>(ArraySource(library), static _ => { }, 1, TimeSpan.Zero, ImmediateScheduler.Instance));
+
+    private static int RunOnNext(ExtensionsLibrary library)
+    {
+        var observer = new IntSignalObserver();
+        if (library == ExtensionsLibrary.Primitives)
+        {
+            PrimitivesExtensions.OnNext(observer, Values);
+        }
+        else
+        {
+            PackageExtensions.OnNext(observer, Values);
+        }
+
+        return observer.Total;
+    }
+
+    private static int RunPairwise(ExtensionsLibrary library)
+    {
+        var observer = new PairObserver();
+        using var subscription = (library == ExtensionsLibrary.Primitives
+                ? PrimitivesExtensions.Pairwise(ArraySource(library))
+                : PackageExtensions.Pairwise(ArraySource(library)))
+            .Subscribe(observer);
+        return observer.Total;
+    }
+
+    private static int RunPartition(ExtensionsLibrary library)
+    {
+        var observer = new IntSignalObserver();
+        if (library == ExtensionsLibrary.Primitives)
+        {
+            var (even, odd) = PrimitivesExtensions.Partition(ArraySource(library), static value => (value & 1) == 0);
+            using var evenSubscription = even.Subscribe(observer);
+            using var oddSubscription = odd.Subscribe(observer);
+        }
+        else
+        {
+            var (even, odd) = PackageExtensions.Partition(ArraySource(library), static value => (value & 1) == 0);
+            using var evenSubscription = even.Subscribe(observer);
+            using var oddSubscription = odd.Subscribe(observer);
+        }
+
+        return observer.Total;
+    }
+
+    private static int RunReplayLastOnSubscribe(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.ReplayLastOnSubscribe(ArraySource(library), Fallback)
+            : PackageExtensions.ReplayLastOnSubscribe(ArraySource(library), Fallback));
+
+    private static int RunRetryForeverWithDelay(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.RetryForeverWithDelay(ArraySource(library), TimeSpan.Zero)
+            : PackageExtensions.RetryForeverWithDelay(ArraySource(library), TimeSpan.Zero));
+
+    private static int RunRetryWithBackoff(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.RetryWithBackoff(ArraySource(library), 1, TimeSpan.Zero, 1.0, TimeSpan.Zero, Sequencer.Immediate)
+            : PackageExtensions.RetryWithBackoff(ArraySource(library), 1, TimeSpan.Zero, 1.0, TimeSpan.Zero, ImmediateScheduler.Instance));
+
+    private static int RunRetryWithDelay(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.RetryWithDelay(ArraySource(library), 1, static _ => TimeSpan.Zero)
+            : PackageExtensions.RetryWithDelay(ArraySource(library), 1, static _ => TimeSpan.Zero));
+
+    private static int RunRetryWithFixedDelay(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.RetryWithFixedDelay(ArraySource(library), 1, TimeSpan.Zero)
+            : PackageExtensions.RetryWithFixedDelay(ArraySource(library), 1, TimeSpan.Zero));
+
+    private static int RunReturn(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesObservables.Return(Value)
+            : PackageObservables.Return(Value));
+
+    private static int RunRunAll(ExtensionsLibrary library) =>
+        library == ExtensionsLibrary.Primitives
+            ? DrainPrimitiveUnit(PrimitivesExtensions.RunAll([PrimitivesObservables.Return(RxVoid.Default)]))
+            : DrainPackageUnit(PackageExtensions.RunAll([PackageObservables.Return(RxUnit.Default)]));
+
+    private static int RunSampleLatest(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.SampleLatest(ArraySource(library), PrimitivesExtensions.SelectConstant(ArraySource(library), new object()))
+            : PackageExtensions.SampleLatest(ArraySource(library), PackageExtensions.SelectConstant(ArraySource(library), new object())));
+
+    private static int RunScanWithInitial(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.ScanWithInitial(ArraySource(library), 0, static (acc, value) => acc + value)
+            : PackageExtensions.ScanWithInitial(ArraySource(library), 0, static (acc, value) => acc + value));
+
+    private static int RunSchedule(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.Schedule(Value, Sequencer.Immediate, static value => value + 1)
+            : PackageExtensions.Schedule(Value, ImmediateScheduler.Instance, static value => value + 1));
+
+    private static int RunScheduleSafe(ExtensionsLibrary library)
+    {
+        var count = 0;
+        using var scheduled = library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.ScheduleSafe(Sequencer.Immediate, () => count++)
+            : PackageExtensions.ScheduleSafe(ImmediateScheduler.Instance, () => count++);
+        return count;
+    }
+
+    private static int RunSelectAsync(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.SelectAsync(ArraySource(library), static value => Task.FromResult(value + 1))
+            : PackageExtensions.SelectAsync(ArraySource(library), static value => Task.FromResult(value + 1)));
+
+    private static int RunSelectAsyncConcurrent(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.SelectAsyncConcurrent(ArraySource(library), static value => Task.FromResult(value + 1), 4)
+            : PackageExtensions.SelectAsyncConcurrent(ArraySource(library), static value => Task.FromResult(value + 1), 4));
+
+    private static int RunSelectAsyncSequential(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.SelectAsyncSequential(ArraySource(library), static value => Task.FromResult(value + 1))
+            : PackageExtensions.SelectAsyncSequential(ArraySource(library), static value => Task.FromResult(value + 1)));
+
+    private static int RunSelectConstant(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.SelectConstant(ArraySource(library), Value)
+            : PackageExtensions.SelectConstant(ArraySource(library), Value));
+
+    private static int RunSelectLatestAsync(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.SelectLatestAsync(ArraySource(library), static value => Task.FromResult(value + 1))
+            : PackageExtensions.SelectLatestAsync(ArraySource(library), static value => Task.FromResult(value + 1)));
+
+    private static int RunSelectManyThen(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.SelectManyThen(
+                PrimitivesObservables.Return(Value),
+                static value => PrimitivesObservables.Return(value + 1),
+                static value => PrimitivesObservables.Return(value + 1))
+            : PackageExtensions.SelectManyThen(
+                PackageObservables.Return(Value),
+                static value => PackageObservables.Return(value + 1),
+                static value => PackageObservables.Return(value + 1)));
+
+    private static int RunShuffle(ExtensionsLibrary library) =>
+        DrainArray(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.Shuffle(PrimitivesObservables.Return(Values))
+            : PackageExtensions.Shuffle(PackageObservables.Return(Values)));
+
+    private static int RunSkipWhileNull(ExtensionsLibrary library) =>
+        DrainString(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.SkipWhileNull(PrimitivesExtensions.FromArray(SkipStrings))
+            : PackageExtensions.SkipWhileNull(PackageExtensions.FromArray(SkipStrings)));
+
+    private static int RunStart(ExtensionsLibrary library) =>
+        library == ExtensionsLibrary.Primitives
+            ? DrainPrimitiveUnit(PrimitivesExtensions.Start(static () => { }, Sequencer.Immediate))
+            : DrainPackageUnit(PackageExtensions.Start(static () => { }, ImmediateScheduler.Instance));
+
+    private static int RunSubscribeAndComplete(ExtensionsLibrary library)
+    {
+        if (library == ExtensionsLibrary.Primitives)
+        {
+            PrimitivesSubscriptionExtensions.SubscribeAndComplete(PrimitivesObservables.Return(RxVoid.Default));
+        }
+        else
+        {
+            PackageSubscriptionExtensions.SubscribeAndComplete(PackageObservables.Return(RxUnit.Default));
+        }
+
+        return 1;
+    }
+
+    private static int RunSubscribeAsync(ExtensionsLibrary library)
+    {
+        var total = 0;
+        using var subscription = library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.SubscribeAsync(ArraySource(library), value =>
+            {
+                total += value;
+                return default;
+            })
+            : PackageExtensions.SubscribeAsync(ArraySource(library), value =>
+            {
+                total += value;
+                return default;
+            });
+        return total;
+    }
+
+    private static int RunSubscribeGetError(ExtensionsLibrary library) =>
+        library == ExtensionsLibrary.Primitives
+            ? PrimitivesSubscriptionExtensions.SubscribeGetError(ThrowInt(library)) is null ? 0 : 1
+            : PackageSubscriptionExtensions.SubscribeGetError(ThrowInt(library)) is null ? 0 : 1;
+
+    private static int RunSubscribeGetValue(ExtensionsLibrary library) =>
+        library == ExtensionsLibrary.Primitives
+            ? PrimitivesSubscriptionExtensions.SubscribeGetValue(ArraySource(library))
+            : PackageSubscriptionExtensions.SubscribeGetValue(ArraySource(library));
+
+    private static int RunSubscribeSynchronous(ExtensionsLibrary library)
+    {
+        var total = 0;
+        using var subscription = library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.SubscribeSynchronous(ArraySource(library), value =>
+            {
+                total += value;
+                return default;
+            })
+            : PackageExtensions.SubscribeSynchronous(ArraySource(library), value =>
+            {
+                total += value;
+                return default;
+            });
+        return total;
+    }
+
+    private static int RunSwitchIfEmpty(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.SwitchIfEmpty(Signal.None<int>(), PrimitivesObservables.Return(Value))
+            : PackageExtensions.SwitchIfEmpty(RxObservable.Empty<int>(), PackageObservables.Return(Value)));
+
+    private static int RunSyncTimer(ExtensionsLibrary library)
+    {
+        if (library == ExtensionsLibrary.Primitives)
+        {
+            var clock = new TestClock();
+            var observer = new CountingSignalObserver<DateTime>();
+            using var subscription = PrimitivesExtensions.SyncTimer(Tick, clock).Subscribe(observer);
+            clock.AdvanceBy(Tick);
+            return observer.Count + observer.CompletionCount;
+        }
+
+        var scheduler = new HistoricalScheduler();
+        var packageObserver = new CountingSignalObserver<DateTime>();
+        using var packageSubscription = PackageExtensions.SyncTimer(Tick, scheduler).Subscribe(packageObserver);
+        scheduler.AdvanceBy(Tick);
+        return packageObserver.Count + packageObserver.CompletionCount;
+    }
+
+    private static int RunSynchronizeAsync(ExtensionsLibrary library) =>
+        DrainSyncTuple(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.SynchronizeAsync(ArraySource(library))
+            : PackageExtensions.SynchronizeAsync(ArraySource(library)));
+
+    private static int RunSynchronizeSynchronous(ExtensionsLibrary library) =>
+        DrainSyncTuple(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.SynchronizeSynchronous(ArraySource(library))
+            : PackageExtensions.SynchronizeSynchronous(ArraySource(library)));
+
+    private static int RunTakeUntil(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.TakeUntil(ArraySource(library), static value => value == Match)
+            : PackageExtensions.TakeUntil(ArraySource(library), static value => value == Match));
+
+    private static int RunThrottleDistinct(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.ThrottleDistinct(ArraySource(library), TimeSpan.Zero, Sequencer.Immediate)
+            : PackageExtensions.ThrottleDistinct(ArraySource(library), TimeSpan.Zero, ImmediateScheduler.Instance));
+
+    private static int RunThrottleFirst(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.ThrottleFirst(ArraySource(library), TimeSpan.Zero, Sequencer.Immediate)
+            : PackageExtensions.ThrottleFirst(ArraySource(library), TimeSpan.Zero, ImmediateScheduler.Instance));
+
+    private static int RunThrottleOnScheduler(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.ThrottleOnScheduler(ArraySource(library), TimeSpan.Zero, Sequencer.Immediate)
+            : PackageExtensions.ThrottleOnScheduler(ArraySource(library), TimeSpan.Zero, ImmediateScheduler.Instance));
+
+    private static int RunThrottleUntilTrue(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.ThrottleUntilTrue(ArraySource(library), TimeSpan.Zero, static value => value >= Match)
+            : PackageExtensions.ThrottleUntilTrue(ArraySource(library), TimeSpan.Zero, static value => value >= Match));
+
+    private static int RunToHotTask(ExtensionsLibrary library) =>
+        library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.ToHotTask(PrimitivesObservables.Return(Value)).GetAwaiter().GetResult()
+            : PackageExtensions.ToHotTask(PackageObservables.Return(Value)).GetAwaiter().GetResult();
+
+    private static int RunToHotValueTask(ExtensionsLibrary library) =>
+        library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.ToHotValueTask(PrimitivesObservables.Return(Value)).GetAwaiter().GetResult()
+            : PackageExtensions.ToHotValueTask(PackageObservables.Return(Value)).GetAwaiter().GetResult();
+
+    private static int RunToPropertyObservable(ExtensionsLibrary library)
+    {
+        var source = new PropertySource();
+        var observer = new IntSignalObserver();
+        using var subscription = (library == ExtensionsLibrary.Primitives
+                ? PrimitivesExtensions.ToPropertyObservable(source, static item => item.Value)
+                : PackageExtensions.ToPropertyObservable(source, static item => item.Value))
+            .Subscribe(observer);
+        source.Value = Value;
+        return observer.Total;
+    }
+
+    private static int RunToReadOnlyBehavior(ExtensionsLibrary library)
+    {
+        var observer = new IntSignalObserver();
+        if (library == ExtensionsLibrary.Primitives)
+        {
+            var behavior = PrimitivesExtensions.ToReadOnlyBehavior(Value);
+            using var subscription = behavior.Observable.Subscribe(observer);
+            behavior.Observer.OnNext(Value + 1);
+        }
+        else
+        {
+            var behavior = PackageExtensions.ToReadOnlyBehavior(Value);
+            using var subscription = behavior.Observable.Subscribe(observer);
+            behavior.Observer.OnNext(Value + 1);
+        }
+
+        return observer.Total;
+    }
+
+    private static int RunTrySelect(ExtensionsLibrary library) =>
+        DrainString(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.TrySelect<int, string>(ArraySource(library), static value => value % 2 == 0 ? value.ToString(CultureInfo.InvariantCulture) : null)
+            : PackageExtensions.TrySelect<int, string>(ArraySource(library), static value => value % 2 == 0 ? value.ToString(CultureInfo.InvariantCulture) : null));
+
+    private static int RunUsing(ExtensionsLibrary library) =>
+        library == ExtensionsLibrary.Primitives
+            ? DrainPrimitiveUnit(PrimitivesExtensions.Using(new DummyResource(), static resource => resource.Touch()))
+            : DrainPackageUnit(PackageExtensions.Using(new DummyResource(), static resource => resource.Touch()));
+
+    private static int RunWaitForCompletion(ExtensionsLibrary library)
+    {
+        if (library == ExtensionsLibrary.Primitives)
+        {
+            PrimitivesSubscriptionExtensions.WaitForCompletion(PrimitivesObservables.Return(RxVoid.Default), TimeSpan.FromSeconds(1));
+        }
+        else
+        {
+            PackageSubscriptionExtensions.WaitForCompletion(PackageObservables.Return(RxUnit.Default), TimeSpan.FromSeconds(1));
+        }
+
+        return 1;
+    }
+
+    private static int RunWaitForError(ExtensionsLibrary library) =>
+        library == ExtensionsLibrary.Primitives
+            ? PrimitivesSubscriptionExtensions.WaitForError(ThrowInt(library), TimeSpan.FromSeconds(1)) is null ? 0 : 1
+            : PackageSubscriptionExtensions.WaitForError(ThrowInt(library), TimeSpan.FromSeconds(1)) is null ? 0 : 1;
+
+    private static int RunWaitForValue(ExtensionsLibrary library) =>
+        library == ExtensionsLibrary.Primitives
+            ? PrimitivesSubscriptionExtensions.WaitForValue(ArraySource(library), TimeSpan.FromSeconds(1))
+            : PackageSubscriptionExtensions.WaitForValue(ArraySource(library), TimeSpan.FromSeconds(1));
+
+    private static int RunWaitUntil(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.WaitUntil(ArraySource(library), static value => value == Match)
+            : PackageExtensions.WaitUntil(ArraySource(library), static value => value == Match));
+
+    private static int RunWhereFalse(ExtensionsLibrary library) =>
+        DrainBool(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.WhereFalse(BoolSource(library))
+            : PackageExtensions.WhereFalse(BoolSource(library)));
+
+    private static int RunWhereIsNotNull(ExtensionsLibrary library) =>
+        DrainString(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.WhereIsNotNull(PrimitivesExtensions.FromArray(NullableStrings))
+            : PackageExtensions.WhereIsNotNull(PackageExtensions.FromArray(NullableStrings)));
+
+    private static int RunWhereSelect(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.WhereSelect(ArraySource(library), static value => (value & 1) == 0, static value => value * 3)
+            : PackageExtensions.WhereSelect(ArraySource(library), static value => (value & 1) == 0, static value => value * 3));
+
+    private static int RunWhereTrue(ExtensionsLibrary library) =>
+        DrainBool(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.WhereTrue(BoolSource(library))
+            : PackageExtensions.WhereTrue(BoolSource(library)));
+
+    private static int RunWhile(ExtensionsLibrary library)
+    {
+        var remaining = Count;
+        var total = 0;
+        return library == ExtensionsLibrary.Primitives
+            ? DrainPrimitiveUnit(PrimitivesExtensions.While(() => remaining-- > 0, () => total++)) + total
+            : DrainPackageUnit(PackageExtensions.While(() => remaining-- > 0, () => total++)) + total;
+    }
+
+    private static int RunWithLimitedConcurrency(ExtensionsLibrary library) =>
+        DrainInt(library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.WithLimitedConcurrency(CompletedTasks(), 4)
+            : PackageExtensions.WithLimitedConcurrency(CompletedTasks(), 4));
+
+    private static int SystemReactiveAsSignal() =>
+        DrainPrimitiveUnit(RxObservable.Range(0, Count).Select(static _ => RxVoid.Default));
+
+    private static int SystemReactiveCatchAndReturn() =>
+        DrainInt(RxObservable.Throw<int>(Boom).Catch(RxObservable.Return(Fallback)));
+
+    private static int SystemReactiveCatchIgnore() =>
+        DrainInt(RxObservable.Throw<int>(Boom).Catch(RxObservable.Empty<int>()));
+
+    private static int SystemReactiveCombineLatestValuesAreAllFalse() =>
+        DrainBool(BoolSources(ExtensionsLibrary.ReactiveUIExtensions, false).CombineLatest(static values => values.All(static value => !value)));
+
+    private static int SystemReactiveCombineLatestValuesAreAllTrue() =>
+        DrainBool(BoolSources(ExtensionsLibrary.ReactiveUIExtensions, true).CombineLatest(static values => values.All(static value => value)));
+
+    private static int SystemReactiveFilter() =>
+        DrainString(RxObservable.ToObservable(StringValues).Where(value => EvenRegex.IsMatch(value)));
+
+    private static int SystemReactiveForEach() =>
+        DrainInt(RxObservable.Return(Values.AsEnumerable()).SelectMany(static values => values));
+
+    private static int SystemReactiveFromArray() =>
+        DrainInt(RxObservable.ToObservable(Values));
+
+    private static int SystemReactiveGetMax() =>
+        DrainInt(RxObservable.CombineLatest(RxObservable.Return(1), RxObservable.Return(2), static (left, right) => Math.Max(left, right)));
+
+    private static int SystemReactiveGetMin() =>
+        DrainInt(RxObservable.CombineLatest(RxObservable.Return(1), RxObservable.Return(2), static (left, right) => Math.Min(left, right)));
+
+    private static int SystemReactiveNot() =>
+        DrainBool(RxObservable.ToObservable(BooleanValues).Select(static value => !value));
+
+    private static int SystemReactivePairwise()
+    {
+        var observer = new PairObserver();
+        using var subscription = RxObservable.Range(0, Count)
+            .Buffer(2, 1)
+            .Where(static values => values.Count == 2)
+            .Select(static values => (Previous: values[0], Current: values[1]))
+            .Subscribe(observer);
+        return observer.Total;
+    }
+
+    private static int SystemReactiveReturn() =>
+        DrainInt(RxObservable.Return(Value));
+
+    private static int SystemReactiveScanWithInitial() =>
+        DrainInt(RxObservable.Range(0, Count).Scan(0, static (acc, value) => acc + value));
+
+    private static int SystemReactiveSelectAsync() =>
+        DrainInt(RxObservable.Range(0, Count).SelectMany(static value => RxObservable.FromAsync(() => Task.FromResult(value + 1))));
+
+    private static int SystemReactiveSelectConstant() =>
+        DrainInt(RxObservable.Range(0, Count).Select(static _ => Value));
+
+    private static int SystemReactiveSelectManyThen() =>
+        DrainInt(RxObservable.Return(Value)
+            .SelectMany(static value => RxObservable.Return(value + 1))
+            .SelectMany(static value => RxObservable.Return(value + 1)));
+
+    private static int SystemReactiveSkipWhileNull() =>
+        DrainString(RxObservable.ToObservable(NullableStrings).SkipWhile(static value => value is null).Select(static value => value!));
+
+    private static int SystemReactiveTakeUntil() =>
+        DrainInt(RxObservable.Range(0, Count).TakeWhile(static value => value <= Match));
+
+    private static int SystemReactiveToHotTask() =>
+        RxObservable.Return(Value).ToTask().GetAwaiter().GetResult();
+
+    private static int SystemReactiveWaitUntil() =>
+        DrainInt(RxObservable.Range(0, Count).FirstAsync(static value => value == Match));
+
+    private static int SystemReactiveWhereFalse() =>
+        DrainBool(RxObservable.ToObservable(BooleanValues).Where(static value => !value));
+
+    private static int SystemReactiveWhereIsNotNull() =>
+        DrainString(RxObservable.ToObservable(NullableStrings).Where(static value => value is not null).Select(static value => value!));
+
+    private static int SystemReactiveWhereSelect() =>
+        DrainInt(RxObservable.Range(0, Count).Where(static value => (value & 1) == 0).Select(static value => value * 3));
+
+    private static int SystemReactiveWhereTrue() =>
+        DrainBool(RxObservable.ToObservable(BooleanValues).Where(static value => value));
+
+    private static int R3AsSignal()
+    {
+        var observer = new IntR3Observer();
+        using var subscription = global::R3.ObservableExtensions.Select(global::R3.Observable.Range(0, Count), static _ => 1).Subscribe(observer);
+        return observer.Total;
+    }
+
+    private static int R3CatchAndReturn()
+    {
+        var observer = new IntR3Observer();
+        using var subscription = global::R3.ObservableExtensions.Catch<int, Exception>(
+                global::R3.Observable.Throw<int>(Boom),
+                static _ => global::R3.Observable.Return(Fallback))
+            .Subscribe(observer);
+        return observer.Total;
+    }
+
+    private static int R3CatchIgnore()
+    {
+        var observer = new IntR3Observer();
+        using var subscription = global::R3.ObservableExtensions.Catch<int, Exception>(
+                global::R3.Observable.Throw<int>(Boom),
+                static _ => global::R3.Observable.Empty<int>())
+            .Subscribe(observer);
+        return observer.Total;
+    }
+
+    private static int R3FromArray()
+    {
+        var observer = new IntR3Observer();
+        using var subscription = global::R3.Observable.ToObservable(Values, CancellationToken.None).Subscribe(observer);
+        return observer.Total;
+    }
+
+    private static int R3Not()
+    {
+        var observer = new R3BoolObserver();
+        using var subscription = global::R3.ObservableExtensions.Select(
+                global::R3.Observable.ToObservable(BooleanValues, CancellationToken.None),
+                static value => !value)
+            .Subscribe(observer);
+        return observer.Total;
+    }
+
+    private static int R3Return()
+    {
+        var observer = new IntR3Observer();
+        using var subscription = global::R3.Observable.Return(Value).Subscribe(observer);
+        return observer.Total;
+    }
+
+    private static int R3SelectConstant()
+    {
+        var observer = new IntR3Observer();
+        using var subscription = global::R3.ObservableExtensions.Select(global::R3.Observable.Range(0, Count), static _ => Value).Subscribe(observer);
+        return observer.Total;
+    }
+
+    private static int R3WhereFalse()
+    {
+        var observer = new R3BoolObserver();
+        using var subscription = global::R3.ObservableExtensions.Where(
+                global::R3.Observable.ToObservable(BooleanValues, CancellationToken.None),
+                static value => !value)
+            .Subscribe(observer);
+        return observer.Total;
+    }
+
+    private static int R3WhereIsNotNull()
+    {
+        var observer = new R3CountingObserver<string>();
+        var source = global::R3.Observable.ToObservable(NullableStrings, CancellationToken.None);
+        var filtered = global::R3.ObservableExtensions.Where(source, static value => value is not null);
+        using var subscription = global::R3.ObservableExtensions.Select(filtered, static value => value!).Subscribe(observer);
+        return observer.Count;
+    }
+
+    private static int R3WhereSelect()
+    {
+        var observer = new IntR3Observer();
+        using var subscription = global::R3.ObservableExtensions.Select(
+                global::R3.ObservableExtensions.Where(global::R3.Observable.Range(0, Count), static value => (value & 1) == 0),
                 static value => value * 3)
             .Subscribe(observer);
         return observer.Total;
     }
 
-    /// <summary>
-    /// Compares the ReactiveUI.Extensions 4.0.0 fused filter/projection operator over a finite range.
-    /// </summary>
-    /// <returns>The observed value total.</returns>
-    [Benchmark]
-    public int PackageWhereSelectRange()
+    private static int R3WhereTrue()
     {
-        var observer = new IntSignalObserver();
-        using var subscription = PackageExtensions.WhereSelect(
-                RxObservable.Range(0, Count),
-                static value => (value & 1) == 0,
-                static value => value * 3)
+        var observer = new R3BoolObserver();
+        using var subscription = global::R3.ObservableExtensions.Where(
+                global::R3.Observable.ToObservable(BooleanValues, CancellationToken.None),
+                static value => value)
             .Subscribe(observer);
         return observer.Total;
     }
 
-    /// <summary>
-    /// Compares the array-to-observable helper over an integer array.
-    /// </summary>
-    /// <returns>The observed value total.</returns>
-    [Benchmark]
-    public int PrimitivesFromArraySubscribe()
+    private static IObservable<int> ArraySource(ExtensionsLibrary library) =>
+        library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.FromArray(Values)
+            : PackageExtensions.FromArray(Values);
+
+    private static IObservable<bool> BoolSource(ExtensionsLibrary library) =>
+        library == ExtensionsLibrary.Primitives
+            ? PrimitivesExtensions.FromArray(BooleanValues)
+            : PackageExtensions.FromArray(BooleanValues);
+
+    private static IEnumerable<IObservable<bool>> BoolSources(ExtensionsLibrary library, bool value)
     {
-        var observer = new IntSignalObserver();
-        using var subscription = PrimitivesExtensions.FromArray(Values).Subscribe(observer);
-        return observer.Total;
+        yield return library == ExtensionsLibrary.Primitives
+            ? PrimitivesObservables.Return(value)
+            : PackageObservables.Return(value);
+        yield return library == ExtensionsLibrary.Primitives
+            ? PrimitivesObservables.Return(value)
+            : PackageObservables.Return(value);
     }
 
-    /// <summary>
-    /// Compares the ReactiveUI.Extensions 4.0.0 array-to-observable helper.
-    /// </summary>
-    /// <returns>The observed value total.</returns>
-    [Benchmark]
-    public int PackageFromArraySubscribe()
+    private static IEnumerable<Task<int>> CompletedTasks()
     {
-        var observer = new IntSignalObserver();
-        using var subscription = PackageExtensions.FromArray(Values).Subscribe(observer);
-        return observer.Total;
+        for (var i = 0; i < Count; i++)
+        {
+            yield return Task.FromResult(i);
+        }
     }
 
-    /// <summary>
-    /// Compares the pairwise operator over a finite range.
-    /// </summary>
-    /// <returns>The aggregate of observed pair values.</returns>
-    [Benchmark]
-    public int PrimitivesPairwiseRange()
-    {
-        var observer = new PairObserver();
-        using var subscription = PrimitivesExtensions.Pairwise(Signal.Sequence(0, Count)).Subscribe(observer);
-        return observer.Total;
-    }
-
-    /// <summary>
-    /// Compares the ReactiveUI.Extensions 4.0.0 pairwise operator over a finite range.
-    /// </summary>
-    /// <returns>The aggregate of observed pair values.</returns>
-    [Benchmark]
-    public int PackagePairwiseRange()
-    {
-        var observer = new PairObserver();
-        using var subscription = PackageExtensions.Pairwise(RxObservable.Range(0, Count)).Subscribe(observer);
-        return observer.Total;
-    }
-
-    /// <summary>
-    /// Compares the delimiter-buffer operator over a finite character stream.
-    /// </summary>
-    /// <returns>The total length of emitted buffers.</returns>
-    [Benchmark]
-    public int PrimitivesBufferUntil()
-    {
-        var observer = new StringLengthObserver();
-        using var subscription = PrimitivesExtensions.BufferUntil(
-                PrimitivesExtensions.FromArray(BufferCharacters),
-                '[',
-                ']')
-            .Subscribe(observer);
-        return observer.TotalLength;
-    }
-
-    /// <summary>
-    /// Compares the ReactiveUI.Extensions 4.0.0 delimiter-buffer operator.
-    /// </summary>
-    /// <returns>The total length of emitted buffers.</returns>
-    [Benchmark]
-    public int PackageBufferUntil()
-    {
-        var observer = new StringLengthObserver();
-        using var subscription = PackageExtensions.BufferUntil(
-                PackageExtensions.FromArray(BufferCharacters),
-                '[',
-                ']')
-            .Subscribe(observer);
-        return observer.TotalLength;
-    }
-
-    /// <summary>
-    /// Compares the boolean negation operator over a finite stream.
-    /// </summary>
-    /// <returns>The number of true values emitted after negation.</returns>
-    [Benchmark]
-    public int PrimitivesNotWhereTrue()
-    {
-        var observer = new BoolSignalObserver();
-        using var subscription = PrimitivesExtensions.WhereTrue(
-                PrimitivesExtensions.Not(
-                    PrimitivesExtensions.FromArray(BooleanValues)))
-            .Subscribe(observer);
-        return observer.Total;
-    }
-
-    /// <summary>
-    /// Compares the ReactiveUI.Extensions 4.0.0 boolean negation and true-filter operators.
-    /// </summary>
-    /// <returns>The number of true values emitted after negation.</returns>
-    [Benchmark]
-    public int PackageNotWhereTrue()
-    {
-        var observer = new BoolSignalObserver();
-        using var subscription = PackageExtensions.WhereTrue(
-                PackageExtensions.Not(
-                    PackageExtensions.FromArray(BooleanValues)))
-            .Subscribe(observer);
-        return observer.Total;
-    }
-
-    /// <summary>
-    /// Creates the shared source array.
-    /// </summary>
-    /// <returns>An array containing values 0..31.</returns>
     private static int[] CreateValues()
     {
         var values = new int[Count];
@@ -193,49 +1088,287 @@ public class ReactiveExtensionsComparisonBenchmarks
         return values;
     }
 
-    /// <summary>
-    /// Observer that aggregates pairwise tuple values.
-    /// </summary>
-    private sealed class PairObserver : IObserver<(int Previous, int Current)>
+    private static int DrainArray(IObservable<int[]> source)
     {
-        /// <summary>
-        /// Gets the aggregate total.
-        /// </summary>
+        var observer = new ArrayObserver();
+        using var subscription = source.Subscribe(observer);
+        return observer.Total;
+    }
+
+    private static int DrainBool(IObservable<bool> source)
+    {
+        var observer = new BoolSignalObserver();
+        using var subscription = source.Subscribe(observer);
+        return observer.Total + observer.NextCount;
+    }
+
+    private static int DrainDateTime(IObservable<DateTime> source)
+    {
+        var observer = new CountingSignalObserver<DateTime>();
+        using var subscription = source.Subscribe(observer);
+        return observer.Count + observer.CompletionCount;
+    }
+
+    private static int DrainHeartbeat(IObservable<ReactiveUI.Primitives.Extensions.Heartbeat<int>> source)
+    {
+        var observer = new CountingSignalObserver<ReactiveUI.Primitives.Extensions.Heartbeat<int>>();
+        using var subscription = source.Subscribe(observer);
+        return observer.Count + observer.CompletionCount;
+    }
+
+    private static int DrainInt(IObservable<int> source)
+    {
+        var observer = new IntSignalObserver();
+        using var subscription = source.Subscribe(observer);
+        return observer.Total + observer.NextCount;
+    }
+
+    private static int DrainList(IObservable<IList<int>> source)
+    {
+        var observer = new ListObserver();
+        using var subscription = source.Subscribe(observer);
+        return observer.Total;
+    }
+
+    private static int DrainPackageHeartbeat(IObservable<ReactiveUI.Extensions.Heartbeat<int>> source)
+    {
+        var observer = new CountingSignalObserver<ReactiveUI.Extensions.Heartbeat<int>>();
+        using var subscription = source.Subscribe(observer);
+        return observer.Count + observer.CompletionCount;
+    }
+
+    private static int DrainPackageStale(IObservable<ReactiveUI.Extensions.Stale<int>> source)
+    {
+        var observer = new CountingSignalObserver<ReactiveUI.Extensions.Stale<int>>();
+        using var subscription = source.Subscribe(observer);
+        return observer.Count + observer.CompletionCount;
+    }
+
+    private static int DrainPackageUnit(IObservable<RxUnit> source)
+    {
+        var observer = new CountingSignalObserver<RxUnit>();
+        using var subscription = source.Subscribe(observer);
+        return observer.Count + observer.CompletionCount;
+    }
+
+    private static int DrainPrimitiveUnit(IObservable<RxVoid> source)
+    {
+        var observer = new CountingSignalObserver<RxVoid>();
+        using var subscription = source.Subscribe(observer);
+        return observer.Count + observer.CompletionCount;
+    }
+
+    private static int DrainStale(IObservable<ReactiveUI.Primitives.Extensions.Stale<int>> source)
+    {
+        var observer = new CountingSignalObserver<ReactiveUI.Primitives.Extensions.Stale<int>>();
+        using var subscription = source.Subscribe(observer);
+        return observer.Count + observer.CompletionCount;
+    }
+
+    private static int DrainString(IObservable<string?> source)
+    {
+        var observer = new NullableStringLengthObserver();
+        using var subscription = source.Subscribe(observer);
+        return observer.TotalLength + observer.Count;
+    }
+
+    private static int DrainSyncTuple(IObservable<(int Value, IDisposable Sync)> source)
+    {
+        var observer = new SyncTupleObserver();
+        using var subscription = source.Subscribe(observer);
+        return observer.Total;
+    }
+
+    private static IObservable<int> Range(ExtensionsLibrary library) =>
+        library == ExtensionsLibrary.Primitives
+            ? Signal.Sequence(0, Count)
+            : RxObservable.Range(0, Count);
+
+    private static IObservable<int> ThrowInt(ExtensionsLibrary library) =>
+        library == ExtensionsLibrary.Primitives
+            ? Signal.Fail<int>(Boom)
+            : RxObservable.Throw<int>(Boom);
+
+    private static IObservable<RxUnit> ThrowPackageUnit() => RxObservable.Throw<RxUnit>(Boom);
+
+    private static IObservable<RxVoid> ThrowPrimitiveUnit() => Signal.Fail<RxVoid>(Boom);
+
+    private enum ExtensionsLibrary
+    {
+        Primitives,
+        ReactiveUIExtensions,
+    }
+
+    public sealed class ExtensionScenario(string name, Func<int> run)
+    {
+        public int Run() => run();
+
+        public override string ToString() => name;
+    }
+
+    private sealed class ArrayObserver : IObserver<int[]>
+    {
         public int Total { get; private set; }
 
-        /// <inheritdoc/>
-        public void OnNext((int Previous, int Current) value) => Total += value.Previous + value.Current;
+        public void OnNext(int[] value) => Total += value.Length;
 
-        /// <inheritdoc/>
         public void OnError(Exception error)
         {
         }
 
-        /// <inheritdoc/>
         public void OnCompleted()
         {
         }
     }
 
-    /// <summary>
-    /// Observer that aggregates emitted string lengths.
-    /// </summary>
-    private sealed class StringLengthObserver : IObserver<string>
+    private sealed class DummyResource : IDisposable
     {
-        /// <summary>
-        /// Gets the combined string length.
-        /// </summary>
-        public int TotalLength { get; private set; }
+        public int Count { get; private set; }
 
-        /// <inheritdoc/>
-        public void OnNext(string value) => TotalLength += value.Length;
+        public void Dispose()
+        {
+        }
 
-        /// <inheritdoc/>
+        public void Touch() => Count++;
+    }
+
+    private sealed class ListObserver : IObserver<IList<int>>
+    {
+        public int Total { get; private set; }
+
+        public void OnNext(IList<int> value) => Total += value.Count;
+
         public void OnError(Exception error)
         {
         }
 
-        /// <inheritdoc/>
+        public void OnCompleted()
+        {
+        }
+    }
+
+    private sealed class NullableStringLengthObserver : IObserver<string?>
+    {
+        public int Count { get; private set; }
+
+        public int TotalLength { get; private set; }
+
+        public void OnNext(string? value)
+        {
+            Count++;
+            TotalLength += value?.Length ?? 0;
+        }
+
+        public void OnError(Exception error)
+        {
+        }
+
+        public void OnCompleted()
+        {
+        }
+    }
+
+    private sealed class PairObserver : IObserver<(int Previous, int Current)>
+    {
+        public int Total { get; private set; }
+
+        public void OnNext((int Previous, int Current) value) => Total += value.Previous + value.Current;
+
+        public void OnError(Exception error)
+        {
+        }
+
+        public void OnCompleted()
+        {
+        }
+    }
+
+    private sealed class PropertySource : INotifyPropertyChanged
+    {
+        private int _value;
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        public int Value
+        {
+            get => _value;
+            set
+            {
+                _value = value;
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Value)));
+            }
+        }
+    }
+
+    private sealed class R3BoolObserver : global::R3.Observer<bool>
+    {
+        public int Total { get; private set; }
+
+        protected override void OnNextCore(bool value)
+        {
+            if (value)
+            {
+                Total++;
+            }
+        }
+
+        protected override void OnErrorResumeCore(Exception error)
+        {
+        }
+
+        protected override void OnCompletedCore(global::R3.Result result)
+        {
+        }
+    }
+
+    private sealed class R3CountingObserver<T> : global::R3.Observer<T>
+    {
+        public int Count { get; private set; }
+
+        protected override void OnNextCore(T value) => Count++;
+
+        protected override void OnErrorResumeCore(Exception error)
+        {
+        }
+
+        protected override void OnCompletedCore(global::R3.Result result)
+        {
+        }
+    }
+
+    private sealed class SyncTupleObserver : IObserver<(int Value, IDisposable Sync)>
+    {
+        public int Total { get; private set; }
+
+        public void OnNext((int Value, IDisposable Sync) value)
+        {
+            Total += value.Value;
+            value.Sync.Dispose();
+        }
+
+        public void OnError(Exception error)
+        {
+        }
+
+        public void OnCompleted()
+        {
+        }
+    }
+
+    private sealed class TupleObserver<T> : IObserver<(T Value, IDisposable Sync)>
+    {
+        public int Count { get; private set; }
+
+        public void OnNext((T Value, IDisposable Sync) value)
+        {
+            Count++;
+            value.Sync.Dispose();
+        }
+
+        public void OnError(Exception error)
+        {
+        }
+
         public void OnCompleted()
         {
         }

--- a/src/benchmarks/ReactiveUI.Primitives.Benchmarks/ReactiveUI.Primitives.Benchmarks.csproj
+++ b/src/benchmarks/ReactiveUI.Primitives.Benchmarks/ReactiveUI.Primitives.Benchmarks.csproj
@@ -6,7 +6,7 @@
     <IsPackable>false</IsPackable>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <RunAnalyzers>true</RunAnalyzers>
-    <NoWarn>$(NoWarn);CA1822</NoWarn>
+    <NoWarn>$(NoWarn);CA1822;CA2012;CS1591;IDE0051;RCS1047;RCS1196;RCS1208;RCS1222;RCS1238;S103;S104;S109;S1128;S1226;S138;S3218;S3358;S4462;S5034;S881;SA1201;SA1600;SA1602;SA1611;SA1615;SA1618;SYSLIB1045</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/benchmarks/ReactiveUI.Primitives.Benchmarks/ReactiveUI.Primitives.Benchmarks.csproj
+++ b/src/benchmarks/ReactiveUI.Primitives.Benchmarks/ReactiveUI.Primitives.Benchmarks.csproj
@@ -6,7 +6,7 @@
     <IsPackable>false</IsPackable>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <RunAnalyzers>true</RunAnalyzers>
-    <NoWarn>$(NoWarn);CA1822;CA2012;CS1591;IDE0051;RCS1047;RCS1196;RCS1208;RCS1222;RCS1238;S103;S104;S109;S1128;S1226;S138;S3218;S3358;S4462;S5034;S881;SA1201;SA1600;SA1602;SA1611;SA1615;SA1618;SYSLIB1045</NoWarn>
+    <NoWarn>$(NoWarn);CA1822</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/tests/ReactiveUI.Primitives.Extensions.Tests/Operators/MinMaxObservableTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Extensions.Tests/Operators/MinMaxObservableTests.cs
@@ -193,6 +193,30 @@ public class MinMaxObservableTests
         await Assert.That(results).IsEmpty();
     }
 
+    /// <summary>Verifies the general three-source path drops notifications after terminal state.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenManySourceMinMaxTerminates_ThenLateSignalsAreDropped()
+    {
+        var a = new SyncDirectSource<int>();
+        var b = new SyncDirectSource<int>();
+        var c = new SyncDirectSource<int>();
+        var results = new List<int>();
+        var completions = 0;
+        Exception? caught = null;
+        var expected = new InvalidOperationException(SourceErrorMessage);
+
+        using var sub = a.GetMax(b, c).Subscribe(results.Add, ex => caught = ex, () => completions++);
+
+        a.Observer.OnError(expected);
+        b.Observer.OnNext(HighValue);
+        c.Observer.OnCompleted();
+
+        await Assert.That(caught).IsSameReferenceAs(expected);
+        await Assert.That(results).IsEmpty();
+        await Assert.That(completions).IsEqualTo(0);
+    }
+
     /// <summary>Verifies that a second error after termination is ignored by the binary fast path.</summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Test]

--- a/src/tests/ReactiveUI.Primitives.Extensions.Tests/Operators/MinMaxObservableTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Extensions.Tests/Operators/MinMaxObservableTests.cs
@@ -110,6 +110,22 @@ public class MinMaxObservableTests
         await Assert.That(results).IsCollectionEqualTo([LowValue, MidValue, HighValue]);
     }
 
+    /// <summary>Verifies <c>GetMin</c> with no additional sources still emits the source's own values verbatim.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenGetMinSingleSource_ThenEmitsSourceValues()
+    {
+        var subject = new Subject<int>();
+        var results = new List<int>();
+        using var sub = subject.GetMin().Subscribe(results.Add);
+
+        subject.OnNext(HighValue);
+        subject.OnNext(MidValue);
+        subject.OnNext(LowValue);
+
+        await Assert.That(results).IsCollectionEqualTo([HighValue, MidValue, LowValue]);
+    }
+
     /// <summary>Verifies that <see cref="MinMaxObservable{T}"/>
     /// with an empty source list completes immediately without emitting.</summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
@@ -175,5 +191,111 @@ public class MinMaxObservableTests
 
         await Assert.That(caught).IsSameReferenceAs(expected);
         await Assert.That(results).IsEmpty();
+    }
+
+    /// <summary>Verifies that a second error after termination is ignored by the binary fast path.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenBinarySourceErrorsAfterError_ThenDropped()
+    {
+        var a = new SyncDirectSource<int>();
+        var b = new SyncDirectSource<int>();
+        var receivedErrors = 0;
+        Exception? caught = null;
+        var expected = new InvalidOperationException(SourceErrorMessage);
+
+        using var sub = a.GetMax(b).Subscribe(
+            static _ => { },
+            ex =>
+            {
+                receivedErrors++;
+                caught = ex;
+            });
+
+        a.Observer.OnError(expected);
+        b.Observer.OnError(new InvalidOperationException("late error"));
+
+        await Assert.That(caught).IsSameReferenceAs(expected);
+        await Assert.That(receivedErrors).IsEqualTo(1);
+    }
+
+    /// <summary>Verifies that completion from an empty left source completes the binary fast path.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenBinaryLeftCompletesEmpty_ThenCompletesAndDropsLaterCompletion()
+    {
+        var a = new SyncDirectSource<int>();
+        var b = new SyncDirectSource<int>();
+        var completions = 0;
+
+        using var sub = a.GetMax(b).Subscribe(static _ => { }, () => completions++);
+
+        a.Observer.OnCompleted();
+        b.Observer.OnCompleted();
+
+        await Assert.That(completions).IsEqualTo(1);
+    }
+
+    /// <summary>Verifies that completion from an empty right source completes the binary fast path.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenBinaryRightCompletesEmpty_ThenCompletesAndDropsLaterCompletion()
+    {
+        var a = new SyncDirectSource<int>();
+        var b = new SyncDirectSource<int>();
+        var completions = 0;
+
+        using var sub = a.GetMin(b).Subscribe(static _ => { }, () => completions++);
+
+        b.Observer.OnCompleted();
+        a.Observer.OnCompleted();
+
+        await Assert.That(completions).IsEqualTo(1);
+    }
+
+    /// <summary>Verifies duplicate left completion is ignored until the right source completes.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenBinaryLeftCompletesTwiceBeforeRight_ThenDuplicateIgnored()
+    {
+        var a = new SyncDirectSource<int>();
+        var b = new SyncDirectSource<int>();
+        var completions = 0;
+
+        using var sub = a.GetMax(b).Subscribe(static _ => { }, () => completions++);
+
+        a.Observer.OnNext(LowValue);
+        b.Observer.OnNext(MidValue);
+        a.Observer.OnCompleted();
+        a.Observer.OnCompleted();
+
+        await Assert.That(completions).IsEqualTo(0);
+
+        b.Observer.OnCompleted();
+
+        await Assert.That(completions).IsEqualTo(1);
+    }
+
+    /// <summary>Verifies duplicate right completion is ignored until the left source completes.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenBinaryRightCompletesTwiceBeforeLeft_ThenDuplicateIgnored()
+    {
+        var a = new SyncDirectSource<int>();
+        var b = new SyncDirectSource<int>();
+        var completions = 0;
+
+        using var sub = a.GetMin(b).Subscribe(static _ => { }, () => completions++);
+
+        a.Observer.OnNext(MidValue);
+        b.Observer.OnNext(HighValue);
+        b.Observer.OnCompleted();
+        b.Observer.OnCompleted();
+
+        await Assert.That(completions).IsEqualTo(0);
+
+        a.Observer.OnCompleted();
+
+        await Assert.That(completions).IsEqualTo(1);
     }
 }

--- a/src/tests/ReactiveUI.Primitives.Extensions.Tests/Operators/UsingActionObservableTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Extensions.Tests/Operators/UsingActionObservableTests.cs
@@ -84,6 +84,15 @@ public partial class UsingActionObservableTests
 
         await completed.Task.WaitAsync(TimeSpan.FromSeconds(5));
         await Assert.That(actionRan).IsTrue();
+
+        // OnCompleted is signalled before the resource is disposed on the scheduler
+        // thread, so wait briefly for the dispose to land.
+        var deadline = Environment.TickCount64 + 5000;
+        while (resource.DisposeCount == 0 && Environment.TickCount64 < deadline)
+        {
+            await Task.Yield();
+        }
+
         await Assert.That(resource.DisposeCount).IsEqualTo(1);
     }
 

--- a/src/tests/ReactiveUI.Primitives.Tests/DisposableTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/DisposableTests.cs
@@ -42,6 +42,28 @@ public class DisposableTests
     }
 
     /// <summary>
+    /// Verifies cancellation disposable state transitions with the default owned token source.
+    /// </summary>
+    [Test]
+    public void CancellationDisposableDefaultConstructorCancelsOwnedToken()
+    {
+        var disposable = new CancellationDisposable();
+
+        Assert.False(disposable.Token.IsCancellationRequested);
+        Assert.False(disposable.IsDisposed);
+
+        disposable.Dispose();
+
+        Assert.True(disposable.Token.IsCancellationRequested);
+        Assert.True(disposable.IsDisposed);
+
+        disposable.Dispose();
+
+        Assert.True(disposable.Token.IsCancellationRequested);
+        Assert.True(disposable.IsDisposed);
+    }
+
+    /// <summary>
     /// Singles the disposable dispose.
     /// </summary>
     [Test]


### PR DESCRIPTION
## Summary
- Add full benchmark coverage for `ReactiveUI.Primitives.Extensions` and compare against `ReactiveUI.Extensions`, System.Reactive, and R3 where applicable.
- Add the `--extensions-smoke` benchmark validation path and update benchmark project warning suppressions for the generated-style comparison harness.
- Optimize `GetMax`/`GetMin` with a dedicated two-source fast path and refresh the README benchmark posture with the latest joined run.

## Testing
- Release solution build passed.
- `ReactiveUI.Primitives.Extensions.Tests` passed on net8.0, net9.0, and net10.0.
- Benchmark smoke validation passed, and the full joined BenchmarkDotNet run completed with 610 benchmarks.

## Notes
- The README benchmark table now reflects the current extension matrix and uses `NA` where no direct System.Reactive or R3 alternative exists.
- Related issue: not provided in the current context.