### PR TITLE
feat(LinqMixins): add fused Choose and SwitchSelect operators

### DIFF
--- a/src/ReactiveUI.Primitives/SignalOperatorMixins.ChooseSwitchSelect.cs
+++ b/src/ReactiveUI.Primitives/SignalOperatorMixins.ChooseSwitchSelect.cs
@@ -1,0 +1,324 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using ReactiveUI.Primitives.Disposables;
+
+namespace ReactiveUI.Primitives;
+
+/// <summary>
+/// Fused projection operators: <c>Choose</c> (filter + map in one sink) and <c>SwitchSelect</c>
+/// (filter-null + map-to-inner + switch-to-latest in one sink).
+/// </summary>
+public static partial class LinqMixins
+{
+    /// <summary>
+    /// Maps each source value to a <c>(HasValue, Value)</c> pair and forwards only the values whose
+    /// <c>HasValue</c> is <see langword="true"/> — a single fused sink in place of <c>Where(...).Select(...)</c>.
+    /// Unlike a <c>TOut?</c>-returning projection, the explicit flag lets a non-nullable value type be skipped.
+    /// </summary>
+    /// <typeparam name="TIn">The source element type.</typeparam>
+    /// <typeparam name="TOut">The forwarded element type.</typeparam>
+    /// <param name="source">The source observable.</param>
+    /// <param name="chooser">Maps a source value to <c>(HasValue, Value)</c>; the value is skipped when <c>HasValue</c> is <see langword="false"/>.</param>
+    /// <returns>An observable of the chosen values.</returns>
+    public static IObservable<TOut> Choose<TIn, TOut>(this IObservable<TIn> source, Func<TIn, (bool HasValue, TOut Value)> chooser)
+    {
+        if (source == null)
+        {
+            throw new ArgumentNullException(nameof(source));
+        }
+
+        if (chooser == null)
+        {
+            throw new ArgumentNullException(nameof(chooser));
+        }
+
+        return new ChooseSignal<TIn, TOut>(source, chooser);
+    }
+
+    /// <summary>
+    /// Filters out null source values, projects each remaining value to an inner observable, and mirrors only the
+    /// latest inner observable — a single fused sink in place of <c>WhereNotNull().Select(selector).Switch()</c>.
+    /// </summary>
+    /// <typeparam name="TSource">The (nullable) source element type.</typeparam>
+    /// <typeparam name="TResult">The element type of the projected inner observables.</typeparam>
+    /// <param name="source">The source observable.</param>
+    /// <param name="selector">Projects each non-null source value to an inner observable.</param>
+    /// <returns>An observable that mirrors the latest projected inner observable.</returns>
+    public static IObservable<TResult> SwitchSelect<TSource, TResult>(this IObservable<TSource?> source, Func<TSource, IObservable<TResult>> selector)
+    {
+        if (source == null)
+        {
+            throw new ArgumentNullException(nameof(source));
+        }
+
+        if (selector == null)
+        {
+            throw new ArgumentNullException(nameof(selector));
+        }
+
+        return new SwitchSelectSignal<TSource, TResult>(source, selector);
+    }
+
+    /// <summary>A fused filter + map observable.</summary>
+    /// <typeparam name="TIn">The source element type.</typeparam>
+    /// <typeparam name="TOut">The forwarded element type.</typeparam>
+    private sealed class ChooseSignal<TIn, TOut>(IObservable<TIn> source, Func<TIn, (bool HasValue, TOut Value)> chooser) : IObservable<TOut>
+    {
+        /// <inheritdoc/>
+        public IDisposable Subscribe(IObserver<TOut> observer)
+        {
+            if (observer == null)
+            {
+                throw new ArgumentNullException(nameof(observer));
+            }
+
+            return source.Subscribe(new Sink(observer, chooser));
+        }
+
+        /// <summary>Applies the chooser to each value and forwards only the chosen ones.</summary>
+        private sealed class Sink(IObserver<TOut> downstream, Func<TIn, (bool HasValue, TOut Value)> chooser) : IObserver<TIn>
+        {
+            /// <inheritdoc/>
+            public void OnNext(TIn value)
+            {
+                (bool HasValue, TOut Value) result;
+                try
+                {
+                    result = chooser(value);
+                }
+                catch (Exception ex)
+                {
+                    downstream.OnError(ex);
+                    return;
+                }
+
+                if (!result.HasValue)
+                {
+                    return;
+                }
+
+                downstream.OnNext(result.Value);
+            }
+
+            /// <inheritdoc/>
+            public void OnError(Exception error) => downstream.OnError(error);
+
+            /// <inheritdoc/>
+            public void OnCompleted() => downstream.OnCompleted();
+        }
+    }
+
+    /// <summary>A fused filter-null + map-to-inner + switch-to-latest observable.</summary>
+    /// <typeparam name="TSource">The (nullable) source element type.</typeparam>
+    /// <typeparam name="TResult">The element type of the projected inner observables.</typeparam>
+    private sealed class SwitchSelectSignal<TSource, TResult>(IObservable<TSource?> source, Func<TSource, IObservable<TResult>> selector) : IObservable<TResult>
+    {
+        /// <inheritdoc/>
+        public IDisposable Subscribe(IObserver<TResult> observer)
+        {
+            if (observer == null)
+            {
+                throw new ArgumentNullException(nameof(observer));
+            }
+
+            var sink = new Sink(selector, observer);
+            sink.Run(source);
+            return sink;
+        }
+
+        /// <summary>Subscribes to the source, switching the active inner subscription on each non-null value.</summary>
+        private sealed class Sink(Func<TSource, IObservable<TResult>> selector, IObserver<TResult> downstream)
+            : IObserver<TSource?>, IDisposable
+        {
+            /// <summary>Guards the switching state so outer and inner notifications stay consistent.</summary>
+            private readonly Lock _gate = new();
+
+            /// <summary>The outer (source) subscription.</summary>
+            private readonly OnceDisposable _outer = new();
+
+            /// <summary>The active inner subscription; assigning a new value disposes the previous one.</summary>
+            private readonly SwapDisposable _inner = new();
+
+            /// <summary>Generation id of the most recent inner observable; stale inner notifications are ignored.</summary>
+            private ulong _latest;
+
+            /// <summary>Whether an inner subscription is currently active.</summary>
+            private bool _hasInner;
+
+            /// <summary>Whether the outer source has completed.</summary>
+            private bool _outerCompleted;
+
+            /// <summary>Whether this sink has been disposed.</summary>
+            private bool _disposed;
+
+            /// <summary>Begins observing the source.</summary>
+            /// <param name="source">The source observable.</param>
+            public void Run(IObservable<TSource?> source) => _outer.Disposable = source.Subscribe(this);
+
+            /// <inheritdoc/>
+            public void OnNext(TSource? value)
+            {
+                if (value is null)
+                {
+                    return;
+                }
+
+                IObservable<TResult> inner;
+                try
+                {
+                    inner = selector(value);
+                }
+                catch (Exception ex)
+                {
+                    OnError(ex);
+                    return;
+                }
+
+                ulong id;
+                lock (_gate)
+                {
+                    if (_disposed)
+                    {
+                        return;
+                    }
+
+                    id = ++_latest;
+                    _hasInner = true;
+                }
+
+                _inner.Disposable = inner.Subscribe(new InnerObserver(this, id));
+            }
+
+            /// <inheritdoc/>
+            public void OnError(Exception error)
+            {
+                lock (_gate)
+                {
+                    if (_disposed)
+                    {
+                        return;
+                    }
+                }
+
+                downstream.OnError(error);
+                Dispose();
+            }
+
+            /// <inheritdoc/>
+            public void OnCompleted()
+            {
+                bool complete;
+                lock (_gate)
+                {
+                    if (_disposed)
+                    {
+                        return;
+                    }
+
+                    _outerCompleted = true;
+                    complete = !_hasInner;
+                }
+
+                if (!complete)
+                {
+                    return;
+                }
+
+                downstream.OnCompleted();
+                Dispose();
+            }
+
+            /// <inheritdoc/>
+            public void Dispose()
+            {
+                lock (_gate)
+                {
+                    if (_disposed)
+                    {
+                        return;
+                    }
+
+                    _disposed = true;
+                }
+
+                _outer.Dispose();
+                _inner.Dispose();
+            }
+
+            /// <summary>Forwards an inner value to the downstream observer if it belongs to the active inner subscription.</summary>
+            /// <param name="id">The generation id of the inner subscription that produced the value.</param>
+            /// <param name="value">The value to forward.</param>
+            private void InnerOnNext(ulong id, TResult value)
+            {
+                lock (_gate)
+                {
+                    if (_disposed || id != _latest)
+                    {
+                        return;
+                    }
+                }
+
+                downstream.OnNext(value);
+            }
+
+            /// <summary>Forwards an inner error to the downstream observer if it belongs to the active inner subscription.</summary>
+            /// <param name="id">The generation id of the inner subscription that errored.</param>
+            /// <param name="error">The error to forward.</param>
+            private void InnerOnError(ulong id, Exception error)
+            {
+                lock (_gate)
+                {
+                    if (_disposed || id != _latest)
+                    {
+                        return;
+                    }
+                }
+
+                downstream.OnError(error);
+                Dispose();
+            }
+
+            /// <summary>Clears the active inner subscription; completes downstream only if the outer has also completed.</summary>
+            /// <param name="id">The generation id of the inner subscription that completed.</param>
+            private void InnerOnCompleted(ulong id)
+            {
+                bool complete;
+                lock (_gate)
+                {
+                    if (_disposed || id != _latest)
+                    {
+                        return;
+                    }
+
+                    _hasInner = false;
+                    complete = _outerCompleted;
+                }
+
+                if (!complete)
+                {
+                    return;
+                }
+
+                downstream.OnCompleted();
+                Dispose();
+            }
+
+            /// <summary>Observes a single inner observable and routes its notifications through the parent sink.</summary>
+            /// <param name="parent">The owning sink.</param>
+            /// <param name="id">The generation id of this inner subscription.</param>
+            private sealed class InnerObserver(Sink parent, ulong id) : IObserver<TResult>
+            {
+                /// <inheritdoc/>
+                public void OnNext(TResult value) => parent.InnerOnNext(id, value);
+
+                /// <inheritdoc/>
+                public void OnError(Exception error) => parent.InnerOnError(id, error);
+
+                /// <inheritdoc/>
+                public void OnCompleted() => parent.InnerOnCompleted(id);
+            }
+        }
+    }
+}

