### PR TITLE
feat: System.Reactive parity packages for all platform adapters

### DIFF
--- a/src/Primitives.Blazor.Shared/Components/ReactiveComponentBase.cs
+++ b/src/Primitives.Blazor.Shared/Components/ReactiveComponentBase.cs
@@ -3,11 +3,12 @@
 // See the LICENSE file in the project root for full license information.
 
 using Microsoft.AspNetCore.Components;
-using ReactiveUI.Primitives.Blazor.Concurrency;
-using ReactiveUI.Primitives.Concurrency;
-using ReactiveUI.Primitives.Disposables;
 
+#if REACTIVE_SHIM
+namespace ReactiveUI.Primitives.Blazor.Reactive.Components;
+#else
 namespace ReactiveUI.Primitives.Blazor.Components;
+#endif
 
 /// <summary>Base component that tracks reactive subscriptions and refreshes through Blazor's renderer dispatcher.</summary>
 [System.Diagnostics.DebuggerDisplay("{DebuggerDisplay,nq}")]

--- a/src/Primitives.Platform.Reactive.Shared/CoalescingDispatchScheduler.cs
+++ b/src/Primitives.Platform.Reactive.Shared/CoalescingDispatchScheduler.cs
@@ -1,0 +1,157 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Collections.Concurrent;
+using System.Reactive.Concurrency;
+using System.Reactive.Disposables;
+
+namespace ReactiveUI.Primitives.Reactive.Concurrency;
+
+/// <summary>
+/// Base <see cref="IScheduler"/> for UI-thread dispatchers that coalesces dispatcher posts: immediate work is queued
+/// and drained one batch per post. A sealed platform scheduler supplies its dispatcher <see cref="Post"/> (and
+/// optionally a native delayed path via <see cref="ScheduleOnDispatcher"/>).
+/// </summary>
+public abstract class CoalescingDispatchScheduler : LocalScheduler
+{
+    /// <summary>Ready work items awaiting a UI-thread drain.</summary>
+    private readonly ConcurrentQueue<IDispatchWorkItem> _ready = new();
+
+    /// <summary>Cached drain callback (this scheduler's <see cref="RunDrain"/>) marshalled by <see cref="Post"/>.</summary>
+    private readonly Action _drain;
+
+    /// <summary>Approximate number of ready items; snapshots a drain batch.</summary>
+    private int _readyCount;
+
+    /// <summary>Gate that keeps at most one queued drain callback pending.</summary>
+    private int _drainPosted;
+
+    /// <summary>Initializes a new instance of the <see cref="CoalescingDispatchScheduler"/> class.</summary>
+    protected CoalescingDispatchScheduler() => _drain = RunDrain;
+
+    /// <summary>Schedules an action to be executed as soon as possible on the dispatcher.</summary>
+    /// <typeparam name="TState">The type of the state passed to the action.</typeparam>
+    /// <param name="state">State passed to the action.</param>
+    /// <param name="action">Action to execute.</param>
+    /// <returns>The disposable used to cancel the scheduled action.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="action"/> is <see langword="null"/>.</exception>
+    public override IDisposable Schedule<TState>(TState state, Func<IScheduler, TState, IDisposable> action)
+    {
+        ArgumentExceptionHelper.ThrowIfNull(action);
+
+        var item = new DispatchWorkItem<TState>(this, state, action);
+        Enqueue(item);
+        return item;
+    }
+
+    /// <summary>Schedules an action to be executed after the specified relative due time on the dispatcher.</summary>
+    /// <typeparam name="TState">The type of the state passed to the action.</typeparam>
+    /// <param name="state">State passed to the action.</param>
+    /// <param name="dueTime">Relative time after which to execute the action.</param>
+    /// <param name="action">Action to execute.</param>
+    /// <returns>The disposable used to cancel the scheduled action.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="action"/> is <see langword="null"/>.</exception>
+    public override IDisposable Schedule<TState>(TState state, TimeSpan dueTime, Func<IScheduler, TState, IDisposable> action)
+    {
+        ArgumentExceptionHelper.ThrowIfNull(action);
+
+        var item = new DispatchWorkItem<TState>(this, state, action);
+        if (Scheduler.Normalize(dueTime) == TimeSpan.Zero)
+        {
+            Enqueue(item);
+            return item;
+        }
+
+        return StableCompositeDisposable.Create(ScheduleOnDispatcher(item.Run, dueTime), item);
+    }
+
+    /// <summary>Posts the cached drain callback to the platform dispatcher.</summary>
+    /// <param name="drain">The drain callback to marshal to the UI thread.</param>
+    /// <returns><see langword="true"/> when the dispatcher accepted the work.</returns>
+    protected abstract bool Post(Action drain);
+
+    /// <summary>
+    /// Runs <paramref name="work"/> on the dispatcher after <paramref name="dueTime"/>. The default marshals the wait
+    /// onto the shared timer, then re-queues the work onto the dispatcher when it is due. Platforms with a native
+    /// UI-thread timer override this to run the work directly on the dispatcher thread.
+    /// </summary>
+    /// <param name="work">Callback to invoke on the dispatcher thread when due.</param>
+    /// <param name="dueTime">Relative time after which to invoke <paramref name="work"/>.</param>
+    /// <returns>The disposable used to cancel the delayed dispatch.</returns>
+    protected virtual IDisposable ScheduleOnDispatcher(Action work, TimeSpan dueTime) =>
+        DefaultScheduler.Instance.Schedule(
+            (owner: this, work),
+            dueTime,
+            static (_, state) => state.owner.Schedule(
+                state.work,
+                static (_, due) =>
+                {
+                    due();
+                    return Disposable.Empty;
+                }));
+
+    /// <summary>Re-posts a drain if work is still queued; platform adapters call this when the dispatcher becomes ready.</summary>
+    protected void RequestDrain() => PostDrain();
+
+    /// <summary>Enqueues immediate work and coalesces a single drain post.</summary>
+    /// <param name="item">Work item to execute on the dispatcher.</param>
+    private void Enqueue(IDispatchWorkItem item)
+    {
+        _ready.Enqueue(item);
+        Interlocked.Increment(ref _readyCount);
+        PostDrain();
+    }
+
+    /// <summary>Attempts to post a drain if queued work is waiting.</summary>
+    private void PostDrain()
+    {
+        if (Volatile.Read(ref _readyCount) == 0)
+        {
+            return;
+        }
+
+        if (Interlocked.Exchange(ref _drainPosted, 1) != 0)
+        {
+            return;
+        }
+
+        try
+        {
+            if (Post(_drain))
+            {
+                return;
+            }
+        }
+        catch
+        {
+            Volatile.Write(ref _drainPosted, 0);
+            throw;
+        }
+
+        Volatile.Write(ref _drainPosted, 0);
+    }
+
+    /// <summary>Runs one dispatcher batch.</summary>
+    private void RunDrain()
+    {
+        Volatile.Write(ref _drainPosted, 0);
+
+        try
+        {
+            var remaining = Volatile.Read(ref _readyCount);
+            while (remaining-- > 0 && _ready.TryDequeue(out var item))
+            {
+                Interlocked.Decrement(ref _readyCount);
+                item.Run();
+            }
+        }
+        finally
+        {
+            if (Volatile.Read(ref _readyCount) != 0)
+            {
+                PostDrain();
+            }
+        }
+    }
+}

--- a/src/Primitives.Platform.Reactive.Shared/DispatchWorkItem.cs
+++ b/src/Primitives.Platform.Reactive.Shared/DispatchWorkItem.cs
@@ -1,0 +1,77 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Reactive.Concurrency;
+using System.Reactive.Disposables;
+
+namespace ReactiveUI.Primitives.Reactive.Concurrency;
+
+/// <summary>A scheduled work item carrying closure-free state and the scheduler passed back to the action.</summary>
+/// <typeparam name="TState">The scheduled state type.</typeparam>
+internal sealed class DispatchWorkItem<TState> : IDispatchWorkItem
+{
+    /// <summary>The scheduler passed back to the scheduled action.</summary>
+    private readonly IScheduler _scheduler;
+
+    /// <summary>Scheduled state.</summary>
+    private readonly TState _state;
+
+    /// <summary>Scheduled action.</summary>
+    private readonly Func<IScheduler, TState, IDisposable> _action;
+
+    /// <summary>Disposable returned by the scheduled action after it starts.</summary>
+    private IDisposable? _disposable;
+
+    /// <summary>Tracks cancellation.</summary>
+    private int _isDisposed;
+
+    /// <summary>Initializes a new instance of the <see cref="DispatchWorkItem{TState}"/> class.</summary>
+    /// <param name="scheduler">The scheduler passed back to the scheduled action.</param>
+    /// <param name="state">Scheduled state.</param>
+    /// <param name="action">Scheduled action.</param>
+    public DispatchWorkItem(IScheduler scheduler, TState state, Func<IScheduler, TState, IDisposable> action)
+    {
+        _scheduler = scheduler;
+        _state = state;
+        _action = action;
+    }
+
+    /// <summary>Gets a value indicating whether the work item has been cancelled.</summary>
+    public bool IsDisposed => Volatile.Read(ref _isDisposed) != 0;
+
+    /// <inheritdoc/>
+    public void Run()
+    {
+        if (IsDisposed)
+        {
+            return;
+        }
+
+        var disposable = _action(_scheduler, _state) ?? Disposable.Empty;
+        var previous = Interlocked.CompareExchange(ref _disposable, disposable, null);
+        if (previous is not null)
+        {
+            disposable.Dispose();
+            return;
+        }
+
+        if (!IsDisposed)
+        {
+            return;
+        }
+
+        disposable.Dispose();
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _isDisposed, 1) != 0)
+        {
+            return;
+        }
+
+        Interlocked.Exchange(ref _disposable, Disposable.Empty)?.Dispose();
+    }
+}

--- a/src/Primitives.Platform.Reactive.Shared/IDispatchWorkItem.cs
+++ b/src/Primitives.Platform.Reactive.Shared/IDispatchWorkItem.cs
@@ -1,0 +1,12 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace ReactiveUI.Primitives.Reactive.Concurrency;
+
+/// <summary>A scheduled, cancellable unit of work drained by a <see cref="CoalescingDispatchScheduler"/>.</summary>
+internal interface IDispatchWorkItem : IDisposable
+{
+    /// <summary>Executes the work unless it has already been cancelled.</summary>
+    void Run();
+}

--- a/src/ReactiveUI.Primitives.Blazor.Reactive/Concurrency/BlazorRendererSequencer.cs
+++ b/src/ReactiveUI.Primitives.Blazor.Reactive/Concurrency/BlazorRendererSequencer.cs
@@ -1,0 +1,28 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using ReactiveUI.Primitives.Reactive.Concurrency;
+
+namespace ReactiveUI.Primitives.Blazor.Reactive.Concurrency;
+
+/// <summary>Scheduler that coalesces scheduled work through a Blazor renderer dispatcher delegate.</summary>
+/// <seealso cref="System.Reactive.Concurrency.IScheduler" />
+public sealed class BlazorRendererSequencer : CoalescingDispatchScheduler
+{
+    /// <summary>Delegate used to marshal work through Blazor's renderer.</summary>
+    private readonly Func<Action, Task> _invokeAsync;
+
+    /// <summary>Initializes a new instance of the <see cref="BlazorRendererSequencer"/> class.</summary>
+    /// <param name="invokeAsync">A delegate such as <c>ComponentBase.InvokeAsync</c> that runs work through the renderer.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="invokeAsync"/> is <see langword="null"/>.</exception>
+    public BlazorRendererSequencer(Func<Action, Task> invokeAsync) =>
+        _invokeAsync = invokeAsync ?? throw new ArgumentNullException(nameof(invokeAsync));
+
+    /// <inheritdoc/>
+    protected override bool Post(Action drain)
+    {
+        _ = _invokeAsync(drain);
+        return true;
+    }
+}

