### PR TITLE
build: restore StyleSharp 3.3 build compliance

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -9,7 +9,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageVersion Include="MinVer" Version="7.0.0" />
-    <PackageVersion Include="StyleSharp.Analyzers" Version="3.2.7" />
+    <PackageVersion Include="StyleSharp.Analyzers" Version="3.3.0" />
     <PackageVersion Include="Roslynator.Analyzers" Version="4.15.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.4" />
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="5.0.0-1.25277.114" />

--- a/src/Polyfills/TaskPolyfillExtensions.cs
+++ b/src/Polyfills/TaskPolyfillExtensions.cs
@@ -40,6 +40,11 @@ internal static class TaskPolyfillExtensions
         }
     }
 
+    /// <summary>Waits for the task to complete, timeout, or cancellation.</summary>
+    /// <param name="task">The task to observe.</param>
+    /// <param name="timeout">The timeout after which the wait fails, or <see cref="Timeout.InfiniteTimeSpan"/> for no timeout.</param>
+    /// <param name="cancellationToken">A token that cancels the wait.</param>
+    /// <returns>A task that completes when the wait condition is resolved.</returns>
     private static async Task WaitForCompletionAsync(Task task, TimeSpan timeout, CancellationToken cancellationToken)
     {
         if (task.IsCompleted)

--- a/src/ReactiveUI.Primitives.Async/Internals/CombineLatestCoordinatorBase.cs
+++ b/src/ReactiveUI.Primitives.Async/Internals/CombineLatestCoordinatorBase.cs
@@ -17,10 +17,7 @@ internal abstract class CombineLatestCoordinatorBase<TResult> : IAsyncDisposable
     /// <summary>Initializes a new instance of the <see cref="CombineLatestCoordinatorBase{TResult}"/> class.</summary>
     /// <param name="observer">The downstream observer.</param>
     /// <param name="sourceCount">The number of upstream sources (e.g. 2 for arity-2).</param>
-    protected CombineLatestCoordinatorBase(IObserverAsync<TResult> observer, int sourceCount)
-    {
-        Lifecycle = new(observer, sourceCount);
-    }
+    protected CombineLatestCoordinatorBase(IObserverAsync<TResult> observer, int sourceCount) => Lifecycle = new(observer, sourceCount);
 
     /// <summary>Gets the shared subscription lifecycle (gate / dispose CTS / external link / forwarders).</summary>
     internal CombineLatestLifecycle<TResult> Lifecycle { get; }

--- a/src/ReactiveUI.Primitives.Async/Signals/Base/BaseReplayLatestSignalAsync.cs
+++ b/src/ReactiveUI.Primitives.Async/Signals/Base/BaseReplayLatestSignalAsync.cs
@@ -301,11 +301,9 @@ public abstract class BaseReplayLatestSignalAsync<T>(Optional<T> startValue) : S
         private int _disposed;
 
         /// <inheritdoc/>
-        public ValueTask DisposeAsync()
-        {
-            return Interlocked.Exchange(ref _disposed, 1) != 0
+        public ValueTask DisposeAsync() =>
+            Interlocked.Exchange(ref _disposed, 1) != 0
                 ? default
                 : signal.RemoveObserverAsync(observer);
-        }
     }
 }

--- a/src/ReactiveUI.Primitives.Async/Signals/Base/BaseStatelessReplayLatestSignalAsync.cs
+++ b/src/ReactiveUI.Primitives.Async/Signals/Base/BaseStatelessReplayLatestSignalAsync.cs
@@ -282,11 +282,9 @@ public abstract class BaseStatelessReplayLatestSignalAsync<T>(Optional<T> startV
         private int _disposed;
 
         /// <inheritdoc/>
-        public ValueTask DisposeAsync()
-        {
-            return Interlocked.Exchange(ref _disposed, 1) != 0
+        public ValueTask DisposeAsync() =>
+            Interlocked.Exchange(ref _disposed, 1) != 0
                 ? default
                 : signal.RemoveObserverAndResetAsync(observer);
-        }
     }
 }