--- a/src/tests/ReactiveUI.Primitives.Extensions.Tests/GlobalTestSetup.cs
+++ b/src/tests/ReactiveUI.Primitives.Extensions.Tests/GlobalTestSetup.cs
@@ -10,16 +10,35 @@ namespace ReactiveUI.Primitives.Extensions.Tests;
 /// </summary>
 internal static class GlobalTestSetup
 {
+    /// <summary>The worker-thread floor for the test process; see <see cref="ConfigureDefaults"/>.</summary>
+    private const int MinPoolThreads = 32;
+
     /// <summary>
-    /// Caps every test at 60 seconds. Without a default cap, a single flaky test that hangs
-    /// stalls the entire assembly (the whole suite is serialised via
-    /// <c>[assembly: NotInParallel(nameof(UnhandledExceptionHandler))]</c>) and we lose the
-    /// per-test failure signal — the CI just reports the workflow-level timeout. 60s is far
-    /// above every legitimate test (slowest non-cancellation test is ~5s) so any future hang
-    /// fails its own test with a clear message instead of killing the whole run.
+    /// Caps every test at 60 seconds and raises the thread-pool worker floor before any test runs.
+    /// <para>
+    /// The 60s cap: without a default, a single flaky test that hangs stalls the entire assembly (the
+    /// whole suite is serialised via <c>[assembly: NotInParallel(nameof(UnhandledExceptionHandler))]</c>)
+    /// and we lose the per-test failure signal — CI just reports the workflow-level timeout. 60s is far
+    /// above every legitimate test (slowest non-cancellation test is ~5s) so any future hang fails its
+    /// own test with a clear message instead of killing the whole run.
+    /// </para>
+    /// <para>
+    /// The thread-pool floor: several tests rendezvous two blocking work items on the default pool
+    /// (e.g. <c>Continuation</c>'s <c>Barrier.SignalAndWait</c>, scheduled retries). A busy CI runner can
+    /// saturate the pool, which only hill-climbs new workers ~1/sec, so a rendezvous needing a second
+    /// thread can miss its guard window and time out. Raising the floor makes those threads available
+    /// immediately rather than starved behind unrelated work.
+    /// </para>
     /// </summary>
     /// <param name="context">The TUnit test-discovery context exposing programmatic settings.</param>
     [Before(HookType.TestDiscovery)]
-    public static void ConfigureDefaults(BeforeTestDiscoveryContext context) =>
+    public static void ConfigureDefaults(BeforeTestDiscoveryContext context)
+    {
         context.Settings.Timeouts.DefaultTestTimeout = TimeSpan.FromSeconds(60);
+
+        ThreadPool.GetMinThreads(out var workerThreads, out var completionPortThreads);
+        _ = ThreadPool.SetMinThreads(
+            Math.Max(workerThreads, MinPoolThreads),
+            Math.Max(completionPortThreads, MinPoolThreads));
+    }
 }

