### PR TITLE
feat(primitives): add enumerable blend and priority queue helpers

### DIFF
--- a/src/ReactiveUI.Primitives/Core/PriorityQueue.cs
+++ b/src/ReactiveUI.Primitives/Core/PriorityQueue.cs
@@ -58,6 +58,45 @@ public sealed class PriorityQueue<T>
         return result;
     }
 
+    /// <summary>Removes up to <paramref name="count"/> queued items in priority order.</summary>
+    /// <param name="count">The maximum number of items to remove.</param>
+    /// <returns>The removed items in dequeue order.</returns>
+    public T[] DequeueSome(int count)
+    {
+        ArgumentOutOfRangeExceptionHelper.ThrowIfNegative(count);
+
+        var result = new T[Math.Min(count, Count)];
+        for (var i = 0; i < result.Length; i++)
+        {
+            result[i] = Dequeue();
+        }
+
+        return result;
+    }
+
+    /// <summary>Removes and returns all queued items in priority order.</summary>
+    /// <returns>The queued items in dequeue order.</returns>
+    public T[] DequeueAll()
+    {
+        return DequeueSome(Count);
+    }
+
+    /// <summary>Dequeues items into a caller-provided buffer.</summary>
+    /// <param name="destination">The destination buffer.</param>
+    /// <returns>The number of items written to <paramref name="destination"/>.</returns>
+    public int DequeueRange(T[] destination)
+    {
+        ArgumentExceptionHelper.ThrowIfNull(destination);
+
+        var count = Math.Min(destination.Length, Count);
+        for (var i = 0; i < count; i++)
+        {
+            destination[i] = Dequeue();
+        }
+
+        return count;
+    }
+
     /// <summary>Adds an item to the queue.</summary>
     /// <param name="item">Item to enqueue.</param>
     public void Enqueue(T item)
@@ -74,6 +113,18 @@ public sealed class PriorityQueue<T>
         Percolate(index);
     }
 
+    /// <summary>Adds multiple items to the queue.</summary>
+    /// <param name="items">Items to enqueue.</param>
+    public void EnqueueRange(T[] items)
+    {
+        ArgumentExceptionHelper.ThrowIfNull(items);
+
+        for (var i = 0; i < items.Length; i++)
+        {
+            Enqueue(items[i]);
+        }
+    }
+
     /// <summary>Returns the highest-priority item without removing it.</summary>
     /// <returns>The highest-priority item.</returns>
     public T Peek()
@@ -84,6 +135,36 @@ public sealed class PriorityQueue<T>
         }
 
         return _items[0].Value;
+    }
+
+    /// <summary>Attempts to return the highest-priority item without removing it.</summary>
+    /// <param name="item">The highest-priority item, or the default value when the queue is empty.</param>
+    /// <returns><see langword="true"/> when an item was available; otherwise, <see langword="false"/>.</returns>
+    public bool TryPeek(out T? item)
+    {
+        if (Count == 0)
+        {
+            item = default;
+            return false;
+        }
+
+        item = _items[0].Value;
+        return true;
+    }
+
+    /// <summary>Attempts to remove and return the highest-priority item.</summary>
+    /// <param name="item">The removed item, or the default value when the queue is empty.</param>
+    /// <returns><see langword="true"/> when an item was available; otherwise, <see langword="false"/>.</returns>
+    public bool TryDequeue(out T? item)
+    {
+        if (Count == 0)
+        {
+            item = default;
+            return false;
+        }
+
+        item = Dequeue();
+        return true;
     }
 
     /// <summary>Removes a matching item from the queue.</summary>
@@ -101,6 +182,35 @@ public sealed class PriorityQueue<T>
         }
 
         return false;
+    }
+
+    /// <summary>Verifies that the internal heap property is currently valid.</summary>
+    /// <returns><see langword="true"/> when every parent has higher priority than its children; otherwise, <see langword="false"/>.</returns>
+    public bool VerifyHeapProperty()
+    {
+        if (Count <= 1)
+        {
+            return true;
+        }
+
+        var lastParentIndex = (Count - 2) / HeapBranchingFactor;
+        for (var i = 0; i <= lastParentIndex; i++)
+        {
+            var left = (HeapBranchingFactor * i) + LeftChildOffset;
+            var right = (HeapBranchingFactor * i) + RightChildOffset;
+
+            if (left < Count && IsHigherPriority(left, i))
+            {
+                return false;
+            }
+
+            if (right < Count && IsHigherPriority(right, i))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /// <summary>Restores heap order from the supplied index downward.</summary>

--- a/src/ReactiveUI.Primitives/Core/PriorityQueue.cs
+++ b/src/ReactiveUI.Primitives/Core/PriorityQueue.cs
@@ -199,7 +199,7 @@ public sealed class PriorityQueue<T>
             var left = (HeapBranchingFactor * i) + LeftChildOffset;
             var right = (HeapBranchingFactor * i) + RightChildOffset;
 
-            if (left < Count && IsHigherPriority(left, i))
+            if (IsHigherPriority(left, i))
             {
                 return false;
             }

--- a/src/ReactiveUI.Primitives/LinqExtensions.BlendEnumerable.cs
+++ b/src/ReactiveUI.Primitives/LinqExtensions.BlendEnumerable.cs
@@ -1,0 +1,26 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using ReactiveUI.Primitives.Signals;
+
+namespace ReactiveUI.Primitives;
+
+/// <summary>Enumerable source overloads for blend operators.</summary>
+public static partial class LinqExtensions
+{
+    /// <summary>Operators for enumerable observable sources.</summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    /// <param name="sources">The observable sources.</param>
+    extension<T>(IEnumerable<IObservable<T>> sources)
+    {
+        /// <summary>Concurrently merges the supplied observable sources.</summary>
+        /// <returns>An observable that forwards values from every source.</returns>
+        public IObservable<T> Blend()
+        {
+            ArgumentExceptionHelper.ThrowIfNull(sources);
+
+            return Signal.FromEnumerable(sources).Blend();
+        }
+    }
+}

--- a/src/ReactiveUI.Primitives/LinqExtensions.BlendEnumerable.cs
+++ b/src/ReactiveUI.Primitives/LinqExtensions.BlendEnumerable.cs
@@ -2,8 +2,6 @@
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using ReactiveUI.Primitives.Signals;
-
 namespace ReactiveUI.Primitives;
 
 /// <summary>Enumerable source overloads for blend operators.</summary>
@@ -20,7 +18,27 @@ public static partial class LinqExtensions
         {
             ArgumentExceptionHelper.ThrowIfNull(sources);
 
-            return Signal.FromEnumerable(sources).Blend();
+            return new EnumerableBlendSignal<T>(sources);
+        }
+    }
+
+    /// <summary>Dedicated signal for enumerable <c>Blend</c> sources.</summary>
+    /// <typeparam name="T">The value type.</typeparam>
+    private sealed class EnumerableBlendSignal<T> : IObservable<T>
+    {
+        /// <summary>The sources to merge.</summary>
+        private readonly IEnumerable<IObservable<T>> _sources;
+
+        /// <summary>Initializes a new instance of the <see cref="EnumerableBlendSignal{T}"/> class.</summary>
+        /// <param name="sources">The sources to merge.</param>
+        internal EnumerableBlendSignal(IEnumerable<IObservable<T>> sources) => _sources = sources;
+
+        /// <inheritdoc/>
+        public IDisposable Subscribe(IObserver<T> observer)
+        {
+            ArgumentExceptionHelper.ThrowIfNull(observer);
+
+            return new BlendCoordinator<T>(observer).Run(_sources);
         }
     }
 }