--- a/src/ReactiveUI.Primitives.Extensions/Internal/CurrentValueSubject.cs
+++ b/src/ReactiveUI.Primitives.Extensions/Internal/CurrentValueSubject.cs
@@ -41,10 +41,7 @@ internal sealed class CurrentValueSubject<T> : IObservable<T>, IObserver<T>, IDi
 
     /// <summary>Initializes a new instance of the <see cref="CurrentValueSubject{T}"/> class with the supplied current value.</summary>
     /// <param name="initialValue">The value replayed to subscribers until <see cref="OnNext"/> overwrites it.</param>
-    public CurrentValueSubject(T initialValue)
-    {
-        _value = initialValue;
-    }
+    public CurrentValueSubject(T initialValue) => _value = initialValue;
 
     /// <summary>Gets the most recently emitted value.</summary>
     public T Value

--- a/src/ReactiveUI.Primitives/Concurrency/VirtualTimeSequencerBase{TAbsolute,TRelative}.cs
+++ b/src/ReactiveUI.Primitives/Concurrency/VirtualTimeSequencerBase{TAbsolute,TRelative}.cs
@@ -331,10 +331,7 @@ public abstract class VirtualTimeSequencerBase<TAbsolute, TRelative> : ISequence
     }
 
     /// <summary>Stops the virtual time scheduler.</summary>
-    public void Stop()
-    {
-        IsEnabled = false;
-    }
+    public void Stop() => IsEnabled = false;
 
     /// <summary>Adds a relative time value to an absolute time value.</summary>
     /// <param name="absolute">Absolute time value.</param>

--- a/src/ReactiveUI.Primitives/Disposables/MultipleDisposable.cs
+++ b/src/ReactiveUI.Primitives/Disposables/MultipleDisposable.cs
@@ -79,13 +79,7 @@ public class MultipleDisposable : IsDisposed
     }
 
     /// <summary>Gets a value indicating whether the object is disposed.</summary>
-    public bool IsDisposed
-    {
-        get
-        {
-            return Volatile.Read(ref _disposed);
-        }
-    }
+    public bool IsDisposed => Volatile.Read(ref _disposed);
 
     /// <summary>Gets the debugger display text.</summary>
     [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]

--- a/src/ReactiveUI.Primitives/Disposables/SingleDisposable.cs
+++ b/src/ReactiveUI.Primitives/Disposables/SingleDisposable.cs
@@ -40,13 +40,7 @@ public class SingleDisposable : IsDisposed
         : this(action) => Create(disposable);
 
     /// <summary>Gets a value indicating whether this instance is disposed.</summary>
-    public bool IsDisposed
-    {
-        get
-        {
-            return ReferenceEquals(Volatile.Read(ref _disposable), DisposedSentinel);
-        }
-    }
+    public bool IsDisposed => ReferenceEquals(Volatile.Read(ref _disposable), DisposedSentinel);
 
     /// <summary>Gets the debugger display text.</summary>
     [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]

--- a/src/ReactiveUI.Primitives/Disposables/SingleReplaceableDisposable.cs
+++ b/src/ReactiveUI.Primitives/Disposables/SingleReplaceableDisposable.cs
@@ -47,13 +47,7 @@ public class SingleReplaceableDisposable : IsDisposed
     /// <value>
     ///   <c>true</c> if this instance is disposed; otherwise, <c>false</c>.
     /// </value>
-    public bool IsDisposed
-    {
-        get
-        {
-            return ReferenceEquals(Volatile.Read(ref _disposable), DisposedSentinel);
-        }
-    }
+    public bool IsDisposed => ReferenceEquals(Volatile.Read(ref _disposable), DisposedSentinel);
 
     /// <summary>Gets the debugger display text.</summary>
     [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]