--- a/src/tests/ReactiveUI.Primitives.Extensions.Tests/ReactiveExtensionsTests.Retry.cs
+++ b/src/tests/ReactiveUI.Primitives.Extensions.Tests/ReactiveExtensionsTests.Retry.cs
@@ -821,21 +821,23 @@ public partial class ReactiveExtensionsTests
     {
         // Given — source always fails
         var source = Observable.Throw<int>(new InvalidOperationException("permanent"));
-        Exception? caught = null;
+        var completion = new TaskCompletionSource<Exception>();
 
         // When
         using var sub = source
             .RetryWithDelay(2, _ => TimeSpan.FromMilliseconds(1))
             .Subscribe(
                 static _ => { },
-                ex => caught = ex);
+                ex => completion.TrySetResult(ex));
 
-        // Allow time for the retry attempts to complete
-        await AsyncTestHelpers.WaitForConditionAsync(() => caught is not null, TimeSpan.FromSeconds(5));
+        // Await the error propagation directly rather than polling a flag against a wall-clock
+        // deadline — the retries run on the default (thread-pool) scheduler, so a fixed budget is
+        // racy under CI load.
+        var caught = await completion.Task;
 
         // Then
         await Assert.That(caught).IsNotNull();
         await Assert.That(caught).IsTypeOf<InvalidOperationException>();