--- a/src/ReactiveUI.Primitives/PublicAPI/net10.0-android/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net10.0-android/PublicAPI.Shipped.txt
@@ -236,11 +236,18 @@ ReactiveUI.Primitives.Core.Moment<T>.Value.get -> T
 ReactiveUI.Primitives.Core.PriorityQueue<T>
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Count.get -> int
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Dequeue() -> T
+ReactiveUI.Primitives.Core.PriorityQueue<T>.DequeueRange(T[]! destination) -> int
+ReactiveUI.Primitives.Core.PriorityQueue<T>.DequeueSome(int count) -> T[]!
+ReactiveUI.Primitives.Core.PriorityQueue<T>.DequeueAll() -> T[]!
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Enqueue(T item) -> void
+ReactiveUI.Primitives.Core.PriorityQueue<T>.EnqueueRange(T[]! items) -> void
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Peek() -> T
 ReactiveUI.Primitives.Core.PriorityQueue<T>.PriorityQueue() -> void
 ReactiveUI.Primitives.Core.PriorityQueue<T>.PriorityQueue(int capacity) -> void
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Remove(T item) -> bool
+ReactiveUI.Primitives.Core.PriorityQueue<T>.TryDequeue(out T? item) -> bool
+ReactiveUI.Primitives.Core.PriorityQueue<T>.TryPeek(out T? item) -> bool
+ReactiveUI.Primitives.Core.PriorityQueue<T>.VerifyHeapProperty() -> bool
 ReactiveUI.Primitives.Core.Spark
 ReactiveUI.Primitives.Core.SparkKind
 ReactiveUI.Primitives.Core.SparkKind.OnCompleted = 2 -> ReactiveUI.Primitives.Core.SparkKind