--- a/src/ReactiveUI.Primitives.Blazor.Reactive/PublicAPI/net10.0/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Blazor.Reactive/PublicAPI/net10.0/PublicAPI.Shipped.txt
@@ -1,0 +1,22 @@
+#nullable enable
+ReactiveUI.Primitives.Blazor.Reactive.Components.ReactiveComponentBase
+ReactiveUI.Primitives.Blazor.Reactive.Components.ReactiveComponentBase.Dispose() -> void
+ReactiveUI.Primitives.Blazor.Reactive.Components.ReactiveComponentBase.InvalidateAsync() -> System.Threading.Tasks.Task!
+ReactiveUI.Primitives.Blazor.Reactive.Components.ReactiveComponentBase.IsDisposed.get -> bool
+ReactiveUI.Primitives.Blazor.Reactive.Components.ReactiveComponentBase.Observe<T>(System.IObservable<T>! source, System.Action<T>! onNext) -> System.IDisposable!
+ReactiveUI.Primitives.Blazor.Reactive.Components.ReactiveComponentBase.Observe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>? onError, System.Action? onCompleted) -> System.IDisposable!
+ReactiveUI.Primitives.Blazor.Reactive.Components.ReactiveComponentBase.Observe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>? onError, System.Action? onCompleted, bool refreshAfterCallbacks) -> System.IDisposable!
+ReactiveUI.Primitives.Blazor.Reactive.Components.ReactiveComponentBase.ReactiveComponentBase() -> void
+ReactiveUI.Primitives.Blazor.Reactive.Components.ReactiveComponentBase.RendererSequencer.get -> System.Reactive.Concurrency.IScheduler!
+ReactiveUI.Primitives.Blazor.Reactive.Components.ReactiveComponentBase.Track(System.IDisposable! subscription) -> System.IDisposable!
+ReactiveUI.Primitives.Blazor.Reactive.Concurrency.BlazorRendererSequencer
+ReactiveUI.Primitives.Blazor.Reactive.Concurrency.BlazorRendererSequencer.BlazorRendererSequencer(System.Func<System.Action!, System.Threading.Tasks.Task!>! invokeAsync) -> void
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.CoalescingDispatchScheduler() -> void
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.RequestDrain() -> void
+abstract ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Post(System.Action! drain) -> bool
+override ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Schedule<TState>(TState state, System.Func<System.Reactive.Concurrency.IScheduler!, TState, System.IDisposable!>! action) -> System.IDisposable!
+override ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Schedule<TState>(TState state, System.TimeSpan dueTime, System.Func<System.Reactive.Concurrency.IScheduler!, TState, System.IDisposable!>! action) -> System.IDisposable!
+virtual ReactiveUI.Primitives.Blazor.Reactive.Components.ReactiveComponentBase.Dispose(bool disposing) -> void
+virtual ReactiveUI.Primitives.Blazor.Reactive.Components.ReactiveComponentBase.OnObservedError(System.Exception! error) -> void
+virtual ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.ScheduleOnDispatcher(System.Action! work, System.TimeSpan dueTime) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.Blazor.Reactive/PublicAPI/net10.0/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Blazor.Reactive/PublicAPI/net10.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/ReactiveUI.Primitives.Blazor.Reactive/PublicAPI/net11.0/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Blazor.Reactive/PublicAPI/net11.0/PublicAPI.Shipped.txt
@@ -1,0 +1,22 @@
+#nullable enable
+ReactiveUI.Primitives.Blazor.Reactive.Components.ReactiveComponentBase
+ReactiveUI.Primitives.Blazor.Reactive.Components.ReactiveComponentBase.Dispose() -> void
+ReactiveUI.Primitives.Blazor.Reactive.Components.ReactiveComponentBase.InvalidateAsync() -> System.Threading.Tasks.Task!
+ReactiveUI.Primitives.Blazor.Reactive.Components.ReactiveComponentBase.IsDisposed.get -> bool
+ReactiveUI.Primitives.Blazor.Reactive.Components.ReactiveComponentBase.Observe<T>(System.IObservable<T>! source, System.Action<T>! onNext) -> System.IDisposable!
+ReactiveUI.Primitives.Blazor.Reactive.Components.ReactiveComponentBase.Observe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>? onError, System.Action? onCompleted) -> System.IDisposable!
+ReactiveUI.Primitives.Blazor.Reactive.Components.ReactiveComponentBase.Observe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>? onError, System.Action? onCompleted, bool refreshAfterCallbacks) -> System.IDisposable!
+ReactiveUI.Primitives.Blazor.Reactive.Components.ReactiveComponentBase.ReactiveComponentBase() -> void
+ReactiveUI.Primitives.Blazor.Reactive.Components.ReactiveComponentBase.RendererSequencer.get -> System.Reactive.Concurrency.IScheduler!
+ReactiveUI.Primitives.Blazor.Reactive.Components.ReactiveComponentBase.Track(System.IDisposable! subscription) -> System.IDisposable!
+ReactiveUI.Primitives.Blazor.Reactive.Concurrency.BlazorRendererSequencer
+ReactiveUI.Primitives.Blazor.Reactive.Concurrency.BlazorRendererSequencer.BlazorRendererSequencer(System.Func<System.Action!, System.Threading.Tasks.Task!>! invokeAsync) -> void
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.CoalescingDispatchScheduler() -> void
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.RequestDrain() -> void
+abstract ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Post(System.Action! drain) -> bool
+override ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Schedule<TState>(TState state, System.Func<System.Reactive.Concurrency.IScheduler!, TState, System.IDisposable!>! action) -> System.IDisposable!
+override ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Schedule<TState>(TState state, System.TimeSpan dueTime, System.Func<System.Reactive.Concurrency.IScheduler!, TState, System.IDisposable!>! action) -> System.IDisposable!
+virtual ReactiveUI.Primitives.Blazor.Reactive.Components.ReactiveComponentBase.Dispose(bool disposing) -> void
+virtual ReactiveUI.Primitives.Blazor.Reactive.Components.ReactiveComponentBase.OnObservedError(System.Exception! error) -> void
+virtual ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.ScheduleOnDispatcher(System.Action! work, System.TimeSpan dueTime) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.Blazor.Reactive/PublicAPI/net11.0/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Blazor.Reactive/PublicAPI/net11.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/ReactiveUI.Primitives.Blazor.Reactive/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Blazor.Reactive/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -1,0 +1,22 @@
+#nullable enable
+ReactiveUI.Primitives.Blazor.Reactive.Components.ReactiveComponentBase
+ReactiveUI.Primitives.Blazor.Reactive.Components.ReactiveComponentBase.Dispose() -> void
+ReactiveUI.Primitives.Blazor.Reactive.Components.ReactiveComponentBase.InvalidateAsync() -> System.Threading.Tasks.Task!
+ReactiveUI.Primitives.Blazor.Reactive.Components.ReactiveComponentBase.IsDisposed.get -> bool
+ReactiveUI.Primitives.Blazor.Reactive.Components.ReactiveComponentBase.Observe<T>(System.IObservable<T>! source, System.Action<T>! onNext) -> System.IDisposable!
+ReactiveUI.Primitives.Blazor.Reactive.Components.ReactiveComponentBase.Observe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>? onError, System.Action? onCompleted) -> System.IDisposable!
+ReactiveUI.Primitives.Blazor.Reactive.Components.ReactiveComponentBase.Observe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>? onError, System.Action? onCompleted, bool refreshAfterCallbacks) -> System.IDisposable!
+ReactiveUI.Primitives.Blazor.Reactive.Components.ReactiveComponentBase.ReactiveComponentBase() -> void
+ReactiveUI.Primitives.Blazor.Reactive.Components.ReactiveComponentBase.RendererSequencer.get -> System.Reactive.Concurrency.IScheduler!
+ReactiveUI.Primitives.Blazor.Reactive.Components.ReactiveComponentBase.Track(System.IDisposable! subscription) -> System.IDisposable!
+ReactiveUI.Primitives.Blazor.Reactive.Concurrency.BlazorRendererSequencer
+ReactiveUI.Primitives.Blazor.Reactive.Concurrency.BlazorRendererSequencer.BlazorRendererSequencer(System.Func<System.Action!, System.Threading.Tasks.Task!>! invokeAsync) -> void
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.CoalescingDispatchScheduler() -> void
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.RequestDrain() -> void
+abstract ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Post(System.Action! drain) -> bool
+override ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Schedule<TState>(TState state, System.Func<System.Reactive.Concurrency.IScheduler!, TState, System.IDisposable!>! action) -> System.IDisposable!
+override ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Schedule<TState>(TState state, System.TimeSpan dueTime, System.Func<System.Reactive.Concurrency.IScheduler!, TState, System.IDisposable!>! action) -> System.IDisposable!
+virtual ReactiveUI.Primitives.Blazor.Reactive.Components.ReactiveComponentBase.Dispose(bool disposing) -> void
+virtual ReactiveUI.Primitives.Blazor.Reactive.Components.ReactiveComponentBase.OnObservedError(System.Exception! error) -> void
+virtual ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.ScheduleOnDispatcher(System.Action! work, System.TimeSpan dueTime) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.Blazor.Reactive/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Blazor.Reactive/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/ReactiveUI.Primitives.Blazor.Reactive/PublicAPI/net9.0/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Blazor.Reactive/PublicAPI/net9.0/PublicAPI.Shipped.txt
@@ -1,0 +1,22 @@
+#nullable enable
+ReactiveUI.Primitives.Blazor.Reactive.Components.ReactiveComponentBase
+ReactiveUI.Primitives.Blazor.Reactive.Components.ReactiveComponentBase.Dispose() -> void
+ReactiveUI.Primitives.Blazor.Reactive.Components.ReactiveComponentBase.InvalidateAsync() -> System.Threading.Tasks.Task!
+ReactiveUI.Primitives.Blazor.Reactive.Components.ReactiveComponentBase.IsDisposed.get -> bool
+ReactiveUI.Primitives.Blazor.Reactive.Components.ReactiveComponentBase.Observe<T>(System.IObservable<T>! source, System.Action<T>! onNext) -> System.IDisposable!
+ReactiveUI.Primitives.Blazor.Reactive.Components.ReactiveComponentBase.Observe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>? onError, System.Action? onCompleted) -> System.IDisposable!
+ReactiveUI.Primitives.Blazor.Reactive.Components.ReactiveComponentBase.Observe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>? onError, System.Action? onCompleted, bool refreshAfterCallbacks) -> System.IDisposable!
+ReactiveUI.Primitives.Blazor.Reactive.Components.ReactiveComponentBase.ReactiveComponentBase() -> void
+ReactiveUI.Primitives.Blazor.Reactive.Components.ReactiveComponentBase.RendererSequencer.get -> System.Reactive.Concurrency.IScheduler!
+ReactiveUI.Primitives.Blazor.Reactive.Components.ReactiveComponentBase.Track(System.IDisposable! subscription) -> System.IDisposable!
+ReactiveUI.Primitives.Blazor.Reactive.Concurrency.BlazorRendererSequencer
+ReactiveUI.Primitives.Blazor.Reactive.Concurrency.BlazorRendererSequencer.BlazorRendererSequencer(System.Func<System.Action!, System.Threading.Tasks.Task!>! invokeAsync) -> void
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.CoalescingDispatchScheduler() -> void
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.RequestDrain() -> void
+abstract ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Post(System.Action! drain) -> bool
+override ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Schedule<TState>(TState state, System.Func<System.Reactive.Concurrency.IScheduler!, TState, System.IDisposable!>! action) -> System.IDisposable!
+override ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Schedule<TState>(TState state, System.TimeSpan dueTime, System.Func<System.Reactive.Concurrency.IScheduler!, TState, System.IDisposable!>! action) -> System.IDisposable!
+virtual ReactiveUI.Primitives.Blazor.Reactive.Components.ReactiveComponentBase.Dispose(bool disposing) -> void
+virtual ReactiveUI.Primitives.Blazor.Reactive.Components.ReactiveComponentBase.OnObservedError(System.Exception! error) -> void
+virtual ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.ScheduleOnDispatcher(System.Action! work, System.TimeSpan dueTime) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.Blazor.Reactive/PublicAPI/net9.0/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Blazor.Reactive/PublicAPI/net9.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/ReactiveUI.Primitives.Blazor.Reactive/ReactiveUI.Primitives.Blazor.Reactive.csproj
+++ b/src/ReactiveUI.Primitives.Blazor.Reactive/ReactiveUI.Primitives.Blazor.Reactive.csproj
@@ -1,0 +1,36 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <!-- System.Reactive-flavoured Blazor leaf: a coalescing IScheduler over the renderer dispatcher plus the
+         shared ReactiveComponentBase. REACTIVE_SHIM + the System.Reactive dependency come from
+         Directory.Build.props via the name suffix. -->
+    <TargetFrameworks>$(BlazorTargetFrameworks)</TargetFrameworks>
+    <PackageDescription>Blazor integration helpers for ReactiveUI.Primitives, recompiled against System.Reactive's IScheduler.</PackageDescription>
+    <PackageTags>system.reactive;rx;reactive;primitives;blazor;components;subscriptions</PackageTags>
+  </PropertyGroup>
+
+  <!-- The coalescing IScheduler base shared by every platform .Reactive package, plus the shared component. -->
+  <ItemGroup>
+    <Compile Include="..\Primitives.Platform.Reactive.Shared\**\*.cs" Link="Primitives.Platform.Reactive.Shared\%(RecursiveDir)%(Filename)%(Extension)" />
+    <Compile Include="..\Primitives.Blazor.Shared\**\*.cs" Link="Primitives.Blazor.Shared\%(RecursiveDir)%(Filename)%(Extension)" />
+  </ItemGroup>
+
+  <!-- The shared ReactiveComponentBase shifts to ReactiveUI.Primitives.Blazor.Reactive.* under REACTIVE_SHIM; these
+       imports let it resolve its renderer sequencer, disposables, and shifted operators without per-file usings. -->
+  <ItemGroup>
+    <Using Include="ReactiveUI.Primitives.Reactive" />
+    <Using Include="ReactiveUI.Primitives.Blazor.Reactive.Concurrency" />
+    <Using Include="ReactiveUI.Primitives.Concurrency" />
+    <Using Include="ReactiveUI.Primitives.Disposables" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Components" />
+    <ProjectReference Include="..\ReactiveUI.Primitives.Reactive\ReactiveUI.Primitives.Reactive.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="ReactiveUI.Primitives.Blazor.Reactive.Tests" />
+  </ItemGroup>
+
+</Project>

--- a/src/ReactiveUI.Primitives.Blazor/ReactiveUI.Primitives.Blazor.csproj
+++ b/src/ReactiveUI.Primitives.Blazor/ReactiveUI.Primitives.Blazor.csproj
@@ -6,6 +6,19 @@
     <PackageTags>system.reactive;rx;reactive;primitives;blazor;components;subscriptions</PackageTags>
   </PropertyGroup>
 
+  <!-- ReactiveComponentBase is shared source: it recompiles unchanged into the System.Reactive leaf, where its
+       renderer sequencer becomes an IScheduler. The globalized usings let the shared file resolve its renderer
+       sequencer, disposables, and operators without per-file usings (which differ between the two leaves). -->
+  <ItemGroup>
+    <Compile Include="..\Primitives.Blazor.Shared\**\*.cs" Link="Primitives.Blazor.Shared\%(RecursiveDir)%(Filename)%(Extension)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="ReactiveUI.Primitives.Blazor.Concurrency" />
+    <Using Include="ReactiveUI.Primitives.Concurrency" />
+    <Using Include="ReactiveUI.Primitives.Disposables" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components" />
     <ProjectReference Include="..\ReactiveUI.Primitives\ReactiveUI.Primitives.csproj" />

--- a/src/ReactiveUI.Primitives.Maui.Reactive/Concurrency/MauiDispatcherSequencer.cs
+++ b/src/ReactiveUI.Primitives.Maui.Reactive/Concurrency/MauiDispatcherSequencer.cs
@@ -1,0 +1,32 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Reactive.Disposables;
+using Microsoft.Maui.Dispatching;
+
+namespace ReactiveUI.Primitives.Reactive.Concurrency;
+
+/// <summary>MAUI dispatcher scheduler that coalesces scheduled work through an <see cref="IDispatcher"/>.</summary>
+/// <seealso cref="System.Reactive.Concurrency.IScheduler" />
+public sealed class MauiDispatcherSequencer : CoalescingDispatchScheduler
+{
+    /// <summary>Initializes a new instance of the <see cref="MauiDispatcherSequencer"/> class.</summary>
+    /// <param name="dispatcher">The dispatcher used to marshal work to the UI thread.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="dispatcher"/> is <see langword="null"/>.</exception>
+    public MauiDispatcherSequencer(IDispatcher dispatcher) =>
+        Dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
+
+    /// <summary>Gets the dispatcher used to marshal work to the UI thread.</summary>
+    public IDispatcher Dispatcher { get; }
+
+    /// <inheritdoc/>
+    protected override bool Post(Action drain) => Dispatcher.Dispatch(drain);
+
+    /// <inheritdoc/>
+    protected override IDisposable ScheduleOnDispatcher(Action work, TimeSpan dueTime)
+    {
+        _ = Dispatcher.DispatchDelayed(dueTime, work);
+        return Disposable.Empty;
+    }
+}

--- a/src/ReactiveUI.Primitives.Maui.Reactive/Concurrency/MauiDispatcherSequencerExtensions.cs
+++ b/src/ReactiveUI.Primitives.Maui.Reactive/Concurrency/MauiDispatcherSequencerExtensions.cs
@@ -1,0 +1,26 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Microsoft.Maui.Dispatching;
+
+namespace ReactiveUI.Primitives.Reactive.Concurrency;
+
+/// <summary>Convenience helpers for MAUI dispatcher schedulers.</summary>
+public static class MauiDispatcherSequencerExtensions
+{
+    /// <summary>Extension methods for MAUI dispatchers.</summary>
+    /// <param name="dispatcher">The dispatcher to adapt.</param>
+    extension(IDispatcher dispatcher)
+    {
+        /// <summary>Adapts a MAUI dispatcher to a coalescing <see cref="System.Reactive.Concurrency.IScheduler"/>.</summary>
+        /// <returns>A scheduler that schedules through <paramref name="dispatcher"/>.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="dispatcher"/> is <see langword="null"/>.</exception>
+        public MauiDispatcherSequencer ToSequencer()
+        {
+            ArgumentNullException.ThrowIfNull(dispatcher);
+
+            return new(dispatcher);
+        }
+    }
+}