-        await Assert.That(caught!.Message).IsEqualTo("permanent");
+        await Assert.That(caught.Message).IsEqualTo("permanent");
     }
 }

--- a/src/tests/ReactiveUI.Primitives.Tests/ApiApprovalTests.Primitives.DotNet10_0.verified.txt
+++ b/src/tests/ReactiveUI.Primitives.Tests/ApiApprovalTests.Primitives.DotNet10_0.verified.txt
@@ -198,6 +198,9 @@ namespace ReactiveUI.Primitives
         public static System.IObservable<TResult> CastTo<TResult>(this System.IObservable<object?> source) { }
         public static System.IObservable<T> Chain<T>(this System.IObservable<System.IObservable<T>> sources) { }
         public static System.IObservable<T> Chain<T>(this System.IObservable<T> first, System.IObservable<T> second) { }
+        public static System.IObservable<TOut> Choose<TIn, TOut>(this System.IObservable<TIn> source, [System.Runtime.CompilerServices.TupleElementNames(new string[] {
+                "HasValue",
+                "Value"})] System.Func<TIn, System.ValueTuple<bool, TOut>> chooser) { }
         public static System.IObservable<T[]> CollectArray<T>(this System.IObservable<T> source) { }
         public static System.Threading.Tasks.Task<T[]> CollectArrayAsync<T>(this System.IObservable<T> source) { }
         public static System.IObservable<System.Collections.Generic.IList<T>> CollectList<T>(this System.IObservable<T> source) { }