@@ -325,6 +332,9 @@ ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<ReactiveUI.
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!)
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Amb() -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Blend() -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>!)
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>!).Blend() -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.Blend<T>(this System.Collections.Generic.IEnumerable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Chain() -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Concat() -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Merge() -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net10.0-ios/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net10.0-ios/PublicAPI.Shipped.txt
@@ -236,11 +236,18 @@ ReactiveUI.Primitives.Core.Moment<T>.Value.get -> T
 ReactiveUI.Primitives.Core.PriorityQueue<T>
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Count.get -> int
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Dequeue() -> T
+ReactiveUI.Primitives.Core.PriorityQueue<T>.DequeueRange(T[]! destination) -> int
+ReactiveUI.Primitives.Core.PriorityQueue<T>.DequeueSome(int count) -> T[]!
+ReactiveUI.Primitives.Core.PriorityQueue<T>.DequeueAll() -> T[]!
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Enqueue(T item) -> void
+ReactiveUI.Primitives.Core.PriorityQueue<T>.EnqueueRange(T[]! items) -> void
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Peek() -> T
 ReactiveUI.Primitives.Core.PriorityQueue<T>.PriorityQueue() -> void
 ReactiveUI.Primitives.Core.PriorityQueue<T>.PriorityQueue(int capacity) -> void
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Remove(T item) -> bool
+ReactiveUI.Primitives.Core.PriorityQueue<T>.TryDequeue(out T? item) -> bool
+ReactiveUI.Primitives.Core.PriorityQueue<T>.TryPeek(out T? item) -> bool
+ReactiveUI.Primitives.Core.PriorityQueue<T>.VerifyHeapProperty() -> bool
 ReactiveUI.Primitives.Core.Spark
 ReactiveUI.Primitives.Core.SparkKind
 ReactiveUI.Primitives.Core.SparkKind.OnCompleted = 2 -> ReactiveUI.Primitives.Core.SparkKind
@@ -325,6 +332,9 @@ ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<ReactiveUI.
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!)
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Amb() -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Blend() -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>!)
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>!).Blend() -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.Blend<T>(this System.Collections.Generic.IEnumerable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Chain() -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Concat() -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Merge() -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net10.0-maccatalyst/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net10.0-maccatalyst/PublicAPI.Shipped.txt
@@ -236,11 +236,18 @@ ReactiveUI.Primitives.Core.Moment<T>.Value.get -> T
 ReactiveUI.Primitives.Core.PriorityQueue<T>
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Count.get -> int
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Dequeue() -> T
+ReactiveUI.Primitives.Core.PriorityQueue<T>.DequeueRange(T[]! destination) -> int
+ReactiveUI.Primitives.Core.PriorityQueue<T>.DequeueSome(int count) -> T[]!
+ReactiveUI.Primitives.Core.PriorityQueue<T>.DequeueAll() -> T[]!
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Enqueue(T item) -> void
+ReactiveUI.Primitives.Core.PriorityQueue<T>.EnqueueRange(T[]! items) -> void
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Peek() -> T
 ReactiveUI.Primitives.Core.PriorityQueue<T>.PriorityQueue() -> void
 ReactiveUI.Primitives.Core.PriorityQueue<T>.PriorityQueue(int capacity) -> void
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Remove(T item) -> bool
+ReactiveUI.Primitives.Core.PriorityQueue<T>.TryDequeue(out T? item) -> bool
+ReactiveUI.Primitives.Core.PriorityQueue<T>.TryPeek(out T? item) -> bool
+ReactiveUI.Primitives.Core.PriorityQueue<T>.VerifyHeapProperty() -> bool
 ReactiveUI.Primitives.Core.Spark
 ReactiveUI.Primitives.Core.SparkKind
 ReactiveUI.Primitives.Core.SparkKind.OnCompleted = 2 -> ReactiveUI.Primitives.Core.SparkKind
@@ -325,6 +332,9 @@ ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<ReactiveUI.
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!)
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Amb() -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Blend() -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>!)
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>!).Blend() -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.Blend<T>(this System.Collections.Generic.IEnumerable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Chain() -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Concat() -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Merge() -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net10.0-macos/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net10.0-macos/PublicAPI.Shipped.txt
@@ -236,11 +236,18 @@ ReactiveUI.Primitives.Core.Moment<T>.Value.get -> T
 ReactiveUI.Primitives.Core.PriorityQueue<T>
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Count.get -> int
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Dequeue() -> T
+ReactiveUI.Primitives.Core.PriorityQueue<T>.DequeueRange(T[]! destination) -> int
+ReactiveUI.Primitives.Core.PriorityQueue<T>.DequeueSome(int count) -> T[]!
+ReactiveUI.Primitives.Core.PriorityQueue<T>.DequeueAll() -> T[]!
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Enqueue(T item) -> void
+ReactiveUI.Primitives.Core.PriorityQueue<T>.EnqueueRange(T[]! items) -> void
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Peek() -> T
 ReactiveUI.Primitives.Core.PriorityQueue<T>.PriorityQueue() -> void
 ReactiveUI.Primitives.Core.PriorityQueue<T>.PriorityQueue(int capacity) -> void
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Remove(T item) -> bool
+ReactiveUI.Primitives.Core.PriorityQueue<T>.TryDequeue(out T? item) -> bool
+ReactiveUI.Primitives.Core.PriorityQueue<T>.TryPeek(out T? item) -> bool
+ReactiveUI.Primitives.Core.PriorityQueue<T>.VerifyHeapProperty() -> bool
 ReactiveUI.Primitives.Core.Spark
 ReactiveUI.Primitives.Core.SparkKind
 ReactiveUI.Primitives.Core.SparkKind.OnCompleted = 2 -> ReactiveUI.Primitives.Core.SparkKind
@@ -325,6 +332,9 @@ ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<ReactiveUI.
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!)
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Amb() -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Blend() -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>!)
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>!).Blend() -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.Blend<T>(this System.Collections.Generic.IEnumerable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Chain() -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Concat() -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Merge() -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net10.0-tvos/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net10.0-tvos/PublicAPI.Shipped.txt
@@ -236,11 +236,18 @@ ReactiveUI.Primitives.Core.Moment<T>.Value.get -> T
 ReactiveUI.Primitives.Core.PriorityQueue<T>
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Count.get -> int
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Dequeue() -> T
+ReactiveUI.Primitives.Core.PriorityQueue<T>.DequeueRange(T[]! destination) -> int
+ReactiveUI.Primitives.Core.PriorityQueue<T>.DequeueSome(int count) -> T[]!
+ReactiveUI.Primitives.Core.PriorityQueue<T>.DequeueAll() -> T[]!
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Enqueue(T item) -> void
+ReactiveUI.Primitives.Core.PriorityQueue<T>.EnqueueRange(T[]! items) -> void
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Peek() -> T
 ReactiveUI.Primitives.Core.PriorityQueue<T>.PriorityQueue() -> void
 ReactiveUI.Primitives.Core.PriorityQueue<T>.PriorityQueue(int capacity) -> void
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Remove(T item) -> bool
+ReactiveUI.Primitives.Core.PriorityQueue<T>.TryDequeue(out T? item) -> bool
+ReactiveUI.Primitives.Core.PriorityQueue<T>.TryPeek(out T? item) -> bool
+ReactiveUI.Primitives.Core.PriorityQueue<T>.VerifyHeapProperty() -> bool
 ReactiveUI.Primitives.Core.Spark
 ReactiveUI.Primitives.Core.SparkKind
 ReactiveUI.Primitives.Core.SparkKind.OnCompleted = 2 -> ReactiveUI.Primitives.Core.SparkKind
@@ -325,6 +332,9 @@ ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<ReactiveUI.
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!)
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Amb() -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Blend() -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>!)
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>!).Blend() -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.Blend<T>(this System.Collections.Generic.IEnumerable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Chain() -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Concat() -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Merge() -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net10.0/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net10.0/PublicAPI.Shipped.txt
@@ -236,11 +236,18 @@ ReactiveUI.Primitives.Core.Moment<T>.Value.get -> T
 ReactiveUI.Primitives.Core.PriorityQueue<T>
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Count.get -> int
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Dequeue() -> T
+ReactiveUI.Primitives.Core.PriorityQueue<T>.DequeueRange(T[]! destination) -> int
+ReactiveUI.Primitives.Core.PriorityQueue<T>.DequeueSome(int count) -> T[]!
+ReactiveUI.Primitives.Core.PriorityQueue<T>.DequeueAll() -> T[]!
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Enqueue(T item) -> void
+ReactiveUI.Primitives.Core.PriorityQueue<T>.EnqueueRange(T[]! items) -> void
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Peek() -> T
 ReactiveUI.Primitives.Core.PriorityQueue<T>.PriorityQueue() -> void
 ReactiveUI.Primitives.Core.PriorityQueue<T>.PriorityQueue(int capacity) -> void
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Remove(T item) -> bool
+ReactiveUI.Primitives.Core.PriorityQueue<T>.TryDequeue(out T? item) -> bool
+ReactiveUI.Primitives.Core.PriorityQueue<T>.TryPeek(out T? item) -> bool
+ReactiveUI.Primitives.Core.PriorityQueue<T>.VerifyHeapProperty() -> bool
 ReactiveUI.Primitives.Core.Spark
 ReactiveUI.Primitives.Core.SparkKind
 ReactiveUI.Primitives.Core.SparkKind.OnCompleted = 2 -> ReactiveUI.Primitives.Core.SparkKind
@@ -325,6 +332,9 @@ ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<ReactiveUI.
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!)
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Amb() -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Blend() -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>!)
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>!).Blend() -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.Blend<T>(this System.Collections.Generic.IEnumerable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Chain() -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Concat() -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Merge() -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net11.0-android/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net11.0-android/PublicAPI.Shipped.txt
@@ -236,11 +236,18 @@ ReactiveUI.Primitives.Core.Moment<T>.Value.get -> T
 ReactiveUI.Primitives.Core.PriorityQueue<T>
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Count.get -> int
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Dequeue() -> T
+ReactiveUI.Primitives.Core.PriorityQueue<T>.DequeueRange(T[]! destination) -> int
+ReactiveUI.Primitives.Core.PriorityQueue<T>.DequeueSome(int count) -> T[]!
+ReactiveUI.Primitives.Core.PriorityQueue<T>.DequeueAll() -> T[]!
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Enqueue(T item) -> void
+ReactiveUI.Primitives.Core.PriorityQueue<T>.EnqueueRange(T[]! items) -> void
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Peek() -> T
 ReactiveUI.Primitives.Core.PriorityQueue<T>.PriorityQueue() -> void
 ReactiveUI.Primitives.Core.PriorityQueue<T>.PriorityQueue(int capacity) -> void
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Remove(T item) -> bool
+ReactiveUI.Primitives.Core.PriorityQueue<T>.TryDequeue(out T? item) -> bool
+ReactiveUI.Primitives.Core.PriorityQueue<T>.TryPeek(out T? item) -> bool
+ReactiveUI.Primitives.Core.PriorityQueue<T>.VerifyHeapProperty() -> bool
 ReactiveUI.Primitives.Core.Spark
 ReactiveUI.Primitives.Core.SparkKind
 ReactiveUI.Primitives.Core.SparkKind.OnCompleted = 2 -> ReactiveUI.Primitives.Core.SparkKind
@@ -325,6 +332,9 @@ ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<ReactiveUI.
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!)
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Amb() -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Blend() -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>!)
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>!).Blend() -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.Blend<T>(this System.Collections.Generic.IEnumerable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Chain() -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Concat() -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Merge() -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net11.0-ios/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net11.0-ios/PublicAPI.Shipped.txt
@@ -236,11 +236,18 @@ ReactiveUI.Primitives.Core.Moment<T>.Value.get -> T
 ReactiveUI.Primitives.Core.PriorityQueue<T>
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Count.get -> int
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Dequeue() -> T
+ReactiveUI.Primitives.Core.PriorityQueue<T>.DequeueRange(T[]! destination) -> int
+ReactiveUI.Primitives.Core.PriorityQueue<T>.DequeueSome(int count) -> T[]!
+ReactiveUI.Primitives.Core.PriorityQueue<T>.DequeueAll() -> T[]!
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Enqueue(T item) -> void
+ReactiveUI.Primitives.Core.PriorityQueue<T>.EnqueueRange(T[]! items) -> void
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Peek() -> T
 ReactiveUI.Primitives.Core.PriorityQueue<T>.PriorityQueue() -> void
 ReactiveUI.Primitives.Core.PriorityQueue<T>.PriorityQueue(int capacity) -> void
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Remove(T item) -> bool
+ReactiveUI.Primitives.Core.PriorityQueue<T>.TryDequeue(out T? item) -> bool
+ReactiveUI.Primitives.Core.PriorityQueue<T>.TryPeek(out T? item) -> bool
+ReactiveUI.Primitives.Core.PriorityQueue<T>.VerifyHeapProperty() -> bool
 ReactiveUI.Primitives.Core.Spark
 ReactiveUI.Primitives.Core.SparkKind
 ReactiveUI.Primitives.Core.SparkKind.OnCompleted = 2 -> ReactiveUI.Primitives.Core.SparkKind
@@ -325,6 +332,9 @@ ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<ReactiveUI.
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!)
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Amb() -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Blend() -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>!)
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>!).Blend() -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.Blend<T>(this System.Collections.Generic.IEnumerable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Chain() -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Concat() -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Merge() -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net11.0-maccatalyst/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net11.0-maccatalyst/PublicAPI.Shipped.txt
@@ -236,11 +236,18 @@ ReactiveUI.Primitives.Core.Moment<T>.Value.get -> T
 ReactiveUI.Primitives.Core.PriorityQueue<T>
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Count.get -> int
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Dequeue() -> T
+ReactiveUI.Primitives.Core.PriorityQueue<T>.DequeueRange(T[]! destination) -> int
+ReactiveUI.Primitives.Core.PriorityQueue<T>.DequeueSome(int count) -> T[]!
+ReactiveUI.Primitives.Core.PriorityQueue<T>.DequeueAll() -> T[]!
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Enqueue(T item) -> void
+ReactiveUI.Primitives.Core.PriorityQueue<T>.EnqueueRange(T[]! items) -> void
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Peek() -> T
 ReactiveUI.Primitives.Core.PriorityQueue<T>.PriorityQueue() -> void
 ReactiveUI.Primitives.Core.PriorityQueue<T>.PriorityQueue(int capacity) -> void
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Remove(T item) -> bool
+ReactiveUI.Primitives.Core.PriorityQueue<T>.TryDequeue(out T? item) -> bool
+ReactiveUI.Primitives.Core.PriorityQueue<T>.TryPeek(out T? item) -> bool
+ReactiveUI.Primitives.Core.PriorityQueue<T>.VerifyHeapProperty() -> bool
 ReactiveUI.Primitives.Core.Spark
 ReactiveUI.Primitives.Core.SparkKind
 ReactiveUI.Primitives.Core.SparkKind.OnCompleted = 2 -> ReactiveUI.Primitives.Core.SparkKind
@@ -325,6 +332,9 @@ ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<ReactiveUI.
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!)
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Amb() -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Blend() -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>!)
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>!).Blend() -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.Blend<T>(this System.Collections.Generic.IEnumerable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Chain() -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Concat() -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Merge() -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net11.0-macos/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net11.0-macos/PublicAPI.Shipped.txt
@@ -236,11 +236,18 @@ ReactiveUI.Primitives.Core.Moment<T>.Value.get -> T
 ReactiveUI.Primitives.Core.PriorityQueue<T>
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Count.get -> int
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Dequeue() -> T
+ReactiveUI.Primitives.Core.PriorityQueue<T>.DequeueRange(T[]! destination) -> int
+ReactiveUI.Primitives.Core.PriorityQueue<T>.DequeueSome(int count) -> T[]!
+ReactiveUI.Primitives.Core.PriorityQueue<T>.DequeueAll() -> T[]!
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Enqueue(T item) -> void
+ReactiveUI.Primitives.Core.PriorityQueue<T>.EnqueueRange(T[]! items) -> void
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Peek() -> T
 ReactiveUI.Primitives.Core.PriorityQueue<T>.PriorityQueue() -> void
 ReactiveUI.Primitives.Core.PriorityQueue<T>.PriorityQueue(int capacity) -> void
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Remove(T item) -> bool
+ReactiveUI.Primitives.Core.PriorityQueue<T>.TryDequeue(out T? item) -> bool
+ReactiveUI.Primitives.Core.PriorityQueue<T>.TryPeek(out T? item) -> bool
+ReactiveUI.Primitives.Core.PriorityQueue<T>.VerifyHeapProperty() -> bool
 ReactiveUI.Primitives.Core.Spark
 ReactiveUI.Primitives.Core.SparkKind
 ReactiveUI.Primitives.Core.SparkKind.OnCompleted = 2 -> ReactiveUI.Primitives.Core.SparkKind
@@ -325,6 +332,9 @@ ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<ReactiveUI.
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!)
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Amb() -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Blend() -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>!)
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>!).Blend() -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.Blend<T>(this System.Collections.Generic.IEnumerable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Chain() -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Concat() -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Merge() -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net11.0-tvos/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net11.0-tvos/PublicAPI.Shipped.txt
@@ -236,11 +236,18 @@ ReactiveUI.Primitives.Core.Moment<T>.Value.get -> T
 ReactiveUI.Primitives.Core.PriorityQueue<T>
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Count.get -> int
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Dequeue() -> T
+ReactiveUI.Primitives.Core.PriorityQueue<T>.DequeueRange(T[]! destination) -> int
+ReactiveUI.Primitives.Core.PriorityQueue<T>.DequeueSome(int count) -> T[]!
+ReactiveUI.Primitives.Core.PriorityQueue<T>.DequeueAll() -> T[]!
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Enqueue(T item) -> void
+ReactiveUI.Primitives.Core.PriorityQueue<T>.EnqueueRange(T[]! items) -> void
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Peek() -> T
 ReactiveUI.Primitives.Core.PriorityQueue<T>.PriorityQueue() -> void
 ReactiveUI.Primitives.Core.PriorityQueue<T>.PriorityQueue(int capacity) -> void
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Remove(T item) -> bool
+ReactiveUI.Primitives.Core.PriorityQueue<T>.TryDequeue(out T? item) -> bool
+ReactiveUI.Primitives.Core.PriorityQueue<T>.TryPeek(out T? item) -> bool
+ReactiveUI.Primitives.Core.PriorityQueue<T>.VerifyHeapProperty() -> bool
 ReactiveUI.Primitives.Core.Spark
 ReactiveUI.Primitives.Core.SparkKind
 ReactiveUI.Primitives.Core.SparkKind.OnCompleted = 2 -> ReactiveUI.Primitives.Core.SparkKind
@@ -325,6 +332,9 @@ ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<ReactiveUI.
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!)
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Amb() -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Blend() -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>!)
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>!).Blend() -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.Blend<T>(this System.Collections.Generic.IEnumerable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Chain() -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Concat() -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Merge() -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net11.0/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net11.0/PublicAPI.Shipped.txt
@@ -236,11 +236,18 @@ ReactiveUI.Primitives.Core.Moment<T>.Value.get -> T
 ReactiveUI.Primitives.Core.PriorityQueue<T>
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Count.get -> int
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Dequeue() -> T
+ReactiveUI.Primitives.Core.PriorityQueue<T>.DequeueRange(T[]! destination) -> int
+ReactiveUI.Primitives.Core.PriorityQueue<T>.DequeueSome(int count) -> T[]!
+ReactiveUI.Primitives.Core.PriorityQueue<T>.DequeueAll() -> T[]!
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Enqueue(T item) -> void
+ReactiveUI.Primitives.Core.PriorityQueue<T>.EnqueueRange(T[]! items) -> void
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Peek() -> T
 ReactiveUI.Primitives.Core.PriorityQueue<T>.PriorityQueue() -> void
 ReactiveUI.Primitives.Core.PriorityQueue<T>.PriorityQueue(int capacity) -> void
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Remove(T item) -> bool
+ReactiveUI.Primitives.Core.PriorityQueue<T>.TryDequeue(out T? item) -> bool
+ReactiveUI.Primitives.Core.PriorityQueue<T>.TryPeek(out T? item) -> bool
+ReactiveUI.Primitives.Core.PriorityQueue<T>.VerifyHeapProperty() -> bool
 ReactiveUI.Primitives.Core.Spark
 ReactiveUI.Primitives.Core.SparkKind
 ReactiveUI.Primitives.Core.SparkKind.OnCompleted = 2 -> ReactiveUI.Primitives.Core.SparkKind
@@ -325,6 +332,9 @@ ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<ReactiveUI.
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!)
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Amb() -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Blend() -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>!)
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>!).Blend() -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.Blend<T>(this System.Collections.Generic.IEnumerable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Chain() -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Concat() -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Merge() -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net462/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net462/PublicAPI.Shipped.txt
@@ -236,11 +236,18 @@ ReactiveUI.Primitives.Core.Moment<T>.Value.get -> T
 ReactiveUI.Primitives.Core.PriorityQueue<T>
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Count.get -> int
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Dequeue() -> T
+ReactiveUI.Primitives.Core.PriorityQueue<T>.DequeueRange(T[]! destination) -> int
+ReactiveUI.Primitives.Core.PriorityQueue<T>.DequeueSome(int count) -> T[]!
+ReactiveUI.Primitives.Core.PriorityQueue<T>.DequeueAll() -> T[]!
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Enqueue(T item) -> void
+ReactiveUI.Primitives.Core.PriorityQueue<T>.EnqueueRange(T[]! items) -> void
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Peek() -> T
 ReactiveUI.Primitives.Core.PriorityQueue<T>.PriorityQueue() -> void
 ReactiveUI.Primitives.Core.PriorityQueue<T>.PriorityQueue(int capacity) -> void
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Remove(T item) -> bool
+ReactiveUI.Primitives.Core.PriorityQueue<T>.TryDequeue(out T? item) -> bool
+ReactiveUI.Primitives.Core.PriorityQueue<T>.TryPeek(out T? item) -> bool
+ReactiveUI.Primitives.Core.PriorityQueue<T>.VerifyHeapProperty() -> bool
 ReactiveUI.Primitives.Core.Spark
 ReactiveUI.Primitives.Core.SparkKind
 ReactiveUI.Primitives.Core.SparkKind.OnCompleted = 2 -> ReactiveUI.Primitives.Core.SparkKind
@@ -325,6 +332,9 @@ ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<ReactiveUI.
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!)
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Amb() -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Blend() -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>!)
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>!).Blend() -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.Blend<T>(this System.Collections.Generic.IEnumerable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Chain() -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Concat() -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Merge() -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -236,11 +236,18 @@ ReactiveUI.Primitives.Core.Moment<T>.Value.get -> T
 ReactiveUI.Primitives.Core.PriorityQueue<T>
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Count.get -> int
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Dequeue() -> T
+ReactiveUI.Primitives.Core.PriorityQueue<T>.DequeueRange(T[]! destination) -> int
+ReactiveUI.Primitives.Core.PriorityQueue<T>.DequeueSome(int count) -> T[]!
+ReactiveUI.Primitives.Core.PriorityQueue<T>.DequeueAll() -> T[]!
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Enqueue(T item) -> void
+ReactiveUI.Primitives.Core.PriorityQueue<T>.EnqueueRange(T[]! items) -> void
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Peek() -> T
 ReactiveUI.Primitives.Core.PriorityQueue<T>.PriorityQueue() -> void
 ReactiveUI.Primitives.Core.PriorityQueue<T>.PriorityQueue(int capacity) -> void
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Remove(T item) -> bool
+ReactiveUI.Primitives.Core.PriorityQueue<T>.TryDequeue(out T? item) -> bool
+ReactiveUI.Primitives.Core.PriorityQueue<T>.TryPeek(out T? item) -> bool
+ReactiveUI.Primitives.Core.PriorityQueue<T>.VerifyHeapProperty() -> bool
 ReactiveUI.Primitives.Core.Spark
 ReactiveUI.Primitives.Core.SparkKind
 ReactiveUI.Primitives.Core.SparkKind.OnCompleted = 2 -> ReactiveUI.Primitives.Core.SparkKind
@@ -325,6 +332,9 @@ ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<ReactiveUI.
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!)
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Amb() -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Blend() -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>!)
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>!).Blend() -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.Blend<T>(this System.Collections.Generic.IEnumerable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Chain() -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Concat() -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Merge() -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net48/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net48/PublicAPI.Shipped.txt
@@ -236,11 +236,18 @@ ReactiveUI.Primitives.Core.Moment<T>.Value.get -> T
 ReactiveUI.Primitives.Core.PriorityQueue<T>
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Count.get -> int
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Dequeue() -> T
+ReactiveUI.Primitives.Core.PriorityQueue<T>.DequeueRange(T[]! destination) -> int
+ReactiveUI.Primitives.Core.PriorityQueue<T>.DequeueSome(int count) -> T[]!
+ReactiveUI.Primitives.Core.PriorityQueue<T>.DequeueAll() -> T[]!
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Enqueue(T item) -> void
+ReactiveUI.Primitives.Core.PriorityQueue<T>.EnqueueRange(T[]! items) -> void
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Peek() -> T
 ReactiveUI.Primitives.Core.PriorityQueue<T>.PriorityQueue() -> void
 ReactiveUI.Primitives.Core.PriorityQueue<T>.PriorityQueue(int capacity) -> void
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Remove(T item) -> bool
+ReactiveUI.Primitives.Core.PriorityQueue<T>.TryDequeue(out T? item) -> bool
+ReactiveUI.Primitives.Core.PriorityQueue<T>.TryPeek(out T? item) -> bool
+ReactiveUI.Primitives.Core.PriorityQueue<T>.VerifyHeapProperty() -> bool
 ReactiveUI.Primitives.Core.Spark
 ReactiveUI.Primitives.Core.SparkKind
 ReactiveUI.Primitives.Core.SparkKind.OnCompleted = 2 -> ReactiveUI.Primitives.Core.SparkKind
@@ -325,6 +332,9 @@ ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<ReactiveUI.
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!)
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Amb() -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Blend() -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>!)
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>!).Blend() -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.Blend<T>(this System.Collections.Generic.IEnumerable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Chain() -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Concat() -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Merge() -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net481/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net481/PublicAPI.Shipped.txt
@@ -236,11 +236,18 @@ ReactiveUI.Primitives.Core.Moment<T>.Value.get -> T
 ReactiveUI.Primitives.Core.PriorityQueue<T>
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Count.get -> int
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Dequeue() -> T
+ReactiveUI.Primitives.Core.PriorityQueue<T>.DequeueRange(T[]! destination) -> int
+ReactiveUI.Primitives.Core.PriorityQueue<T>.DequeueSome(int count) -> T[]!
+ReactiveUI.Primitives.Core.PriorityQueue<T>.DequeueAll() -> T[]!
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Enqueue(T item) -> void
+ReactiveUI.Primitives.Core.PriorityQueue<T>.EnqueueRange(T[]! items) -> void
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Peek() -> T
 ReactiveUI.Primitives.Core.PriorityQueue<T>.PriorityQueue() -> void
 ReactiveUI.Primitives.Core.PriorityQueue<T>.PriorityQueue(int capacity) -> void
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Remove(T item) -> bool
+ReactiveUI.Primitives.Core.PriorityQueue<T>.TryDequeue(out T? item) -> bool
+ReactiveUI.Primitives.Core.PriorityQueue<T>.TryPeek(out T? item) -> bool
+ReactiveUI.Primitives.Core.PriorityQueue<T>.VerifyHeapProperty() -> bool
 ReactiveUI.Primitives.Core.Spark
 ReactiveUI.Primitives.Core.SparkKind
 ReactiveUI.Primitives.Core.SparkKind.OnCompleted = 2 -> ReactiveUI.Primitives.Core.SparkKind
@@ -325,6 +332,9 @@ ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<ReactiveUI.
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!)
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Amb() -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Blend() -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>!)
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>!).Blend() -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.Blend<T>(this System.Collections.Generic.IEnumerable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Chain() -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Concat() -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Merge() -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -236,11 +236,18 @@ ReactiveUI.Primitives.Core.Moment<T>.Value.get -> T
 ReactiveUI.Primitives.Core.PriorityQueue<T>
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Count.get -> int
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Dequeue() -> T
+ReactiveUI.Primitives.Core.PriorityQueue<T>.DequeueRange(T[]! destination) -> int
+ReactiveUI.Primitives.Core.PriorityQueue<T>.DequeueSome(int count) -> T[]!
+ReactiveUI.Primitives.Core.PriorityQueue<T>.DequeueAll() -> T[]!
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Enqueue(T item) -> void
+ReactiveUI.Primitives.Core.PriorityQueue<T>.EnqueueRange(T[]! items) -> void
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Peek() -> T
 ReactiveUI.Primitives.Core.PriorityQueue<T>.PriorityQueue() -> void
 ReactiveUI.Primitives.Core.PriorityQueue<T>.PriorityQueue(int capacity) -> void
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Remove(T item) -> bool
+ReactiveUI.Primitives.Core.PriorityQueue<T>.TryDequeue(out T? item) -> bool
+ReactiveUI.Primitives.Core.PriorityQueue<T>.TryPeek(out T? item) -> bool
+ReactiveUI.Primitives.Core.PriorityQueue<T>.VerifyHeapProperty() -> bool
 ReactiveUI.Primitives.Core.Spark
 ReactiveUI.Primitives.Core.SparkKind
 ReactiveUI.Primitives.Core.SparkKind.OnCompleted = 2 -> ReactiveUI.Primitives.Core.SparkKind
@@ -325,6 +332,9 @@ ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<ReactiveUI.
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!)
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Amb() -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Blend() -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>!)
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>!).Blend() -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.Blend<T>(this System.Collections.Generic.IEnumerable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Chain() -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Concat() -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Merge() -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net9.0/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net9.0/PublicAPI.Shipped.txt
@@ -236,11 +236,18 @@ ReactiveUI.Primitives.Core.Moment<T>.Value.get -> T
 ReactiveUI.Primitives.Core.PriorityQueue<T>
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Count.get -> int
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Dequeue() -> T
+ReactiveUI.Primitives.Core.PriorityQueue<T>.DequeueRange(T[]! destination) -> int
+ReactiveUI.Primitives.Core.PriorityQueue<T>.DequeueSome(int count) -> T[]!
+ReactiveUI.Primitives.Core.PriorityQueue<T>.DequeueAll() -> T[]!
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Enqueue(T item) -> void
+ReactiveUI.Primitives.Core.PriorityQueue<T>.EnqueueRange(T[]! items) -> void
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Peek() -> T
 ReactiveUI.Primitives.Core.PriorityQueue<T>.PriorityQueue() -> void
 ReactiveUI.Primitives.Core.PriorityQueue<T>.PriorityQueue(int capacity) -> void
 ReactiveUI.Primitives.Core.PriorityQueue<T>.Remove(T item) -> bool
+ReactiveUI.Primitives.Core.PriorityQueue<T>.TryDequeue(out T? item) -> bool
+ReactiveUI.Primitives.Core.PriorityQueue<T>.TryPeek(out T? item) -> bool
+ReactiveUI.Primitives.Core.PriorityQueue<T>.VerifyHeapProperty() -> bool
 ReactiveUI.Primitives.Core.Spark
 ReactiveUI.Primitives.Core.SparkKind
 ReactiveUI.Primitives.Core.SparkKind.OnCompleted = 2 -> ReactiveUI.Primitives.Core.SparkKind
@@ -325,6 +332,9 @@ ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<ReactiveUI.
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!)
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Amb() -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Blend() -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>!)
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>!).Blend() -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.Blend<T>(this System.Collections.Generic.IEnumerable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Chain() -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Concat() -> System.IObservable<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<System.IObservable<T>!>!).Merge() -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/SignalOperatorMixins.Coordinators.cs
+++ b/src/ReactiveUI.Primitives/SignalOperatorMixins.Coordinators.cs
@@ -387,6 +387,20 @@ public static partial class LinqExtensions
             return this;
         }
 