--- a/src/ReactiveUI.Primitives.Maui.Reactive/PublicAPI/net10.0/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Maui.Reactive/PublicAPI/net10.0/PublicAPI.Shipped.txt
@@ -1,0 +1,15 @@
+#nullable enable
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.CoalescingDispatchScheduler() -> void
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.RequestDrain() -> void
+ReactiveUI.Primitives.Reactive.Concurrency.MauiDispatcherSequencer
+ReactiveUI.Primitives.Reactive.Concurrency.MauiDispatcherSequencer.Dispatcher.get -> Microsoft.Maui.Dispatching.IDispatcher!
+ReactiveUI.Primitives.Reactive.Concurrency.MauiDispatcherSequencer.MauiDispatcherSequencer(Microsoft.Maui.Dispatching.IDispatcher! dispatcher) -> void
+ReactiveUI.Primitives.Reactive.Concurrency.MauiDispatcherSequencerExtensions
+ReactiveUI.Primitives.Reactive.Concurrency.MauiDispatcherSequencerExtensions.extension(Microsoft.Maui.Dispatching.IDispatcher!)
+ReactiveUI.Primitives.Reactive.Concurrency.MauiDispatcherSequencerExtensions.extension(Microsoft.Maui.Dispatching.IDispatcher!).ToSequencer() -> ReactiveUI.Primitives.Reactive.Concurrency.MauiDispatcherSequencer!
+abstract ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Post(System.Action! drain) -> bool
+override ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Schedule<TState>(TState state, System.Func<System.Reactive.Concurrency.IScheduler!, TState, System.IDisposable!>! action) -> System.IDisposable!
+override ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Schedule<TState>(TState state, System.TimeSpan dueTime, System.Func<System.Reactive.Concurrency.IScheduler!, TState, System.IDisposable!>! action) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.Concurrency.MauiDispatcherSequencerExtensions.ToSequencer(this Microsoft.Maui.Dispatching.IDispatcher! dispatcher) -> ReactiveUI.Primitives.Reactive.Concurrency.MauiDispatcherSequencer!
+virtual ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.ScheduleOnDispatcher(System.Action! work, System.TimeSpan dueTime) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.Maui.Reactive/PublicAPI/net10.0/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Maui.Reactive/PublicAPI/net10.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/ReactiveUI.Primitives.Maui.Reactive/PublicAPI/net11.0/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Maui.Reactive/PublicAPI/net11.0/PublicAPI.Shipped.txt
@@ -1,0 +1,15 @@
+#nullable enable
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.CoalescingDispatchScheduler() -> void
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.RequestDrain() -> void
+ReactiveUI.Primitives.Reactive.Concurrency.MauiDispatcherSequencer
+ReactiveUI.Primitives.Reactive.Concurrency.MauiDispatcherSequencer.Dispatcher.get -> Microsoft.Maui.Dispatching.IDispatcher!
+ReactiveUI.Primitives.Reactive.Concurrency.MauiDispatcherSequencer.MauiDispatcherSequencer(Microsoft.Maui.Dispatching.IDispatcher! dispatcher) -> void
+ReactiveUI.Primitives.Reactive.Concurrency.MauiDispatcherSequencerExtensions
+ReactiveUI.Primitives.Reactive.Concurrency.MauiDispatcherSequencerExtensions.extension(Microsoft.Maui.Dispatching.IDispatcher!)
+ReactiveUI.Primitives.Reactive.Concurrency.MauiDispatcherSequencerExtensions.extension(Microsoft.Maui.Dispatching.IDispatcher!).ToSequencer() -> ReactiveUI.Primitives.Reactive.Concurrency.MauiDispatcherSequencer!
+abstract ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Post(System.Action! drain) -> bool
+override ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Schedule<TState>(TState state, System.Func<System.Reactive.Concurrency.IScheduler!, TState, System.IDisposable!>! action) -> System.IDisposable!
+override ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Schedule<TState>(TState state, System.TimeSpan dueTime, System.Func<System.Reactive.Concurrency.IScheduler!, TState, System.IDisposable!>! action) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.Concurrency.MauiDispatcherSequencerExtensions.ToSequencer(this Microsoft.Maui.Dispatching.IDispatcher! dispatcher) -> ReactiveUI.Primitives.Reactive.Concurrency.MauiDispatcherSequencer!
+virtual ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.ScheduleOnDispatcher(System.Action! work, System.TimeSpan dueTime) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.Maui.Reactive/PublicAPI/net11.0/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Maui.Reactive/PublicAPI/net11.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/ReactiveUI.Primitives.Maui.Reactive/PublicAPI/net9.0/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Maui.Reactive/PublicAPI/net9.0/PublicAPI.Shipped.txt
@@ -1,0 +1,15 @@
+#nullable enable
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.CoalescingDispatchScheduler() -> void
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.RequestDrain() -> void
+ReactiveUI.Primitives.Reactive.Concurrency.MauiDispatcherSequencer
+ReactiveUI.Primitives.Reactive.Concurrency.MauiDispatcherSequencer.Dispatcher.get -> Microsoft.Maui.Dispatching.IDispatcher!
+ReactiveUI.Primitives.Reactive.Concurrency.MauiDispatcherSequencer.MauiDispatcherSequencer(Microsoft.Maui.Dispatching.IDispatcher! dispatcher) -> void
+ReactiveUI.Primitives.Reactive.Concurrency.MauiDispatcherSequencerExtensions
+ReactiveUI.Primitives.Reactive.Concurrency.MauiDispatcherSequencerExtensions.extension(Microsoft.Maui.Dispatching.IDispatcher!)
+ReactiveUI.Primitives.Reactive.Concurrency.MauiDispatcherSequencerExtensions.extension(Microsoft.Maui.Dispatching.IDispatcher!).ToSequencer() -> ReactiveUI.Primitives.Reactive.Concurrency.MauiDispatcherSequencer!
+abstract ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Post(System.Action! drain) -> bool
+override ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Schedule<TState>(TState state, System.Func<System.Reactive.Concurrency.IScheduler!, TState, System.IDisposable!>! action) -> System.IDisposable!
+override ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Schedule<TState>(TState state, System.TimeSpan dueTime, System.Func<System.Reactive.Concurrency.IScheduler!, TState, System.IDisposable!>! action) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.Concurrency.MauiDispatcherSequencerExtensions.ToSequencer(this Microsoft.Maui.Dispatching.IDispatcher! dispatcher) -> ReactiveUI.Primitives.Reactive.Concurrency.MauiDispatcherSequencer!
+virtual ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.ScheduleOnDispatcher(System.Action! work, System.TimeSpan dueTime) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.Maui.Reactive/PublicAPI/net9.0/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Maui.Reactive/PublicAPI/net9.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/ReactiveUI.Primitives.Maui.Reactive/ReactiveUI.Primitives.Maui.Reactive.csproj
+++ b/src/ReactiveUI.Primitives.Maui.Reactive/ReactiveUI.Primitives.Maui.Reactive.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <!-- System.Reactive-flavoured MAUI leaf: a coalescing IScheduler over the MAUI dispatcher.
+         REACTIVE_SHIM + the System.Reactive dependency come from Directory.Build.props via the name suffix. -->
+    <TargetFrameworks>$(MauiTargetFrameworks)</TargetFrameworks>
+    <PackageDescription>MAUI dispatcher scheduler for ReactiveUI.Primitives, recompiled against System.Reactive's IScheduler.</PackageDescription>
+    <PackageTags>system.reactive;rx;reactive;primitives;maui;dispatcher;scheduler</PackageTags>
+  </PropertyGroup>
+
+  <!-- The coalescing IScheduler base shared by every platform .Reactive package. -->
+  <ItemGroup>
+    <Compile Include="..\Primitives.Platform.Reactive.Shared\**\*.cs" Link="Primitives.Platform.Reactive.Shared\%(RecursiveDir)%(Filename)%(Extension)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Maui.Core" />
+    <ProjectReference Include="..\ReactiveUI.Primitives.Reactive\ReactiveUI.Primitives.Reactive.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net11.0'))">
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="ReactiveUI.Primitives.Maui.Reactive.Tests" />
+  </ItemGroup>
+
+</Project>