@@ -271,6 +274,7 @@ namespace ReactiveUI.Primitives
         public static System.IObservable<T> Stabilize<T>(this System.IObservable<T> source, System.TimeSpan dueTime) { }
         public static System.IObservable<T> Stabilize<T>(this System.IObservable<T> source, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) { }
         public static System.IObservable<T> SubscribeOn<T>(this System.IObservable<T> source, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
+        public static System.IObservable<TResult> SwitchSelect<TSource, TResult>(this System.IObservable<TSource?> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public static System.IObservable<T> SwitchTo<T>(this System.IObservable<System.IObservable<T>> sources) { }
         public static System.IObservable<TResult> SyncLatest<TLeft, TRight, TResult>(this System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public static System.IObservable<T> Take<T>(this System.IObservable<T> source, int count) { }

--- a/src/tests/ReactiveUI.Primitives.Tests/ApiApprovalTests.Primitives.DotNet8_0.verified.txt
+++ b/src/tests/ReactiveUI.Primitives.Tests/ApiApprovalTests.Primitives.DotNet8_0.verified.txt
@@ -198,6 +198,9 @@ namespace ReactiveUI.Primitives
         public static System.IObservable<TResult> CastTo<TResult>(this System.IObservable<object?> source) { }
         public static System.IObservable<T> Chain<T>(this System.IObservable<System.IObservable<T>> sources) { }
         public static System.IObservable<T> Chain<T>(this System.IObservable<T> first, System.IObservable<T> second) { }
+        public static System.IObservable<TOut> Choose<TIn, TOut>(this System.IObservable<TIn> source, [System.Runtime.CompilerServices.TupleElementNames(new string[] {
+                "HasValue",
+                "Value"})] System.Func<TIn, System.ValueTuple<bool, TOut>> chooser) { }
         public static System.IObservable<T[]> CollectArray<T>(this System.IObservable<T> source) { }
         public static System.Threading.Tasks.Task<T[]> CollectArrayAsync<T>(this System.IObservable<T> source) { }
         public static System.IObservable<System.Collections.Generic.IList<T>> CollectList<T>(this System.IObservable<T> source) { }
@@ -271,6 +274,7 @@ namespace ReactiveUI.Primitives
         public static System.IObservable<T> Stabilize<T>(this System.IObservable<T> source, System.TimeSpan dueTime) { }
         public static System.IObservable<T> Stabilize<T>(this System.IObservable<T> source, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) { }
         public static System.IObservable<T> SubscribeOn<T>(this System.IObservable<T> source, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
+        public static System.IObservable<TResult> SwitchSelect<TSource, TResult>(this System.IObservable<TSource?> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public static System.IObservable<T> SwitchTo<T>(this System.IObservable<System.IObservable<T>> sources) { }
         public static System.IObservable<TResult> SyncLatest<TLeft, TRight, TResult>(this System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public static System.IObservable<T> Take<T>(this System.IObservable<T> source, int count) { }

--- a/src/tests/ReactiveUI.Primitives.Tests/ApiApprovalTests.Primitives.DotNet9_0.verified.txt
+++ b/src/tests/ReactiveUI.Primitives.Tests/ApiApprovalTests.Primitives.DotNet9_0.verified.txt
@@ -198,6 +198,9 @@ namespace ReactiveUI.Primitives
         public static System.IObservable<TResult> CastTo<TResult>(this System.IObservable<object?> source) { }
         public static System.IObservable<T> Chain<T>(this System.IObservable<System.IObservable<T>> sources) { }
         public static System.IObservable<T> Chain<T>(this System.IObservable<T> first, System.IObservable<T> second) { }
+        public static System.IObservable<TOut> Choose<TIn, TOut>(this System.IObservable<TIn> source, [System.Runtime.CompilerServices.TupleElementNames(new string[] {
+                "HasValue",
+                "Value"})] System.Func<TIn, System.ValueTuple<bool, TOut>> chooser) { }
         public static System.IObservable<T[]> CollectArray<T>(this System.IObservable<T> source) { }
         public static System.Threading.Tasks.Task<T[]> CollectArrayAsync<T>(this System.IObservable<T> source) { }
         public static System.IObservable<System.Collections.Generic.IList<T>> CollectList<T>(this System.IObservable<T> source) { }
@@ -271,6 +274,7 @@ namespace ReactiveUI.Primitives
         public static System.IObservable<T> Stabilize<T>(this System.IObservable<T> source, System.TimeSpan dueTime) { }
         public static System.IObservable<T> Stabilize<T>(this System.IObservable<T> source, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) { }
         public static System.IObservable<T> SubscribeOn<T>(this System.IObservable<T> source, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
+        public static System.IObservable<TResult> SwitchSelect<TSource, TResult>(this System.IObservable<TSource?> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public static System.IObservable<T> SwitchTo<T>(this System.IObservable<System.IObservable<T>> sources) { }
         public static System.IObservable<TResult> SyncLatest<TLeft, TRight, TResult>(this System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public static System.IObservable<T> Take<T>(this System.IObservable<T> source, int count) { }

--- a/src/tests/ReactiveUI.Primitives.Tests/ChooseSwitchSelectTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/ChooseSwitchSelectTests.cs
@@ -2,6 +2,7 @@
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using ReactiveUI.Primitives.Disposables;
 using ReactiveUI.Primitives.Signals;
 
 namespace ReactiveUI.Primitives.Tests;
@@ -224,6 +225,49 @@ public class ChooseSwitchSelectTests
         Assert.Equal(Once, completed);
     }
 
+    /// <summary>
+    /// Verifies the SwitchSelect race guards drop notifications from a superseded inner observable and
+    /// from the outer/active-inner sources after disposal — the defensive early-returns that a
+    /// well-behaved (unsubscribing) source would otherwise hide.
+    /// </summary>
+    [Test]
+    public void SwitchSelectGuardsIgnoreStaleAndPostDisposeNotifications()
+    {
+        var outer = new ManualObservable<string?>();
+        var inner1 = new ManualObservable<int>();
+        var inner2 = new ManualObservable<int>();
+        var values = new List<int>();
+        Exception? error = null;
+        var completed = 0;
+
+        var subscription = outer
+            .SwitchSelect(key => key == KeyA ? inner1 : inner2)
+            .Subscribe(values.Add, ex => error = ex, () => completed++);
+
+        outer.Next(KeyA); // inner1 active
+        outer.Next(KeyB); // inner2 active; inner1 now superseded
+
+        // Superseded inner1 (its id != the latest): every notification hits the stale guard.
+        inner1.Next(Eleven);
+        inner1.Error(new InvalidOperationException(Boom));
+        inner1.Complete();
+
+        subscription.Dispose();
+        subscription.Dispose(); // idempotent: the second dispose hits the disposed guard
+
+        // After disposal every outer and active-inner notification hits the disposed guard.
+        outer.Next(KeyA);
+        outer.Error(new InvalidOperationException(Boom));
+        outer.Complete();
+        inner2.Next(Twenty);
+        inner2.Error(new InvalidOperationException(Boom));
+        inner2.Complete();
+
+        Assert.Equal(0, values.Count);
+        Assert.True(error is null);
+        Assert.Equal(0, completed);
+    }
+
     /// <summary>Verifies argument validation for both operators and their subscriptions.</summary>
     [Test]
     public void NullArgumentsThrow()
@@ -234,5 +278,36 @@ public class ChooseSwitchSelectTests
         Assert.Throws<ArgumentNullException>(() => default(IObservable<string?>)!.SwitchSelect(_ => Signal.None<int>()));
         Assert.Throws<ArgumentNullException>(() => new Signal<string?>().SwitchSelect<string, int>(null!));
         Assert.Throws<ArgumentNullException>(() => new Signal<string?>().SwitchSelect(_ => Signal.None<int>()).Subscribe((IObserver<int>)null!));
+    }
+
+    /// <summary>
+    /// An observable whose subscription deliberately ignores disposal, retaining its observer so a test
+    /// can keep pushing notifications after the operator has switched away from it or disposed it. A
+    /// well-behaved source unsubscribes on either event; this misbehaving source is what the operator's
+    /// race guards exist to defend against.
+    /// </summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    private sealed class ManualObservable<T> : IObservable<T>
+    {
+        /// <summary>The observer retained from the most recent subscription.</summary>
+        private IObserver<T>? _observer;
+
+        /// <inheritdoc/>
+        public IDisposable Subscribe(IObserver<T> observer)
+        {
+            _observer = observer;
+            return Disposable.Empty;
+        }
+
+        /// <summary>Pushes a value to the retained observer.</summary>
+        /// <param name="value">The value to push.</param>
+        public void Next(T value) => _observer?.OnNext(value);
+
+        /// <summary>Pushes an error to the retained observer.</summary>
+        /// <param name="exception">The error to push.</param>
+        public void Error(Exception exception) => _observer?.OnError(exception);
+
+        /// <summary>Pushes completion to the retained observer.</summary>
+        public void Complete() => _observer?.OnCompleted();
     }
 }

--- a/src/tests/ReactiveUI.Primitives.Tests/ChooseSwitchSelectTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/ChooseSwitchSelectTests.cs
@@ -1,0 +1,238 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using ReactiveUI.Primitives.Signals;
+
+namespace ReactiveUI.Primitives.Tests;
+
+/// <summary>
+/// Tests for the fused <see cref="LinqMixins.Choose{TIn, TOut}"/> and
+/// <see cref="LinqMixins.SwitchSelect{TSource, TResult}"/> projection operators.
+/// </summary>
+public class ChooseSwitchSelectTests
+{
+    /// <summary>The value ten.</summary>
+    private const int Ten = 10;
+
+    /// <summary>The value eleven (stale inner value that must be ignored).</summary>
+    private const int Eleven = 11;
+
+    /// <summary>The value twenty.</summary>
+    private const int Twenty = 20;
+
+    /// <summary>The divisor used to select even values in the Choose test.</summary>
+    private const int Two = 2;
+
+    /// <summary>The expected single-occurrence count.</summary>
+    private const int Once = 1;
+
+    /// <summary>The first outer selector key.</summary>
+    private const string KeyA = "a";
+
+    /// <summary>The second outer selector key.</summary>
+    private const string KeyB = "b";
+
+    /// <summary>Shared error message.</summary>
+    private const string Boom = "boom";
+
+    /// <summary>Source values for the Choose test.</summary>
+    private static readonly int[] _oneToFour = [1, 2, 3, 4];
+
+    /// <summary>Expected even values chosen from <see cref="_oneToFour"/>.</summary>
+    private static readonly int[] _evens = [2, 4];
+
+    /// <summary>Expected forwarded values after switching inner sources.</summary>
+    private static readonly int[] _tenThenTwenty = [Ten, Twenty];
+
+    /// <summary>Expected single forwarded value before disposal.</summary>
+    private static readonly int[] _tenOnly = [Ten];
+
+    /// <summary>Verifies that Choose forwards only values whose chooser returns <c>HasValue = true</c>.</summary>
+    [Test]
+    public void ChooseForwardsOnlyChosenValues()
+    {
+        var values = new List<int>();
+
+        Signal.FromEnumerable(_oneToFour)
+            .Choose(x => (x % Two == 0, x))
+            .Subscribe(values.Add);
+
+        Assert.Equal(_evens, values);
+    }
+
+    /// <summary>Verifies that a chooser exception is forwarded as an error.</summary>
+    [Test]
+    public void ChooseForwardsChooserError()
+    {
+        Exception? error = null;
+
+        Signal.FromEnumerable(_oneToFour)
+            .Choose<int, int>(_ => throw new InvalidOperationException("boom"))
+            .Subscribe(_ => { }, ex => error = ex, () => { });
+
+        Assert.NotNull(error);
+        Assert.True(error is InvalidOperationException);
+    }
+
+    /// <summary>
+    /// Verifies that SwitchSelect skips null source values, mirrors the latest inner observable, and ignores
+    /// values from a superseded inner observable.
+    /// </summary>
+    [Test]
+    public void SwitchSelectFiltersNullSwitchesAndIgnoresStaleInner()
+    {
+        var outer = new Signal<string?>();
+        var inner1 = new Signal<int>();
+        var inner2 = new Signal<int>();
+        var values = new List<int>();
+
+        outer.SwitchSelect(key => key == KeyA ? inner1 : inner2)
+            .Subscribe(values.Add);
+
+        outer.OnNext(null);    // skipped (null)
+        outer.OnNext(KeyA);    // subscribe inner1
+        inner1.OnNext(Ten);    // forwarded
+        outer.OnNext(KeyB);    // switch to inner2; inner1 superseded
+        inner1.OnNext(Eleven); // stale -> ignored
+        inner2.OnNext(Twenty); // forwarded
+
+        Assert.Equal(_tenThenTwenty, values);
+    }
+
+    /// <summary>Verifies that SwitchSelect completes only once both the outer and the active inner have completed.</summary>
+    [Test]
+    public void SwitchSelectCompletesAfterOuterAndInner()
+    {
+        var outer = new Signal<string?>();
+        var inner = new Signal<int>();
+        var completed = 0;
+
+        outer.SwitchSelect(_ => inner)
+            .Subscribe(_ => { }, ex => throw ex, () => completed++);
+
+        outer.OnNext(KeyA);  // active inner
+        outer.OnCompleted(); // outer done, inner still active -> not complete
+        Assert.Equal(0, completed);
+        inner.OnCompleted(); // now complete
+        Assert.Equal(Once, completed);
+    }
+
+    /// <summary>Verifies that a source error is forwarded through Choose.</summary>
+    [Test]
+    public void ChooseForwardsSourceError()
+    {
+        var source = new Signal<int>();
+        Exception? error = null;
+
+        source.Choose(x => (true, x)).Subscribe(_ => { }, ex => error = ex, () => { });
+        source.OnError(new InvalidOperationException(Boom));
+
+        Assert.True(error is InvalidOperationException);
+    }
+
+    /// <summary>Verifies that a selector exception terminates SwitchSelect with an error.</summary>
+    [Test]
+    public void SwitchSelectForwardsSelectorError()
+    {
+        var outer = new Signal<string?>();
+        Exception? error = null;
+
+        outer.SwitchSelect<string, int>(_ => throw new InvalidOperationException(Boom))
+            .Subscribe(_ => { }, ex => error = ex, () => { });
+        outer.OnNext(KeyA);
+
+        Assert.True(error is InvalidOperationException);
+    }
+
+    /// <summary>Verifies that an outer error terminates SwitchSelect.</summary>
+    [Test]
+    public void SwitchSelectForwardsOuterError()
+    {
+        var outer = new Signal<string?>();
+        var inner = new Signal<int>();
+        Exception? error = null;
+
+        outer.SwitchSelect(_ => inner).Subscribe(_ => { }, ex => error = ex, () => { });
+        outer.OnNext(KeyA);
+        outer.OnError(new InvalidOperationException(Boom));
+
+        Assert.True(error is InvalidOperationException);
+    }
+
+    /// <summary>Verifies that an inner error terminates SwitchSelect.</summary>
+    [Test]
+    public void SwitchSelectForwardsInnerError()
+    {
+        var outer = new Signal<string?>();
+        var inner = new Signal<int>();
+        Exception? error = null;
+
+        outer.SwitchSelect(_ => inner).Subscribe(_ => { }, ex => error = ex, () => { });
+        outer.OnNext(KeyA);
+        inner.OnError(new InvalidOperationException(Boom));
+
+        Assert.True(error is InvalidOperationException);
+    }
+
+    /// <summary>Verifies that disposing SwitchSelect tears down the outer and inner subscriptions.</summary>
+    [Test]
+    public void SwitchSelectDisposeUnsubscribes()
+    {
+        var outer = new Signal<string?>();
+        var inner = new Signal<int>();
+        var values = new List<int>();
+
+        var subscription = outer.SwitchSelect(_ => inner).Subscribe(values.Add);
+        outer.OnNext(KeyA);
+        inner.OnNext(Ten);
+        subscription.Dispose();
+        inner.OnNext(Eleven); // disposed -> ignored
+        outer.OnNext(KeyB);   // disposed -> ignored
+
+        Assert.Equal(_tenOnly, values);
+    }
+
+    /// <summary>Verifies completion when the inner completes before the outer.</summary>
+    [Test]
+    public void SwitchSelectCompletesWhenInnerThenOuterComplete()
+    {
+        var outer = new Signal<string?>();
+        var inner = new Signal<int>();
+        var completed = 0;
+
+        outer.SwitchSelect(_ => inner).Subscribe(_ => { }, ex => throw ex, () => completed++);
+
+        outer.OnNext(KeyA);
+        inner.OnCompleted(); // inner done; outer still open -> not complete
+        Assert.Equal(0, completed);
+        outer.OnCompleted(); // outer done, no active inner -> complete
+        Assert.Equal(Once, completed);
+    }
+
+    /// <summary>Verifies completion when the outer completes before any value is emitted.</summary>
+    [Test]
+    public void SwitchSelectCompletesWhenOuterCompletesWithNoValue()
+    {
+        var outer = new Signal<string?>();
+        var completed = 0;
+
+        outer.SwitchSelect(_ => new Signal<int>())
+            .Subscribe(_ => { }, ex => throw ex, () => completed++);
+        outer.OnCompleted();
+
+        Assert.Equal(Once, completed);
+    }
+
+    /// <summary>Verifies argument validation for both operators and their subscriptions.</summary>
+    [Test]
+    public void NullArgumentsThrow()
+    {
+        Assert.Throws<ArgumentNullException>(() => default(IObservable<int>)!.Choose<int, int>(x => (true, x)));
+        Assert.Throws<ArgumentNullException>(() => Signal.FromEnumerable(_oneToFour).Choose<int, int>(null!));
+        Assert.Throws<ArgumentNullException>(() => Signal.FromEnumerable(_oneToFour).Choose(x => (true, x)).Subscribe((IObserver<int>)null!));
+        Assert.Throws<ArgumentNullException>(() => default(IObservable<string?>)!.SwitchSelect(_ => Signal.None<int>()));
+        Assert.Throws<ArgumentNullException>(() => new Signal<string?>().SwitchSelect<string, int>(null!));
+        Assert.Throws<ArgumentNullException>(() => new Signal<string?>().SwitchSelect(_ => Signal.None<int>()).Subscribe((IObserver<int>)null!));
+    }
+}


### PR DESCRIPTION
## What

Two fused projection operators on `LinqMixins`, each a single sink:

```csharp
public static IObservable<TOut> Choose<TIn, TOut>(this IObservable<TIn> source, Func<TIn, (bool HasValue, TOut Value)> chooser);
public static IObservable<TResult> SwitchSelect<TSource, TResult>(this IObservable<TSource?> source, Func<TSource, IObservable<TResult>> selector);
```

- **`Choose`** — folds `Where` + `Select` into one sink via a `(HasValue, Value)` chooser. Unlike the existing `TrySelect` (which returns `TOut?` and treats null as "skip"), the explicit `HasValue` flag lets a **non-nullable value type** be skipped without conflating it with a valid value.
- **`SwitchSelect`** — folds `WhereNotNull()` + `Select(selector)` + `Switch()` into one sink: skips null source values, projects each remaining value to an inner observable, and mirrors only the **latest** inner (notifications from a superseded inner are ignored via a generation id). Completes once both the outer and the active inner have completed.

## Why

Both are common fused chains that otherwise cost multiple operator sinks/allocations per use (downstream consumers build them constantly in binding/routing code). `Switch`-with-projection (switchMap) in particular had no Primitives equivalent — only `SwitchTo` (plain switch).

## Tests

New `ChooseSwitchSelectTests` (12 cases): choose filter+map, chooser error, null-filter + switch + stale-inner suppression, both completion orderings, selector/outer/inner error propagation, dispose teardown, and argument validation. Full `ReactiveUI.Primitives.Tests` suite green (net9.0); core builds net8.0/net9.0/net462; API approval snapshots updated for all three TFMs. Line coverage 93.3% — the only uncovered lines are the `_disposed`/stale-`id` race guards (unreachable single-threaded, since dispose/switch unsubscribes the sources first).