+        /// <summary>Subscribes directly to enumerable sources.</summary>
+        /// <param name="sources">The sources to merge.</param>
+        /// <returns>The subscription cleanup.</returns>
+        internal BlendCoordinator<T> Run(IEnumerable<IObservable<T>> sources)
+        {
+            foreach (var source in sources)
+            {
+                OnSource(source);
+            }
+
+            OnOuterCompleted();
+            return this;
+        }
+
         /// <summary>Subscribes a new inner source concurrently.</summary>
         /// <param name="source">The inner source.</param>
         private void OnSource(IObservable<T> source)

--- a/src/tests/ReactiveUI.Primitives.Tests/PriorityQueueTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/PriorityQueueTests.cs
@@ -9,6 +9,77 @@ namespace ReactiveUI.Primitives.Tests;
 /// <summary>Verifies <see cref="PriorityQueue{T}"/> indexed-item equality contracts.</summary>
 public class PriorityQueueTests
 {
+    private const int SecondValue = 2;
+
+    private const int ThirdValue = 3;
+
+    private const int FourthValue = 4;
+
+    private const int FifthValue = 5;
+
+    private const int SixthValue = 6;
+
+    private const int SeventhValue = 7;
+
+    private const int EighthValue = 8;
+
+    private const int DestinationLength = 2;
+
+    private const int DequeueLimit = 2;
+
+    /// <summary>Verifies public helper methods preserve priority order.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task PublicHelpersPreservePriorityOrder()
+    {
+        PriorityQueue<int> queue = new(1);
+
+        await Assert.That(queue.TryPeek(out var emptyPeek)).IsFalse();
+        await Assert.That(emptyPeek).IsEqualTo(default);
+        await Assert.That(queue.TryDequeue(out var emptyDequeue)).IsFalse();
+        await Assert.That(emptyDequeue).IsEqualTo(default);
+        await Assert.That(queue.VerifyHeapProperty()).IsTrue();
+
+        queue.EnqueueRange([ThirdValue, 1, SecondValue]);
+
+        await Assert.That(queue.VerifyHeapProperty()).IsTrue();
+        await Assert.That(queue.TryPeek(out var first)).IsTrue();
+        await Assert.That(first).IsEqualTo(1);
+
+        var buffer = new int[DestinationLength];
+        var written = queue.DequeueRange(buffer);
+
+        await Assert.That(written).IsEqualTo(DestinationLength);
+        await Assert.That(buffer.SequenceEqual([1, SecondValue])).IsTrue();
+        await Assert.That(queue.TryDequeue(out var last)).IsTrue();
+        await Assert.That(last).IsEqualTo(ThirdValue);
+        await Assert.That(queue.Count).IsEqualTo(0);
+
+        queue.EnqueueRange([FifthValue, FourthValue, SixthValue]);
+
+        await Assert.That(queue.DequeueSome(DequeueLimit).SequenceEqual([FourthValue, FifthValue])).IsTrue();
+
+        queue.EnqueueRange([EighthValue, SeventhValue]);
+
+        await Assert.That(queue.DequeueAll().SequenceEqual([SixthValue, SeventhValue, EighthValue])).IsTrue();
+        await Assert.That(queue.VerifyHeapProperty()).IsTrue();
+    }
+
+    /// <summary>Verifies public helper methods validate invalid arguments.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task PublicHelpersValidateArguments()
+    {
+        PriorityQueue<int> queue = new();
+
+        Assert.Throws<ArgumentNullException>(() => queue.EnqueueRange(null!));
+        Assert.Throws<ArgumentNullException>(() => queue.DequeueRange(null!));
+        Assert.Throws<ArgumentOutOfRangeException>(() => queue.DequeueSome(-1));
+
+        await Assert.That(queue.DequeueSome(0).Length).IsEqualTo(0);
+        await Assert.That(queue.DequeueRange(new int[DestinationLength])).IsEqualTo(0);
+    }
+
     /// <summary>Covers indexed-item equality, hashing, and type mismatch handling.</summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Test]

--- a/src/tests/ReactiveUI.Primitives.Tests/PriorityQueueTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/PriorityQueueTests.cs
@@ -55,6 +55,19 @@ public class PriorityQueueTests
         await Assert.That(last).IsEqualTo(ThirdValue);
         await Assert.That(queue.Count).IsEqualTo(0);
 
+        queue.Enqueue(SecondValue);
+
+        await Assert.That(queue.DequeueSome(DequeueLimit).SequenceEqual([SecondValue])).IsTrue();
+        await Assert.That(queue.Count).IsEqualTo(0);
+
+        queue.Enqueue(1);
+        queue.Enqueue(SecondValue);
+
+        await Assert.That(queue.VerifyHeapProperty()).IsTrue();
+
+        await Assert.That(queue.Dequeue()).IsEqualTo(1);
+        await Assert.That(queue.Dequeue()).IsEqualTo(SecondValue);
+
         queue.EnqueueRange([FifthValue, FourthValue, SixthValue]);
 
         await Assert.That(queue.DequeueSome(DequeueLimit).SequenceEqual([FourthValue, FifthValue])).IsTrue();
@@ -80,6 +93,22 @@ public class PriorityQueueTests
         await Assert.That(queue.DequeueRange(new int[DestinationLength])).IsEqualTo(0);
     }
 
