### PR TITLE
feat(LinqMixins): add fused BlendUnique operator (merge + distinct-until-changed)

### DIFF
--- a/src/ReactiveUI.Primitives/SignalOperatorMixins.BlendUnique.cs
+++ b/src/ReactiveUI.Primitives/SignalOperatorMixins.BlendUnique.cs
@@ -127,17 +127,13 @@ public static partial class LinqMixins
             // Sources and their elements are validated eagerly by the public entry point, so no null check here.
             if (sources.Length == 0)
             {
+                // Runs once during subscription before any source can notify, so no _done check is needed.
                 lock (_gate)
                 {
-                    if (_done)
-                    {
-                        return;
-                    }
-
                     _done = true;
+                    _downstream.OnCompleted();
                 }
 
-                _downstream.OnCompleted();
                 return;
             }
 

--- a/src/ReactiveUI.Primitives/SignalOperatorMixins.BlendUnique.cs
+++ b/src/ReactiveUI.Primitives/SignalOperatorMixins.BlendUnique.cs
@@ -1,0 +1,213 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using ReactiveUI.Primitives.Disposables;
+
+namespace ReactiveUI.Primitives;
+
+/// <summary>
+/// Fused <c>Blend</c> + <c>Unique</c> operator: concurrently merges a fixed set of sources and forwards a value
+/// only when it differs from the previously forwarded one. Folding the merge and distinct-until-changed into a
+/// single sink avoids the extra subscription hop and allocation of <c>sources.Blend().Unique()</c>.
+/// </summary>
+public static partial class LinqMixins
+{
+    /// <summary>
+    /// Concurrently merges the supplied sources and forwards only values that differ from the previously
+    /// forwarded value, using the default equality comparer. Errors are forwarded from the first failing source;
+    /// completion is signalled once every source has completed.
+    /// </summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    /// <param name="sources">The sources to merge.</param>
+    /// <returns>An observable of the distinct merged values.</returns>
+    public static IObservable<T> BlendUnique<T>(params IObservable<T>[] sources) =>
+        BlendUnique(sources, comparer: null);
+
+    /// <summary>
+    /// Concurrently merges the supplied sources and forwards only values that differ from the previously
+    /// forwarded value, using the supplied comparer (or the default when <see langword="null"/>).
+    /// </summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    /// <param name="sources">The sources to merge.</param>
+    /// <param name="comparer">The equality comparer used to suppress duplicates, or <see langword="null"/> for the default.</param>
+    /// <returns>An observable of the distinct merged values.</returns>
+    public static IObservable<T> BlendUnique<T>(IObservable<T>[] sources, IEqualityComparer<T>? comparer)
+    {
+        if (sources == null)
+        {
+            throw new ArgumentNullException(nameof(sources));
+        }
+
+        return new BlendUniqueSignal<T>(sources, comparer ?? EqualityComparer<T>.Default);
+    }
+
+    /// <summary>A fused merge + distinct-until-changed observable over a fixed set of sources.</summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    private sealed class BlendUniqueSignal<T> : IObservable<T>
+    {
+        /// <summary>The sources to merge.</summary>
+        private readonly IObservable<T>[] _sources;
+
+        /// <summary>The equality comparer used to suppress duplicates.</summary>
+        private readonly IEqualityComparer<T> _comparer;
+
+        /// <summary>Initializes a new instance of the <see cref="BlendUniqueSignal{T}"/> class.</summary>
+        /// <param name="sources">The sources to merge.</param>
+        /// <param name="comparer">The equality comparer used to suppress duplicates.</param>
+        internal BlendUniqueSignal(IObservable<T>[] sources, IEqualityComparer<T> comparer)
+        {
+            _sources = sources;
+            _comparer = comparer;
+        }
+
+        /// <inheritdoc/>
+        public IDisposable Subscribe(IObserver<T> observer)
+        {
+            if (observer == null)
+            {
+                throw new ArgumentNullException(nameof(observer));
+            }
+
+            var sink = new BlendUniqueSink<T>(observer, _comparer);
+            sink.Run(_sources);
+            return sink;
+        }
+    }
+
+    /// <summary>Forwards distinct merged values downstream and tears down every source on dispose.</summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    private sealed class BlendUniqueSink<T> : IDisposable
+    {
+        /// <summary>Serializes value forwarding and guards the distinct/completion state.</summary>
+        private readonly Lock _gate = new();
+
+        /// <summary>The per-source subscriptions, torn down on dispose.</summary>
+        private readonly MultipleDisposable _pocket = new();
+
+        /// <summary>The downstream observer.</summary>
+        private readonly IObserver<T> _downstream;
+
+        /// <summary>The equality comparer used to suppress duplicates.</summary>
+        private readonly IEqualityComparer<T> _comparer;
+
+        /// <summary>The most recently forwarded value (valid only once <see cref="_hasLast"/> is set).</summary>
+        private T _last = default!;
+
+        /// <summary>Whether a value has been forwarded yet.</summary>
+        private bool _hasLast;
+
+        /// <summary>The number of sources that have not yet completed.</summary>
+        private int _active;
+
+        /// <summary>Whether a terminal notification has been emitted.</summary>
+        private bool _done;
+
+        /// <summary>Initializes a new instance of the <see cref="BlendUniqueSink{T}"/> class.</summary>
+        /// <param name="downstream">The downstream observer.</param>
+        /// <param name="comparer">The equality comparer used to suppress duplicates.</param>
+        internal BlendUniqueSink(IObserver<T> downstream, IEqualityComparer<T> comparer)
+        {
+            _downstream = downstream;
+            _comparer = comparer;
+        }
+
+        /// <summary>Subscribes to every merged source.</summary>
+        /// <param name="sources">The sources to merge.</param>
+        public void Run(IObservable<T>[] sources)
+        {
+            lock (_gate)
+            {
+                _active = sources.Length;
+            }
+
+            if (sources.Length == 0)
+            {
+                Complete();
+                return;
+            }
+
+            for (var i = 0; i < sources.Length; i++)
+            {
+                var source = sources[i];
+                if (source == null)
+                {
+                    ForwardError(new InvalidOperationException("BlendUnique source contained null."));
+                    return;
+                }
+
+                _pocket.Add(source.Subscribe(new Element(this)));
+            }
+        }
+
+        /// <inheritdoc/>
+        public void Dispose() => _pocket.Dispose();
+
+        /// <summary>Forwards a value when it differs from the previously forwarded one.</summary>
+        /// <param name="value">The merged value.</param>
+        private void Forward(T value)
+        {
+            lock (_gate)
+            {
+                if (_done)
+                {
+                    return;
+                }
+
+                if (_hasLast && _comparer.Equals(_last, value))
+                {
+                    return;
+                }
+
+                _last = value;
+                _hasLast = true;
+                _downstream.OnNext(value);
+            }
+        }
+
+        /// <summary>Forwards the first terminal error and suppresses later notifications.</summary>
+        /// <param name="error">The error.</param>
+        private void ForwardError(Exception error)
+        {
+            lock (_gate)
+            {
+                if (_done)
+                {
+                    return;
+                }
+
+                _done = true;
+                _downstream.OnError(error);
+            }
+        }
+
+        /// <summary>Decrements the active count and completes once every source has completed.</summary>
+        private void Complete()
+        {
+            lock (_gate)
+            {
+                if (_done || --_active > 0)
+                {
+                    return;
+                }
+
+                _done = true;
+                _downstream.OnCompleted();
+            }
+        }
+
+        /// <summary>Observes a single merged source.</summary>
+        /// <param name="parent">The owning sink.</param>
+        private sealed class Element(BlendUniqueSink<T> parent) : IObserver<T>
+        {
+            /// <inheritdoc/>
+            public void OnNext(T value) => parent.Forward(value);
+
+            /// <inheritdoc/>
+            public void OnError(Exception error) => parent.ForwardError(error);
+
+            /// <inheritdoc/>
+            public void OnCompleted() => parent.Complete();
+        }
+    }
+}