--- a/src/ReactiveUI.Primitives.WinForms.Reactive/Concurrency/ControlSequencer.cs
+++ b/src/ReactiveUI.Primitives.WinForms.Reactive/Concurrency/ControlSequencer.cs
@@ -1,0 +1,52 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace ReactiveUI.Primitives.Reactive.Concurrency;
+
+/// <summary>Windows Forms scheduler that coalesces scheduled work through a UI control.</summary>
+/// <seealso cref="System.Reactive.Concurrency.IScheduler" />
+public sealed class ControlSequencer : CoalescingDispatchScheduler
+{
+    /// <summary>Initializes a new instance of the <see cref="ControlSequencer"/> class.</summary>
+    /// <param name="control">The control used to marshal work to the UI thread.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="control"/> is <see langword="null"/>.</exception>
+    public ControlSequencer(Control control)
+    {
+        Control = control ?? throw new ArgumentNullException(nameof(control));
+        Control.HandleCreated += OnHandleCreated;
+    }
+
+    /// <summary>Gets the control used to marshal work to the UI thread.</summary>
+    public Control Control { get; }
+
+    /// <inheritdoc/>
+    /// <exception cref="ObjectDisposedException">The control has been disposed.</exception>
+    protected override bool Post(Action drain)
+    {
+        if (Control.IsDisposed)
+        {
+            throw new ObjectDisposedException(Control.GetType().FullName);
+        }
+
+        if (!Control.IsHandleCreated)
+        {
+            return false;
+        }
+
+        try
+        {
+            Control.BeginInvoke(drain);
+            return true;
+        }
+        catch (InvalidOperationException) when (!Control.IsDisposed)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>Posts queued work once the control handle becomes available.</summary>
+    /// <param name="sender">The event source.</param>
+    /// <param name="e">The event arguments.</param>
+    private void OnHandleCreated(object? sender, EventArgs e) => RequestDrain();
+}

--- a/src/ReactiveUI.Primitives.WinForms.Reactive/PublicAPI/net10.0-windows/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.WinForms.Reactive/PublicAPI/net10.0-windows/PublicAPI.Shipped.txt
@@ -1,0 +1,11 @@
+#nullable enable
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.CoalescingDispatchScheduler() -> void
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.RequestDrain() -> void
+ReactiveUI.Primitives.Reactive.Concurrency.ControlSequencer
+ReactiveUI.Primitives.Reactive.Concurrency.ControlSequencer.Control.get -> System.Windows.Forms.Control!
+ReactiveUI.Primitives.Reactive.Concurrency.ControlSequencer.ControlSequencer(System.Windows.Forms.Control! control) -> void
+abstract ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Post(System.Action! drain) -> bool
+override ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Schedule<TState>(TState state, System.Func<System.Reactive.Concurrency.IScheduler!, TState, System.IDisposable!>! action) -> System.IDisposable!
+override ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Schedule<TState>(TState state, System.TimeSpan dueTime, System.Func<System.Reactive.Concurrency.IScheduler!, TState, System.IDisposable!>! action) -> System.IDisposable!
+virtual ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.ScheduleOnDispatcher(System.Action! work, System.TimeSpan dueTime) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.WinForms.Reactive/PublicAPI/net10.0-windows/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.WinForms.Reactive/PublicAPI/net10.0-windows/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/ReactiveUI.Primitives.WinForms.Reactive/PublicAPI/net11.0-windows/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.WinForms.Reactive/PublicAPI/net11.0-windows/PublicAPI.Shipped.txt
@@ -1,0 +1,11 @@
+#nullable enable
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.CoalescingDispatchScheduler() -> void
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.RequestDrain() -> void
+ReactiveUI.Primitives.Reactive.Concurrency.ControlSequencer
+ReactiveUI.Primitives.Reactive.Concurrency.ControlSequencer.Control.get -> System.Windows.Forms.Control!
+ReactiveUI.Primitives.Reactive.Concurrency.ControlSequencer.ControlSequencer(System.Windows.Forms.Control! control) -> void
+abstract ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Post(System.Action! drain) -> bool
+override ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Schedule<TState>(TState state, System.Func<System.Reactive.Concurrency.IScheduler!, TState, System.IDisposable!>! action) -> System.IDisposable!
+override ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Schedule<TState>(TState state, System.TimeSpan dueTime, System.Func<System.Reactive.Concurrency.IScheduler!, TState, System.IDisposable!>! action) -> System.IDisposable!
+virtual ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.ScheduleOnDispatcher(System.Action! work, System.TimeSpan dueTime) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.WinForms.Reactive/PublicAPI/net11.0-windows/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.WinForms.Reactive/PublicAPI/net11.0-windows/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/ReactiveUI.Primitives.WinForms.Reactive/PublicAPI/net462/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.WinForms.Reactive/PublicAPI/net462/PublicAPI.Shipped.txt
@@ -1,0 +1,11 @@
+#nullable enable
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.CoalescingDispatchScheduler() -> void
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.RequestDrain() -> void
+ReactiveUI.Primitives.Reactive.Concurrency.ControlSequencer
+ReactiveUI.Primitives.Reactive.Concurrency.ControlSequencer.Control.get -> System.Windows.Forms.Control!
+ReactiveUI.Primitives.Reactive.Concurrency.ControlSequencer.ControlSequencer(System.Windows.Forms.Control! control) -> void
+abstract ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Post(System.Action! drain) -> bool
+override ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Schedule<TState>(TState state, System.Func<System.Reactive.Concurrency.IScheduler!, TState, System.IDisposable!>! action) -> System.IDisposable!
+override ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Schedule<TState>(TState state, System.TimeSpan dueTime, System.Func<System.Reactive.Concurrency.IScheduler!, TState, System.IDisposable!>! action) -> System.IDisposable!
+virtual ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.ScheduleOnDispatcher(System.Action! work, System.TimeSpan dueTime) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.WinForms.Reactive/PublicAPI/net462/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.WinForms.Reactive/PublicAPI/net462/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/ReactiveUI.Primitives.WinForms.Reactive/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.WinForms.Reactive/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -1,0 +1,11 @@
+#nullable enable
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.CoalescingDispatchScheduler() -> void
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.RequestDrain() -> void
+ReactiveUI.Primitives.Reactive.Concurrency.ControlSequencer
+ReactiveUI.Primitives.Reactive.Concurrency.ControlSequencer.Control.get -> System.Windows.Forms.Control!
+ReactiveUI.Primitives.Reactive.Concurrency.ControlSequencer.ControlSequencer(System.Windows.Forms.Control! control) -> void
+abstract ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Post(System.Action! drain) -> bool
+override ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Schedule<TState>(TState state, System.Func<System.Reactive.Concurrency.IScheduler!, TState, System.IDisposable!>! action) -> System.IDisposable!
+override ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Schedule<TState>(TState state, System.TimeSpan dueTime, System.Func<System.Reactive.Concurrency.IScheduler!, TState, System.IDisposable!>! action) -> System.IDisposable!
+virtual ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.ScheduleOnDispatcher(System.Action! work, System.TimeSpan dueTime) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.WinForms.Reactive/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.WinForms.Reactive/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/ReactiveUI.Primitives.WinForms.Reactive/PublicAPI/net48/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.WinForms.Reactive/PublicAPI/net48/PublicAPI.Shipped.txt
@@ -1,0 +1,11 @@
+#nullable enable
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.CoalescingDispatchScheduler() -> void
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.RequestDrain() -> void
+ReactiveUI.Primitives.Reactive.Concurrency.ControlSequencer
+ReactiveUI.Primitives.Reactive.Concurrency.ControlSequencer.Control.get -> System.Windows.Forms.Control!
+ReactiveUI.Primitives.Reactive.Concurrency.ControlSequencer.ControlSequencer(System.Windows.Forms.Control! control) -> void
+abstract ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Post(System.Action! drain) -> bool
+override ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Schedule<TState>(TState state, System.Func<System.Reactive.Concurrency.IScheduler!, TState, System.IDisposable!>! action) -> System.IDisposable!
+override ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Schedule<TState>(TState state, System.TimeSpan dueTime, System.Func<System.Reactive.Concurrency.IScheduler!, TState, System.IDisposable!>! action) -> System.IDisposable!
+virtual ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.ScheduleOnDispatcher(System.Action! work, System.TimeSpan dueTime) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.WinForms.Reactive/PublicAPI/net48/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.WinForms.Reactive/PublicAPI/net48/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/ReactiveUI.Primitives.WinForms.Reactive/PublicAPI/net481/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.WinForms.Reactive/PublicAPI/net481/PublicAPI.Shipped.txt
@@ -1,0 +1,11 @@
+#nullable enable
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.CoalescingDispatchScheduler() -> void
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.RequestDrain() -> void
+ReactiveUI.Primitives.Reactive.Concurrency.ControlSequencer
+ReactiveUI.Primitives.Reactive.Concurrency.ControlSequencer.Control.get -> System.Windows.Forms.Control!
+ReactiveUI.Primitives.Reactive.Concurrency.ControlSequencer.ControlSequencer(System.Windows.Forms.Control! control) -> void
+abstract ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Post(System.Action! drain) -> bool
+override ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Schedule<TState>(TState state, System.Func<System.Reactive.Concurrency.IScheduler!, TState, System.IDisposable!>! action) -> System.IDisposable!
+override ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Schedule<TState>(TState state, System.TimeSpan dueTime, System.Func<System.Reactive.Concurrency.IScheduler!, TState, System.IDisposable!>! action) -> System.IDisposable!
+virtual ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.ScheduleOnDispatcher(System.Action! work, System.TimeSpan dueTime) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.WinForms.Reactive/PublicAPI/net481/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.WinForms.Reactive/PublicAPI/net481/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/ReactiveUI.Primitives.WinForms.Reactive/PublicAPI/net8.0-windows/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.WinForms.Reactive/PublicAPI/net8.0-windows/PublicAPI.Shipped.txt
@@ -1,0 +1,11 @@
+#nullable enable
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.CoalescingDispatchScheduler() -> void
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.RequestDrain() -> void
+ReactiveUI.Primitives.Reactive.Concurrency.ControlSequencer
+ReactiveUI.Primitives.Reactive.Concurrency.ControlSequencer.Control.get -> System.Windows.Forms.Control!
+ReactiveUI.Primitives.Reactive.Concurrency.ControlSequencer.ControlSequencer(System.Windows.Forms.Control! control) -> void
+abstract ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Post(System.Action! drain) -> bool
+override ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Schedule<TState>(TState state, System.Func<System.Reactive.Concurrency.IScheduler!, TState, System.IDisposable!>! action) -> System.IDisposable!
+override ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Schedule<TState>(TState state, System.TimeSpan dueTime, System.Func<System.Reactive.Concurrency.IScheduler!, TState, System.IDisposable!>! action) -> System.IDisposable!
+virtual ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.ScheduleOnDispatcher(System.Action! work, System.TimeSpan dueTime) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.WinForms.Reactive/PublicAPI/net8.0-windows/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.WinForms.Reactive/PublicAPI/net8.0-windows/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/ReactiveUI.Primitives.WinForms.Reactive/PublicAPI/net9.0-windows/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.WinForms.Reactive/PublicAPI/net9.0-windows/PublicAPI.Shipped.txt
@@ -1,0 +1,11 @@
+#nullable enable
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.CoalescingDispatchScheduler() -> void
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.RequestDrain() -> void
+ReactiveUI.Primitives.Reactive.Concurrency.ControlSequencer
+ReactiveUI.Primitives.Reactive.Concurrency.ControlSequencer.Control.get -> System.Windows.Forms.Control!
+ReactiveUI.Primitives.Reactive.Concurrency.ControlSequencer.ControlSequencer(System.Windows.Forms.Control! control) -> void
+abstract ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Post(System.Action! drain) -> bool
+override ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Schedule<TState>(TState state, System.Func<System.Reactive.Concurrency.IScheduler!, TState, System.IDisposable!>! action) -> System.IDisposable!
+override ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Schedule<TState>(TState state, System.TimeSpan dueTime, System.Func<System.Reactive.Concurrency.IScheduler!, TState, System.IDisposable!>! action) -> System.IDisposable!
+virtual ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.ScheduleOnDispatcher(System.Action! work, System.TimeSpan dueTime) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.WinForms.Reactive/PublicAPI/net9.0-windows/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.WinForms.Reactive/PublicAPI/net9.0-windows/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/ReactiveUI.Primitives.WinForms.Reactive/ReactiveUI.Primitives.WinForms.Reactive.csproj
+++ b/src/ReactiveUI.Primitives.WinForms.Reactive/ReactiveUI.Primitives.WinForms.Reactive.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <!-- System.Reactive-flavoured Windows Forms leaf: a coalescing IScheduler over a UI control.
+         REACTIVE_SHIM + the System.Reactive dependency come from Directory.Build.props via the name suffix. -->
+    <TargetFrameworks>$(WindowsLibraryTargetFrameworks)</TargetFrameworks>
+    <UseWindowsForms>true</UseWindowsForms>
+    <PackageDescription>Windows Forms scheduler for ReactiveUI.Primitives, recompiled against System.Reactive's IScheduler.</PackageDescription>
+    <PackageTags>system.reactive;rx;reactive;primitives;winforms;windows-forms;scheduler</PackageTags>
+  </PropertyGroup>
+
+  <!-- The coalescing IScheduler base shared by every platform .Reactive package. -->
+  <ItemGroup>
+    <Compile Include="..\Primitives.Platform.Reactive.Shared\**\*.cs" Link="Primitives.Platform.Reactive.Shared\%(RecursiveDir)%(Filename)%(Extension)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ReactiveUI.Primitives.Reactive\ReactiveUI.Primitives.Reactive.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="ReactiveUI.Primitives.WinForms.Reactive.Tests" />
+  </ItemGroup>
+
+</Project>

--- a/src/ReactiveUI.Primitives.WinUI.Reactive/Concurrency/DispatcherQueueSequencer.cs
+++ b/src/ReactiveUI.Primitives.WinUI.Reactive/Concurrency/DispatcherQueueSequencer.cs
@@ -1,0 +1,72 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Reactive.Disposables;
+using Microsoft.UI.Dispatching;
+
+namespace ReactiveUI.Primitives.Reactive.Concurrency;
+
+/// <summary>WinUI dispatcher queue scheduler that coalesces scheduled work through a <see cref="DispatcherQueue"/>.</summary>
+/// <seealso cref="System.Reactive.Concurrency.IScheduler" />
+public sealed class DispatcherQueueSequencer : CoalescingDispatchScheduler
+{
+    /// <summary>Cached dispatcher queue handler used for the drain.</summary>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Maintainability",
+        "SST1422:Move this field into the method that uses it",
+        Justification = "Persistent lazy cache: the dispatcher queue handler is built once and reused across every post, so it cannot be a method local.")]
+    private DispatcherQueueHandler? _handler;
+
+    /// <summary>Initializes a new instance of the <see cref="DispatcherQueueSequencer"/> class.</summary>
+    /// <param name="dispatcherQueue">The dispatcher queue used to marshal work to the UI thread.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="dispatcherQueue"/> is <see langword="null"/>.</exception>
+    public DispatcherQueueSequencer(DispatcherQueue dispatcherQueue)
+        : this(dispatcherQueue, DispatcherQueuePriority.Normal)
+    {
+    }
+
+    /// <summary>Initializes a new instance of the <see cref="DispatcherQueueSequencer"/> class.</summary>
+    /// <param name="dispatcherQueue">The dispatcher queue used to marshal work to the UI thread.</param>
+    /// <param name="priority">Dispatcher queue priority used for posted drains.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="dispatcherQueue"/> is <see langword="null"/>.</exception>
+    public DispatcherQueueSequencer(DispatcherQueue dispatcherQueue, DispatcherQueuePriority priority)
+    {
+        DispatcherQueue = dispatcherQueue ?? throw new ArgumentNullException(nameof(dispatcherQueue));
+        Priority = priority;
+    }
+
+    /// <summary>Gets the dispatcher queue used to marshal work to the UI thread.</summary>
+    public DispatcherQueue DispatcherQueue { get; }
+
+    /// <summary>Gets the dispatcher queue priority used for posted drains.</summary>
+    public DispatcherQueuePriority Priority { get; }
+
+    /// <inheritdoc/>
+    /// <exception cref="InvalidOperationException">The dispatcher queue is no longer accepting work.</exception>
+    protected override bool Post(Action drain)
+    {
+        _handler ??= drain.Invoke;
+        if (DispatcherQueue.TryEnqueue(Priority, _handler))
+        {
+            return true;
+        }
+
+        throw new InvalidOperationException("The dispatcher queue is no longer accepting work.");
+    }
+
+    /// <inheritdoc/>
+    protected override IDisposable ScheduleOnDispatcher(Action work, TimeSpan dueTime)
+    {
+        var timer = DispatcherQueue.CreateTimer();
+        timer.Interval = dueTime;
+        timer.IsRepeating = false;
+        timer.Tick += (_, _) =>
+        {
+            timer.Stop();
+            work();
+        };
+        timer.Start();
+        return Disposable.Create(timer, static t => t.Stop());
+    }
+}

--- a/src/ReactiveUI.Primitives.WinUI.Reactive/Concurrency/DispatcherQueueSequencerExtensions.cs
+++ b/src/ReactiveUI.Primitives.WinUI.Reactive/Concurrency/DispatcherQueueSequencerExtensions.cs
@@ -1,0 +1,26 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Microsoft.UI.Dispatching;
+
+namespace ReactiveUI.Primitives.Reactive.Concurrency;
+
+/// <summary>Convenience helpers for WinUI dispatcher queue schedulers.</summary>
+public static class DispatcherQueueSequencerExtensions
+{
+    /// <summary>Extension methods for <see cref="DispatcherQueue"/>.</summary>
+    /// <param name="dispatcherQueue">The dispatcher queue to adapt.</param>
+    extension(DispatcherQueue dispatcherQueue)
+    {
+        /// <summary>Adapts a WinUI dispatcher queue to a coalescing <see cref="System.Reactive.Concurrency.IScheduler"/>.</summary>
+        /// <returns>A scheduler that schedules through <paramref name="dispatcherQueue"/>.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="dispatcherQueue"/> is <see langword="null"/>.</exception>
+        public DispatcherQueueSequencer ToSequencer()
+        {
+            ArgumentNullException.ThrowIfNull(dispatcherQueue);
+
+            return new(dispatcherQueue);
+        }
+    }
+}

