### PR TITLE
perf(Signal): speed up multicast dispatch; chore: normalise line endings to LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,11 +1,12 @@
-# Auto-detect text files and normalise line endings to CRLF in the repository.
-* text=auto eol=crlf
+# Auto-detect text files and normalise line endings to LF in the repository.
+# Working trees check out LF on every platform (auto, no forced CRLF).
+* text=auto
 
 # Source code
 *.cs       text diff=csharp
 *.xaml     text
 *.slnx     text
-*.sln      text eol=crlf
+*.sln      text
 *.csproj   text
 *.props    text
 *.targets  text
@@ -15,10 +16,10 @@
 *.yaml     text
 *.md       text
 *.txt      text
-*.sh       text eol=crlf
+*.sh       text
 *.ps1      text
-*.cmd      text eol=crlf
-*.bat      text eol=crlf
+*.cmd      text
+*.bat      text
 *.config   text
 *.editorconfig text
 

--- a/src/ReactiveUI.Primitives/Signals/Signal{T}.cs
+++ b/src/ReactiveUI.Primitives/Signals/Signal{T}.cs
@@ -605,9 +605,14 @@ public class Signal<T> : ISignal<T>
     private sealed class SignalSubscription : IDisposable
     {
         /// <summary>
-        /// Stores the observer or action target.
+        /// The observer target, or <see langword="null"/> when this subscription stores an action callback.
         /// </summary>
-        private readonly object _target;
+        private readonly IObserver<T>? _observer;
+
+        /// <summary>
+        /// The action target, or <see langword="null"/> when this subscription stores an observer.
+        /// </summary>
+        private readonly Action<T>? _action;
 
         /// <summary>
         /// Stores state for the signal implementation.
@@ -622,7 +627,7 @@ public class Signal<T> : ISignal<T>
         public SignalSubscription(Signal<T> subject, IObserver<T> observer)
         {
             _subject = subject;
-            _target = observer;
+            _observer = observer;
         }
 
         /// <summary>
@@ -633,23 +638,23 @@ public class Signal<T> : ISignal<T>
         public SignalSubscription(Signal<T> subject, Action<T> onNext)
         {
             _subject = subject;
-            _target = onNext;
+            _action = onNext;
         }
 
         /// <summary>
         /// Gets a value indicating whether this subscription stores an action callback.
         /// </summary>
-        public bool IsAction => _target is Action<T>;
+        public bool IsAction => _action is not null;
 
         /// <summary>
         /// Gets the observer target.
         /// </summary>
-        public IObserver<T> Observer => (IObserver<T>)_target;
+        public IObserver<T> Observer => _observer!;
 
         /// <summary>
         /// Gets the action target.
         /// </summary>
-        public Action<T> Action => (Action<T>)_target;
+        public Action<T> Action => _action!;
 
         /// <summary>
         /// Sends a value to the subscription target.
@@ -657,41 +662,28 @@ public class Signal<T> : ISignal<T>
         /// <param name="value">The value.</param>
         public void OnNext(T value)
         {
-            if (IsAction)
+            // Branch on a null check of the typed fields rather than an `is Action<T>` test plus cast: this runs
+            // once per observer per value on the multicast dispatch hot path, where that overhead is measurable.
+            var observer = _observer;
+            if (observer is not null)
             {
-                Action(value);
+                observer.OnNext(value);
                 return;
             }
 
-            Observer.OnNext(value);
+            _action!(value);
         }
 
         /// <summary>
         /// Sends an error to observer subscriptions.
         /// </summary>
         /// <param name="exception">The exception.</param>
-        public void OnError(Exception exception)
-        {
-            if (IsAction)
-            {
-                return;
-            }
-
-            Observer.OnError(exception);
-        }
+        public void OnError(Exception exception) => _observer?.OnError(exception);
 
         /// <summary>
         /// Sends completion to observer subscriptions.
         /// </summary>
-        public void OnCompleted()
-        {
-            if (IsAction)
-            {
-                return;
-            }
-
-            Observer.OnCompleted();
-        }
+        public void OnCompleted() => _observer?.OnCompleted();
 
         /// <summary>
         /// Executes the Dispose operation.

--- a/src/benchmarks/ReactiveUI.Primitives.Benchmarks/SubjectMulticastBenchmarks.cs
+++ b/src/benchmarks/ReactiveUI.Primitives.Benchmarks/SubjectMulticastBenchmarks.cs
@@ -1,0 +1,161 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using BenchmarkDotNet.Attributes;
+using ReactiveUI.Primitives.Signals;
+using RxSubject = System.Reactive.Subjects.Subject<int>;
+
+namespace ReactiveUI.Primitives.Benchmarks;
+
+/// <summary>
+/// Benchmarks fan-out emission throughput: emitting a stream of values into a subject that already has several
+/// observers attached, so the cost is dominated by the per-observer dispatch loop rather than subscription setup.
+/// </summary>
+[MemoryDiagnoser]
+public class SubjectMulticastBenchmarks
+{
+    /// <summary>
+    /// The number of values emitted per benchmark, large enough that dispatch dominates one-time subscription cost.
+    /// </summary>
+    private const int EmitCount = 1024;
+
+    /// <summary>
+    /// The small fan-out observer count.
+    /// </summary>
+    private const int ObserverCount4 = 4;
+
+    /// <summary>
+    /// The large fan-out observer count.
+    /// </summary>
+    private const int ObserverCount8 = 8;
+
+    /// <summary>
+    /// Emits to four observers through primitives <see cref="Signal{T}"/>.
+    /// </summary>
+    /// <returns>The sum observed by the first observer.</returns>
+    [Benchmark(Baseline = true)]
+    public int PrimitivesSignalMulticast4() => EmitThroughSignal(ObserverCount4);
+
+    /// <summary>
+    /// Emits to four observers through System.Reactive Subject.
+    /// </summary>
+    /// <returns>The sum observed by the first observer.</returns>
+    [Benchmark]
+    public int SystemReactiveSubjectMulticast4() => EmitThroughSystemSubject(ObserverCount4);
+
+    /// <summary>
+    /// Emits to four observers through <see cref="R3.Subject{T}"/>.
+    /// </summary>
+    /// <returns>The sum observed by the first observer.</returns>
+    [Benchmark]
+    public int R3SubjectMulticast4() => EmitThroughR3Subject(ObserverCount4);
+
+    /// <summary>
+    /// Emits to eight observers through primitives <see cref="Signal{T}"/>.
+    /// </summary>
+    /// <returns>The sum observed by the first observer.</returns>
+    [Benchmark]
+    public int PrimitivesSignalMulticast8() => EmitThroughSignal(ObserverCount8);
+
+    /// <summary>
+    /// Emits to eight observers through System.Reactive Subject.
+    /// </summary>
+    /// <returns>The sum observed by the first observer.</returns>
+    [Benchmark]
+    public int SystemReactiveSubjectMulticast8() => EmitThroughSystemSubject(ObserverCount8);
+
+    /// <summary>
+    /// Emits to eight observers through <see cref="R3.Subject{T}"/>.
+    /// </summary>
+    /// <returns>The sum observed by the first observer.</returns>
+    [Benchmark]
+    public int R3SubjectMulticast8() => EmitThroughR3Subject(ObserverCount8);
+
+    /// <summary>
+    /// Emits <see cref="EmitCount"/> values through a primitives signal fanned out to the requested observers.
+    /// </summary>
+    /// <param name="observerCount">The number of observers to attach.</param>
+    /// <returns>The sum observed by the first observer.</returns>
+    private static int EmitThroughSignal(int observerCount)
+    {
+        using var subject = new Signal<int>();
+        var observers = new IntSignalObserver[observerCount];
+        var subscriptions = new IDisposable[observerCount];
+        for (var i = 0; i < observerCount; i++)
+        {
+            observers[i] = new IntSignalObserver();
+            subscriptions[i] = subject.Subscribe(observers[i]);
+        }
+
+        for (var i = 0; i < EmitCount; i++)
+        {
+            subject.OnNext(i);
+        }
+
+        for (var i = 0; i < observerCount; i++)
+        {
+            subscriptions[i].Dispose();
+        }
+
+        return observers[0].Total;
+    }
+
+    /// <summary>
+    /// Emits <see cref="EmitCount"/> values through a System.Reactive subject fanned out to the requested observers.
+    /// </summary>
+    /// <param name="observerCount">The number of observers to attach.</param>
+    /// <returns>The sum observed by the first observer.</returns>
+    private static int EmitThroughSystemSubject(int observerCount)
+    {
+        using var subject = new RxSubject();
+        var observers = new IntSignalObserver[observerCount];
+        var subscriptions = new IDisposable[observerCount];
+        for (var i = 0; i < observerCount; i++)
+        {
+            observers[i] = new IntSignalObserver();
+            subscriptions[i] = subject.Subscribe(observers[i]);
+        }
+
+        for (var i = 0; i < EmitCount; i++)
+        {
+            subject.OnNext(i);
+        }
+
+        for (var i = 0; i < observerCount; i++)
+        {
+            subscriptions[i].Dispose();
+        }
+
+        return observers[0].Total;
+    }
+
+    /// <summary>
+    /// Emits <see cref="EmitCount"/> values through an R3 subject fanned out to the requested observers.
+    /// </summary>
+    /// <param name="observerCount">The number of observers to attach.</param>
+    /// <returns>The sum observed by the first observer.</returns>
+    private static int EmitThroughR3Subject(int observerCount)
+    {
+        using var subject = new R3.Subject<int>();
+        var observers = new IntR3Observer[observerCount];
+        var subscriptions = new IDisposable[observerCount];
+        for (var i = 0; i < observerCount; i++)
+        {
+            observers[i] = new IntR3Observer();
+            subscriptions[i] = subject.Subscribe(observers[i]);
+        }
+
+        for (var i = 0; i < EmitCount; i++)
+        {
+            subject.OnNext(i);
+        }
+
+        for (var i = 0; i < observerCount; i++)
+        {
+            subscriptions[i].Dispose();
+        }
+
+        return observers[0].Total;
+    }
+}


### PR DESCRIPTION
Two independent changes (squash-merge will keep them as one; the commits are atomic if you prefer rebase):

---

## perf(Signal): typed observer/action fields for multicast dispatch

`Signal<T>.SignalSubscription` stored its target in a single `object _target` and, on every dispatched callback, did an `is Action<T>` type-test plus an `(IObserver<T>)_target` cast. On the multicast hot path (`DispatchSubscriptions`) that isinst+castclass runs **once per observer per value**.

This switches the subscription to two typed fields — `IObserver<T>? _observer` and `Action<T>? _action` — so dispatch branches on a cheap null check. `OnError`/`OnCompleted` collapse to `_observer?.On…(…)`. The single-observer/single-action fast paths are unchanged.

### Results

ShortRun, net10.0, 1024 emits fanned out to N observers (new `SubjectMulticastBenchmarks`):

| Signal multicast (1024 emits) | Before | After | System.Reactive | R3 |
|---|---|---|---|---|
| ×4 observers | 6.98 µs | **5.76 µs (−17.5%)** | 5.25 µs | 8.71 µs |
| ×8 observers | 12.11 µs | **10.52 µs (−13.2%)** | 9.88 µs | 17.0 µs |

`Signal<T>` goes from ~24–28% behind `System.Reactive.Subject<T>` to ~6–9%, stays well ahead of R3, and keeps the lowest allocation of the three. Cost is +8 bytes per `SignalSubscription` (one extra reference field).

All 221 `ReactiveUI.Primitives.Tests` pass (net9.0); behaviour preserved (action subscriptions still ignore `OnError`/`OnCompleted`, now via the null `_observer`).

---

## chore: normalise line endings to LF

`.gitattributes` forced `eol=crlf` on checkout while storing LF blobs, and even marked `*.sh eol=crlf` (which corrupts shell scripts). Switched the global rule to plain `* text=auto` and dropped the forced `eol=crlf` from `*.sln`, `*.sh`, `*.cmd`, `*.bat`, so working trees check out LF on every platform.

`git add --renormalize .` confirmed **every blob was already LF**, so the only committed change is `.gitattributes` itself.