--- a/src/ReactiveUI.Primitives/SignalOperatorParityMixins.AsyncHelpers.cs
+++ b/src/ReactiveUI.Primitives/SignalOperatorParityMixins.AsyncHelpers.cs
@@ -11,6 +11,11 @@ namespace ReactiveUI.Primitives;
 /// <summary>Async enumerable collection helpers for the operator surface.</summary>
 public static partial class LinqExtensions
 {
+    /// <summary>Tries to collect values from an async-enumerable-backed signal into an array task.</summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    /// <param name="source">The observable source to inspect.</param>
+    /// <param name="task">The collection task when the source is async-enumerable-backed.</param>
+    /// <returns><see langword="true"/> when an async enumerable fast path is available; otherwise, <see langword="false"/>.</returns>
     private static bool TryCollectArrayFromAsyncEnumerable<T>(IObservable<T> source, [NotNullWhen(true)] out Task<T[]>? task)
     {
         if (source is IAsyncEnumerableBackedSignal<T> asyncEnumerable)
@@ -23,6 +28,11 @@ public static partial class LinqExtensions
         return false;
     }
 
+    /// <summary>Collects an async enumerable into a densely packed array.</summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    /// <param name="values">The async enumerable values to collect.</param>
+    /// <param name="cancellationToken">The token used to cancel enumeration.</param>
+    /// <returns>A task that resolves to the collected array.</returns>
     private static async Task<T[]> CollectAsyncEnumerableArrayAsync<T>(IAsyncEnumerable<T> values, CancellationToken cancellationToken)
     {
         const int InitialCapacity = 16;

--- a/src/ReactiveUI.Primitives/Signals/BehaviorSignal{T}.cs
+++ b/src/ReactiveUI.Primitives/Signals/BehaviorSignal{T}.cs
@@ -70,13 +70,7 @@ public class BehaviorSignal<T> : ISignal<T>
 
     /// <summary>Gets the string representation of this object for debugger display purposes.</summary>
     [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
-    private string? DebuggerDisplay
-    {
-        get
-        {
-            return ToString();
-        }
-    }
+    private string? DebuggerDisplay => ToString();
 
     /// <summary>Tries to get the current value or throws an exception.</summary>
     /// <param name="value">The initial value passed to the constructor until <see cref="OnNext"/> is called; after which, the last value passed to <see cref="OnNext"/>.</param>

--- a/src/ReactiveUI.Primitives/Signals/CommandSignal{TResult}.cs
+++ b/src/ReactiveUI.Primitives/Signals/CommandSignal{TResult}.cs
@@ -342,10 +342,7 @@ public sealed class CommandSignal<TResult> : IObservable<TResult>, IDisposable
 
     /// <summary>Publishes a fault when the faults surface has been requested.</summary>
     /// <param name="error">The command error.</param>
-    private void PublishFault(Exception error)
-    {
-        Volatile.Read(ref _faults)?.OnNext(error);
-    }
+    private void PublishFault(Exception error) => Volatile.Read(ref _faults)?.OnNext(error);
 
     /// <summary>Executes the ThrowIfDisposed operation.</summary>
     private void ThrowIfDisposed()

--- a/src/ReactiveUI.Primitives/Signals/TaskSignal{T}.cs
+++ b/src/ReactiveUI.Primitives/Signals/TaskSignal{T}.cs
@@ -73,10 +73,7 @@ internal sealed class TaskSignal<T> : ITaskSignal<T>
     }
 
     /// <summary>Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.</summary>
-    public void Dispose()
-    {
-        Dispose(true);
-    }
+    public void Dispose() => Dispose(true);
 
     /// <summary>Releases unmanaged and - optionally - managed resources.</summary>
     /// <param name="disposing"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>

--- a/src/ReactiveUI.Primitives/Sinks/CountAggregator.cs
+++ b/src/ReactiveUI.Primitives/Sinks/CountAggregator.cs
@@ -8,6 +8,8 @@ namespace ReactiveUI.Primitives;
 /// <typeparam name="T">The observed value type.</typeparam>
 internal readonly record struct CountAggregator<T> : IAggregator<T, int, CountAggregator<T>>
 {
+    /// <summary>Initializes a new instance of the <see cref="CountAggregator{T}"/> struct.</summary>
+    /// <param name="result">The current accumulated count.</param>
     private CountAggregator(int result) => Result = result;
 
     /// <inheritdoc/>

--- a/src/ReactiveUI.Primitives/Sinks/CountPredicateAggregator.cs
+++ b/src/ReactiveUI.Primitives/Sinks/CountPredicateAggregator.cs
@@ -17,6 +17,9 @@ internal readonly record struct CountPredicateAggregator<T> : IAggregator<T, int
     {
     }
 
+    /// <summary>Initializes a new instance of the <see cref="CountPredicateAggregator{T}"/> struct.</summary>
+    /// <param name="predicate">The predicate selecting which values to count.</param>
+    /// <param name="result">The current accumulated count.</param>
     private CountPredicateAggregator(Func<T, bool> predicate, int result)
     {
         _predicate = predicate;

--- a/src/ReactiveUI.Primitives/Sinks/DistinctByCountAggregator.cs
+++ b/src/ReactiveUI.Primitives/Sinks/DistinctByCountAggregator.cs
@@ -21,6 +21,10 @@ internal readonly record struct DistinctByCountAggregator<T, TKey> : IAggregator
     {
     }
 
+    /// <summary>Initializes a new instance of the <see cref="DistinctByCountAggregator{T,TKey}"/> struct.</summary>
+    /// <param name="keySelector">The key selector.</param>
+    /// <param name="seen">The set of keys that have already been observed.</param>
+    /// <param name="result">The current accumulated count.</param>
     private DistinctByCountAggregator(Func<T, TKey> keySelector, HashSet<TKey> seen, int result)
     {
         _keySelector = keySelector;

--- a/src/ReactiveUI.Primitives/Sinks/DistinctByLongCountAggregator.cs
+++ b/src/ReactiveUI.Primitives/Sinks/DistinctByLongCountAggregator.cs
@@ -21,6 +21,10 @@ internal readonly record struct DistinctByLongCountAggregator<T, TKey> : IAggreg
     {
     }
 
+    /// <summary>Initializes a new instance of the <see cref="DistinctByLongCountAggregator{T,TKey}"/> struct.</summary>
+    /// <param name="keySelector">The key selector.</param>
+    /// <param name="seen">The set of keys that have already been observed.</param>
+    /// <param name="result">The current accumulated count.</param>
     private DistinctByLongCountAggregator(Func<T, TKey> keySelector, HashSet<TKey> seen, long result)
     {
         _keySelector = keySelector;

--- a/src/ReactiveUI.Primitives/Sinks/LongCountAggregator.cs
+++ b/src/ReactiveUI.Primitives/Sinks/LongCountAggregator.cs
@@ -8,6 +8,8 @@ namespace ReactiveUI.Primitives;
 /// <typeparam name="T">The observed value type.</typeparam>
 internal readonly record struct LongCountAggregator<T> : IAggregator<T, long, LongCountAggregator<T>>
 {
+    /// <summary>Initializes a new instance of the <see cref="LongCountAggregator{T}"/> struct.</summary>
+    /// <param name="result">The current accumulated count.</param>
     private LongCountAggregator(long result) => Result = result;
 
     /// <inheritdoc/>

--- a/src/ReactiveUI.Primitives/Sinks/LongCountPredicateAggregator.cs
+++ b/src/ReactiveUI.Primitives/Sinks/LongCountPredicateAggregator.cs
@@ -17,6 +17,9 @@ internal readonly record struct LongCountPredicateAggregator<T> : IAggregator<T,
     {
     }
 
+    /// <summary>Initializes a new instance of the <see cref="LongCountPredicateAggregator{T}"/> struct.</summary>
+    /// <param name="predicate">The predicate selecting which values to count.</param>
+    /// <param name="result">The current accumulated count.</param>
     private LongCountPredicateAggregator(Func<T, bool> predicate, long result)
     {
         _predicate = predicate;

--- a/src/tests/ReactiveUI.Primitives.Async.Tests/AotSafeAssertionExtensions.cs
+++ b/src/tests/ReactiveUI.Primitives.Async.Tests/AotSafeAssertionExtensions.cs
@@ -10,6 +10,7 @@ namespace ReactiveUI.Primitives.Async.Tests;
 /// <summary>AOT-safe collection-equality helpers.</summary>
 internal static class AotSafeAssertionExtensions
 {
+    /// <summary>Provides collection-equality assertions for assertion sources.</summary>
     /// <param name="source">The assertion source.</param>
     /// <typeparam name="TCollection">The collection type being asserted.</typeparam>
     /// <typeparam name="TItem">The element type.</typeparam>

--- a/src/tests/ReactiveUI.Primitives.Tests/InternalInfrastructureCoverageTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/InternalInfrastructureCoverageTests.cs
@@ -506,10 +506,8 @@ public partial class InternalInfrastructureCoverageTests
         /// <param name="dueTime">The due time for the scheduled item.</param>
         /// <param name="invoke">The factory invoked when the item runs.</param>
         public ScheduledProbe(int dueTime, Func<IDisposable> invoke)
-            : base(dueTime, Comparer<int>.Default)
-        {
+            : base(dueTime, Comparer<int>.Default) =>
             _invoke = invoke;
-        }
 
         /// <summary>Invokes the supplied factory.</summary>
         /// <returns>The disposable returned by the factory.</returns>

--- a/src/tests/ReactiveUI.Primitives.Tests/RxNameParityTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/RxNameParityTests.cs
@@ -377,10 +377,11 @@ public class RxNameParityTests
 
     /// <summary>Verifies <c>Sample</c> mirrors <c>Probe</c> when sampled against an identical virtual clock drive.</summary>
     [Test]
-    public void SampleMatchesProbe()
-    {
-        Assert.Equal<int>(RunSampling((s, c) => s.Probe(TimeSpan.FromTicks(Two), c)), RunSampling((s, c) => s.Sample(TimeSpan.FromTicks(Two), c)));
-    }
+    public void SampleMatchesProbe() =>
+        Assert.Equal<int>(
+            RunSampling((s, c) => s.Probe(TimeSpan.FromTicks(Two), c)),
+            RunSampling((s, c) =>
+                s.Sample(TimeSpan.FromTicks(Two), c)));
 
     /// <summary>Verifies the 3-arg <c>SelectMany</c> mirrors the 3-arg <c>FlatMap</c>.</summary>
     [Test]
@@ -416,10 +417,7 @@ public class RxNameParityTests
 
     /// <summary>Verifies <c>Retry</c> mirrors the source when no error occurs (covers the happy path).</summary>
     [Test]
-    public void RetryMirrorsSourceWhenNoError()
-    {
-        Assert.Equal<int>(_oneToThree, Collect(Signal.FromEnumerable(_oneToThree).Retry(Two)));
-    }
+    public void RetryMirrorsSourceWhenNoError() => Assert.Equal<int>(_oneToThree, Collect(Signal.FromEnumerable(_oneToThree).Retry(Two)));
 
     /// <summary>Exercises the default-sequencer (no-scheduler) overloads of the time operators.</summary>
     [Test]

--- a/src/tests/ReactiveUI.Primitives.Tests/SinkObserverTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/SinkObserverTests.cs
@@ -403,6 +403,8 @@ public class SinkObserverTests
     /// <summary>A user-defined accumulator that sums observed values, exercising the public <see cref="IAggregator{T,TResult,TSelf}"/> contract.</summary>
     private readonly record struct SumAggregator : IAggregator<int, int, SumAggregator>
     {
+        /// <summary>Initializes a new instance of the <see cref="SumAggregator"/> struct.</summary>
+        /// <param name="result">The current accumulated sum.</param>
         private SumAggregator(int result) => Result = result;
 
         /// <inheritdoc/>


### PR DESCRIPTION
## What kind of change does this PR introduce?
Build and code-quality maintenance.

## What is the new behavior?
The repository now builds cleanly after upgrading to `StyleSharp.Analyzers` 3.3.0.

This branch brings the codebase into compliance with the newer analyzer rules by:
- adding concise XML documentation to private and internal helpers that now require it
- cleaning up a small number of formatting and expression-bodied-member violations raised by the new analyzer version
- keeping the changes behavior-preserving so consumers get the same runtime behavior with a green build and analyzer-clean source tree

For end users of `ReactiveUI.Primitives`, the practical outcome is that the package source and test projects are back to compiling successfully under the stricter analyzer set, which keeps future maintenance and releases unblocked.

## What is the current behavior?
Before this PR, the branch could not build successfully once `StyleSharp.Analyzers` 3.3.0 rules were applied because the stricter analyzer set reported documentation and formatting violations across core, async, and test projects.

## What might this PR break?
None.

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [ ] Tests have been added or updated (for bug fixes / features)
- [x] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information
- Verification: `dotnet build "ReactiveUI.Primitives.slnx"` from `src`
- Additional spot checks from review: `ReactiveUI.Primitives`, `ReactiveUI.Primitives.Async`, and `ReactiveUI.Primitives.Tests` project builds succeeded
- No public API or runtime behavior changes are intended in this branch