--- a/src/ReactiveUI.Primitives.WinUI.Reactive/PublicAPI/net10.0-windows10.0.19041.0/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.WinUI.Reactive/PublicAPI/net10.0-windows10.0.19041.0/PublicAPI.Shipped.txt
@@ -1,0 +1,17 @@
+#nullable enable
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.CoalescingDispatchScheduler() -> void
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.RequestDrain() -> void
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherQueueSequencer
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherQueueSequencer.DispatcherQueue.get -> Microsoft.UI.Dispatching.DispatcherQueue!
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherQueueSequencer.DispatcherQueueSequencer(Microsoft.UI.Dispatching.DispatcherQueue! dispatcherQueue) -> void
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherQueueSequencer.DispatcherQueueSequencer(Microsoft.UI.Dispatching.DispatcherQueue! dispatcherQueue, Microsoft.UI.Dispatching.DispatcherQueuePriority priority) -> void
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherQueueSequencer.Priority.get -> Microsoft.UI.Dispatching.DispatcherQueuePriority
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherQueueSequencerExtensions
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherQueueSequencerExtensions.extension(Microsoft.UI.Dispatching.DispatcherQueue!)
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherQueueSequencerExtensions.extension(Microsoft.UI.Dispatching.DispatcherQueue!).ToSequencer() -> ReactiveUI.Primitives.Reactive.Concurrency.DispatcherQueueSequencer!
+abstract ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Post(System.Action! drain) -> bool
+override ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Schedule<TState>(TState state, System.Func<System.Reactive.Concurrency.IScheduler!, TState, System.IDisposable!>! action) -> System.IDisposable!
+override ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Schedule<TState>(TState state, System.TimeSpan dueTime, System.Func<System.Reactive.Concurrency.IScheduler!, TState, System.IDisposable!>! action) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.Concurrency.DispatcherQueueSequencerExtensions.ToSequencer(this Microsoft.UI.Dispatching.DispatcherQueue! dispatcherQueue) -> ReactiveUI.Primitives.Reactive.Concurrency.DispatcherQueueSequencer!
+virtual ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.ScheduleOnDispatcher(System.Action! work, System.TimeSpan dueTime) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.WinUI.Reactive/PublicAPI/net10.0-windows10.0.19041.0/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.WinUI.Reactive/PublicAPI/net10.0-windows10.0.19041.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/ReactiveUI.Primitives.WinUI.Reactive/PublicAPI/net11.0-windows10.0.19041.0/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.WinUI.Reactive/PublicAPI/net11.0-windows10.0.19041.0/PublicAPI.Shipped.txt
@@ -1,0 +1,17 @@
+#nullable enable
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.CoalescingDispatchScheduler() -> void
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.RequestDrain() -> void
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherQueueSequencer
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherQueueSequencer.DispatcherQueue.get -> Microsoft.UI.Dispatching.DispatcherQueue!
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherQueueSequencer.DispatcherQueueSequencer(Microsoft.UI.Dispatching.DispatcherQueue! dispatcherQueue) -> void
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherQueueSequencer.DispatcherQueueSequencer(Microsoft.UI.Dispatching.DispatcherQueue! dispatcherQueue, Microsoft.UI.Dispatching.DispatcherQueuePriority priority) -> void
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherQueueSequencer.Priority.get -> Microsoft.UI.Dispatching.DispatcherQueuePriority
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherQueueSequencerExtensions
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherQueueSequencerExtensions.extension(Microsoft.UI.Dispatching.DispatcherQueue!)
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherQueueSequencerExtensions.extension(Microsoft.UI.Dispatching.DispatcherQueue!).ToSequencer() -> ReactiveUI.Primitives.Reactive.Concurrency.DispatcherQueueSequencer!
+abstract ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Post(System.Action! drain) -> bool
+override ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Schedule<TState>(TState state, System.Func<System.Reactive.Concurrency.IScheduler!, TState, System.IDisposable!>! action) -> System.IDisposable!
+override ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Schedule<TState>(TState state, System.TimeSpan dueTime, System.Func<System.Reactive.Concurrency.IScheduler!, TState, System.IDisposable!>! action) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.Concurrency.DispatcherQueueSequencerExtensions.ToSequencer(this Microsoft.UI.Dispatching.DispatcherQueue! dispatcherQueue) -> ReactiveUI.Primitives.Reactive.Concurrency.DispatcherQueueSequencer!
+virtual ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.ScheduleOnDispatcher(System.Action! work, System.TimeSpan dueTime) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.WinUI.Reactive/PublicAPI/net11.0-windows10.0.19041.0/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.WinUI.Reactive/PublicAPI/net11.0-windows10.0.19041.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/ReactiveUI.Primitives.WinUI.Reactive/PublicAPI/net8.0-windows10.0.19041.0/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.WinUI.Reactive/PublicAPI/net8.0-windows10.0.19041.0/PublicAPI.Shipped.txt
@@ -1,0 +1,17 @@
+#nullable enable
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.CoalescingDispatchScheduler() -> void
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.RequestDrain() -> void
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherQueueSequencer
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherQueueSequencer.DispatcherQueue.get -> Microsoft.UI.Dispatching.DispatcherQueue!
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherQueueSequencer.DispatcherQueueSequencer(Microsoft.UI.Dispatching.DispatcherQueue! dispatcherQueue) -> void
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherQueueSequencer.DispatcherQueueSequencer(Microsoft.UI.Dispatching.DispatcherQueue! dispatcherQueue, Microsoft.UI.Dispatching.DispatcherQueuePriority priority) -> void
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherQueueSequencer.Priority.get -> Microsoft.UI.Dispatching.DispatcherQueuePriority
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherQueueSequencerExtensions
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherQueueSequencerExtensions.extension(Microsoft.UI.Dispatching.DispatcherQueue!)
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherQueueSequencerExtensions.extension(Microsoft.UI.Dispatching.DispatcherQueue!).ToSequencer() -> ReactiveUI.Primitives.Reactive.Concurrency.DispatcherQueueSequencer!
+abstract ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Post(System.Action! drain) -> bool
+override ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Schedule<TState>(TState state, System.Func<System.Reactive.Concurrency.IScheduler!, TState, System.IDisposable!>! action) -> System.IDisposable!
+override ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Schedule<TState>(TState state, System.TimeSpan dueTime, System.Func<System.Reactive.Concurrency.IScheduler!, TState, System.IDisposable!>! action) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.Concurrency.DispatcherQueueSequencerExtensions.ToSequencer(this Microsoft.UI.Dispatching.DispatcherQueue! dispatcherQueue) -> ReactiveUI.Primitives.Reactive.Concurrency.DispatcherQueueSequencer!
+virtual ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.ScheduleOnDispatcher(System.Action! work, System.TimeSpan dueTime) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.WinUI.Reactive/PublicAPI/net8.0-windows10.0.19041.0/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.WinUI.Reactive/PublicAPI/net8.0-windows10.0.19041.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/ReactiveUI.Primitives.WinUI.Reactive/PublicAPI/net9.0-windows10.0.19041.0/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.WinUI.Reactive/PublicAPI/net9.0-windows10.0.19041.0/PublicAPI.Shipped.txt
@@ -1,0 +1,17 @@
+#nullable enable
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.CoalescingDispatchScheduler() -> void
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.RequestDrain() -> void
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherQueueSequencer
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherQueueSequencer.DispatcherQueue.get -> Microsoft.UI.Dispatching.DispatcherQueue!
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherQueueSequencer.DispatcherQueueSequencer(Microsoft.UI.Dispatching.DispatcherQueue! dispatcherQueue) -> void
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherQueueSequencer.DispatcherQueueSequencer(Microsoft.UI.Dispatching.DispatcherQueue! dispatcherQueue, Microsoft.UI.Dispatching.DispatcherQueuePriority priority) -> void
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherQueueSequencer.Priority.get -> Microsoft.UI.Dispatching.DispatcherQueuePriority
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherQueueSequencerExtensions
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherQueueSequencerExtensions.extension(Microsoft.UI.Dispatching.DispatcherQueue!)
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherQueueSequencerExtensions.extension(Microsoft.UI.Dispatching.DispatcherQueue!).ToSequencer() -> ReactiveUI.Primitives.Reactive.Concurrency.DispatcherQueueSequencer!
+abstract ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Post(System.Action! drain) -> bool
+override ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Schedule<TState>(TState state, System.Func<System.Reactive.Concurrency.IScheduler!, TState, System.IDisposable!>! action) -> System.IDisposable!
+override ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Schedule<TState>(TState state, System.TimeSpan dueTime, System.Func<System.Reactive.Concurrency.IScheduler!, TState, System.IDisposable!>! action) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.Concurrency.DispatcherQueueSequencerExtensions.ToSequencer(this Microsoft.UI.Dispatching.DispatcherQueue! dispatcherQueue) -> ReactiveUI.Primitives.Reactive.Concurrency.DispatcherQueueSequencer!
+virtual ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.ScheduleOnDispatcher(System.Action! work, System.TimeSpan dueTime) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.WinUI.Reactive/PublicAPI/net9.0-windows10.0.19041.0/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.WinUI.Reactive/PublicAPI/net9.0-windows10.0.19041.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/ReactiveUI.Primitives.WinUI.Reactive/ReactiveUI.Primitives.WinUI.Reactive.csproj
+++ b/src/ReactiveUI.Primitives.WinUI.Reactive/ReactiveUI.Primitives.WinUI.Reactive.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <!-- System.Reactive-flavoured WinUI leaf: a coalescing IScheduler over a DispatcherQueue.
+         REACTIVE_SHIM + the System.Reactive dependency come from Directory.Build.props via the name suffix. -->
+    <TargetFrameworks>$(WinUITargetFrameworks)</TargetFrameworks>
+    <UseWinUI>true</UseWinUI>
+    <AppxGeneratePriEnabled Condition="'$(OS)' != 'Windows_NT'">false</AppxGeneratePriEnabled>
+    <IncludePriFilesOutputGroup Condition="'$(OS)' != 'Windows_NT'">false</IncludePriFilesOutputGroup>
+    <IncludeProjectPriFile Condition="'$(OS)' != 'Windows_NT'">false</IncludeProjectPriFile>
+    <PackageDescription>WinUI dispatcher queue scheduler for ReactiveUI.Primitives, recompiled against System.Reactive's IScheduler.</PackageDescription>
+    <PackageTags>system.reactive;rx;reactive;primitives;winui;dispatcher-queue;scheduler</PackageTags>
+  </PropertyGroup>
+
+  <!-- The coalescing IScheduler base shared by every platform .Reactive package. -->
+  <ItemGroup>
+    <Compile Include="..\Primitives.Platform.Reactive.Shared\**\*.cs" Link="Primitives.Platform.Reactive.Shared\%(RecursiveDir)%(Filename)%(Extension)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.WindowsAppSDK" />
+    <ProjectReference Include="..\ReactiveUI.Primitives.Reactive\ReactiveUI.Primitives.Reactive.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="ReactiveUI.Primitives.WinUI.Reactive.Tests" />
+  </ItemGroup>
+
+</Project>

--- a/src/ReactiveUI.Primitives.Wpf.Reactive/Concurrency/DispatcherSequencer.cs
+++ b/src/ReactiveUI.Primitives.Wpf.Reactive/Concurrency/DispatcherSequencer.cs
@@ -1,0 +1,57 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Reactive.Disposables;
+using System.Windows.Threading;
+
+namespace ReactiveUI.Primitives.Reactive.Concurrency;
+
+/// <summary>WPF dispatcher scheduler that coalesces scheduled work onto a dispatcher drain.</summary>
+/// <seealso cref="System.Reactive.Concurrency.IScheduler" />
+public sealed class DispatcherSequencer : CoalescingDispatchScheduler
+{
+    /// <summary>Initializes a new instance of the <see cref="DispatcherSequencer"/> class.</summary>
+    /// <param name="dispatcher">The dispatcher.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="dispatcher"/> is <see langword="null"/>.</exception>
+    public DispatcherSequencer(Dispatcher dispatcher)
+        : this(dispatcher, DispatcherPriority.Normal)
+    {
+    }
+
+    /// <summary>Initializes a new instance of the <see cref="DispatcherSequencer"/> class.</summary>
+    /// <param name="dispatcher">The dispatcher.</param>
+    /// <param name="priority">Dispatcher priority used for posted drains.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="dispatcher"/> is <see langword="null"/>.</exception>
+    public DispatcherSequencer(Dispatcher dispatcher, DispatcherPriority priority)
+    {
+        Dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
+        Priority = priority;
+    }
+
+    /// <summary>Gets the dispatcher.</summary>
+    public Dispatcher Dispatcher { get; }
+
+    /// <summary>Gets the dispatcher priority used for posted drains.</summary>
+    public DispatcherPriority Priority { get; }
+
+    /// <inheritdoc/>
+    protected override bool Post(Action drain)
+    {
+        Dispatcher.BeginInvoke(drain, Priority);
+        return true;
+    }
+
+    /// <inheritdoc/>
+    protected override IDisposable ScheduleOnDispatcher(Action work, TimeSpan dueTime)
+    {
+        DispatcherTimer timer = new(Priority, Dispatcher) { Interval = dueTime };
+        timer.Tick += (_, _) =>
+        {
+            timer.Stop();
+            work();
+        };
+        timer.Start();
+        return Disposable.Create(timer, static t => t.Stop());
+    }
+}