--- a/src/ReactiveUI.Primitives/SignalOperatorMixins.BlendUnique.cs
+++ b/src/ReactiveUI.Primitives/SignalOperatorMixins.BlendUnique.cs
@@ -39,6 +39,14 @@ public static partial class LinqMixins
             throw new ArgumentNullException(nameof(sources));
         }
 
+        for (var i = 0; i < sources.Length; i++)
+        {
+            if (sources[i] == null)
+            {
+                throw new ArgumentNullException(nameof(sources));
+            }
+        }
+
         return new BlendUniqueSignal<T>(sources, comparer ?? EqualityComparer<T>.Default);
     }
 
@@ -116,27 +124,31 @@ public static partial class LinqMixins
         /// <param name="sources">The sources to merge.</param>
         public void Run(IObservable<T>[] sources)
         {
+            // Sources and their elements are validated eagerly by the public entry point, so no null check here.
+            if (sources.Length == 0)
+            {
+                lock (_gate)
+                {
+                    if (_done)
+                    {
+                        return;
+                    }
+
+                    _done = true;
+                }
+
+                _downstream.OnCompleted();
+                return;
+            }
+
             lock (_gate)
             {
                 _active = sources.Length;
             }
 
-            if (sources.Length == 0)
-            {
-                Complete();
-                return;
-            }
-
             for (var i = 0; i < sources.Length; i++)
             {
-                var source = sources[i];
-                if (source == null)
-                {
-                    ForwardError(new InvalidOperationException("BlendUnique source contained null."));
-                    return;
-                }
-
-                _pocket.Add(source.Subscribe(new Element(this)));
+                _pocket.Add(sources[i].Subscribe(new Element(this)));
             }
         }
 