+    /// <summary>Verifies heap verification detects invalid child priority ordering.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task VerifyHeapPropertyDetectsMutablePriorityDrift()
+    {
+        var leftQueue = CreateMutableQueue(out _, out var left, out _);
+        left.Priority = 0;
+
+        await Assert.That(leftQueue.VerifyHeapProperty()).IsFalse();
+
+        var rightQueue = CreateMutableQueue(out _, out _, out var right);
+        right.Priority = 0;
+
+        await Assert.That(rightQueue.VerifyHeapProperty()).IsFalse();
+    }
+
     /// <summary>Covers indexed-item equality, hashing, and type mismatch handling.</summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Test]
@@ -87,9 +116,51 @@ public class PriorityQueueTests
     {
         PriorityQueue<int>.IndexedItem left = new() { Id = 1L, Value = 1 };
         PriorityQueue<int>.IndexedItem right = new() { Id = 1L, Value = 1 };
+        PriorityQueue<int>.IndexedItem later = new() { Id = 2L, Value = 1 };
+
         await Assert.That(left.Equals(right)).IsTrue();
         await Assert.That(left.Equals((object)right)).IsTrue();
         await Assert.That(left.Equals("not-item")).IsFalse();
         await Assert.That(left.GetHashCode()).IsNotEqualTo(0);
+        await Assert.That(left < later).IsTrue();
+        await Assert.That(left <= right).IsTrue();
+        await Assert.That(later > left).IsTrue();
+        await Assert.That(right >= left).IsTrue();
+    }
+
+    /// <summary>Creates a three-item queue whose item priorities can be mutated after enqueue.</summary>
+    /// <param name="parent">The root priority item.</param>
+    /// <param name="left">The expected left child priority item.</param>
+    /// <param name="right">The expected right child priority item.</param>
+    /// <returns>The populated priority queue.</returns>
+    private static PriorityQueue<PriorityItem> CreateMutableQueue(
+        out PriorityItem parent,
+        out PriorityItem left,
+        out PriorityItem right)
+    {
+        parent = new(1);
+        left = new(SecondValue);
+        right = new(ThirdValue);
+
+        PriorityQueue<PriorityItem> queue = new();
+        queue.Enqueue(parent);
+        queue.Enqueue(left);
+        queue.Enqueue(right);
+
+        return queue;
+    }
+
+    /// <summary>A mutable comparable item used to invalidate heap ordering after enqueue.</summary>
+    /// <param name="priority">The initial priority.</param>
+    private sealed class PriorityItem(int priority) : IComparable<PriorityItem>
+    {
+        /// <summary>Gets or sets the comparable priority.</summary>
+        public int Priority { get; set; } = priority;
+
+        /// <inheritdoc/>
+        public int CompareTo(PriorityItem? other)
+        {
+            return other is null ? 1 : Priority.CompareTo(other.Priority);
+        }
     }
 }