--- a/src/ReactiveUI.Primitives.Wpf.Reactive/PublicAPI/net10.0-windows/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Wpf.Reactive/PublicAPI/net10.0-windows/PublicAPI.Shipped.txt
@@ -1,0 +1,13 @@
+#nullable enable
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.CoalescingDispatchScheduler() -> void
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.RequestDrain() -> void
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherSequencer
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherSequencer.Dispatcher.get -> System.Windows.Threading.Dispatcher!
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherSequencer.DispatcherSequencer(System.Windows.Threading.Dispatcher! dispatcher) -> void
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherSequencer.DispatcherSequencer(System.Windows.Threading.Dispatcher! dispatcher, System.Windows.Threading.DispatcherPriority priority) -> void
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherSequencer.Priority.get -> System.Windows.Threading.DispatcherPriority
+abstract ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Post(System.Action! drain) -> bool
+override ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Schedule<TState>(TState state, System.Func<System.Reactive.Concurrency.IScheduler!, TState, System.IDisposable!>! action) -> System.IDisposable!
+override ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Schedule<TState>(TState state, System.TimeSpan dueTime, System.Func<System.Reactive.Concurrency.IScheduler!, TState, System.IDisposable!>! action) -> System.IDisposable!
+virtual ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.ScheduleOnDispatcher(System.Action! work, System.TimeSpan dueTime) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.Wpf.Reactive/PublicAPI/net10.0-windows/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Wpf.Reactive/PublicAPI/net10.0-windows/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/ReactiveUI.Primitives.Wpf.Reactive/PublicAPI/net11.0-windows/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Wpf.Reactive/PublicAPI/net11.0-windows/PublicAPI.Shipped.txt
@@ -1,0 +1,13 @@
+#nullable enable
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.CoalescingDispatchScheduler() -> void
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.RequestDrain() -> void
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherSequencer
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherSequencer.Dispatcher.get -> System.Windows.Threading.Dispatcher!
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherSequencer.DispatcherSequencer(System.Windows.Threading.Dispatcher! dispatcher) -> void
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherSequencer.DispatcherSequencer(System.Windows.Threading.Dispatcher! dispatcher, System.Windows.Threading.DispatcherPriority priority) -> void
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherSequencer.Priority.get -> System.Windows.Threading.DispatcherPriority
+abstract ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Post(System.Action! drain) -> bool
+override ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Schedule<TState>(TState state, System.Func<System.Reactive.Concurrency.IScheduler!, TState, System.IDisposable!>! action) -> System.IDisposable!
+override ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Schedule<TState>(TState state, System.TimeSpan dueTime, System.Func<System.Reactive.Concurrency.IScheduler!, TState, System.IDisposable!>! action) -> System.IDisposable!
+virtual ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.ScheduleOnDispatcher(System.Action! work, System.TimeSpan dueTime) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.Wpf.Reactive/PublicAPI/net11.0-windows/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Wpf.Reactive/PublicAPI/net11.0-windows/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/ReactiveUI.Primitives.Wpf.Reactive/PublicAPI/net462/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Wpf.Reactive/PublicAPI/net462/PublicAPI.Shipped.txt
@@ -1,0 +1,13 @@
+#nullable enable
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.CoalescingDispatchScheduler() -> void
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.RequestDrain() -> void
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherSequencer
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherSequencer.Dispatcher.get -> System.Windows.Threading.Dispatcher!
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherSequencer.DispatcherSequencer(System.Windows.Threading.Dispatcher! dispatcher) -> void
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherSequencer.DispatcherSequencer(System.Windows.Threading.Dispatcher! dispatcher, System.Windows.Threading.DispatcherPriority priority) -> void
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherSequencer.Priority.get -> System.Windows.Threading.DispatcherPriority
+abstract ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Post(System.Action! drain) -> bool
+override ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Schedule<TState>(TState state, System.Func<System.Reactive.Concurrency.IScheduler!, TState, System.IDisposable!>! action) -> System.IDisposable!
+override ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Schedule<TState>(TState state, System.TimeSpan dueTime, System.Func<System.Reactive.Concurrency.IScheduler!, TState, System.IDisposable!>! action) -> System.IDisposable!
+virtual ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.ScheduleOnDispatcher(System.Action! work, System.TimeSpan dueTime) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.Wpf.Reactive/PublicAPI/net462/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Wpf.Reactive/PublicAPI/net462/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/ReactiveUI.Primitives.Wpf.Reactive/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Wpf.Reactive/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -1,0 +1,13 @@
+#nullable enable
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.CoalescingDispatchScheduler() -> void
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.RequestDrain() -> void
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherSequencer
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherSequencer.Dispatcher.get -> System.Windows.Threading.Dispatcher!
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherSequencer.DispatcherSequencer(System.Windows.Threading.Dispatcher! dispatcher) -> void
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherSequencer.DispatcherSequencer(System.Windows.Threading.Dispatcher! dispatcher, System.Windows.Threading.DispatcherPriority priority) -> void
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherSequencer.Priority.get -> System.Windows.Threading.DispatcherPriority
+abstract ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Post(System.Action! drain) -> bool
+override ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Schedule<TState>(TState state, System.Func<System.Reactive.Concurrency.IScheduler!, TState, System.IDisposable!>! action) -> System.IDisposable!
+override ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Schedule<TState>(TState state, System.TimeSpan dueTime, System.Func<System.Reactive.Concurrency.IScheduler!, TState, System.IDisposable!>! action) -> System.IDisposable!
+virtual ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.ScheduleOnDispatcher(System.Action! work, System.TimeSpan dueTime) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.Wpf.Reactive/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Wpf.Reactive/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/ReactiveUI.Primitives.Wpf.Reactive/PublicAPI/net48/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Wpf.Reactive/PublicAPI/net48/PublicAPI.Shipped.txt
@@ -1,0 +1,13 @@
+#nullable enable
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.CoalescingDispatchScheduler() -> void
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.RequestDrain() -> void
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherSequencer
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherSequencer.Dispatcher.get -> System.Windows.Threading.Dispatcher!
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherSequencer.DispatcherSequencer(System.Windows.Threading.Dispatcher! dispatcher) -> void
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherSequencer.DispatcherSequencer(System.Windows.Threading.Dispatcher! dispatcher, System.Windows.Threading.DispatcherPriority priority) -> void
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherSequencer.Priority.get -> System.Windows.Threading.DispatcherPriority
+abstract ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Post(System.Action! drain) -> bool
+override ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Schedule<TState>(TState state, System.Func<System.Reactive.Concurrency.IScheduler!, TState, System.IDisposable!>! action) -> System.IDisposable!
+override ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Schedule<TState>(TState state, System.TimeSpan dueTime, System.Func<System.Reactive.Concurrency.IScheduler!, TState, System.IDisposable!>! action) -> System.IDisposable!
+virtual ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.ScheduleOnDispatcher(System.Action! work, System.TimeSpan dueTime) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.Wpf.Reactive/PublicAPI/net48/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Wpf.Reactive/PublicAPI/net48/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/ReactiveUI.Primitives.Wpf.Reactive/PublicAPI/net481/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Wpf.Reactive/PublicAPI/net481/PublicAPI.Shipped.txt
@@ -1,0 +1,13 @@
+#nullable enable
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.CoalescingDispatchScheduler() -> void
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.RequestDrain() -> void
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherSequencer
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherSequencer.Dispatcher.get -> System.Windows.Threading.Dispatcher!
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherSequencer.DispatcherSequencer(System.Windows.Threading.Dispatcher! dispatcher) -> void
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherSequencer.DispatcherSequencer(System.Windows.Threading.Dispatcher! dispatcher, System.Windows.Threading.DispatcherPriority priority) -> void
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherSequencer.Priority.get -> System.Windows.Threading.DispatcherPriority
+abstract ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Post(System.Action! drain) -> bool
+override ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Schedule<TState>(TState state, System.Func<System.Reactive.Concurrency.IScheduler!, TState, System.IDisposable!>! action) -> System.IDisposable!
+override ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Schedule<TState>(TState state, System.TimeSpan dueTime, System.Func<System.Reactive.Concurrency.IScheduler!, TState, System.IDisposable!>! action) -> System.IDisposable!
+virtual ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.ScheduleOnDispatcher(System.Action! work, System.TimeSpan dueTime) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.Wpf.Reactive/PublicAPI/net481/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Wpf.Reactive/PublicAPI/net481/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/ReactiveUI.Primitives.Wpf.Reactive/PublicAPI/net8.0-windows/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Wpf.Reactive/PublicAPI/net8.0-windows/PublicAPI.Shipped.txt
@@ -1,0 +1,13 @@
+#nullable enable
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.CoalescingDispatchScheduler() -> void
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.RequestDrain() -> void
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherSequencer
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherSequencer.Dispatcher.get -> System.Windows.Threading.Dispatcher!
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherSequencer.DispatcherSequencer(System.Windows.Threading.Dispatcher! dispatcher) -> void
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherSequencer.DispatcherSequencer(System.Windows.Threading.Dispatcher! dispatcher, System.Windows.Threading.DispatcherPriority priority) -> void
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherSequencer.Priority.get -> System.Windows.Threading.DispatcherPriority
+abstract ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Post(System.Action! drain) -> bool
+override ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Schedule<TState>(TState state, System.Func<System.Reactive.Concurrency.IScheduler!, TState, System.IDisposable!>! action) -> System.IDisposable!
+override ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Schedule<TState>(TState state, System.TimeSpan dueTime, System.Func<System.Reactive.Concurrency.IScheduler!, TState, System.IDisposable!>! action) -> System.IDisposable!
+virtual ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.ScheduleOnDispatcher(System.Action! work, System.TimeSpan dueTime) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.Wpf.Reactive/PublicAPI/net8.0-windows/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Wpf.Reactive/PublicAPI/net8.0-windows/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/ReactiveUI.Primitives.Wpf.Reactive/PublicAPI/net9.0-windows/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Wpf.Reactive/PublicAPI/net9.0-windows/PublicAPI.Shipped.txt
@@ -1,0 +1,13 @@
+#nullable enable
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.CoalescingDispatchScheduler() -> void
+ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.RequestDrain() -> void
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherSequencer
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherSequencer.Dispatcher.get -> System.Windows.Threading.Dispatcher!
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherSequencer.DispatcherSequencer(System.Windows.Threading.Dispatcher! dispatcher) -> void
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherSequencer.DispatcherSequencer(System.Windows.Threading.Dispatcher! dispatcher, System.Windows.Threading.DispatcherPriority priority) -> void
+ReactiveUI.Primitives.Reactive.Concurrency.DispatcherSequencer.Priority.get -> System.Windows.Threading.DispatcherPriority
+abstract ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Post(System.Action! drain) -> bool
+override ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Schedule<TState>(TState state, System.Func<System.Reactive.Concurrency.IScheduler!, TState, System.IDisposable!>! action) -> System.IDisposable!
+override ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.Schedule<TState>(TState state, System.TimeSpan dueTime, System.Func<System.Reactive.Concurrency.IScheduler!, TState, System.IDisposable!>! action) -> System.IDisposable!
+virtual ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler.ScheduleOnDispatcher(System.Action! work, System.TimeSpan dueTime) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.Wpf.Reactive/PublicAPI/net9.0-windows/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Wpf.Reactive/PublicAPI/net9.0-windows/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/ReactiveUI.Primitives.Wpf.Reactive/ReactiveUI.Primitives.Wpf.Reactive.csproj
+++ b/src/ReactiveUI.Primitives.Wpf.Reactive/ReactiveUI.Primitives.Wpf.Reactive.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <!-- System.Reactive-flavoured WPF leaf: a coalescing IScheduler over the WPF dispatcher.
+         REACTIVE_SHIM + the System.Reactive dependency come from Directory.Build.props via the name suffix. -->
+    <TargetFrameworks>$(WindowsLibraryTargetFrameworks)</TargetFrameworks>
+    <UseWPF>true</UseWPF>
+    <PackageDescription>WPF dispatcher scheduler for ReactiveUI.Primitives, recompiled against System.Reactive's IScheduler.</PackageDescription>
+    <PackageTags>system.reactive;rx;reactive;primitives;wpf;dispatcher;scheduler</PackageTags>
+  </PropertyGroup>
+
+  <!-- The coalescing IScheduler base shared by every platform .Reactive package. -->
+  <ItemGroup>
+    <Compile Include="..\Primitives.Platform.Reactive.Shared\**\*.cs" Link="Primitives.Platform.Reactive.Shared\%(RecursiveDir)%(Filename)%(Extension)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ReactiveUI.Primitives.Reactive\ReactiveUI.Primitives.Reactive.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="ReactiveUI.Primitives.Wpf.Reactive.Tests" />
+  </ItemGroup>
+
+</Project>

--- a/src/ReactiveUI.Primitives.slnx
+++ b/src/ReactiveUI.Primitives.slnx
@@ -21,21 +21,31 @@
     </Folder>
     <Folder Name="/Reactive/">
         <Project Path="ReactiveUI.Primitives.Async.Reactive/ReactiveUI.Primitives.Async.Reactive.csproj" />
+        <Project Path="ReactiveUI.Primitives.Blazor.Reactive/ReactiveUI.Primitives.Blazor.Reactive.csproj" />
         <Project Path="ReactiveUI.Primitives.Extensions.Reactive/ReactiveUI.Primitives.Extensions.Reactive.csproj" />
+        <Project Path="ReactiveUI.Primitives.Maui.Reactive/ReactiveUI.Primitives.Maui.Reactive.csproj" />
         <Project Path="ReactiveUI.Primitives.Reactive/ReactiveUI.Primitives.Reactive.csproj" />
+        <Project Path="ReactiveUI.Primitives.WinForms.Reactive/ReactiveUI.Primitives.WinForms.Reactive.csproj" />
+        <Project Path="ReactiveUI.Primitives.WinUI.Reactive/ReactiveUI.Primitives.WinUI.Reactive.csproj" />
+        <Project Path="ReactiveUI.Primitives.Wpf.Reactive/ReactiveUI.Primitives.Wpf.Reactive.csproj" />
     </Folder>
     <Folder Name="/tests/">
         <Project Path="tests/ReactiveUI.Disposables.Tests/ReactiveUI.Disposables.Tests.csproj" />
         <Project Path="tests/ReactiveUI.Primitives.Async.Tests/ReactiveUI.Primitives.Async.Tests.csproj" />
         <Project Path="tests/ReactiveUI.Primitives.Async.Reactive.Tests/ReactiveUI.Primitives.Async.Reactive.Tests.csproj" />
+        <Project Path="tests/ReactiveUI.Primitives.Blazor.Reactive.Tests/ReactiveUI.Primitives.Blazor.Reactive.Tests.csproj" />
         <Project Path="tests/ReactiveUI.Primitives.Blazor.Tests/ReactiveUI.Primitives.Blazor.Tests.csproj" />
         <Project Path="tests/ReactiveUI.Primitives.Extensions.Reactive.Tests/ReactiveUI.Primitives.Extensions.Reactive.Tests.csproj" />
         <Project Path="tests/ReactiveUI.Primitives.Extensions.Tests/ReactiveUI.Primitives.Extensions.Tests.csproj" />
+        <Project Path="tests/ReactiveUI.Primitives.Maui.Reactive.Tests/ReactiveUI.Primitives.Maui.Reactive.Tests.csproj" />
         <Project Path="tests/ReactiveUI.Primitives.Maui.Tests/ReactiveUI.Primitives.Maui.Tests.csproj" />
         <Project Path="tests/ReactiveUI.Primitives.Reactive.Tests/ReactiveUI.Primitives.Reactive.Tests.csproj" />
         <Project Path="tests/ReactiveUI.Primitives.Tests/ReactiveUI.Primitives.Tests.csproj" />
+        <Project Path="tests/ReactiveUI.Primitives.WinForms.Reactive.Tests/ReactiveUI.Primitives.WinForms.Reactive.Tests.csproj" />
         <Project Path="tests/ReactiveUI.Primitives.WinForms.Tests/ReactiveUI.Primitives.WinForms.Tests.csproj" />
+        <Project Path="tests/ReactiveUI.Primitives.WinUI.Reactive.Tests/ReactiveUI.Primitives.WinUI.Reactive.Tests.csproj" />
         <Project Path="tests/ReactiveUI.Primitives.WinUI.Tests/ReactiveUI.Primitives.WinUI.Tests.csproj" />
+        <Project Path="tests/ReactiveUI.Primitives.Wpf.Reactive.Tests/ReactiveUI.Primitives.Wpf.Reactive.Tests.csproj" />
         <Project Path="tests/ReactiveUI.Primitives.Wpf.Tests/ReactiveUI.Primitives.Wpf.Tests.csproj" />
     </Folder>
     <Project Path="ReactiveUI.Disposables/ReactiveUI.Disposables.csproj" />

--- a/src/tests/ReactiveUI.Primitives.Blazor.Reactive.Tests/BlazorRendererSequencerTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Blazor.Reactive.Tests/BlazorRendererSequencerTests.cs
@@ -1,0 +1,124 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Reactive.Concurrency;
+using ReactiveUI.Primitives.Blazor.Reactive.Components;
+using ReactiveUI.Primitives.Blazor.Reactive.Concurrency;
+using ReactiveUI.Primitives.Disposables;
+
+namespace ReactiveUI.Primitives.Blazor.Reactive.Tests;
+
+/// <summary>Tests for <see cref="BlazorRendererSequencer"/> as an <see cref="IScheduler"/> driven through a fake renderer delegate.</summary>
+public sealed class BlazorRendererSequencerTests
+{
+    /// <summary>Expected values produced by an immediate burst, used to verify FIFO order.</summary>
+    private static readonly int[] ExpectedBurst = [1, 2, 3];
+
+    /// <summary>Verifies the constructor rejects a null renderer delegate.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task ConstructorRejectsNullDelegate() =>
+        await Assert.That(() => new BlazorRendererSequencer(null!)).ThrowsExactly<ArgumentNullException>();
+
+    /// <summary>Verifies reactive component observation guards reject null inputs.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task ReactiveComponentObserveRejectsNullArguments()
+    {
+        TestReactiveComponent component = new();
+        PassiveObservable<int> source = new();
+
+        await Assert.That(() => component.ObserveSource<int>(null!, static _ => { }))
+            .ThrowsExactly<ArgumentNullException>();
+        await Assert.That(() => component.ObserveSource(source, null!)).ThrowsExactly<ArgumentNullException>();
+    }
+
+    /// <summary>Verifies the default observed-error handler validates and wraps errors.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task ReactiveComponentObservedErrorRejectsNullAndWrapsError()
+    {
+        TestReactiveComponent component = new();
+        await Assert.That(() => component.NotifyObservedError(null!)).ThrowsExactly<ArgumentNullException>();
+
+        InvalidOperationException error = new("observed");
+        var caught = await Assert.That(() => component.NotifyObservedError(error))
+            .ThrowsExactly<InvalidOperationException>();
+
+        await Assert.That(caught!.InnerException).IsSameReferenceAs(error);
+    }
+
+    /// <summary>Verifies immediate work is marshalled through the renderer delegate and executed.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task ImmediateScheduleMarshalsThroughRenderer()
+    {
+        FakeRenderer renderer = new();
+        BlazorRendererSequencer scheduler = new(renderer.InvokeAsync);
+        var executed = false;
+
+        scheduler.Schedule(() => executed = true);
+
+        await Assert.That(executed).IsTrue();
+        await Assert.That(renderer.InvokeCount).IsGreaterThan(0);
+    }
+
+    /// <summary>Verifies a burst of immediate work items all execute in FIFO order.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task ImmediateBurstExecutesInOrder()
+    {
+        FakeRenderer renderer = new();
+        BlazorRendererSequencer scheduler = new(renderer.InvokeAsync);
+        List<int> values = [];
+
+        foreach (var value in ExpectedBurst)
+        {
+            var captured = value;
+            scheduler.Schedule(() => values.Add(captured));
+        }
+
+        await Assert.That(values).IsEquivalentTo(ExpectedBurst, EqualityComparer<int>.Default);
+    }
+
+    /// <summary>Fake renderer that runs marshalled work synchronously and records how often it was invoked.</summary>
+    private sealed class FakeRenderer
+    {
+        /// <summary>Gets the number of times <see cref="InvokeAsync(Action)"/> was called.</summary>
+        public int InvokeCount { get; private set; }
+
+        /// <summary>Runs the supplied work synchronously, mimicking <c>ComponentBase.InvokeAsync</c>.</summary>
+        /// <param name="action">The work to run.</param>
+        /// <returns>A completed task.</returns>
+        public Task InvokeAsync(Action action)
+        {
+            InvokeCount++;
+            action();
+            return Task.CompletedTask;
+        }
+    }
+
+    /// <summary>Test component that exposes protected reactive component members.</summary>
+    private sealed class TestReactiveComponent : ReactiveComponentBase
+    {
+        /// <summary>Calls the protected observe method.</summary>
+        /// <typeparam name="T">The observed value type.</typeparam>
+        /// <param name="source">The source sequence.</param>
+        /// <param name="onNext">The value callback.</param>
+        /// <returns>The tracked subscription.</returns>
+        public IDisposable ObserveSource<T>(IObservable<T> source, Action<T> onNext) => Observe(source, onNext);
+
+        /// <summary>Calls the protected observed-error handler.</summary>
+        /// <param name="error">The observed error.</param>
+        public void NotifyObservedError(Exception error) => OnObservedError(error);
+    }
+
+    /// <summary>Observable that records subscriptions without producing signals.</summary>
+    /// <typeparam name="T">The value type.</typeparam>
+    private sealed class PassiveObservable<T> : IObservable<T>
+    {
+        /// <inheritdoc/>
+        public IDisposable Subscribe(IObserver<T> observer) => EmptyDisposable.Instance;
+    }
+}