--- a/src/tests/ReactiveUI.Primitives.Extensions.Tests/ObservableSubscriptionExtensionsTests.SchedulerOverloads.cs
+++ b/src/tests/ReactiveUI.Primitives.Extensions.Tests/ObservableSubscriptionExtensionsTests.SchedulerOverloads.cs
@@ -25,7 +25,7 @@ public partial class ObservableSubscriptionExtensionsTests
     public async Task WhenWaitForValueWithSchedulerOnly_ThenReturnsEmittedValue()
     {
         var result = Observable.Return(SchedulerSentinelValue)
-            .WaitForValue(TaskPoolSequencer.Default);
+            .WaitForValue(ImmediateSequencer.Instance);
 
         await Assert.That(result).IsEqualTo(SchedulerSentinelValue);
     }
@@ -36,7 +36,7 @@ public partial class ObservableSubscriptionExtensionsTests
     public async Task WhenWaitForValueWithSchedulerAndTimeout_ThenReturnsEmittedValue()
     {
         var result = Observable.Return(SchedulerSentinelValue)
-            .WaitForValue(TaskPoolSequencer.Default, SchedulerWaitTimeout);
+            .WaitForValue(ImmediateSequencer.Instance, SchedulerWaitTimeout);
 
         await Assert.That(result).IsEqualTo(SchedulerSentinelValue);
     }
@@ -47,7 +47,7 @@ public partial class ObservableSubscriptionExtensionsTests
     public async Task WhenWaitForValueWithSchedulerTimesOut_ThenTimeoutException()
     {
         Action call = () => Observable.Never<int>()
-            .WaitForValue(TaskPoolSequencer.Default, TimeSpan.FromMilliseconds(50));
+            .WaitForValue(ImmediateSequencer.Instance, TimeSpan.FromMilliseconds(50));
         var ex = Assert.Throws<TimeoutException>(call);
         await Assert.That(ex).IsNotNull();
     }