--- a/src/tests/ReactiveUI.Primitives.Tests/SignalOperatorMixinsTests.Deterministic.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/SignalOperatorMixinsTests.Deterministic.cs
@@ -106,6 +106,11 @@ public partial class SignalOperatorMixinsTests
     public async Task RangeAsyncFastPathsAndNullGuardsCoverRemainingLines()
     {
         var source = Signal.FromEnumerable([Three, Four]);
+        IEnumerable<IObservable<int>> blendSources = [Signal.Emit(One), Signal.Emit(Two)];
+        List<int> blended = [];
+        blendSources.Blend().Subscribe(blended.Add);
+        await Assert.That(blended.SequenceEqual([One, Two])).IsTrue();
+        Assert.Throws<ArgumentNullException>(() => blendSources.Blend().Subscribe((IObserver<int>)null!));
         List<int[]> rangeArray = [];
         List<IList<int>> rangeList = [];
         Signal.Sequence(Five, Three).CollectArray().Subscribe(rangeArray.Add);

--- a/src/tests/ReactiveUI.Primitives.Tests/SignalOperatorMixinsTests.Deterministic.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/SignalOperatorMixinsTests.Deterministic.cs
@@ -157,7 +157,10 @@ public partial class SignalOperatorMixinsTests
         await Assert.That(canceledTask.IsCanceled).IsTrue();
         Assert.Throws<ArgumentNullException>(() => LinqExtensions.Count<int>(null!, value => value > 0));
         Assert.Throws<ArgumentNullException>(() => LinqExtensions.LongCount<int>(null!, value => value > 0));
-        Assert.Throws<ArgumentNullException>(() => LinqExtensions.Blend<int>(null!));
+        Assert.Throws<ArgumentNullException>(() =>
+            LinqExtensions.Blend<int>((IObservable<IObservable<int>>)null!));
+        Assert.Throws<ArgumentNullException>(() =>
+            LinqExtensions.Blend<int>((IEnumerable<IObservable<int>>)null!));
         Assert.Throws<ArgumentNullException>(() => LinqExtensions.Race<int>(null!));
         Assert.Throws<ArgumentNullException>(() => LinqExtensions.CollectArray<int>(null!));
         Assert.Throws<ArgumentNullException>(() => SubscribeExtensions.Subscribe<int>(null!, _ => { }));


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature and build fix for ReactiveUI.Primitives public API surface.

## What is the new behavior?

- `IEnumerable<IObservable<T>>.Blend()` is available for enumerable observable sources.
- `PriorityQueue<T>` exposes bulk enqueue/dequeue, try-peek/try-dequeue, and heap verification helpers.
- Blend null-guard coverage is explicit for both observable-of-observables and enumerable overloads so the solution builds without ambiguous overload resolution.

## What is the current behavior?

- Only the observable-of-observables `Blend` overload was available in the LINQ extension surface.
- `PriorityQueue<T>` did not expose bulk/try helper methods.
- The null-guard test used an untyped `null`, which became ambiguous once both `Blend` overloads existed.

## Checklist
- [x] I have read the Contribute guide 
- [x] Tests have been added or updated (for bug fixes / features) 
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the main branch 
- [x] PR title follows Conventional Commits 

## Additional information

Validated with:
- `dotnet build "ReactiveUI.Primitives.slnx" -c Debug --no-restore /m:1 /nr:false`
- `dotnet test "tests\ReactiveUI.Primitives.Tests\ReactiveUI.Primitives.Tests.csproj" -c Debug --no-build -- --treenode-filter "/*/*/PriorityQueueTests/*" --output Detailed`
- `dotnet test "tests\ReactiveUI.Primitives.Tests\ReactiveUI.Primitives.Tests.csproj" -c Debug --no-build -- --treenode-filter "/*/*/SignalOperatorMixinsTests/RangeAsyncFastPathsAndNullGuardsCoverRemainingLines" --output Detailed`
- `dotnet test "ReactiveUI.Primitives.slnx" -c Debug --no-build -- --output Detailed --fail-fast`
- MTP/TUnit coverage summary: 92.00% line / 87.79% branch.