--- a/src/tests/ReactiveUI.Primitives.Blazor.Reactive.Tests/ReactiveUI.Primitives.Blazor.Reactive.Tests.csproj
+++ b/src/tests/ReactiveUI.Primitives.Blazor.Reactive.Tests/ReactiveUI.Primitives.Blazor.Reactive.Tests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>$(BlazorTargetFrameworks)</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Reactive"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\ReactiveUI.Primitives.Blazor.Reactive\ReactiveUI.Primitives.Blazor.Reactive.csproj"/>
+  </ItemGroup>
+
+</Project>

--- a/src/tests/ReactiveUI.Primitives.Maui.Reactive.Tests/MauiDispatcherSequencerTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Maui.Reactive.Tests/MauiDispatcherSequencerTests.cs
@@ -1,0 +1,170 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Reactive.Concurrency;
+using Microsoft.Maui.Dispatching;
+using ReactiveUI.Primitives.Reactive.Concurrency;
+
+namespace ReactiveUI.Primitives.Maui.Reactive.Tests;
+
+/// <summary>
+/// Tests for <see cref="MauiDispatcherSequencer"/> as an <see cref="IScheduler"/>, exercised through a fake
+/// <see cref="IDispatcher"/> so the immediate and time-based dispatch paths run deterministically on any platform.
+/// </summary>
+public sealed class MauiDispatcherSequencerTests
+{
+    /// <summary>Expected values produced by an immediate burst, used to verify FIFO order.</summary>
+    private static readonly int[] ExpectedBurst = [1, 2, 3];
+
+    /// <summary>Verifies the constructor rejects a null dispatcher.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task ConstructorRejectsNullDispatcher() =>
+        await Assert.That(() => new MauiDispatcherSequencer(null!)).ThrowsExactly<ArgumentNullException>();
+
+    /// <summary>Verifies the dispatcher extension method validates and adapts dispatchers.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task ToSequencerValidatesAndAdaptsDispatcher()
+    {
+        const IDispatcher nullDispatcher = null!;
+        await Assert.That(() => nullDispatcher!.ToSequencer()).ThrowsExactly<ArgumentNullException>();
+
+        FakeDispatcher dispatcher = new();
+        var scheduler = dispatcher.ToSequencer();
+
+        await Assert.That(scheduler).IsNotNull();
+    }
+
+    /// <summary>Verifies immediate work is marshalled through <see cref="IDispatcher.Dispatch(Action)"/> and executed.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task ImmediateScheduleDispatchesAndExecutes()
+    {
+        FakeDispatcher dispatcher = new();
+        MauiDispatcherSequencer scheduler = new(dispatcher);
+        var executed = false;
+
+        scheduler.Schedule(() => executed = true);
+
+        await Assert.That(executed).IsTrue();
+        await Assert.That(dispatcher.DispatchCount).IsGreaterThan(0);
+        await Assert.That(dispatcher.DispatchDelayedCount).IsEqualTo(0);
+    }
+
+    /// <summary>
+    /// Verifies work due in the future routes through <see cref="IDispatcher.DispatchDelayed(TimeSpan, Action)"/>
+    /// with a positive delay, and runs on the dispatcher without the shared-timer marshal hop.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task DelayedScheduleUsesDispatchDelayed()
+    {
+        FakeDispatcher dispatcher = new();
+        MauiDispatcherSequencer scheduler = new(dispatcher);
+        var executed = false;
+
+        scheduler.Schedule(TimeSpan.FromSeconds(1), () => executed = true);
+
+        await Assert.That(executed).IsTrue();
+        await Assert.That(dispatcher.DispatchDelayedCount).IsEqualTo(1);
+        await Assert.That(dispatcher.LastDelay).IsGreaterThan(TimeSpan.Zero);
+    }
+
+    /// <summary>Verifies a zero due time takes the immediate path rather than the delayed timer.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task ZeroDueTimeUsesImmediatePath()
+    {
+        FakeDispatcher dispatcher = new();
+        MauiDispatcherSequencer scheduler = new(dispatcher);
+        var executed = false;
+
+        scheduler.Schedule(TimeSpan.Zero, () => executed = true);
+
+        await Assert.That(executed).IsTrue();
+        await Assert.That(dispatcher.DispatchCount).IsGreaterThan(0);
+        await Assert.That(dispatcher.DispatchDelayedCount).IsEqualTo(0);
+    }
+
+    /// <summary>Verifies a burst of immediate work items all execute in FIFO order.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task ImmediateBurstExecutesInOrder()
+    {
+        FakeDispatcher dispatcher = new();
+        MauiDispatcherSequencer scheduler = new(dispatcher);
+        List<int> values = [];
+
+        foreach (var value in ExpectedBurst)
+        {
+            var captured = value;
+            scheduler.Schedule(() => values.Add(captured));
+        }
+
+        await Assert.That(values).IsEquivalentTo(ExpectedBurst, EqualityComparer<int>.Default);
+    }
+
+    /// <summary>Fake MAUI dispatcher that runs marshalled work synchronously and records how it was dispatched.</summary>
+    private sealed class FakeDispatcher : IDispatcher
+    {
+        /// <summary>Gets the number of times <see cref="Dispatch(Action)"/> was called.</summary>
+        public int DispatchCount { get; private set; }
+
+        /// <summary>Gets the number of times <see cref="DispatchDelayed(TimeSpan, Action)"/> was called.</summary>
+        public int DispatchDelayedCount { get; private set; }
+
+        /// <summary>Gets the delay passed to the most recent <see cref="DispatchDelayed(TimeSpan, Action)"/> call.</summary>
+        public TimeSpan LastDelay { get; private set; }
+
+        /// <inheritdoc/>
+        public bool IsDispatchRequired => true;
+
+        /// <inheritdoc/>
+        public bool Dispatch(Action action)
+        {
+            DispatchCount++;
+            action();
+            return true;
+        }
+
+        /// <inheritdoc/>
+        public bool DispatchDelayed(TimeSpan delay, Action action)
+        {
+            DispatchDelayedCount++;
+            LastDelay = delay;
+            action();
+            return true;
+        }
+
+        /// <inheritdoc/>
+        public IDispatcherTimer CreateTimer() => new FakeDispatcherTimer();
+
+        /// <summary>Fake dispatcher timer that fires its tick immediately on start.</summary>
+        private sealed class FakeDispatcherTimer : IDispatcherTimer
+        {
+            /// <inheritdoc/>
+            public event EventHandler? Tick;
+
+            /// <inheritdoc/>
+            public TimeSpan Interval { get; set; }
+
+            /// <inheritdoc/>
+            public bool IsRepeating { get; set; }
+
+            /// <inheritdoc/>
+            public bool IsRunning { get; private set; }
+
+            /// <inheritdoc/>
+            public void Start()
+            {
+                IsRunning = true;
+                Tick?.Invoke(this, EventArgs.Empty);
+            }
+
+            /// <inheritdoc/>
+            public void Stop() => IsRunning = false;
+        }
+    }
+}

--- a/src/tests/ReactiveUI.Primitives.Maui.Reactive.Tests/ReactiveUI.Primitives.Maui.Reactive.Tests.csproj
+++ b/src/tests/ReactiveUI.Primitives.Maui.Reactive.Tests/ReactiveUI.Primitives.Maui.Reactive.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!-- MAUI .Reactive scheduler tests target runnable cross-platform TFMs only (net9.0;net10.0;net11.0).
+       MauiDispatcherSequencer marshals through the IDispatcher interface, so these tests use a fake
+       dispatcher and run on any platform (including Linux/CI) without the MAUI workload or a real UI thread. -->
+  <PropertyGroup>
+    <TargetFrameworks>$(MauiTestTargetFrameworks)</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Reactive"/>
+  </ItemGroup>
+
+  <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net11.0'))">
+    <PackageReference Include="Microsoft.Extensions.Configuration"/>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection"/>
+    <PackageReference Include="Microsoft.Extensions.Logging"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\ReactiveUI.Primitives.Maui.Reactive\ReactiveUI.Primitives.Maui.Reactive.csproj"/>
+  </ItemGroup>
+
+</Project>

--- a/src/tests/ReactiveUI.Primitives.WinForms.Reactive.Tests/ControlSequencerTests.cs
+++ b/src/tests/ReactiveUI.Primitives.WinForms.Reactive.Tests/ControlSequencerTests.cs
@@ -1,0 +1,83 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Reactive.Concurrency;
+using ReactiveUI.Primitives.Reactive.Concurrency;
+
+namespace ReactiveUI.Primitives.WinForms.Reactive.Tests;
+
+/// <summary>
+/// Tests for <see cref="ControlSequencer"/> as an <see cref="IScheduler"/>, exercised against a real Windows Forms
+/// <see cref="Control"/> whose handle is created on a dedicated STA thread running a message loop, so posted work
+/// runs end to end. Compiled only on Windows builds (see the csproj).
+/// </summary>
+public sealed class ControlSequencerTests
+{
+    /// <summary>Maximum time to wait for work to be marshalled onto the control thread before failing.</summary>
+    private static readonly TimeSpan WaitTimeout = TimeSpan.FromSeconds(5);
+
+    /// <summary>Verifies the constructor rejects a null control.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task ConstructorRejectsNullControl() =>
+        await Assert.That(() => new ControlSequencer(null!)).ThrowsExactly<ArgumentNullException>();
+
+    /// <summary>Verifies immediate work is posted to and executed on the control's UI thread.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task ImmediateScheduleExecutesOnControlThread()
+    {
+        using var harness = new ControlHarness();
+        var scheduler = new ControlSequencer(harness.Control);
+        var completion = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        scheduler.Schedule(() => completion.TrySetResult(Environment.CurrentManagedThreadId));
+
+        var ranOnThreadId = await completion.Task.WaitAsync(WaitTimeout);
+        await Assert.That(ranOnThreadId).IsEqualTo(harness.ThreadId);
+    }
+
+    /// <summary>Hosts a Windows Forms <see cref="Control"/> on a dedicated STA thread running a message loop, exiting it and joining the thread on disposal.</summary>
+    private sealed class ControlHarness : IDisposable
+    {
+        /// <summary>The thread running the Windows Forms message loop.</summary>
+        private readonly Thread _thread;
+
+        /// <summary>Initializes a new instance of the <see cref="ControlHarness"/> class and waits until the control handle and message loop are running.</summary>
+        public ControlHarness()
+        {
+            using var ready = new ManualResetEventSlim(false);
+            _thread = new Thread(() =>
+            {
+                Control = new Control();
+                _ = Control.Handle; // Force handle creation so BeginInvoke can marshal work.
+                ThreadId = Environment.CurrentManagedThreadId;
+                ready.Set();
+                Application.Run();
+            })
+            {
+                IsBackground = true,
+                Name = "WinFormsControlHarness",
+            };
+
+            _thread.SetApartmentState(ApartmentState.STA);
+            _thread.Start();
+            ready.Wait();
+        }
+
+        /// <summary>Gets the hosted control.</summary>
+        public Control Control { get; private set; } = null!;
+
+        /// <summary>Gets the managed thread id the control runs on.</summary>
+        public int ThreadId { get; private set; }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            _ = Control.BeginInvoke(Application.ExitThread);
+            _ = _thread.Join(WaitTimeout);
+            Control.Dispose();
+        }
+    }
+}

--- a/src/tests/ReactiveUI.Primitives.WinForms.Reactive.Tests/CrossPlatformPlaceholderTests.cs
+++ b/src/tests/ReactiveUI.Primitives.WinForms.Reactive.Tests/CrossPlatformPlaceholderTests.cs
@@ -1,0 +1,18 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace ReactiveUI.Primitives.WinForms.Reactive.Tests;
+
+/// <summary>
+/// Placeholder so the cross-platform test host runs a test and does not report a zero-test run.
+/// The real Windows Forms control tests compile and run on Windows only (see the csproj).
+/// </summary>
+public sealed class CrossPlatformPlaceholderTests
+{
+    /// <summary>Verifies this build leg is the cross-platform one, where the Windows Forms control tests are absent.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task ControlTestsRunOnWindowsOnly() =>
+        await Assert.That(OperatingSystem.IsWindows()).IsFalse();
+}