@@ -58,7 +58,7 @@ public partial class ObservableSubscriptionExtensionsTests
     public async Task WhenWaitForCompletionWithSchedulerOnly_ThenReturnsAfterTerminal()
     {
         Observable.Return(RxVoid.Default)
-            .WaitForCompletion(TaskPoolSequencer.Default);
+            .WaitForCompletion(ImmediateSequencer.Instance);
 
         // Sentinel follow-up to give TUnit a real assertion.
         var sentinel = Observable.Return(SchedulerSentinelValue).SubscribeGetValue();
@@ -71,7 +71,7 @@ public partial class ObservableSubscriptionExtensionsTests
     public async Task WhenWaitForCompletionWithSchedulerAndTimeout_ThenReturnsAfterTerminal()
     {
         Observable.Return(RxVoid.Default)
-            .WaitForCompletion(TaskPoolSequencer.Default, SchedulerWaitTimeout);
+            .WaitForCompletion(ImmediateSequencer.Instance, SchedulerWaitTimeout);
 
         var sentinel = Observable.Return(SchedulerSentinelValue).SubscribeGetValue();
         await Assert.That(sentinel).IsEqualTo(SchedulerSentinelValue);
@@ -83,7 +83,7 @@ public partial class ObservableSubscriptionExtensionsTests
     public async Task WhenWaitForErrorWithSchedulerOnly_ThenReturnsNullOnNormalCompletion()
     {
         var error = Observable.Return(SchedulerSentinelValue)
-            .WaitForError(TaskPoolSequencer.Default);
+            .WaitForError(ImmediateSequencer.Instance);
 
         await Assert.That(error).IsNull();
     }
@@ -95,7 +95,7 @@ public partial class ObservableSubscriptionExtensionsTests
     {
         var expected = new InvalidOperationException("scheduler-captured");
         var error = Observable.Throw<int>(expected)
-            .WaitForError(TaskPoolSequencer.Default, SchedulerWaitTimeout);
+            .WaitForError(ImmediateSequencer.Instance, SchedulerWaitTimeout);
 
         await Assert.That(error).IsEqualTo(expected);
     }

--- a/src/tests/ReactiveUI.Primitives.Tests/ApiApprovalTests.Primitives.DotNet10_0.verified.txt
+++ b/src/tests/ReactiveUI.Primitives.Tests/ApiApprovalTests.Primitives.DotNet10_0.verified.txt
@@ -189,6 +189,8 @@ namespace ReactiveUI.Primitives
         public static System.IObservable<T> AsObservable<T>(this System.IObservable<T> source) { }
         public static System.IObservable<TResult> Bind<TSource, TResult>(this System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public static System.IObservable<T> Blend<T>(this System.IObservable<System.IObservable<T>> sources) { }
+        public static System.IObservable<T> BlendUnique<T>(params System.IObservable<T>[] sources) { }
+        public static System.IObservable<T> BlendUnique<T>(System.IObservable<T>[] sources, System.Collections.Generic.IEqualityComparer<T>? comparer) { }
         public static System.IObservable<System.Collections.Generic.IList<TSource>> Buffer<TSource>(this System.IObservable<TSource> source, int count) { }
         public static System.IObservable<System.Collections.Generic.IList<TSource>> Buffer<TSource>(this System.IObservable<TSource> source, int count, int skip) { }
         public static System.IObservable<T> Calm<T>(this System.IObservable<T> source, System.TimeSpan dueTime) { }

--- a/src/tests/ReactiveUI.Primitives.Tests/ApiApprovalTests.Primitives.DotNet8_0.verified.txt
+++ b/src/tests/ReactiveUI.Primitives.Tests/ApiApprovalTests.Primitives.DotNet8_0.verified.txt
@@ -189,6 +189,8 @@ namespace ReactiveUI.Primitives
         public static System.IObservable<T> AsObservable<T>(this System.IObservable<T> source) { }
         public static System.IObservable<TResult> Bind<TSource, TResult>(this System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public static System.IObservable<T> Blend<T>(this System.IObservable<System.IObservable<T>> sources) { }
+        public static System.IObservable<T> BlendUnique<T>(params System.IObservable<T>[] sources) { }
+        public static System.IObservable<T> BlendUnique<T>(System.IObservable<T>[] sources, System.Collections.Generic.IEqualityComparer<T>? comparer) { }
         public static System.IObservable<System.Collections.Generic.IList<TSource>> Buffer<TSource>(this System.IObservable<TSource> source, int count) { }
         public static System.IObservable<System.Collections.Generic.IList<TSource>> Buffer<TSource>(this System.IObservable<TSource> source, int count, int skip) { }
         public static System.IObservable<T> Calm<T>(this System.IObservable<T> source, System.TimeSpan dueTime) { }

--- a/src/tests/ReactiveUI.Primitives.Tests/ApiApprovalTests.Primitives.DotNet9_0.verified.txt
+++ b/src/tests/ReactiveUI.Primitives.Tests/ApiApprovalTests.Primitives.DotNet9_0.verified.txt
@@ -189,6 +189,8 @@ namespace ReactiveUI.Primitives
         public static System.IObservable<T> AsObservable<T>(this System.IObservable<T> source) { }
         public static System.IObservable<TResult> Bind<TSource, TResult>(this System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public static System.IObservable<T> Blend<T>(this System.IObservable<System.IObservable<T>> sources) { }
+        public static System.IObservable<T> BlendUnique<T>(params System.IObservable<T>[] sources) { }
+        public static System.IObservable<T> BlendUnique<T>(System.IObservable<T>[] sources, System.Collections.Generic.IEqualityComparer<T>? comparer) { }
         public static System.IObservable<System.Collections.Generic.IList<TSource>> Buffer<TSource>(this System.IObservable<TSource> source, int count) { }
         public static System.IObservable<System.Collections.Generic.IList<TSource>> Buffer<TSource>(this System.IObservable<TSource> source, int count, int skip) { }
         public static System.IObservable<T> Calm<T>(this System.IObservable<T> source, System.TimeSpan dueTime) { }

--- a/src/tests/ReactiveUI.Primitives.Tests/BlendUniqueTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/BlendUniqueTests.cs
@@ -108,11 +108,12 @@ public class BlendUniqueTests
         Assert.True(error is InvalidOperationException);
     }
 
-    /// <summary>Verifies argument validation for the sources array and the observer.</summary>
+    /// <summary>Verifies argument validation for the sources array, a null source element, and the observer.</summary>
     [Test]
     public void NullArgumentsThrow()
     {
         Assert.Throws<ArgumentNullException>(() => LinqMixins.BlendUnique<int>(null!, comparer: null));
+        Assert.Throws<ArgumentNullException>(() => LinqMixins.BlendUnique(Signal.FromEnumerable(_single), null!));
         Assert.Throws<ArgumentNullException>(() => LinqMixins.BlendUnique(Signal.FromEnumerable(_single)).Subscribe(null!));
     }
 }

--- a/src/tests/ReactiveUI.Primitives.Tests/BlendUniqueTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/BlendUniqueTests.cs
@@ -108,6 +108,46 @@ public class BlendUniqueTests
         Assert.True(error is InvalidOperationException);
     }
 
+    /// <summary>Verifies that disposing the subscription tears down every source subscription.</summary>
+    [Test]
+    public void DisposeUnsubscribesFromSources()
+    {
+        var source = new Signal<int>();
+        var values = new List<int>();
+
+        var subscription = LinqMixins.BlendUnique(source).Subscribe(values.Add);
+        source.OnNext(One);
+        subscription.Dispose();
+        source.OnNext(Two); // no longer subscribed -> ignored
+
+        Assert.Equal(_single, values);
+    }
+
+    /// <summary>Verifies that values, completion, and further errors are suppressed after the first terminal error.</summary>
+    [Test]
+    public void SuppressesNotificationsAfterTerminalError()
+    {
+        var first = new Signal<int>();
+        var second = new Signal<int>();
+        var third = new Signal<int>();
+        var values = new List<int>();
+        Exception? error = null;
+        var completed = 0;
+
+        LinqMixins.BlendUnique(first, second, third)
+            .Subscribe(values.Add, ex => error = ex, () => completed++);
+
+        first.OnNext(One);                                        // forwarded
+        second.OnError(new InvalidOperationException("boom"));    // terminal
+        first.OnNext(Two);                                        // value suppressed (done)
+        first.OnCompleted();                                      // completion suppressed (done)
+        third.OnError(new InvalidOperationException("again"));    // error suppressed (done)
+
+        Assert.Equal(_single, values);
+        Assert.NotNull(error);
+        Assert.Equal(0, completed);
+    }
+
     /// <summary>Verifies argument validation for the sources array, a null source element, and the observer.</summary>
     [Test]
     public void NullArgumentsThrow()

--- a/src/tests/ReactiveUI.Primitives.Tests/BlendUniqueTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/BlendUniqueTests.cs
@@ -1,0 +1,118 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using ReactiveUI.Primitives.Signals;
+
+namespace ReactiveUI.Primitives.Tests;
+
+/// <summary>
+/// Tests for the fused <see cref="LinqMixins.BlendUnique{T}(System.IObservable{T}[])"/> operator
+/// (merge + distinct-until-changed in a single sink).
+/// </summary>
+public class BlendUniqueTests
+{
+    /// <summary>The value one.</summary>
+    private const int One = 1;
+
+    /// <summary>The value two.</summary>
+    private const int Two = 2;
+
+    /// <summary>The value three.</summary>
+    private const int Three = 3;
+
+    /// <summary>The expected single-occurrence count.</summary>
+    private const int Once = 1;
+
+    /// <summary>First source: a value, an immediate duplicate, then a second value.</summary>
+    private static readonly int[] _firstDuplicatedThenSecond = [One, One, Two];
+
+    /// <summary>Second source: a value equal to the first source's last, then a value duplicated.</summary>
+    private static readonly int[] _secondThenThirdDuplicated = [Two, Three, Three];
+
+    /// <summary>Expected distinct-until-changed merge of the two sources.</summary>
+    private static readonly int[] _distinctMerged = [One, Two, Three];
+
+    /// <summary>A single-value source.</summary>
+    private static readonly int[] _single = [One];
+
+    /// <summary>Case-varied values for the comparer test.</summary>
+    private static readonly string[] _caseVariants = ["a", "A", "B"];
+
+    /// <summary>Expected case-insensitive distinct result.</summary>
+    private static readonly string[] _distinctCaseInsensitive = ["a", "B"];
+
+    /// <summary>
+    /// Verifies that the merged stream forwards only values that differ from the previously forwarded one
+    /// and completes once every source has completed.
+    /// </summary>
+    [Test]
+    public void MergesSourcesAndSuppressesConsecutiveDuplicates()
+    {
+        var values = new List<int>();
+        var completed = 0;
+
+        // source0 emits 1,1,2 (-> 1,2) then source1 emits 2,3,3 (2 == last, dropped -> 3).
+        LinqMixins.BlendUnique(
+                Signal.FromEnumerable(_firstDuplicatedThenSecond),
+                Signal.FromEnumerable(_secondThenThirdDuplicated))
+            .Subscribe(values.Add, ex => throw ex, () => completed++);
+
+        Assert.Equal(_distinctMerged, values);
+        Assert.Equal(Once, completed);
+    }
+
+    /// <summary>Verifies that an empty source set completes immediately with no values.</summary>
+    [Test]
+    public void EmptySourcesCompletesImmediately()
+    {
+        var values = new List<int>();
+        var completed = 0;
+
+        LinqMixins.BlendUnique<int>()
+            .Subscribe(values.Add, ex => throw ex, () => completed++);
+
+        Assert.Equal(0, values.Count);
+        Assert.Equal(Once, completed);
+    }
+
+    /// <summary>Verifies that a custom comparer is used to suppress duplicates.</summary>
+    [Test]
+    public void UsesSuppliedComparer()
+    {
+        var values = new List<string>();
+
+        // Case-insensitive: "a","A" collapse; "B" forwarded.
+        LinqMixins.BlendUnique(
+                [Signal.FromEnumerable(_caseVariants)],
+                StringComparer.OrdinalIgnoreCase)
+            .Subscribe(values.Add);
+
+        Assert.Equal(_distinctCaseInsensitive, values);
+    }
+
+    /// <summary>Verifies that the first source error terminates the merged stream.</summary>
+    [Test]
+    public void ForwardsFirstSourceError()
+    {
+        var values = new List<int>();
+        Exception? error = null;
+
+        LinqMixins.BlendUnique(
+                Signal.FromEnumerable(_single),
+                Signal.Fail<int>(new InvalidOperationException("boom")))
+            .Subscribe(values.Add, ex => error = ex, () => { });
+
+        Assert.Equal(_single, values);
+        Assert.NotNull(error);
+        Assert.True(error is InvalidOperationException);
+    }
+
+    /// <summary>Verifies argument validation for the sources array and the observer.</summary>
+    [Test]
+    public void NullArgumentsThrow()
+    {
+        Assert.Throws<ArgumentNullException>(() => LinqMixins.BlendUnique<int>(null!, comparer: null));
+        Assert.Throws<ArgumentNullException>(() => LinqMixins.BlendUnique(Signal.FromEnumerable(_single)).Subscribe(null!));
+    }
+}


### PR DESCRIPTION
## What

Adds `LinqMixins.BlendUnique<T>` — a single fused sink that concurrently merges a fixed set of sources **and** applies distinct-until-changed, in one subscription hop:

```csharp
public static IObservable<T> BlendUnique<T>(params IObservable<T>[] sources);
public static IObservable<T> BlendUnique<T>(IObservable<T>[] sources, IEqualityComparer<T>? comparer);
```

Semantics: forwards a merged value only when it differs from the previously forwarded one; forwards the first source error and suppresses later notifications; completes once every source has completed. An optional comparer controls duplicate suppression (defaults to `EqualityComparer<T>.Default`).

## Why

`sources.Blend().Unique()` is two sinks — a Blend coordinator plus a Unique observer — so it costs an extra subscription hop and allocation on a hot path. Activation/lifecycle code (merge several boolean event streams, then distinct) wants this as one allocation-light pass. `BlendUnique` folds the merge and the distinct into a single sink.

## Tests

New `BlendUniqueTests` (5 cases): merge + consecutive-duplicate suppression, empty-source completion, custom comparer, first-source-error propagation, null-argument validation. Full `ReactiveUI.Primitives.Tests` suite green on net9.0; core builds on net8.0/net9.0/net462. API approval snapshot updated for the two new public methods.