--- a/src/tests/ReactiveUI.Primitives.WinForms.Reactive.Tests/ReactiveUI.Primitives.WinForms.Reactive.Tests.csproj
+++ b/src/tests/ReactiveUI.Primitives.WinForms.Reactive.Tests/ReactiveUI.Primitives.WinForms.Reactive.Tests.csproj
@@ -1,0 +1,37 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!-- ControlSequencer wraps a real Windows Forms Control as an IScheduler. The project targets plain .NET
+       everywhere and adds the -windows TFMs only on Windows. The windows TFM (via the Choose below) turns on
+       UseWindowsForms, references the WinForms .Reactive library, and compiles the real control tests; the
+       cross-platform build compiles only the skipped placeholder so the host reports a discovered test. -->
+  <PropertyGroup>
+    <TargetFrameworks>$(NetTargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(WindowsNetTargetFrameworks)</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Reactive"/>
+  </ItemGroup>
+
+  <!-- The control tests need WinForms types; include them only on the windows TFM (see the Choose). -->
+  <ItemGroup>
+    <Compile Remove="ControlSequencerTests.cs"/>
+  </ItemGroup>
+
+  <Choose>
+    <When Condition="$(TargetFramework.EndsWith('-windows'))">
+      <PropertyGroup>
+        <UseWindowsForms>true</UseWindowsForms>
+        <DefineConstants>$(DefineConstants);WINDOWS</DefineConstants>
+      </PropertyGroup>
+      <ItemGroup>
+        <ProjectReference Include="..\..\ReactiveUI.Primitives.WinForms.Reactive\ReactiveUI.Primitives.WinForms.Reactive.csproj"/>
+        <Compile Include="ControlSequencerTests.cs"/>
+        <Compile Remove="CrossPlatformPlaceholderTests.cs"/>
+      </ItemGroup>
+    </When>
+  </Choose>
+
+</Project>

--- a/src/tests/ReactiveUI.Primitives.WinUI.Reactive.Tests/CrossPlatformPlaceholderTests.cs
+++ b/src/tests/ReactiveUI.Primitives.WinUI.Reactive.Tests/CrossPlatformPlaceholderTests.cs
@@ -1,0 +1,18 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace ReactiveUI.Primitives.WinUI.Reactive.Tests;
+
+/// <summary>
+/// Placeholder so the cross-platform test host runs a test and does not report a zero-test run.
+/// The real WinUI dispatcher tests compile and run on Windows only (see the csproj).
+/// </summary>
+public sealed class CrossPlatformPlaceholderTests
+{
+    /// <summary>Verifies this build leg is the cross-platform one, where the WinUI dispatcher tests are absent.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task DispatcherQueueTestsRunOnWindowsOnly() =>
+        await Assert.That(OperatingSystem.IsWindows()).IsFalse();
+}

--- a/src/tests/ReactiveUI.Primitives.WinUI.Reactive.Tests/DispatcherQueueSequencerTests.cs
+++ b/src/tests/ReactiveUI.Primitives.WinUI.Reactive.Tests/DispatcherQueueSequencerTests.cs
@@ -1,0 +1,77 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Reactive.Concurrency;
+using Microsoft.UI.Dispatching;
+using ReactiveUI.Primitives.Reactive.Concurrency;
+
+namespace ReactiveUI.Primitives.WinUI.Reactive.Tests;
+
+/// <summary>
+/// Tests for <see cref="DispatcherQueueSequencer"/> as an <see cref="IScheduler"/>, exercised against a real WinUI
+/// <see cref="DispatcherQueue"/> running on a dedicated thread so both the immediate and timer-based dispatch
+/// paths run end to end. Compiled only on Windows builds (see the csproj).
+/// </summary>
+public sealed class DispatcherQueueSequencerTests
+{
+    /// <summary>Maximum time to wait for work to be marshalled onto the dispatcher-queue thread before failing.</summary>
+    private static readonly TimeSpan WaitTimeout = TimeSpan.FromSeconds(5);
+
+    /// <summary>Verifies the constructor rejects a null dispatcher queue.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task ConstructorRejectsNullDispatcherQueue() =>
+        await Assert.That(() => new DispatcherQueueSequencer(null!)).ThrowsExactly<ArgumentNullException>();
+
+    /// <summary>Verifies immediate work is enqueued to and executed on the dispatcher-queue thread.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task ImmediateScheduleExecutesOnQueueThread()
+    {
+        await using var harness = new DispatcherQueueHarness();
+        var scheduler = new DispatcherQueueSequencer(harness.DispatcherQueue);
+        var completion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        scheduler.Schedule(() => completion.TrySetResult(harness.DispatcherQueue.HasThreadAccess));
+
+        var ranOnQueueThread = await completion.Task.WaitAsync(WaitTimeout);
+        await Assert.That(ranOnQueueThread).IsTrue();
+    }
+
+    /// <summary>Verifies work due in the future is executed on the dispatcher-queue thread via the queue timer.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task DelayedScheduleExecutesOnQueueThread()
+    {
+        await using var harness = new DispatcherQueueHarness();
+        var scheduler = new DispatcherQueueSequencer(harness.DispatcherQueue);
+        var completion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        scheduler.Schedule(TimeSpan.FromMilliseconds(50), () => completion.TrySetResult(harness.DispatcherQueue.HasThreadAccess));
+
+        var ranOnQueueThread = await completion.Task.WaitAsync(WaitTimeout);
+        await Assert.That(ranOnQueueThread).IsTrue();
+    }
+
+    /// <summary>Hosts a WinUI <see cref="DispatcherQueue"/> on a dedicated thread and shuts the queue down on disposal.</summary>
+    private sealed class DispatcherQueueHarness : IAsyncDisposable
+    {
+        /// <summary>The controller owning the dedicated dispatcher-queue thread.</summary>
+        private readonly DispatcherQueueController _controller;
+
+        /// <summary>Initializes a new instance of the <see cref="DispatcherQueueHarness"/> class.</summary>
+        public DispatcherQueueHarness()
+        {
+            _controller = DispatcherQueueController.CreateOnDedicatedThread();
+            DispatcherQueue = _controller.DispatcherQueue;
+        }
+
+        /// <summary>Gets the hosted dispatcher queue.</summary>
+        public DispatcherQueue DispatcherQueue { get; }
+
+        /// <inheritdoc/>
+        /// <returns>A task representing the asynchronous operation.</returns>
+        public async ValueTask DisposeAsync() => await _controller.ShutdownQueueAsync().AsTask().WaitAsync(WaitTimeout);
+    }
+}

--- a/src/tests/ReactiveUI.Primitives.WinUI.Reactive.Tests/ReactiveUI.Primitives.WinUI.Reactive.Tests.csproj
+++ b/src/tests/ReactiveUI.Primitives.WinUI.Reactive.Tests/ReactiveUI.Primitives.WinUI.Reactive.Tests.csproj
@@ -1,0 +1,41 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!-- DispatcherQueueSequencer wraps the concrete WinUI Microsoft.UI.Dispatching.DispatcherQueue as an
+       IScheduler. The project targets plain .NET everywhere and adds the WinUI TFMs only on Windows. The WinUI
+       TFM (via the Choose below) turns on UseWinUI, references the WinUI .Reactive library, and compiles the
+       real dispatcher tests (self-contained so DispatcherQueueController activation works without a machine-wide
+       runtime); the cross-platform build compiles only the placeholder so the host reports a discovered test. -->
+  <PropertyGroup>
+    <TargetFrameworks>$(NetTargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(WinUITargetFrameworks)</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Reactive"/>
+  </ItemGroup>
+
+  <!-- The dispatcher tests need WinUI types; include them only on the WinUI TFM (see the Choose). -->
+  <ItemGroup>
+    <Compile Remove="DispatcherQueueSequencerTests.cs"/>
+  </ItemGroup>
+
+  <Choose>
+    <When Condition="$(TargetFramework.EndsWith('-windows10.0.19041.0'))">
+      <PropertyGroup>
+        <UseWinUI>true</UseWinUI>
+        <WindowsPackageType>None</WindowsPackageType>
+        <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
+        <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+        <DefineConstants>$(DefineConstants);WINDOWS</DefineConstants>
+      </PropertyGroup>
+      <ItemGroup>
+        <ProjectReference Include="..\..\ReactiveUI.Primitives.WinUI.Reactive\ReactiveUI.Primitives.WinUI.Reactive.csproj"/>
+        <Compile Include="DispatcherQueueSequencerTests.cs"/>
+        <Compile Remove="CrossPlatformPlaceholderTests.cs"/>
+      </ItemGroup>
+    </When>
+  </Choose>
+
+</Project>

--- a/src/tests/ReactiveUI.Primitives.Wpf.Reactive.Tests/CrossPlatformPlaceholderTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Wpf.Reactive.Tests/CrossPlatformPlaceholderTests.cs
@@ -1,0 +1,18 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace ReactiveUI.Primitives.Wpf.Reactive.Tests;
+
+/// <summary>
+/// Placeholder so the cross-platform test host runs a test and does not report a zero-test run.
+/// The real WPF dispatcher tests compile and run on Windows only (see the csproj).
+/// </summary>
+public sealed class CrossPlatformPlaceholderTests
+{
+    /// <summary>Verifies this build leg is the cross-platform one, where the WPF dispatcher tests are absent.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task DispatcherTestsRunOnWindowsOnly() =>
+        await Assert.That(OperatingSystem.IsWindows()).IsFalse();
+}

--- a/src/tests/ReactiveUI.Primitives.Wpf.Reactive.Tests/DispatcherSequencerTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Wpf.Reactive.Tests/DispatcherSequencerTests.cs
@@ -1,0 +1,97 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Reactive.Concurrency;
+using System.Windows.Threading;
+using ReactiveUI.Primitives.Reactive.Concurrency;
+
+namespace ReactiveUI.Primitives.Wpf.Reactive.Tests;
+
+/// <summary>
+/// Tests for <see cref="DispatcherSequencer"/> as an <see cref="IScheduler"/>, exercised against a real WPF
+/// <see cref="Dispatcher"/> pumped on a dedicated STA thread so both the immediate and timer-based dispatch
+/// paths run end to end. Compiled only on Windows builds (see the csproj).
+/// </summary>
+public sealed class DispatcherSequencerTests
+{
+    /// <summary>Maximum time to wait for work to be marshalled onto the dispatcher thread before failing.</summary>
+    private static readonly TimeSpan WaitTimeout = TimeSpan.FromSeconds(5);
+
+    /// <summary>Verifies the constructor rejects a null dispatcher.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task ConstructorRejectsNullDispatcher() =>
+        await Assert.That(() => new DispatcherSequencer(null!)).ThrowsExactly<ArgumentNullException>();
+
+    /// <summary>Verifies immediate work is posted to and executed on the dispatcher thread.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task ImmediateScheduleExecutesOnDispatcherThread()
+    {
+        using var harness = new DispatcherHarness();
+        var scheduler = new DispatcherSequencer(harness.Dispatcher);
+        var completion = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        scheduler.Schedule(() => completion.TrySetResult(Environment.CurrentManagedThreadId));
+
+        var ranOnThreadId = await completion.Task.WaitAsync(WaitTimeout);
+        await Assert.That(ranOnThreadId).IsEqualTo(harness.ThreadId);
+    }
+
+    /// <summary>Verifies work due in the future is executed on the dispatcher thread via the dispatcher timer.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task DelayedScheduleExecutesOnDispatcherThread()
+    {
+        using var harness = new DispatcherHarness();
+        var scheduler = new DispatcherSequencer(harness.Dispatcher);
+        var completion = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        scheduler.Schedule(TimeSpan.FromMilliseconds(50), () => completion.TrySetResult(Environment.CurrentManagedThreadId));
+
+        var ranOnThreadId = await completion.Task.WaitAsync(WaitTimeout);
+        await Assert.That(ranOnThreadId).IsEqualTo(harness.ThreadId);
+    }
+
+    /// <summary>Hosts a WPF <see cref="Dispatcher"/> on a dedicated STA thread and pumps its message loop, shutting it down and joining the thread on disposal.</summary>
+    private sealed class DispatcherHarness : IDisposable
+    {
+        /// <summary>The thread running the dispatcher message loop.</summary>
+        private readonly Thread _thread;
+
+        /// <summary>Initializes a new instance of the <see cref="DispatcherHarness"/> class and waits until the dispatcher is running.</summary>
+        public DispatcherHarness()
+        {
+            using var ready = new ManualResetEventSlim(false);
+            _thread = new Thread(() =>
+            {
+                Dispatcher = Dispatcher.CurrentDispatcher;
+                ThreadId = Environment.CurrentManagedThreadId;
+                ready.Set();
+                Dispatcher.Run();
+            })
+            {
+                IsBackground = true,
+                Name = "WpfDispatcherHarness",
+            };
+
+            _thread.SetApartmentState(ApartmentState.STA);
+            _thread.Start();
+            ready.Wait();
+        }
+
+        /// <summary>Gets the hosted dispatcher.</summary>
+        public Dispatcher Dispatcher { get; private set; } = null!;
+
+        /// <summary>Gets the managed thread id the dispatcher runs on.</summary>
+        public int ThreadId { get; private set; }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            Dispatcher.InvokeShutdown();
+            _thread.Join(WaitTimeout);
+        }
+    }
+}

--- a/src/tests/ReactiveUI.Primitives.Wpf.Reactive.Tests/ReactiveUI.Primitives.Wpf.Reactive.Tests.csproj
+++ b/src/tests/ReactiveUI.Primitives.Wpf.Reactive.Tests/ReactiveUI.Primitives.Wpf.Reactive.Tests.csproj
@@ -1,0 +1,37 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!-- DispatcherSequencer wraps the concrete WPF System.Windows.Threading.Dispatcher as an IScheduler. The
+       project targets plain .NET everywhere and adds the -windows TFMs only on Windows. The windows TFM (via
+       the Choose below) turns on UseWPF, references the WPF .Reactive library, and compiles the real dispatcher
+       tests; the cross-platform build compiles only the skipped placeholder so the host reports a discovered test. -->
+  <PropertyGroup>
+    <TargetFrameworks>$(NetTargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(WindowsNetTargetFrameworks)</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Reactive"/>
+  </ItemGroup>
+
+  <!-- The dispatcher tests need WPF types; include them only on the windows TFM (see the Choose). -->
+  <ItemGroup>
+    <Compile Remove="DispatcherSequencerTests.cs"/>
+  </ItemGroup>
+
+  <Choose>
+    <When Condition="$(TargetFramework.EndsWith('-windows'))">
+      <PropertyGroup>
+        <UseWPF>true</UseWPF>
+        <DefineConstants>$(DefineConstants);WINDOWS</DefineConstants>
+      </PropertyGroup>
+      <ItemGroup>
+        <ProjectReference Include="..\..\ReactiveUI.Primitives.Wpf.Reactive\ReactiveUI.Primitives.Wpf.Reactive.csproj"/>
+        <Compile Include="DispatcherSequencerTests.cs"/>
+        <Compile Remove="CrossPlatformPlaceholderTests.cs"/>
+      </ItemGroup>
+    </When>
+  </Choose>
+
+</Project>


### PR DESCRIPTION
## What kind of change does this PR introduce?
Feature — extends the Core/`.Reactive` split to every platform adapter so **all** production code now ships a System.Reactive-flavoured leaf.

## What is the new behavior?
Five new packages, each referencing `ReactiveUI.Primitives.Reactive` (the project-name suffix supplies `REACTIVE_SHIM` + the `System.Reactive` dependency):

- `ReactiveUI.Primitives.Wpf.Reactive`
- `ReactiveUI.Primitives.WinForms.Reactive`
- `ReactiveUI.Primitives.Maui.Reactive`
- `ReactiveUI.Primitives.WinUI.Reactive`
- `ReactiveUI.Primitives.Blazor.Reactive`

Design notes:
- **Sequencers can't be shimmed.** The lean platform sequencers *implement* `ISequencer` (`Schedule(IWorkItem)`); under the alias that becomes `System.Reactive.Concurrency.IScheduler`, whose required members are entirely different, so the source can't be recompiled. They're implemented natively instead, **keeping the lean type names** (`DispatcherSequencer`, `ControlSequencer`, `MauiDispatcherSequencer`, `DispatcherQueueSequencer`, `BlazorRendererSequencer`) and `ToSequencer()` (Maui/WinUI) — now returning an `IScheduler`.
- A shared, source-linked `CoalescingDispatchScheduler : LocalScheduler` base replicates the lean `DispatchSequencerState` coalescing on top of `IScheduler` (batched drain post per dispatch, abstract `Post`, overridable native delayed timer). Each platform supplies only its dispatcher post + optional UI timer.
- Blazor's `ReactiveComponentBase` **is** shimmable (its only seam reference is the `RendererSequencer` property type) — moved to `Primitives.Blazor.Shared` and source-linked into both leaves; the lean API is unchanged and the System.Reactive leaf exposes the renderer sequencer as an `IScheduler`.
- Added `.Reactive` test projects for each platform, registered all new projects in the solution, and generated per-TFM PublicAPI baselines (27 TFMs).

## What is the current behavior?
Only the base, `Extensions`, and `Async` families had `.Reactive` leaves. The five platform adapter packages had no System.Reactive-flavoured equivalent, so consumers on System.Reactive had no parity dispatcher scheduler for WPF/WinForms/MAUI/WinUI/Blazor.

## What might this PR break?
None. All changes are additive except moving Blazor's `ReactiveComponentBase` to shared source — its public namespace, type, and surface are unchanged (verified against the existing PublicAPI baseline).

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [x] Tests have been added or updated (for bug fixes / features)
- [x] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information
Verified: full `dotnet build ReactiveUI.Primitives.slnx` is clean on Linux and on real Windows (Release, all Windows TFMs, `TrackPublicApi` on). New cross-platform Reactive tests pass (Maui 6, Blazor 5); WPF/WinForms/WinUI real dispatcher tests are Windows-gated via the existing `Choose` + placeholder pattern.