### PR TITLE
feature: Add `DelayableNotificationSignal<T>` for enhanced signal handling

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1126,6 +1126,7 @@ stylesharp.summary_single_line_max_length = 120
 stylesharp.document_exposed_elements = true
 stylesharp.document_internal_elements = true
 stylesharp.document_private_elements = true
+stylesharp.document_private_fields = true
 stylesharp.document_interfaces = all
 stylesharp.SST1305.allowed_hungarian_prefixes = rx
 

--- a/src/Polyfills/TaskCompletionSource.cs
+++ b/src/Polyfills/TaskCompletionSource.cs
@@ -12,6 +12,7 @@ namespace System.Threading.Tasks;
 [SuppressMessage("Performance", "CA1812", Justification = "Broadcast polyfill; not instantiated in every consuming leaf.")]
 internal sealed class TaskCompletionSource
 {
+    /// <summary>The underlying generic completion source that backs this non-generic facade.</summary>
     private readonly TaskCompletionSource<bool> _inner;
 
     /// <summary>Initializes a new instance of the <see cref="TaskCompletionSource"/> class.</summary>

--- a/src/Primitives.Shared/Signals/ScheduledSignal{T}.cs
+++ b/src/Primitives.Shared/Signals/ScheduledSignal{T}.cs
@@ -22,7 +22,7 @@ public class ScheduledSignal<T> : ISignal<T>
     private readonly ISequencer _scheduler;
 
     /// <summary>Stores the underlying signal implementation.</summary>
-    private readonly Signal<T> _subject = new();
+    private readonly ISignal<T> _subject;
 
     /// <summary>Stores the active non-default observer count.</summary>
     private int _observerRefCount;
@@ -44,11 +44,21 @@ public class ScheduledSignal<T> : ISignal<T>
     /// <param name="scheduler">The sequencer to emit items on.</param>
     /// <param name="defaultObserver">A default observer which will receive values when no other subscribers are active.</param>
     public ScheduledSignal(ISequencer scheduler, IObserver<T>? defaultObserver)
+        : this(scheduler, defaultObserver, null)
+    {
+    }
+
+    /// <summary>Initializes a new instance of the <see cref="ScheduledSignal{T}"/> class.</summary>
+    /// <param name="scheduler">The sequencer to emit items on.</param>
+    /// <param name="defaultObserver">A default observer which will receive values when no other subscribers are active.</param>
+    /// <param name="defaultSubject">An optional backing signal this instance wraps; a new <see cref="Signal{T}"/> is used when null.</param>
+    public ScheduledSignal(ISequencer scheduler, IObserver<T>? defaultObserver, ISignal<T>? defaultSubject)
     {
         ArgumentExceptionHelper.ThrowIfNull(scheduler);
 
         _scheduler = scheduler;
         _defaultObserver = defaultObserver;
+        _subject = defaultSubject ?? new Signal<T>();
         _defaultObserverSub = defaultObserver is null ? null : SubscribeDefaultObserver(defaultObserver);
     }
 

--- a/src/Primitives.Shared/Signals/Signal{Subjects}.cs
+++ b/src/Primitives.Shared/Signals/Signal{Subjects}.cs
@@ -1,0 +1,40 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+#if REACTIVE_SHIM
+namespace ReactiveUI.Primitives.Reactive.Signals;
+#else
+namespace ReactiveUI.Primitives.Signals;
+#endif
+
+/// <summary>Factory surface for the multicast subject signals, for callers who prefer a factory over the concrete constructors.</summary>
+public static partial class Signal
+{
+    /// <summary>Creates a signal that dispatches its notifications on <paramref name="scheduler"/>.</summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    /// <param name="scheduler">The scheduler to dispatch notifications on.</param>
+    /// <returns>A scheduled signal.</returns>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Major Code Smell",
+        "S4018:Generic methods should provide type parameters",
+        Justification = "The type parameter defines the element type for this Rx-style factory and cannot be inferred from the arguments.")]
+    public static ScheduledSignal<T> Scheduled<T>(ISequencer scheduler) =>
+        new(scheduler);
+
+    /// <summary>Creates a signal that dispatches its notifications on <paramref name="scheduler"/>, with a default observer active while no other subscribers are present.</summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    /// <param name="scheduler">The scheduler to dispatch notifications on.</param>
+    /// <param name="defaultObserver">A default observer which receives values when no other subscribers are active.</param>
+    /// <returns>A scheduled signal.</returns>
+    public static ScheduledSignal<T> Scheduled<T>(ISequencer scheduler, IObserver<T>? defaultObserver) =>
+        new(scheduler, defaultObserver);
+
+    /// <summary>Creates a signal that buffers notifications while delayed and emits a de-duplicated batch when <see cref="DelayableNotificationSignal{T}.Flush"/> is called.</summary>
+    /// <typeparam name="T">The notification type.</typeparam>
+    /// <param name="isDelayed">Returns whether notifications are currently delayed.</param>
+    /// <param name="flushDistinct">De-duplicates a buffered batch before it is emitted on flush.</param>
+    /// <returns>A delayable notification signal.</returns>
+    public static DelayableNotificationSignal<T> Delayable<T>(Func<bool> isDelayed, Func<IList<T>, IEnumerable<T>> flushDistinct) =>
+        new(isDelayed, flushDistinct);
+}

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/CallbackWitnessAsync.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/CallbackWitnessAsync.cs
@@ -14,9 +14,11 @@ public sealed class CallbackWitnessAsync<T>(
     Func<Exception, CancellationToken, ValueTask>? onErrorResumeAsync = null,
     Func<Result, ValueTask>? onCompletedAsync = null) : WitnessAsync<T>
 {
+    /// <summary>The asynchronous function invoked when a resumable error occurs.</summary>
     private readonly Func<Exception, CancellationToken, ValueTask> _onErrorResumeAsync =
         onErrorResumeAsync ?? ReportUnhandledError;
 
+    /// <summary>The asynchronous function invoked when the sequence completes.</summary>
     private readonly Func<Result, ValueTask> _onCompletedAsync =
         onCompletedAsync ?? ReportUnhandledCompletion;
 

--- a/src/ReactiveUI.Primitives.Core/Advanced/CountPredicateAggregator.cs
+++ b/src/ReactiveUI.Primitives.Core/Advanced/CountPredicateAggregator.cs
@@ -8,6 +8,7 @@ namespace ReactiveUI.Primitives.Advanced;
 /// <typeparam name="T">The observed value type.</typeparam>
 public readonly record struct CountPredicateAggregator<T> : IAggregator<T, int, CountPredicateAggregator<T>>
 {
+    /// <summary>The predicate selecting which values to count.</summary>
     private readonly Func<T, bool> _predicate;
 
     /// <summary>Initializes a new instance of the <see cref="CountPredicateAggregator{T}"/> struct.</summary>

--- a/src/ReactiveUI.Primitives.Core/Advanced/DistinctByCountAggregator.cs
+++ b/src/ReactiveUI.Primitives.Core/Advanced/DistinctByCountAggregator.cs
@@ -9,8 +9,10 @@ namespace ReactiveUI.Primitives.Advanced;
 /// <typeparam name="TKey">The key type.</typeparam>
 public readonly record struct DistinctByCountAggregator<T, TKey> : IAggregator<T, int, DistinctByCountAggregator<T, TKey>>
 {
+    /// <summary>The selector that projects each value to its distinctness key.</summary>
     private readonly Func<T, TKey> _keySelector;
 
+    /// <summary>The set of keys that have already been observed.</summary>
     private readonly HashSet<TKey> _seen;
 
     /// <summary>Initializes a new instance of the <see cref="DistinctByCountAggregator{T,TKey}"/> struct.</summary>

--- a/src/ReactiveUI.Primitives.Core/Advanced/DistinctByLongCountAggregator.cs
+++ b/src/ReactiveUI.Primitives.Core/Advanced/DistinctByLongCountAggregator.cs
@@ -9,8 +9,10 @@ namespace ReactiveUI.Primitives.Advanced;
 /// <typeparam name="TKey">The key type.</typeparam>
 public readonly record struct DistinctByLongCountAggregator<T, TKey> : IAggregator<T, long, DistinctByLongCountAggregator<T, TKey>>
 {
+    /// <summary>The selector that projects each value to its distinctness key.</summary>
     private readonly Func<T, TKey> _keySelector;
 
+    /// <summary>The set of keys that have already been observed.</summary>
     private readonly HashSet<TKey> _seen;
 
     /// <summary>Initializes a new instance of the <see cref="DistinctByLongCountAggregator{T,TKey}"/> struct.</summary>

--- a/src/ReactiveUI.Primitives.Core/Advanced/LongCountPredicateAggregator.cs
+++ b/src/ReactiveUI.Primitives.Core/Advanced/LongCountPredicateAggregator.cs
@@ -8,6 +8,7 @@ namespace ReactiveUI.Primitives.Advanced;
 /// <typeparam name="T">The observed value type.</typeparam>
 public readonly record struct LongCountPredicateAggregator<T> : IAggregator<T, long, LongCountPredicateAggregator<T>>
 {
+    /// <summary>The predicate selecting which values to count.</summary>
     private readonly Func<T, bool> _predicate;
 
     /// <summary>Initializes a new instance of the <see cref="LongCountPredicateAggregator{T}"/> struct.</summary>

--- a/src/ReactiveUI.Primitives.Core/PublicAPI/net10.0/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Core/PublicAPI/net10.0/PublicAPI.Shipped.txt
@@ -514,6 +514,16 @@ ReactiveUI.Primitives.Signals.CommandSignal<TResult>.Faults.get -> System.IObser
 ReactiveUI.Primitives.Signals.CommandSignal<TResult>.IsRunning.get -> ReactiveUI.Primitives.Signals.StateSignal<bool>!
 ReactiveUI.Primitives.Signals.CommandSignal<TResult>.Results.get -> System.IObservable<TResult>!
 ReactiveUI.Primitives.Signals.CommandSignal<TResult>.Subscribe(System.IObserver<TResult>! observer) -> System.IDisposable!
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.DelayableNotificationSignal(System.Func<bool>! isDelayed, System.Func<System.Collections.Generic.IList<T>!, System.Collections.Generic.IEnumerable<T>!>! flushDistinct) -> void
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.Dispose() -> void
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.Flush() -> void
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.HasObservers.get -> bool
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.IsDisposed.get -> bool
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.OnCompleted() -> void
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.OnError(System.Exception! error) -> void
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.OnNext(T value) -> void
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Signals.DelegateWitness<T>
 ReactiveUI.Primitives.Signals.DelegateWitness<T>.DelegateWitness(System.Action<T>! onNext, System.Action<System.Exception!>? onError = null, System.Action? onCompleted = null) -> void
 ReactiveUI.Primitives.Signals.DelegateWitness<T>.OnCompleted() -> void

--- a/src/ReactiveUI.Primitives.Core/PublicAPI/net11.0/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Core/PublicAPI/net11.0/PublicAPI.Shipped.txt
@@ -514,6 +514,16 @@ ReactiveUI.Primitives.Signals.CommandSignal<TResult>.Faults.get -> System.IObser
 ReactiveUI.Primitives.Signals.CommandSignal<TResult>.IsRunning.get -> ReactiveUI.Primitives.Signals.StateSignal<bool>!
 ReactiveUI.Primitives.Signals.CommandSignal<TResult>.Results.get -> System.IObservable<TResult>!
 ReactiveUI.Primitives.Signals.CommandSignal<TResult>.Subscribe(System.IObserver<TResult>! observer) -> System.IDisposable!
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.DelayableNotificationSignal(System.Func<bool>! isDelayed, System.Func<System.Collections.Generic.IList<T>!, System.Collections.Generic.IEnumerable<T>!>! flushDistinct) -> void
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.Dispose() -> void
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.Flush() -> void
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.HasObservers.get -> bool
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.IsDisposed.get -> bool
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.OnCompleted() -> void
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.OnError(System.Exception! error) -> void
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.OnNext(T value) -> void
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Signals.DelegateWitness<T>
 ReactiveUI.Primitives.Signals.DelegateWitness<T>.DelegateWitness(System.Action<T>! onNext, System.Action<System.Exception!>? onError = null, System.Action? onCompleted = null) -> void
 ReactiveUI.Primitives.Signals.DelegateWitness<T>.OnCompleted() -> void

--- a/src/ReactiveUI.Primitives.Core/PublicAPI/net462/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Core/PublicAPI/net462/PublicAPI.Shipped.txt
@@ -506,6 +506,16 @@ ReactiveUI.Primitives.Signals.CommandSignal<TResult>.Faults.get -> System.IObser
 ReactiveUI.Primitives.Signals.CommandSignal<TResult>.IsRunning.get -> ReactiveUI.Primitives.Signals.StateSignal<bool>!
 ReactiveUI.Primitives.Signals.CommandSignal<TResult>.Results.get -> System.IObservable<TResult>!
 ReactiveUI.Primitives.Signals.CommandSignal<TResult>.Subscribe(System.IObserver<TResult>! observer) -> System.IDisposable!
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.DelayableNotificationSignal(System.Func<bool>! isDelayed, System.Func<System.Collections.Generic.IList<T>!, System.Collections.Generic.IEnumerable<T>!>! flushDistinct) -> void
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.Dispose() -> void
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.Flush() -> void
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.HasObservers.get -> bool
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.IsDisposed.get -> bool
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.OnCompleted() -> void
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.OnError(System.Exception! error) -> void
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.OnNext(T value) -> void
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Signals.DelegateWitness<T>
 ReactiveUI.Primitives.Signals.DelegateWitness<T>.DelegateWitness(System.Action<T>! onNext, System.Action<System.Exception!>? onError = null, System.Action? onCompleted = null) -> void
 ReactiveUI.Primitives.Signals.DelegateWitness<T>.OnCompleted() -> void

--- a/src/ReactiveUI.Primitives.Core/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Core/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -506,6 +506,16 @@ ReactiveUI.Primitives.Signals.CommandSignal<TResult>.Faults.get -> System.IObser
 ReactiveUI.Primitives.Signals.CommandSignal<TResult>.IsRunning.get -> ReactiveUI.Primitives.Signals.StateSignal<bool>!
 ReactiveUI.Primitives.Signals.CommandSignal<TResult>.Results.get -> System.IObservable<TResult>!
 ReactiveUI.Primitives.Signals.CommandSignal<TResult>.Subscribe(System.IObserver<TResult>! observer) -> System.IDisposable!
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.DelayableNotificationSignal(System.Func<bool>! isDelayed, System.Func<System.Collections.Generic.IList<T>!, System.Collections.Generic.IEnumerable<T>!>! flushDistinct) -> void
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.Dispose() -> void
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.Flush() -> void
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.HasObservers.get -> bool
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.IsDisposed.get -> bool
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.OnCompleted() -> void
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.OnError(System.Exception! error) -> void
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.OnNext(T value) -> void
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Signals.DelegateWitness<T>
 ReactiveUI.Primitives.Signals.DelegateWitness<T>.DelegateWitness(System.Action<T>! onNext, System.Action<System.Exception!>? onError = null, System.Action? onCompleted = null) -> void
 ReactiveUI.Primitives.Signals.DelegateWitness<T>.OnCompleted() -> void

--- a/src/ReactiveUI.Primitives.Core/PublicAPI/net48/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Core/PublicAPI/net48/PublicAPI.Shipped.txt
@@ -506,6 +506,16 @@ ReactiveUI.Primitives.Signals.CommandSignal<TResult>.Faults.get -> System.IObser
 ReactiveUI.Primitives.Signals.CommandSignal<TResult>.IsRunning.get -> ReactiveUI.Primitives.Signals.StateSignal<bool>!
 ReactiveUI.Primitives.Signals.CommandSignal<TResult>.Results.get -> System.IObservable<TResult>!
 ReactiveUI.Primitives.Signals.CommandSignal<TResult>.Subscribe(System.IObserver<TResult>! observer) -> System.IDisposable!
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.DelayableNotificationSignal(System.Func<bool>! isDelayed, System.Func<System.Collections.Generic.IList<T>!, System.Collections.Generic.IEnumerable<T>!>! flushDistinct) -> void
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.Dispose() -> void
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.Flush() -> void
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.HasObservers.get -> bool
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.IsDisposed.get -> bool
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.OnCompleted() -> void
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.OnError(System.Exception! error) -> void
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.OnNext(T value) -> void
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Signals.DelegateWitness<T>
 ReactiveUI.Primitives.Signals.DelegateWitness<T>.DelegateWitness(System.Action<T>! onNext, System.Action<System.Exception!>? onError = null, System.Action? onCompleted = null) -> void
 ReactiveUI.Primitives.Signals.DelegateWitness<T>.OnCompleted() -> void

--- a/src/ReactiveUI.Primitives.Core/PublicAPI/net481/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Core/PublicAPI/net481/PublicAPI.Shipped.txt
@@ -506,6 +506,16 @@ ReactiveUI.Primitives.Signals.CommandSignal<TResult>.Faults.get -> System.IObser
 ReactiveUI.Primitives.Signals.CommandSignal<TResult>.IsRunning.get -> ReactiveUI.Primitives.Signals.StateSignal<bool>!
 ReactiveUI.Primitives.Signals.CommandSignal<TResult>.Results.get -> System.IObservable<TResult>!
 ReactiveUI.Primitives.Signals.CommandSignal<TResult>.Subscribe(System.IObserver<TResult>! observer) -> System.IDisposable!
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.DelayableNotificationSignal(System.Func<bool>! isDelayed, System.Func<System.Collections.Generic.IList<T>!, System.Collections.Generic.IEnumerable<T>!>! flushDistinct) -> void
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.Dispose() -> void
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.Flush() -> void
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.HasObservers.get -> bool
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.IsDisposed.get -> bool
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.OnCompleted() -> void
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.OnError(System.Exception! error) -> void
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.OnNext(T value) -> void
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Signals.DelegateWitness<T>
 ReactiveUI.Primitives.Signals.DelegateWitness<T>.DelegateWitness(System.Action<T>! onNext, System.Action<System.Exception!>? onError = null, System.Action? onCompleted = null) -> void
 ReactiveUI.Primitives.Signals.DelegateWitness<T>.OnCompleted() -> void

--- a/src/ReactiveUI.Primitives.Core/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Core/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -514,6 +514,16 @@ ReactiveUI.Primitives.Signals.CommandSignal<TResult>.Faults.get -> System.IObser
 ReactiveUI.Primitives.Signals.CommandSignal<TResult>.IsRunning.get -> ReactiveUI.Primitives.Signals.StateSignal<bool>!
 ReactiveUI.Primitives.Signals.CommandSignal<TResult>.Results.get -> System.IObservable<TResult>!
 ReactiveUI.Primitives.Signals.CommandSignal<TResult>.Subscribe(System.IObserver<TResult>! observer) -> System.IDisposable!
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.DelayableNotificationSignal(System.Func<bool>! isDelayed, System.Func<System.Collections.Generic.IList<T>!, System.Collections.Generic.IEnumerable<T>!>! flushDistinct) -> void
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.Dispose() -> void
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.Flush() -> void
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.HasObservers.get -> bool
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.IsDisposed.get -> bool
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.OnCompleted() -> void
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.OnError(System.Exception! error) -> void
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.OnNext(T value) -> void
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Signals.DelegateWitness<T>
 ReactiveUI.Primitives.Signals.DelegateWitness<T>.DelegateWitness(System.Action<T>! onNext, System.Action<System.Exception!>? onError = null, System.Action? onCompleted = null) -> void
 ReactiveUI.Primitives.Signals.DelegateWitness<T>.OnCompleted() -> void

--- a/src/ReactiveUI.Primitives.Core/PublicAPI/net9.0/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Core/PublicAPI/net9.0/PublicAPI.Shipped.txt
@@ -514,6 +514,16 @@ ReactiveUI.Primitives.Signals.CommandSignal<TResult>.Faults.get -> System.IObser
 ReactiveUI.Primitives.Signals.CommandSignal<TResult>.IsRunning.get -> ReactiveUI.Primitives.Signals.StateSignal<bool>!
 ReactiveUI.Primitives.Signals.CommandSignal<TResult>.Results.get -> System.IObservable<TResult>!
 ReactiveUI.Primitives.Signals.CommandSignal<TResult>.Subscribe(System.IObserver<TResult>! observer) -> System.IDisposable!
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.DelayableNotificationSignal(System.Func<bool>! isDelayed, System.Func<System.Collections.Generic.IList<T>!, System.Collections.Generic.IEnumerable<T>!>! flushDistinct) -> void
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.Dispose() -> void
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.Flush() -> void
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.HasObservers.get -> bool
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.IsDisposed.get -> bool
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.OnCompleted() -> void
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.OnError(System.Exception! error) -> void
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.OnNext(T value) -> void
+ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Signals.DelegateWitness<T>
 ReactiveUI.Primitives.Signals.DelegateWitness<T>.DelegateWitness(System.Action<T>! onNext, System.Action<System.Exception!>? onError = null, System.Action? onCompleted = null) -> void
 ReactiveUI.Primitives.Signals.DelegateWitness<T>.OnCompleted() -> void

--- a/src/ReactiveUI.Primitives.Core/Signals/DelayableNotificationSignal{T}.cs
+++ b/src/ReactiveUI.Primitives.Core/Signals/DelayableNotificationSignal{T}.cs
@@ -1,0 +1,185 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using ReactiveUI.Primitives.Disposables;
+
+namespace ReactiveUI.Primitives.Signals;
+
+/// <summary>
+/// A signal that passes notifications through immediately while they are not delayed, but buffers them while delayed
+/// and emits a de-duplicated batch when <see cref="Flush"/> is called (typically as the delay window opens or closes).
+/// Fuses the <c>Buffer(boundary).SelectMany(distinct).Publish().RefCount()</c> pipeline into one allocation-light sink.
+/// </summary>
+/// <typeparam name="T">The notification type.</typeparam>
+public sealed class DelayableNotificationSignal<T> : ISignal<T>
+{
+    /// <summary>Guards the observer set, buffer, and terminal state.</summary>
+    private readonly Lock _gate = new();
+
+    /// <summary>Returns whether notifications are currently delayed.</summary>
+    private readonly Func<bool> _isDelayed;
+
+    /// <summary>De-duplicates a buffered batch before it is emitted on flush.</summary>
+    private readonly Func<IList<T>, IEnumerable<T>> _flushDistinct;
+
+    /// <summary>The observers subscribed to this signal.</summary>
+    private Broadcaster<T> _broadcaster;
+
+    /// <summary>Holds notifications produced while delayed; null until the first buffered notification.</summary>
+    private List<T>? _buffer;
+
+    /// <summary>The terminal error, if the signal errored.</summary>
+    private Exception? _error;
+
+    /// <summary>Whether the signal has terminated (completed or errored).</summary>
+    private bool _stopped;
+
+    /// <summary>Whether the signal has been disposed.</summary>
+    private bool _disposed;
+
+    /// <summary>Initializes a new instance of the <see cref="DelayableNotificationSignal{T}"/> class.</summary>
+    /// <param name="isDelayed">Returns whether notifications are currently delayed.</param>
+    /// <param name="flushDistinct">De-duplicates a buffered batch before it is emitted on flush.</param>
+    public DelayableNotificationSignal(Func<bool> isDelayed, Func<IList<T>, IEnumerable<T>> flushDistinct)
+    {
+        ArgumentExceptionHelper.ThrowIfNull(isDelayed);
+        ArgumentExceptionHelper.ThrowIfNull(flushDistinct);
+
+        _isDelayed = isDelayed;
+        _flushDistinct = flushDistinct;
+        _broadcaster = default;
+    }
+
+    /// <inheritdoc/>
+    public bool HasObservers => _broadcaster.HasObservers && !_stopped;
+
+    /// <inheritdoc/>
+    public bool IsDisposed => _disposed;
+
+    /// <inheritdoc/>
+    public void OnNext(T value)
+    {
+        lock (_gate)
+        {
+            if (_stopped)
+            {
+                return;
+            }
+
+            if (_isDelayed())
+            {
+                (_buffer ??= []).Add(value);
+                return;
+            }
+        }
+
+        _broadcaster.Next(value);
+    }
+
+    /// <inheritdoc/>
+    public void OnError(Exception error)
+    {
+        lock (_gate)
+        {
+            if (_stopped)
+            {
+                return;
+            }
+
+            _stopped = true;
+            _error = error;
+        }
+
+        _broadcaster.Error(error);
+    }
+
+    /// <inheritdoc/>
+    public void OnCompleted()
+    {
+        lock (_gate)
+        {
+            if (_stopped)
+            {
+                return;
+            }
+
+            _stopped = true;
+        }
+
+        _broadcaster.Completed();
+    }
+
+    /// <summary>Emits any buffered notifications as a de-duplicated batch; call when the delay window opens or closes.</summary>
+    public void Flush()
+    {
+        List<T> batch;
+        lock (_gate)
+        {
+            if (_stopped || _buffer is null || _buffer.Count == 0)
+            {
+                return;
+            }
+
+            batch = [.. _flushDistinct(_buffer)];
+            _buffer.Clear();
+        }
+
+        for (var i = 0; i < batch.Count; i++)
+        {
+            _broadcaster.Next(batch[i]);
+        }
+    }
+
+    /// <inheritdoc/>
+    public IDisposable Subscribe(IObserver<T> observer)
+    {
+        ArgumentExceptionHelper.ThrowIfNull(observer);
+        lock (_gate)
+        {
+            if (_error is not null)
+            {
+                observer.OnError(_error);
+                return EmptyDisposable.Instance;
+            }
+
+            if (_stopped)
+            {
+                observer.OnCompleted();
+                return EmptyDisposable.Instance;
+            }
+
+            _broadcaster.Add(observer);
+        }
+
+        return new Subscription(this, observer);
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        lock (_gate)
+        {
+            _disposed = true;
+        }
+    }
+
+    /// <summary>Removes an observer from the signal.</summary>
+    /// <param name="observer">The observer to remove.</param>
+    private void Unsubscribe(IObserver<T> observer)
+    {
+        lock (_gate)
+        {
+            _broadcaster.Remove(observer);
+        }
+    }
+
+    /// <summary>Removes its observer from the signal when disposed.</summary>
+    /// <param name="parent">The owning signal.</param>
+    /// <param name="observer">The subscribed observer.</param>
+    private sealed class Subscription(DelayableNotificationSignal<T> parent, IObserver<T> observer) : IDisposable
+    {
+        /// <inheritdoc/>
+        public void Dispose() => parent.Unsubscribe(observer);
+    }
+}

--- a/src/ReactiveUI.Primitives.Core/Signals/DelegateWitness{T}.cs
+++ b/src/ReactiveUI.Primitives.Core/Signals/DelegateWitness{T}.cs
@@ -20,6 +20,7 @@ public sealed class DelegateWitness<T>(
     Action<Exception>? onError = null,
     Action? onCompleted = null) : IObserver<T>
 {
+    /// <summary>The delegate invoked for each observed value.</summary>
     private readonly Action<T> _onNext = onNext ?? throw new ArgumentNullException(nameof(onNext));
 
     /// <inheritdoc/>

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0/PublicAPI.Shipped.txt
@@ -268,6 +268,7 @@ ReactiveUI.Primitives.Reactive.Signals.ScheduledSignal<T>.OnError(System.Excepti
 ReactiveUI.Primitives.Reactive.Signals.ScheduledSignal<T>.OnNext(T value) -> void
 ReactiveUI.Primitives.Reactive.Signals.ScheduledSignal<T>.ScheduledSignal(System.Reactive.Concurrency.IScheduler! scheduler) -> void
 ReactiveUI.Primitives.Reactive.Signals.ScheduledSignal<T>.ScheduledSignal(System.Reactive.Concurrency.IScheduler! scheduler, System.IObserver<T>? defaultObserver) -> void
+ReactiveUI.Primitives.Reactive.Signals.ScheduledSignal<T>.ScheduledSignal(System.Reactive.Concurrency.IScheduler! scheduler, System.IObserver<T>? defaultObserver, ReactiveUI.Primitives.Signals.ISignal<T>? defaultSubject) -> void
 ReactiveUI.Primitives.Reactive.Signals.ScheduledSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Reactive.Signals.Signal
 ReactiveUI.Primitives.Reactive.Signals.SignalExtensions
@@ -494,6 +495,7 @@ static ReactiveUI.Primitives.Reactive.Signals.Signal.CreateSafe<T>(System.Func<S
 static ReactiveUI.Primitives.Reactive.Signals.Signal.CreateWithState<T, TState>(TState state, System.Func<TState, System.IObserver<T>!, System.IDisposable!>! subscribe) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.CreateWithState<T, TState>(TState state, System.Func<TState, System.IObserver<T>!, System.IDisposable!>! subscribe, bool isRequiredSubscribeOnCurrentThread) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Defer<T>(System.Func<System.IObservable<T>!>! observableFactory) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Delayable<T>(System.Func<bool>! isDelayed, System.Func<System.Collections.Generic.IList<T>!, System.Collections.Generic.IEnumerable<T>!>! flushDistinct) -> ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Emit(System.Reactive.Unit value) -> System.IObservable<System.Reactive.Unit>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Emit(bool value) -> System.IObservable<bool>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Emit(int value) -> System.IObservable<int>!
@@ -538,6 +540,8 @@ static ReactiveUI.Primitives.Reactive.Signals.Signal.Pulse(System.TimeSpan perio
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Pulse(System.TimeSpan period, System.Reactive.Concurrency.IScheduler! scheduler) -> System.IObservable<long>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Race<T>(params System.IObservable<T>![]! sources) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Recover<TSource>(params System.IObservable<TSource>![]! sources) -> System.IObservable<TSource>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Scheduled<T>(System.Reactive.Concurrency.IScheduler! scheduler) -> ReactiveUI.Primitives.Reactive.Signals.ScheduledSignal<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Scheduled<T>(System.Reactive.Concurrency.IScheduler! scheduler, System.IObserver<T>? defaultObserver) -> ReactiveUI.Primitives.Reactive.Signals.ScheduledSignal<T>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Sequence(int start, int count) -> System.IObservable<int>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Sequence(int start, int count, System.Reactive.Concurrency.IScheduler! scheduler) -> System.IObservable<int>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Silent<T>() -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0/PublicAPI.Shipped.txt
@@ -268,6 +268,7 @@ ReactiveUI.Primitives.Reactive.Signals.ScheduledSignal<T>.OnError(System.Excepti
 ReactiveUI.Primitives.Reactive.Signals.ScheduledSignal<T>.OnNext(T value) -> void
 ReactiveUI.Primitives.Reactive.Signals.ScheduledSignal<T>.ScheduledSignal(System.Reactive.Concurrency.IScheduler! scheduler) -> void
 ReactiveUI.Primitives.Reactive.Signals.ScheduledSignal<T>.ScheduledSignal(System.Reactive.Concurrency.IScheduler! scheduler, System.IObserver<T>? defaultObserver) -> void
+ReactiveUI.Primitives.Reactive.Signals.ScheduledSignal<T>.ScheduledSignal(System.Reactive.Concurrency.IScheduler! scheduler, System.IObserver<T>? defaultObserver, ReactiveUI.Primitives.Signals.ISignal<T>? defaultSubject) -> void
 ReactiveUI.Primitives.Reactive.Signals.ScheduledSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Reactive.Signals.Signal
 ReactiveUI.Primitives.Reactive.Signals.SignalExtensions
@@ -494,6 +495,7 @@ static ReactiveUI.Primitives.Reactive.Signals.Signal.CreateSafe<T>(System.Func<S
 static ReactiveUI.Primitives.Reactive.Signals.Signal.CreateWithState<T, TState>(TState state, System.Func<TState, System.IObserver<T>!, System.IDisposable!>! subscribe) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.CreateWithState<T, TState>(TState state, System.Func<TState, System.IObserver<T>!, System.IDisposable!>! subscribe, bool isRequiredSubscribeOnCurrentThread) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Defer<T>(System.Func<System.IObservable<T>!>! observableFactory) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Delayable<T>(System.Func<bool>! isDelayed, System.Func<System.Collections.Generic.IList<T>!, System.Collections.Generic.IEnumerable<T>!>! flushDistinct) -> ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Emit(System.Reactive.Unit value) -> System.IObservable<System.Reactive.Unit>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Emit(bool value) -> System.IObservable<bool>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Emit(int value) -> System.IObservable<int>!
@@ -538,6 +540,8 @@ static ReactiveUI.Primitives.Reactive.Signals.Signal.Pulse(System.TimeSpan perio
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Pulse(System.TimeSpan period, System.Reactive.Concurrency.IScheduler! scheduler) -> System.IObservable<long>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Race<T>(params System.IObservable<T>![]! sources) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Recover<TSource>(params System.IObservable<TSource>![]! sources) -> System.IObservable<TSource>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Scheduled<T>(System.Reactive.Concurrency.IScheduler! scheduler) -> ReactiveUI.Primitives.Reactive.Signals.ScheduledSignal<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Scheduled<T>(System.Reactive.Concurrency.IScheduler! scheduler, System.IObserver<T>? defaultObserver) -> ReactiveUI.Primitives.Reactive.Signals.ScheduledSignal<T>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Sequence(int start, int count) -> System.IObservable<int>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Sequence(int start, int count, System.Reactive.Concurrency.IScheduler! scheduler) -> System.IObservable<int>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Silent<T>() -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net462/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net462/PublicAPI.Shipped.txt
@@ -268,6 +268,7 @@ ReactiveUI.Primitives.Reactive.Signals.ScheduledSignal<T>.OnError(System.Excepti
 ReactiveUI.Primitives.Reactive.Signals.ScheduledSignal<T>.OnNext(T value) -> void
 ReactiveUI.Primitives.Reactive.Signals.ScheduledSignal<T>.ScheduledSignal(System.Reactive.Concurrency.IScheduler! scheduler) -> void
 ReactiveUI.Primitives.Reactive.Signals.ScheduledSignal<T>.ScheduledSignal(System.Reactive.Concurrency.IScheduler! scheduler, System.IObserver<T>? defaultObserver) -> void
+ReactiveUI.Primitives.Reactive.Signals.ScheduledSignal<T>.ScheduledSignal(System.Reactive.Concurrency.IScheduler! scheduler, System.IObserver<T>? defaultObserver, ReactiveUI.Primitives.Signals.ISignal<T>? defaultSubject) -> void
 ReactiveUI.Primitives.Reactive.Signals.ScheduledSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Reactive.Signals.Signal
 ReactiveUI.Primitives.Reactive.Signals.SignalExtensions
@@ -494,6 +495,7 @@ static ReactiveUI.Primitives.Reactive.Signals.Signal.CreateSafe<T>(System.Func<S
 static ReactiveUI.Primitives.Reactive.Signals.Signal.CreateWithState<T, TState>(TState state, System.Func<TState, System.IObserver<T>!, System.IDisposable!>! subscribe) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.CreateWithState<T, TState>(TState state, System.Func<TState, System.IObserver<T>!, System.IDisposable!>! subscribe, bool isRequiredSubscribeOnCurrentThread) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Defer<T>(System.Func<System.IObservable<T>!>! observableFactory) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Delayable<T>(System.Func<bool>! isDelayed, System.Func<System.Collections.Generic.IList<T>!, System.Collections.Generic.IEnumerable<T>!>! flushDistinct) -> ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Emit(System.Reactive.Unit value) -> System.IObservable<System.Reactive.Unit>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Emit(bool value) -> System.IObservable<bool>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Emit(int value) -> System.IObservable<int>!
@@ -536,6 +538,8 @@ static ReactiveUI.Primitives.Reactive.Signals.Signal.Pulse(System.TimeSpan perio
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Pulse(System.TimeSpan period, System.Reactive.Concurrency.IScheduler! scheduler) -> System.IObservable<long>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Race<T>(params System.IObservable<T>![]! sources) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Recover<TSource>(params System.IObservable<TSource>![]! sources) -> System.IObservable<TSource>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Scheduled<T>(System.Reactive.Concurrency.IScheduler! scheduler) -> ReactiveUI.Primitives.Reactive.Signals.ScheduledSignal<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Scheduled<T>(System.Reactive.Concurrency.IScheduler! scheduler, System.IObserver<T>? defaultObserver) -> ReactiveUI.Primitives.Reactive.Signals.ScheduledSignal<T>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Sequence(int start, int count) -> System.IObservable<int>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Sequence(int start, int count, System.Reactive.Concurrency.IScheduler! scheduler) -> System.IObservable<int>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Silent<T>() -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -268,6 +268,7 @@ ReactiveUI.Primitives.Reactive.Signals.ScheduledSignal<T>.OnError(System.Excepti
 ReactiveUI.Primitives.Reactive.Signals.ScheduledSignal<T>.OnNext(T value) -> void
 ReactiveUI.Primitives.Reactive.Signals.ScheduledSignal<T>.ScheduledSignal(System.Reactive.Concurrency.IScheduler! scheduler) -> void
 ReactiveUI.Primitives.Reactive.Signals.ScheduledSignal<T>.ScheduledSignal(System.Reactive.Concurrency.IScheduler! scheduler, System.IObserver<T>? defaultObserver) -> void
+ReactiveUI.Primitives.Reactive.Signals.ScheduledSignal<T>.ScheduledSignal(System.Reactive.Concurrency.IScheduler! scheduler, System.IObserver<T>? defaultObserver, ReactiveUI.Primitives.Signals.ISignal<T>? defaultSubject) -> void
 ReactiveUI.Primitives.Reactive.Signals.ScheduledSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Reactive.Signals.Signal
 ReactiveUI.Primitives.Reactive.Signals.SignalExtensions
@@ -494,6 +495,7 @@ static ReactiveUI.Primitives.Reactive.Signals.Signal.CreateSafe<T>(System.Func<S
 static ReactiveUI.Primitives.Reactive.Signals.Signal.CreateWithState<T, TState>(TState state, System.Func<TState, System.IObserver<T>!, System.IDisposable!>! subscribe) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.CreateWithState<T, TState>(TState state, System.Func<TState, System.IObserver<T>!, System.IDisposable!>! subscribe, bool isRequiredSubscribeOnCurrentThread) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Defer<T>(System.Func<System.IObservable<T>!>! observableFactory) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Delayable<T>(System.Func<bool>! isDelayed, System.Func<System.Collections.Generic.IList<T>!, System.Collections.Generic.IEnumerable<T>!>! flushDistinct) -> ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Emit(System.Reactive.Unit value) -> System.IObservable<System.Reactive.Unit>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Emit(bool value) -> System.IObservable<bool>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Emit(int value) -> System.IObservable<int>!
@@ -536,6 +538,8 @@ static ReactiveUI.Primitives.Reactive.Signals.Signal.Pulse(System.TimeSpan perio
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Pulse(System.TimeSpan period, System.Reactive.Concurrency.IScheduler! scheduler) -> System.IObservable<long>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Race<T>(params System.IObservable<T>![]! sources) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Recover<TSource>(params System.IObservable<TSource>![]! sources) -> System.IObservable<TSource>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Scheduled<T>(System.Reactive.Concurrency.IScheduler! scheduler) -> ReactiveUI.Primitives.Reactive.Signals.ScheduledSignal<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Scheduled<T>(System.Reactive.Concurrency.IScheduler! scheduler, System.IObserver<T>? defaultObserver) -> ReactiveUI.Primitives.Reactive.Signals.ScheduledSignal<T>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Sequence(int start, int count) -> System.IObservable<int>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Sequence(int start, int count, System.Reactive.Concurrency.IScheduler! scheduler) -> System.IObservable<int>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Silent<T>() -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net48/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net48/PublicAPI.Shipped.txt
@@ -268,6 +268,7 @@ ReactiveUI.Primitives.Reactive.Signals.ScheduledSignal<T>.OnError(System.Excepti
 ReactiveUI.Primitives.Reactive.Signals.ScheduledSignal<T>.OnNext(T value) -> void
 ReactiveUI.Primitives.Reactive.Signals.ScheduledSignal<T>.ScheduledSignal(System.Reactive.Concurrency.IScheduler! scheduler) -> void
 ReactiveUI.Primitives.Reactive.Signals.ScheduledSignal<T>.ScheduledSignal(System.Reactive.Concurrency.IScheduler! scheduler, System.IObserver<T>? defaultObserver) -> void
+ReactiveUI.Primitives.Reactive.Signals.ScheduledSignal<T>.ScheduledSignal(System.Reactive.Concurrency.IScheduler! scheduler, System.IObserver<T>? defaultObserver, ReactiveUI.Primitives.Signals.ISignal<T>? defaultSubject) -> void
 ReactiveUI.Primitives.Reactive.Signals.ScheduledSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Reactive.Signals.Signal
 ReactiveUI.Primitives.Reactive.Signals.SignalExtensions
@@ -494,6 +495,7 @@ static ReactiveUI.Primitives.Reactive.Signals.Signal.CreateSafe<T>(System.Func<S
 static ReactiveUI.Primitives.Reactive.Signals.Signal.CreateWithState<T, TState>(TState state, System.Func<TState, System.IObserver<T>!, System.IDisposable!>! subscribe) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.CreateWithState<T, TState>(TState state, System.Func<TState, System.IObserver<T>!, System.IDisposable!>! subscribe, bool isRequiredSubscribeOnCurrentThread) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Defer<T>(System.Func<System.IObservable<T>!>! observableFactory) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Delayable<T>(System.Func<bool>! isDelayed, System.Func<System.Collections.Generic.IList<T>!, System.Collections.Generic.IEnumerable<T>!>! flushDistinct) -> ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Emit(System.Reactive.Unit value) -> System.IObservable<System.Reactive.Unit>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Emit(bool value) -> System.IObservable<bool>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Emit(int value) -> System.IObservable<int>!
@@ -536,6 +538,8 @@ static ReactiveUI.Primitives.Reactive.Signals.Signal.Pulse(System.TimeSpan perio
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Pulse(System.TimeSpan period, System.Reactive.Concurrency.IScheduler! scheduler) -> System.IObservable<long>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Race<T>(params System.IObservable<T>![]! sources) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Recover<TSource>(params System.IObservable<TSource>![]! sources) -> System.IObservable<TSource>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Scheduled<T>(System.Reactive.Concurrency.IScheduler! scheduler) -> ReactiveUI.Primitives.Reactive.Signals.ScheduledSignal<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Scheduled<T>(System.Reactive.Concurrency.IScheduler! scheduler, System.IObserver<T>? defaultObserver) -> ReactiveUI.Primitives.Reactive.Signals.ScheduledSignal<T>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Sequence(int start, int count) -> System.IObservable<int>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Sequence(int start, int count, System.Reactive.Concurrency.IScheduler! scheduler) -> System.IObservable<int>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Silent<T>() -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net481/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net481/PublicAPI.Shipped.txt
@@ -268,6 +268,7 @@ ReactiveUI.Primitives.Reactive.Signals.ScheduledSignal<T>.OnError(System.Excepti
 ReactiveUI.Primitives.Reactive.Signals.ScheduledSignal<T>.OnNext(T value) -> void
 ReactiveUI.Primitives.Reactive.Signals.ScheduledSignal<T>.ScheduledSignal(System.Reactive.Concurrency.IScheduler! scheduler) -> void
 ReactiveUI.Primitives.Reactive.Signals.ScheduledSignal<T>.ScheduledSignal(System.Reactive.Concurrency.IScheduler! scheduler, System.IObserver<T>? defaultObserver) -> void
+ReactiveUI.Primitives.Reactive.Signals.ScheduledSignal<T>.ScheduledSignal(System.Reactive.Concurrency.IScheduler! scheduler, System.IObserver<T>? defaultObserver, ReactiveUI.Primitives.Signals.ISignal<T>? defaultSubject) -> void
 ReactiveUI.Primitives.Reactive.Signals.ScheduledSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Reactive.Signals.Signal
 ReactiveUI.Primitives.Reactive.Signals.SignalExtensions
@@ -494,6 +495,7 @@ static ReactiveUI.Primitives.Reactive.Signals.Signal.CreateSafe<T>(System.Func<S
 static ReactiveUI.Primitives.Reactive.Signals.Signal.CreateWithState<T, TState>(TState state, System.Func<TState, System.IObserver<T>!, System.IDisposable!>! subscribe) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.CreateWithState<T, TState>(TState state, System.Func<TState, System.IObserver<T>!, System.IDisposable!>! subscribe, bool isRequiredSubscribeOnCurrentThread) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Defer<T>(System.Func<System.IObservable<T>!>! observableFactory) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Delayable<T>(System.Func<bool>! isDelayed, System.Func<System.Collections.Generic.IList<T>!, System.Collections.Generic.IEnumerable<T>!>! flushDistinct) -> ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Emit(System.Reactive.Unit value) -> System.IObservable<System.Reactive.Unit>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Emit(bool value) -> System.IObservable<bool>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Emit(int value) -> System.IObservable<int>!
@@ -536,6 +538,8 @@ static ReactiveUI.Primitives.Reactive.Signals.Signal.Pulse(System.TimeSpan perio
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Pulse(System.TimeSpan period, System.Reactive.Concurrency.IScheduler! scheduler) -> System.IObservable<long>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Race<T>(params System.IObservable<T>![]! sources) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Recover<TSource>(params System.IObservable<TSource>![]! sources) -> System.IObservable<TSource>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Scheduled<T>(System.Reactive.Concurrency.IScheduler! scheduler) -> ReactiveUI.Primitives.Reactive.Signals.ScheduledSignal<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Scheduled<T>(System.Reactive.Concurrency.IScheduler! scheduler, System.IObserver<T>? defaultObserver) -> ReactiveUI.Primitives.Reactive.Signals.ScheduledSignal<T>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Sequence(int start, int count) -> System.IObservable<int>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Sequence(int start, int count, System.Reactive.Concurrency.IScheduler! scheduler) -> System.IObservable<int>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Silent<T>() -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -268,6 +268,7 @@ ReactiveUI.Primitives.Reactive.Signals.ScheduledSignal<T>.OnError(System.Excepti
 ReactiveUI.Primitives.Reactive.Signals.ScheduledSignal<T>.OnNext(T value) -> void
 ReactiveUI.Primitives.Reactive.Signals.ScheduledSignal<T>.ScheduledSignal(System.Reactive.Concurrency.IScheduler! scheduler) -> void
 ReactiveUI.Primitives.Reactive.Signals.ScheduledSignal<T>.ScheduledSignal(System.Reactive.Concurrency.IScheduler! scheduler, System.IObserver<T>? defaultObserver) -> void
+ReactiveUI.Primitives.Reactive.Signals.ScheduledSignal<T>.ScheduledSignal(System.Reactive.Concurrency.IScheduler! scheduler, System.IObserver<T>? defaultObserver, ReactiveUI.Primitives.Signals.ISignal<T>? defaultSubject) -> void
 ReactiveUI.Primitives.Reactive.Signals.ScheduledSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Reactive.Signals.Signal
 ReactiveUI.Primitives.Reactive.Signals.SignalExtensions
@@ -494,6 +495,7 @@ static ReactiveUI.Primitives.Reactive.Signals.Signal.CreateSafe<T>(System.Func<S
 static ReactiveUI.Primitives.Reactive.Signals.Signal.CreateWithState<T, TState>(TState state, System.Func<TState, System.IObserver<T>!, System.IDisposable!>! subscribe) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.CreateWithState<T, TState>(TState state, System.Func<TState, System.IObserver<T>!, System.IDisposable!>! subscribe, bool isRequiredSubscribeOnCurrentThread) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Defer<T>(System.Func<System.IObservable<T>!>! observableFactory) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Delayable<T>(System.Func<bool>! isDelayed, System.Func<System.Collections.Generic.IList<T>!, System.Collections.Generic.IEnumerable<T>!>! flushDistinct) -> ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Emit(System.Reactive.Unit value) -> System.IObservable<System.Reactive.Unit>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Emit(bool value) -> System.IObservable<bool>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Emit(int value) -> System.IObservable<int>!
@@ -538,6 +540,8 @@ static ReactiveUI.Primitives.Reactive.Signals.Signal.Pulse(System.TimeSpan perio
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Pulse(System.TimeSpan period, System.Reactive.Concurrency.IScheduler! scheduler) -> System.IObservable<long>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Race<T>(params System.IObservable<T>![]! sources) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Recover<TSource>(params System.IObservable<TSource>![]! sources) -> System.IObservable<TSource>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Scheduled<T>(System.Reactive.Concurrency.IScheduler! scheduler) -> ReactiveUI.Primitives.Reactive.Signals.ScheduledSignal<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Scheduled<T>(System.Reactive.Concurrency.IScheduler! scheduler, System.IObserver<T>? defaultObserver) -> ReactiveUI.Primitives.Reactive.Signals.ScheduledSignal<T>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Sequence(int start, int count) -> System.IObservable<int>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Sequence(int start, int count, System.Reactive.Concurrency.IScheduler! scheduler) -> System.IObservable<int>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Silent<T>() -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net9.0/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net9.0/PublicAPI.Shipped.txt
@@ -268,6 +268,7 @@ ReactiveUI.Primitives.Reactive.Signals.ScheduledSignal<T>.OnError(System.Excepti
 ReactiveUI.Primitives.Reactive.Signals.ScheduledSignal<T>.OnNext(T value) -> void
 ReactiveUI.Primitives.Reactive.Signals.ScheduledSignal<T>.ScheduledSignal(System.Reactive.Concurrency.IScheduler! scheduler) -> void
 ReactiveUI.Primitives.Reactive.Signals.ScheduledSignal<T>.ScheduledSignal(System.Reactive.Concurrency.IScheduler! scheduler, System.IObserver<T>? defaultObserver) -> void
+ReactiveUI.Primitives.Reactive.Signals.ScheduledSignal<T>.ScheduledSignal(System.Reactive.Concurrency.IScheduler! scheduler, System.IObserver<T>? defaultObserver, ReactiveUI.Primitives.Signals.ISignal<T>? defaultSubject) -> void
 ReactiveUI.Primitives.Reactive.Signals.ScheduledSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Reactive.Signals.Signal
 ReactiveUI.Primitives.Reactive.Signals.SignalExtensions
@@ -494,6 +495,7 @@ static ReactiveUI.Primitives.Reactive.Signals.Signal.CreateSafe<T>(System.Func<S
 static ReactiveUI.Primitives.Reactive.Signals.Signal.CreateWithState<T, TState>(TState state, System.Func<TState, System.IObserver<T>!, System.IDisposable!>! subscribe) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.CreateWithState<T, TState>(TState state, System.Func<TState, System.IObserver<T>!, System.IDisposable!>! subscribe, bool isRequiredSubscribeOnCurrentThread) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Defer<T>(System.Func<System.IObservable<T>!>! observableFactory) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Delayable<T>(System.Func<bool>! isDelayed, System.Func<System.Collections.Generic.IList<T>!, System.Collections.Generic.IEnumerable<T>!>! flushDistinct) -> ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Emit(System.Reactive.Unit value) -> System.IObservable<System.Reactive.Unit>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Emit(bool value) -> System.IObservable<bool>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Emit(int value) -> System.IObservable<int>!
@@ -538,6 +540,8 @@ static ReactiveUI.Primitives.Reactive.Signals.Signal.Pulse(System.TimeSpan perio
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Pulse(System.TimeSpan period, System.Reactive.Concurrency.IScheduler! scheduler) -> System.IObservable<long>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Race<T>(params System.IObservable<T>![]! sources) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Recover<TSource>(params System.IObservable<TSource>![]! sources) -> System.IObservable<TSource>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Scheduled<T>(System.Reactive.Concurrency.IScheduler! scheduler) -> ReactiveUI.Primitives.Reactive.Signals.ScheduledSignal<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Scheduled<T>(System.Reactive.Concurrency.IScheduler! scheduler, System.IObserver<T>? defaultObserver) -> ReactiveUI.Primitives.Reactive.Signals.ScheduledSignal<T>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Sequence(int start, int count) -> System.IObservable<int>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Sequence(int start, int count, System.Reactive.Concurrency.IScheduler! scheduler) -> System.IObservable<int>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Silent<T>() -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net10.0-android/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net10.0-android/PublicAPI.Shipped.txt
@@ -387,6 +387,7 @@ ReactiveUI.Primitives.Signals.ScheduledSignal<T>.OnError(System.Exception! error
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.OnNext(T value) -> void
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> void
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler, System.IObserver<T>? defaultObserver) -> void
+ReactiveUI.Primitives.Signals.ScheduledSignal<T>.ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler, System.IObserver<T>? defaultObserver, ReactiveUI.Primitives.Signals.ISignal<T>? defaultSubject) -> void
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Signals.Signal
 ReactiveUI.Primitives.Signals.SignalExtensions
@@ -653,6 +654,7 @@ static ReactiveUI.Primitives.Signals.Signal.CreateSafe<T>(System.Func<System.IOb
 static ReactiveUI.Primitives.Signals.Signal.CreateWithState<T, TState>(TState state, System.Func<TState, System.IObserver<T>!, System.IDisposable!>! subscribe) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Signals.Signal.CreateWithState<T, TState>(TState state, System.Func<TState, System.IObserver<T>!, System.IDisposable!>! subscribe, bool isRequiredSubscribeOnCurrentThread) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Signals.Signal.Defer<T>(System.Func<System.IObservable<T>!>! observableFactory) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Delayable<T>(System.Func<bool>! isDelayed, System.Func<System.Collections.Generic.IList<T>!, System.Collections.Generic.IEnumerable<T>!>! flushDistinct) -> ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>!
 static ReactiveUI.Primitives.Signals.Signal.Emit(ReactiveUI.Primitives.RxVoid value) -> System.IObservable<ReactiveUI.Primitives.RxVoid>!
 static ReactiveUI.Primitives.Signals.Signal.Emit(bool value) -> System.IObservable<bool>!
 static ReactiveUI.Primitives.Signals.Signal.Emit(int value) -> System.IObservable<int>!
@@ -697,6 +699,8 @@ static ReactiveUI.Primitives.Signals.Signal.Pulse(System.TimeSpan period) -> Sys
 static ReactiveUI.Primitives.Signals.Signal.Pulse(System.TimeSpan period, ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> System.IObservable<long>!
 static ReactiveUI.Primitives.Signals.Signal.Race<T>(params System.IObservable<T>![]! sources) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Signals.Signal.Recover<TSource>(params System.IObservable<TSource>![]! sources) -> System.IObservable<TSource>!
+static ReactiveUI.Primitives.Signals.Signal.Scheduled<T>(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> ReactiveUI.Primitives.Signals.ScheduledSignal<T>!
+static ReactiveUI.Primitives.Signals.Signal.Scheduled<T>(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler, System.IObserver<T>? defaultObserver) -> ReactiveUI.Primitives.Signals.ScheduledSignal<T>!
 static ReactiveUI.Primitives.Signals.Signal.Sequence(int start, int count) -> System.IObservable<int>!
 static ReactiveUI.Primitives.Signals.Signal.Sequence(int start, int count, ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> System.IObservable<int>!
 static ReactiveUI.Primitives.Signals.Signal.Silent<T>() -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net10.0-ios/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net10.0-ios/PublicAPI.Shipped.txt
@@ -383,6 +383,7 @@ ReactiveUI.Primitives.Signals.ScheduledSignal<T>.OnError(System.Exception! error
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.OnNext(T value) -> void
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> void
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler, System.IObserver<T>? defaultObserver) -> void
+ReactiveUI.Primitives.Signals.ScheduledSignal<T>.ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler, System.IObserver<T>? defaultObserver, ReactiveUI.Primitives.Signals.ISignal<T>? defaultSubject) -> void
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Signals.Signal
 ReactiveUI.Primitives.Signals.SignalExtensions
@@ -649,6 +650,7 @@ static ReactiveUI.Primitives.Signals.Signal.CreateSafe<T>(System.Func<System.IOb
 static ReactiveUI.Primitives.Signals.Signal.CreateWithState<T, TState>(TState state, System.Func<TState, System.IObserver<T>!, System.IDisposable!>! subscribe) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Signals.Signal.CreateWithState<T, TState>(TState state, System.Func<TState, System.IObserver<T>!, System.IDisposable!>! subscribe, bool isRequiredSubscribeOnCurrentThread) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Signals.Signal.Defer<T>(System.Func<System.IObservable<T>!>! observableFactory) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Delayable<T>(System.Func<bool>! isDelayed, System.Func<System.Collections.Generic.IList<T>!, System.Collections.Generic.IEnumerable<T>!>! flushDistinct) -> ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>!
 static ReactiveUI.Primitives.Signals.Signal.Emit(ReactiveUI.Primitives.RxVoid value) -> System.IObservable<ReactiveUI.Primitives.RxVoid>!
 static ReactiveUI.Primitives.Signals.Signal.Emit(bool value) -> System.IObservable<bool>!
 static ReactiveUI.Primitives.Signals.Signal.Emit(int value) -> System.IObservable<int>!
@@ -693,6 +695,8 @@ static ReactiveUI.Primitives.Signals.Signal.Pulse(System.TimeSpan period) -> Sys
 static ReactiveUI.Primitives.Signals.Signal.Pulse(System.TimeSpan period, ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> System.IObservable<long>!
 static ReactiveUI.Primitives.Signals.Signal.Race<T>(params System.IObservable<T>![]! sources) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Signals.Signal.Recover<TSource>(params System.IObservable<TSource>![]! sources) -> System.IObservable<TSource>!
+static ReactiveUI.Primitives.Signals.Signal.Scheduled<T>(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> ReactiveUI.Primitives.Signals.ScheduledSignal<T>!
+static ReactiveUI.Primitives.Signals.Signal.Scheduled<T>(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler, System.IObserver<T>? defaultObserver) -> ReactiveUI.Primitives.Signals.ScheduledSignal<T>!
 static ReactiveUI.Primitives.Signals.Signal.Sequence(int start, int count) -> System.IObservable<int>!
 static ReactiveUI.Primitives.Signals.Signal.Sequence(int start, int count, ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> System.IObservable<int>!
 static ReactiveUI.Primitives.Signals.Signal.Silent<T>() -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net10.0-maccatalyst/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net10.0-maccatalyst/PublicAPI.Shipped.txt
@@ -383,6 +383,7 @@ ReactiveUI.Primitives.Signals.ScheduledSignal<T>.OnError(System.Exception! error
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.OnNext(T value) -> void
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> void
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler, System.IObserver<T>? defaultObserver) -> void
+ReactiveUI.Primitives.Signals.ScheduledSignal<T>.ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler, System.IObserver<T>? defaultObserver, ReactiveUI.Primitives.Signals.ISignal<T>? defaultSubject) -> void
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Signals.Signal
 ReactiveUI.Primitives.Signals.SignalExtensions
@@ -649,6 +650,7 @@ static ReactiveUI.Primitives.Signals.Signal.CreateSafe<T>(System.Func<System.IOb
 static ReactiveUI.Primitives.Signals.Signal.CreateWithState<T, TState>(TState state, System.Func<TState, System.IObserver<T>!, System.IDisposable!>! subscribe) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Signals.Signal.CreateWithState<T, TState>(TState state, System.Func<TState, System.IObserver<T>!, System.IDisposable!>! subscribe, bool isRequiredSubscribeOnCurrentThread) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Signals.Signal.Defer<T>(System.Func<System.IObservable<T>!>! observableFactory) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Delayable<T>(System.Func<bool>! isDelayed, System.Func<System.Collections.Generic.IList<T>!, System.Collections.Generic.IEnumerable<T>!>! flushDistinct) -> ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>!
 static ReactiveUI.Primitives.Signals.Signal.Emit(ReactiveUI.Primitives.RxVoid value) -> System.IObservable<ReactiveUI.Primitives.RxVoid>!
 static ReactiveUI.Primitives.Signals.Signal.Emit(bool value) -> System.IObservable<bool>!
 static ReactiveUI.Primitives.Signals.Signal.Emit(int value) -> System.IObservable<int>!
@@ -693,6 +695,8 @@ static ReactiveUI.Primitives.Signals.Signal.Pulse(System.TimeSpan period) -> Sys
 static ReactiveUI.Primitives.Signals.Signal.Pulse(System.TimeSpan period, ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> System.IObservable<long>!
 static ReactiveUI.Primitives.Signals.Signal.Race<T>(params System.IObservable<T>![]! sources) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Signals.Signal.Recover<TSource>(params System.IObservable<TSource>![]! sources) -> System.IObservable<TSource>!
+static ReactiveUI.Primitives.Signals.Signal.Scheduled<T>(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> ReactiveUI.Primitives.Signals.ScheduledSignal<T>!
+static ReactiveUI.Primitives.Signals.Signal.Scheduled<T>(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler, System.IObserver<T>? defaultObserver) -> ReactiveUI.Primitives.Signals.ScheduledSignal<T>!
 static ReactiveUI.Primitives.Signals.Signal.Sequence(int start, int count) -> System.IObservable<int>!
 static ReactiveUI.Primitives.Signals.Signal.Sequence(int start, int count, ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> System.IObservable<int>!
 static ReactiveUI.Primitives.Signals.Signal.Silent<T>() -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net10.0-macos/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net10.0-macos/PublicAPI.Shipped.txt
@@ -383,6 +383,7 @@ ReactiveUI.Primitives.Signals.ScheduledSignal<T>.OnError(System.Exception! error
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.OnNext(T value) -> void
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> void
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler, System.IObserver<T>? defaultObserver) -> void
+ReactiveUI.Primitives.Signals.ScheduledSignal<T>.ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler, System.IObserver<T>? defaultObserver, ReactiveUI.Primitives.Signals.ISignal<T>? defaultSubject) -> void
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Signals.Signal
 ReactiveUI.Primitives.Signals.SignalExtensions
@@ -649,6 +650,7 @@ static ReactiveUI.Primitives.Signals.Signal.CreateSafe<T>(System.Func<System.IOb
 static ReactiveUI.Primitives.Signals.Signal.CreateWithState<T, TState>(TState state, System.Func<TState, System.IObserver<T>!, System.IDisposable!>! subscribe) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Signals.Signal.CreateWithState<T, TState>(TState state, System.Func<TState, System.IObserver<T>!, System.IDisposable!>! subscribe, bool isRequiredSubscribeOnCurrentThread) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Signals.Signal.Defer<T>(System.Func<System.IObservable<T>!>! observableFactory) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Delayable<T>(System.Func<bool>! isDelayed, System.Func<System.Collections.Generic.IList<T>!, System.Collections.Generic.IEnumerable<T>!>! flushDistinct) -> ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>!
 static ReactiveUI.Primitives.Signals.Signal.Emit(ReactiveUI.Primitives.RxVoid value) -> System.IObservable<ReactiveUI.Primitives.RxVoid>!
 static ReactiveUI.Primitives.Signals.Signal.Emit(bool value) -> System.IObservable<bool>!
 static ReactiveUI.Primitives.Signals.Signal.Emit(int value) -> System.IObservable<int>!
@@ -693,6 +695,8 @@ static ReactiveUI.Primitives.Signals.Signal.Pulse(System.TimeSpan period) -> Sys
 static ReactiveUI.Primitives.Signals.Signal.Pulse(System.TimeSpan period, ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> System.IObservable<long>!
 static ReactiveUI.Primitives.Signals.Signal.Race<T>(params System.IObservable<T>![]! sources) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Signals.Signal.Recover<TSource>(params System.IObservable<TSource>![]! sources) -> System.IObservable<TSource>!
+static ReactiveUI.Primitives.Signals.Signal.Scheduled<T>(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> ReactiveUI.Primitives.Signals.ScheduledSignal<T>!
+static ReactiveUI.Primitives.Signals.Signal.Scheduled<T>(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler, System.IObserver<T>? defaultObserver) -> ReactiveUI.Primitives.Signals.ScheduledSignal<T>!
 static ReactiveUI.Primitives.Signals.Signal.Sequence(int start, int count) -> System.IObservable<int>!
 static ReactiveUI.Primitives.Signals.Signal.Sequence(int start, int count, ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> System.IObservable<int>!
 static ReactiveUI.Primitives.Signals.Signal.Silent<T>() -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net10.0-tvos/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net10.0-tvos/PublicAPI.Shipped.txt
@@ -383,6 +383,7 @@ ReactiveUI.Primitives.Signals.ScheduledSignal<T>.OnError(System.Exception! error
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.OnNext(T value) -> void
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> void
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler, System.IObserver<T>? defaultObserver) -> void
+ReactiveUI.Primitives.Signals.ScheduledSignal<T>.ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler, System.IObserver<T>? defaultObserver, ReactiveUI.Primitives.Signals.ISignal<T>? defaultSubject) -> void
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Signals.Signal
 ReactiveUI.Primitives.Signals.SignalExtensions
@@ -649,6 +650,7 @@ static ReactiveUI.Primitives.Signals.Signal.CreateSafe<T>(System.Func<System.IOb
 static ReactiveUI.Primitives.Signals.Signal.CreateWithState<T, TState>(TState state, System.Func<TState, System.IObserver<T>!, System.IDisposable!>! subscribe) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Signals.Signal.CreateWithState<T, TState>(TState state, System.Func<TState, System.IObserver<T>!, System.IDisposable!>! subscribe, bool isRequiredSubscribeOnCurrentThread) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Signals.Signal.Defer<T>(System.Func<System.IObservable<T>!>! observableFactory) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Delayable<T>(System.Func<bool>! isDelayed, System.Func<System.Collections.Generic.IList<T>!, System.Collections.Generic.IEnumerable<T>!>! flushDistinct) -> ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>!
 static ReactiveUI.Primitives.Signals.Signal.Emit(ReactiveUI.Primitives.RxVoid value) -> System.IObservable<ReactiveUI.Primitives.RxVoid>!
 static ReactiveUI.Primitives.Signals.Signal.Emit(bool value) -> System.IObservable<bool>!
 static ReactiveUI.Primitives.Signals.Signal.Emit(int value) -> System.IObservable<int>!
@@ -693,6 +695,8 @@ static ReactiveUI.Primitives.Signals.Signal.Pulse(System.TimeSpan period) -> Sys
 static ReactiveUI.Primitives.Signals.Signal.Pulse(System.TimeSpan period, ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> System.IObservable<long>!
 static ReactiveUI.Primitives.Signals.Signal.Race<T>(params System.IObservable<T>![]! sources) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Signals.Signal.Recover<TSource>(params System.IObservable<TSource>![]! sources) -> System.IObservable<TSource>!
+static ReactiveUI.Primitives.Signals.Signal.Scheduled<T>(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> ReactiveUI.Primitives.Signals.ScheduledSignal<T>!
+static ReactiveUI.Primitives.Signals.Signal.Scheduled<T>(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler, System.IObserver<T>? defaultObserver) -> ReactiveUI.Primitives.Signals.ScheduledSignal<T>!
 static ReactiveUI.Primitives.Signals.Signal.Sequence(int start, int count) -> System.IObservable<int>!
 static ReactiveUI.Primitives.Signals.Signal.Sequence(int start, int count, ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> System.IObservable<int>!
 static ReactiveUI.Primitives.Signals.Signal.Silent<T>() -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net10.0/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net10.0/PublicAPI.Shipped.txt
@@ -378,6 +378,7 @@ ReactiveUI.Primitives.Signals.ScheduledSignal<T>.OnError(System.Exception! error
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.OnNext(T value) -> void
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> void
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler, System.IObserver<T>? defaultObserver) -> void
+ReactiveUI.Primitives.Signals.ScheduledSignal<T>.ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler, System.IObserver<T>? defaultObserver, ReactiveUI.Primitives.Signals.ISignal<T>? defaultSubject) -> void
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Signals.Signal
 ReactiveUI.Primitives.Signals.SignalExtensions
@@ -642,6 +643,7 @@ static ReactiveUI.Primitives.Signals.Signal.CreateSafe<T>(System.Func<System.IOb
 static ReactiveUI.Primitives.Signals.Signal.CreateWithState<T, TState>(TState state, System.Func<TState, System.IObserver<T>!, System.IDisposable!>! subscribe) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Signals.Signal.CreateWithState<T, TState>(TState state, System.Func<TState, System.IObserver<T>!, System.IDisposable!>! subscribe, bool isRequiredSubscribeOnCurrentThread) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Signals.Signal.Defer<T>(System.Func<System.IObservable<T>!>! observableFactory) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Delayable<T>(System.Func<bool>! isDelayed, System.Func<System.Collections.Generic.IList<T>!, System.Collections.Generic.IEnumerable<T>!>! flushDistinct) -> ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>!
 static ReactiveUI.Primitives.Signals.Signal.Emit(ReactiveUI.Primitives.RxVoid value) -> System.IObservable<ReactiveUI.Primitives.RxVoid>!
 static ReactiveUI.Primitives.Signals.Signal.Emit(bool value) -> System.IObservable<bool>!
 static ReactiveUI.Primitives.Signals.Signal.Emit(int value) -> System.IObservable<int>!
@@ -686,6 +688,8 @@ static ReactiveUI.Primitives.Signals.Signal.Pulse(System.TimeSpan period) -> Sys
 static ReactiveUI.Primitives.Signals.Signal.Pulse(System.TimeSpan period, ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> System.IObservable<long>!
 static ReactiveUI.Primitives.Signals.Signal.Race<T>(params System.IObservable<T>![]! sources) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Signals.Signal.Recover<TSource>(params System.IObservable<TSource>![]! sources) -> System.IObservable<TSource>!
+static ReactiveUI.Primitives.Signals.Signal.Scheduled<T>(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> ReactiveUI.Primitives.Signals.ScheduledSignal<T>!
+static ReactiveUI.Primitives.Signals.Signal.Scheduled<T>(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler, System.IObserver<T>? defaultObserver) -> ReactiveUI.Primitives.Signals.ScheduledSignal<T>!
 static ReactiveUI.Primitives.Signals.Signal.Sequence(int start, int count) -> System.IObservable<int>!
 static ReactiveUI.Primitives.Signals.Signal.Sequence(int start, int count, ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> System.IObservable<int>!
 static ReactiveUI.Primitives.Signals.Signal.Silent<T>() -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net11.0-android/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net11.0-android/PublicAPI.Shipped.txt
@@ -387,6 +387,7 @@ ReactiveUI.Primitives.Signals.ScheduledSignal<T>.OnError(System.Exception! error
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.OnNext(T value) -> void
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> void
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler, System.IObserver<T>? defaultObserver) -> void
+ReactiveUI.Primitives.Signals.ScheduledSignal<T>.ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler, System.IObserver<T>? defaultObserver, ReactiveUI.Primitives.Signals.ISignal<T>? defaultSubject) -> void
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Signals.Signal
 ReactiveUI.Primitives.Signals.SignalExtensions
@@ -653,6 +654,7 @@ static ReactiveUI.Primitives.Signals.Signal.CreateSafe<T>(System.Func<System.IOb
 static ReactiveUI.Primitives.Signals.Signal.CreateWithState<T, TState>(TState state, System.Func<TState, System.IObserver<T>!, System.IDisposable!>! subscribe) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Signals.Signal.CreateWithState<T, TState>(TState state, System.Func<TState, System.IObserver<T>!, System.IDisposable!>! subscribe, bool isRequiredSubscribeOnCurrentThread) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Signals.Signal.Defer<T>(System.Func<System.IObservable<T>!>! observableFactory) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Delayable<T>(System.Func<bool>! isDelayed, System.Func<System.Collections.Generic.IList<T>!, System.Collections.Generic.IEnumerable<T>!>! flushDistinct) -> ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>!
 static ReactiveUI.Primitives.Signals.Signal.Emit(ReactiveUI.Primitives.RxVoid value) -> System.IObservable<ReactiveUI.Primitives.RxVoid>!
 static ReactiveUI.Primitives.Signals.Signal.Emit(bool value) -> System.IObservable<bool>!
 static ReactiveUI.Primitives.Signals.Signal.Emit(int value) -> System.IObservable<int>!
@@ -697,6 +699,8 @@ static ReactiveUI.Primitives.Signals.Signal.Pulse(System.TimeSpan period) -> Sys
 static ReactiveUI.Primitives.Signals.Signal.Pulse(System.TimeSpan period, ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> System.IObservable<long>!
 static ReactiveUI.Primitives.Signals.Signal.Race<T>(params System.IObservable<T>![]! sources) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Signals.Signal.Recover<TSource>(params System.IObservable<TSource>![]! sources) -> System.IObservable<TSource>!
+static ReactiveUI.Primitives.Signals.Signal.Scheduled<T>(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> ReactiveUI.Primitives.Signals.ScheduledSignal<T>!
+static ReactiveUI.Primitives.Signals.Signal.Scheduled<T>(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler, System.IObserver<T>? defaultObserver) -> ReactiveUI.Primitives.Signals.ScheduledSignal<T>!
 static ReactiveUI.Primitives.Signals.Signal.Sequence(int start, int count) -> System.IObservable<int>!
 static ReactiveUI.Primitives.Signals.Signal.Sequence(int start, int count, ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> System.IObservable<int>!
 static ReactiveUI.Primitives.Signals.Signal.Silent<T>() -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net11.0-ios/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net11.0-ios/PublicAPI.Shipped.txt
@@ -383,6 +383,7 @@ ReactiveUI.Primitives.Signals.ScheduledSignal<T>.OnError(System.Exception! error
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.OnNext(T value) -> void
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> void
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler, System.IObserver<T>? defaultObserver) -> void
+ReactiveUI.Primitives.Signals.ScheduledSignal<T>.ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler, System.IObserver<T>? defaultObserver, ReactiveUI.Primitives.Signals.ISignal<T>? defaultSubject) -> void
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Signals.Signal
 ReactiveUI.Primitives.Signals.SignalExtensions
@@ -649,6 +650,7 @@ static ReactiveUI.Primitives.Signals.Signal.CreateSafe<T>(System.Func<System.IOb
 static ReactiveUI.Primitives.Signals.Signal.CreateWithState<T, TState>(TState state, System.Func<TState, System.IObserver<T>!, System.IDisposable!>! subscribe) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Signals.Signal.CreateWithState<T, TState>(TState state, System.Func<TState, System.IObserver<T>!, System.IDisposable!>! subscribe, bool isRequiredSubscribeOnCurrentThread) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Signals.Signal.Defer<T>(System.Func<System.IObservable<T>!>! observableFactory) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Delayable<T>(System.Func<bool>! isDelayed, System.Func<System.Collections.Generic.IList<T>!, System.Collections.Generic.IEnumerable<T>!>! flushDistinct) -> ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>!
 static ReactiveUI.Primitives.Signals.Signal.Emit(ReactiveUI.Primitives.RxVoid value) -> System.IObservable<ReactiveUI.Primitives.RxVoid>!
 static ReactiveUI.Primitives.Signals.Signal.Emit(bool value) -> System.IObservable<bool>!
 static ReactiveUI.Primitives.Signals.Signal.Emit(int value) -> System.IObservable<int>!
@@ -693,6 +695,8 @@ static ReactiveUI.Primitives.Signals.Signal.Pulse(System.TimeSpan period) -> Sys
 static ReactiveUI.Primitives.Signals.Signal.Pulse(System.TimeSpan period, ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> System.IObservable<long>!
 static ReactiveUI.Primitives.Signals.Signal.Race<T>(params System.IObservable<T>![]! sources) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Signals.Signal.Recover<TSource>(params System.IObservable<TSource>![]! sources) -> System.IObservable<TSource>!
+static ReactiveUI.Primitives.Signals.Signal.Scheduled<T>(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> ReactiveUI.Primitives.Signals.ScheduledSignal<T>!
+static ReactiveUI.Primitives.Signals.Signal.Scheduled<T>(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler, System.IObserver<T>? defaultObserver) -> ReactiveUI.Primitives.Signals.ScheduledSignal<T>!
 static ReactiveUI.Primitives.Signals.Signal.Sequence(int start, int count) -> System.IObservable<int>!
 static ReactiveUI.Primitives.Signals.Signal.Sequence(int start, int count, ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> System.IObservable<int>!
 static ReactiveUI.Primitives.Signals.Signal.Silent<T>() -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net11.0-maccatalyst/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net11.0-maccatalyst/PublicAPI.Shipped.txt
@@ -383,6 +383,7 @@ ReactiveUI.Primitives.Signals.ScheduledSignal<T>.OnError(System.Exception! error
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.OnNext(T value) -> void
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> void
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler, System.IObserver<T>? defaultObserver) -> void
+ReactiveUI.Primitives.Signals.ScheduledSignal<T>.ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler, System.IObserver<T>? defaultObserver, ReactiveUI.Primitives.Signals.ISignal<T>? defaultSubject) -> void
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Signals.Signal
 ReactiveUI.Primitives.Signals.SignalExtensions
@@ -649,6 +650,7 @@ static ReactiveUI.Primitives.Signals.Signal.CreateSafe<T>(System.Func<System.IOb
 static ReactiveUI.Primitives.Signals.Signal.CreateWithState<T, TState>(TState state, System.Func<TState, System.IObserver<T>!, System.IDisposable!>! subscribe) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Signals.Signal.CreateWithState<T, TState>(TState state, System.Func<TState, System.IObserver<T>!, System.IDisposable!>! subscribe, bool isRequiredSubscribeOnCurrentThread) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Signals.Signal.Defer<T>(System.Func<System.IObservable<T>!>! observableFactory) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Delayable<T>(System.Func<bool>! isDelayed, System.Func<System.Collections.Generic.IList<T>!, System.Collections.Generic.IEnumerable<T>!>! flushDistinct) -> ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>!
 static ReactiveUI.Primitives.Signals.Signal.Emit(ReactiveUI.Primitives.RxVoid value) -> System.IObservable<ReactiveUI.Primitives.RxVoid>!
 static ReactiveUI.Primitives.Signals.Signal.Emit(bool value) -> System.IObservable<bool>!
 static ReactiveUI.Primitives.Signals.Signal.Emit(int value) -> System.IObservable<int>!
@@ -693,6 +695,8 @@ static ReactiveUI.Primitives.Signals.Signal.Pulse(System.TimeSpan period) -> Sys
 static ReactiveUI.Primitives.Signals.Signal.Pulse(System.TimeSpan period, ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> System.IObservable<long>!
 static ReactiveUI.Primitives.Signals.Signal.Race<T>(params System.IObservable<T>![]! sources) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Signals.Signal.Recover<TSource>(params System.IObservable<TSource>![]! sources) -> System.IObservable<TSource>!
+static ReactiveUI.Primitives.Signals.Signal.Scheduled<T>(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> ReactiveUI.Primitives.Signals.ScheduledSignal<T>!
+static ReactiveUI.Primitives.Signals.Signal.Scheduled<T>(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler, System.IObserver<T>? defaultObserver) -> ReactiveUI.Primitives.Signals.ScheduledSignal<T>!
 static ReactiveUI.Primitives.Signals.Signal.Sequence(int start, int count) -> System.IObservable<int>!
 static ReactiveUI.Primitives.Signals.Signal.Sequence(int start, int count, ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> System.IObservable<int>!
 static ReactiveUI.Primitives.Signals.Signal.Silent<T>() -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net11.0-macos/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net11.0-macos/PublicAPI.Shipped.txt
@@ -383,6 +383,7 @@ ReactiveUI.Primitives.Signals.ScheduledSignal<T>.OnError(System.Exception! error
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.OnNext(T value) -> void
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> void
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler, System.IObserver<T>? defaultObserver) -> void
+ReactiveUI.Primitives.Signals.ScheduledSignal<T>.ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler, System.IObserver<T>? defaultObserver, ReactiveUI.Primitives.Signals.ISignal<T>? defaultSubject) -> void
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Signals.Signal
 ReactiveUI.Primitives.Signals.SignalExtensions
@@ -649,6 +650,7 @@ static ReactiveUI.Primitives.Signals.Signal.CreateSafe<T>(System.Func<System.IOb
 static ReactiveUI.Primitives.Signals.Signal.CreateWithState<T, TState>(TState state, System.Func<TState, System.IObserver<T>!, System.IDisposable!>! subscribe) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Signals.Signal.CreateWithState<T, TState>(TState state, System.Func<TState, System.IObserver<T>!, System.IDisposable!>! subscribe, bool isRequiredSubscribeOnCurrentThread) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Signals.Signal.Defer<T>(System.Func<System.IObservable<T>!>! observableFactory) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Delayable<T>(System.Func<bool>! isDelayed, System.Func<System.Collections.Generic.IList<T>!, System.Collections.Generic.IEnumerable<T>!>! flushDistinct) -> ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>!
 static ReactiveUI.Primitives.Signals.Signal.Emit(ReactiveUI.Primitives.RxVoid value) -> System.IObservable<ReactiveUI.Primitives.RxVoid>!
 static ReactiveUI.Primitives.Signals.Signal.Emit(bool value) -> System.IObservable<bool>!
 static ReactiveUI.Primitives.Signals.Signal.Emit(int value) -> System.IObservable<int>!
@@ -693,6 +695,8 @@ static ReactiveUI.Primitives.Signals.Signal.Pulse(System.TimeSpan period) -> Sys
 static ReactiveUI.Primitives.Signals.Signal.Pulse(System.TimeSpan period, ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> System.IObservable<long>!
 static ReactiveUI.Primitives.Signals.Signal.Race<T>(params System.IObservable<T>![]! sources) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Signals.Signal.Recover<TSource>(params System.IObservable<TSource>![]! sources) -> System.IObservable<TSource>!
+static ReactiveUI.Primitives.Signals.Signal.Scheduled<T>(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> ReactiveUI.Primitives.Signals.ScheduledSignal<T>!
+static ReactiveUI.Primitives.Signals.Signal.Scheduled<T>(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler, System.IObserver<T>? defaultObserver) -> ReactiveUI.Primitives.Signals.ScheduledSignal<T>!
 static ReactiveUI.Primitives.Signals.Signal.Sequence(int start, int count) -> System.IObservable<int>!
 static ReactiveUI.Primitives.Signals.Signal.Sequence(int start, int count, ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> System.IObservable<int>!
 static ReactiveUI.Primitives.Signals.Signal.Silent<T>() -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net11.0-tvos/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net11.0-tvos/PublicAPI.Shipped.txt
@@ -383,6 +383,7 @@ ReactiveUI.Primitives.Signals.ScheduledSignal<T>.OnError(System.Exception! error
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.OnNext(T value) -> void
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> void
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler, System.IObserver<T>? defaultObserver) -> void
+ReactiveUI.Primitives.Signals.ScheduledSignal<T>.ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler, System.IObserver<T>? defaultObserver, ReactiveUI.Primitives.Signals.ISignal<T>? defaultSubject) -> void
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Signals.Signal
 ReactiveUI.Primitives.Signals.SignalExtensions
@@ -649,6 +650,7 @@ static ReactiveUI.Primitives.Signals.Signal.CreateSafe<T>(System.Func<System.IOb
 static ReactiveUI.Primitives.Signals.Signal.CreateWithState<T, TState>(TState state, System.Func<TState, System.IObserver<T>!, System.IDisposable!>! subscribe) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Signals.Signal.CreateWithState<T, TState>(TState state, System.Func<TState, System.IObserver<T>!, System.IDisposable!>! subscribe, bool isRequiredSubscribeOnCurrentThread) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Signals.Signal.Defer<T>(System.Func<System.IObservable<T>!>! observableFactory) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Delayable<T>(System.Func<bool>! isDelayed, System.Func<System.Collections.Generic.IList<T>!, System.Collections.Generic.IEnumerable<T>!>! flushDistinct) -> ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>!
 static ReactiveUI.Primitives.Signals.Signal.Emit(ReactiveUI.Primitives.RxVoid value) -> System.IObservable<ReactiveUI.Primitives.RxVoid>!
 static ReactiveUI.Primitives.Signals.Signal.Emit(bool value) -> System.IObservable<bool>!
 static ReactiveUI.Primitives.Signals.Signal.Emit(int value) -> System.IObservable<int>!
@@ -693,6 +695,8 @@ static ReactiveUI.Primitives.Signals.Signal.Pulse(System.TimeSpan period) -> Sys
 static ReactiveUI.Primitives.Signals.Signal.Pulse(System.TimeSpan period, ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> System.IObservable<long>!
 static ReactiveUI.Primitives.Signals.Signal.Race<T>(params System.IObservable<T>![]! sources) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Signals.Signal.Recover<TSource>(params System.IObservable<TSource>![]! sources) -> System.IObservable<TSource>!
+static ReactiveUI.Primitives.Signals.Signal.Scheduled<T>(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> ReactiveUI.Primitives.Signals.ScheduledSignal<T>!
+static ReactiveUI.Primitives.Signals.Signal.Scheduled<T>(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler, System.IObserver<T>? defaultObserver) -> ReactiveUI.Primitives.Signals.ScheduledSignal<T>!
 static ReactiveUI.Primitives.Signals.Signal.Sequence(int start, int count) -> System.IObservable<int>!
 static ReactiveUI.Primitives.Signals.Signal.Sequence(int start, int count, ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> System.IObservable<int>!
 static ReactiveUI.Primitives.Signals.Signal.Silent<T>() -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net11.0/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net11.0/PublicAPI.Shipped.txt
@@ -378,6 +378,7 @@ ReactiveUI.Primitives.Signals.ScheduledSignal<T>.OnError(System.Exception! error
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.OnNext(T value) -> void
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> void
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler, System.IObserver<T>? defaultObserver) -> void
+ReactiveUI.Primitives.Signals.ScheduledSignal<T>.ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler, System.IObserver<T>? defaultObserver, ReactiveUI.Primitives.Signals.ISignal<T>? defaultSubject) -> void
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Signals.Signal
 ReactiveUI.Primitives.Signals.SignalExtensions
@@ -642,6 +643,7 @@ static ReactiveUI.Primitives.Signals.Signal.CreateSafe<T>(System.Func<System.IOb
 static ReactiveUI.Primitives.Signals.Signal.CreateWithState<T, TState>(TState state, System.Func<TState, System.IObserver<T>!, System.IDisposable!>! subscribe) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Signals.Signal.CreateWithState<T, TState>(TState state, System.Func<TState, System.IObserver<T>!, System.IDisposable!>! subscribe, bool isRequiredSubscribeOnCurrentThread) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Signals.Signal.Defer<T>(System.Func<System.IObservable<T>!>! observableFactory) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Delayable<T>(System.Func<bool>! isDelayed, System.Func<System.Collections.Generic.IList<T>!, System.Collections.Generic.IEnumerable<T>!>! flushDistinct) -> ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>!
 static ReactiveUI.Primitives.Signals.Signal.Emit(ReactiveUI.Primitives.RxVoid value) -> System.IObservable<ReactiveUI.Primitives.RxVoid>!
 static ReactiveUI.Primitives.Signals.Signal.Emit(bool value) -> System.IObservable<bool>!
 static ReactiveUI.Primitives.Signals.Signal.Emit(int value) -> System.IObservable<int>!
@@ -686,6 +688,8 @@ static ReactiveUI.Primitives.Signals.Signal.Pulse(System.TimeSpan period) -> Sys
 static ReactiveUI.Primitives.Signals.Signal.Pulse(System.TimeSpan period, ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> System.IObservable<long>!
 static ReactiveUI.Primitives.Signals.Signal.Race<T>(params System.IObservable<T>![]! sources) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Signals.Signal.Recover<TSource>(params System.IObservable<TSource>![]! sources) -> System.IObservable<TSource>!
+static ReactiveUI.Primitives.Signals.Signal.Scheduled<T>(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> ReactiveUI.Primitives.Signals.ScheduledSignal<T>!
+static ReactiveUI.Primitives.Signals.Signal.Scheduled<T>(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler, System.IObserver<T>? defaultObserver) -> ReactiveUI.Primitives.Signals.ScheduledSignal<T>!
 static ReactiveUI.Primitives.Signals.Signal.Sequence(int start, int count) -> System.IObservable<int>!
 static ReactiveUI.Primitives.Signals.Signal.Sequence(int start, int count, ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> System.IObservable<int>!
 static ReactiveUI.Primitives.Signals.Signal.Silent<T>() -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net462/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net462/PublicAPI.Shipped.txt
@@ -378,6 +378,7 @@ ReactiveUI.Primitives.Signals.ScheduledSignal<T>.OnError(System.Exception! error
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.OnNext(T value) -> void
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> void
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler, System.IObserver<T>? defaultObserver) -> void
+ReactiveUI.Primitives.Signals.ScheduledSignal<T>.ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler, System.IObserver<T>? defaultObserver, ReactiveUI.Primitives.Signals.ISignal<T>? defaultSubject) -> void
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Signals.Signal
 ReactiveUI.Primitives.Signals.SignalExtensions
@@ -642,6 +643,7 @@ static ReactiveUI.Primitives.Signals.Signal.CreateSafe<T>(System.Func<System.IOb
 static ReactiveUI.Primitives.Signals.Signal.CreateWithState<T, TState>(TState state, System.Func<TState, System.IObserver<T>!, System.IDisposable!>! subscribe) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Signals.Signal.CreateWithState<T, TState>(TState state, System.Func<TState, System.IObserver<T>!, System.IDisposable!>! subscribe, bool isRequiredSubscribeOnCurrentThread) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Signals.Signal.Defer<T>(System.Func<System.IObservable<T>!>! observableFactory) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Delayable<T>(System.Func<bool>! isDelayed, System.Func<System.Collections.Generic.IList<T>!, System.Collections.Generic.IEnumerable<T>!>! flushDistinct) -> ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>!
 static ReactiveUI.Primitives.Signals.Signal.Emit(ReactiveUI.Primitives.RxVoid value) -> System.IObservable<ReactiveUI.Primitives.RxVoid>!
 static ReactiveUI.Primitives.Signals.Signal.Emit(bool value) -> System.IObservable<bool>!
 static ReactiveUI.Primitives.Signals.Signal.Emit(int value) -> System.IObservable<int>!
@@ -684,6 +686,8 @@ static ReactiveUI.Primitives.Signals.Signal.Pulse(System.TimeSpan period) -> Sys
 static ReactiveUI.Primitives.Signals.Signal.Pulse(System.TimeSpan period, ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> System.IObservable<long>!
 static ReactiveUI.Primitives.Signals.Signal.Race<T>(params System.IObservable<T>![]! sources) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Signals.Signal.Recover<TSource>(params System.IObservable<TSource>![]! sources) -> System.IObservable<TSource>!
+static ReactiveUI.Primitives.Signals.Signal.Scheduled<T>(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> ReactiveUI.Primitives.Signals.ScheduledSignal<T>!
+static ReactiveUI.Primitives.Signals.Signal.Scheduled<T>(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler, System.IObserver<T>? defaultObserver) -> ReactiveUI.Primitives.Signals.ScheduledSignal<T>!
 static ReactiveUI.Primitives.Signals.Signal.Sequence(int start, int count) -> System.IObservable<int>!
 static ReactiveUI.Primitives.Signals.Signal.Sequence(int start, int count, ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> System.IObservable<int>!
 static ReactiveUI.Primitives.Signals.Signal.Silent<T>() -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -378,6 +378,7 @@ ReactiveUI.Primitives.Signals.ScheduledSignal<T>.OnError(System.Exception! error
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.OnNext(T value) -> void
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> void
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler, System.IObserver<T>? defaultObserver) -> void
+ReactiveUI.Primitives.Signals.ScheduledSignal<T>.ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler, System.IObserver<T>? defaultObserver, ReactiveUI.Primitives.Signals.ISignal<T>? defaultSubject) -> void
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Signals.Signal
 ReactiveUI.Primitives.Signals.SignalExtensions
@@ -642,6 +643,7 @@ static ReactiveUI.Primitives.Signals.Signal.CreateSafe<T>(System.Func<System.IOb
 static ReactiveUI.Primitives.Signals.Signal.CreateWithState<T, TState>(TState state, System.Func<TState, System.IObserver<T>!, System.IDisposable!>! subscribe) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Signals.Signal.CreateWithState<T, TState>(TState state, System.Func<TState, System.IObserver<T>!, System.IDisposable!>! subscribe, bool isRequiredSubscribeOnCurrentThread) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Signals.Signal.Defer<T>(System.Func<System.IObservable<T>!>! observableFactory) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Delayable<T>(System.Func<bool>! isDelayed, System.Func<System.Collections.Generic.IList<T>!, System.Collections.Generic.IEnumerable<T>!>! flushDistinct) -> ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>!
 static ReactiveUI.Primitives.Signals.Signal.Emit(ReactiveUI.Primitives.RxVoid value) -> System.IObservable<ReactiveUI.Primitives.RxVoid>!
 static ReactiveUI.Primitives.Signals.Signal.Emit(bool value) -> System.IObservable<bool>!
 static ReactiveUI.Primitives.Signals.Signal.Emit(int value) -> System.IObservable<int>!
@@ -684,6 +686,8 @@ static ReactiveUI.Primitives.Signals.Signal.Pulse(System.TimeSpan period) -> Sys
 static ReactiveUI.Primitives.Signals.Signal.Pulse(System.TimeSpan period, ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> System.IObservable<long>!
 static ReactiveUI.Primitives.Signals.Signal.Race<T>(params System.IObservable<T>![]! sources) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Signals.Signal.Recover<TSource>(params System.IObservable<TSource>![]! sources) -> System.IObservable<TSource>!
+static ReactiveUI.Primitives.Signals.Signal.Scheduled<T>(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> ReactiveUI.Primitives.Signals.ScheduledSignal<T>!
+static ReactiveUI.Primitives.Signals.Signal.Scheduled<T>(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler, System.IObserver<T>? defaultObserver) -> ReactiveUI.Primitives.Signals.ScheduledSignal<T>!
 static ReactiveUI.Primitives.Signals.Signal.Sequence(int start, int count) -> System.IObservable<int>!
 static ReactiveUI.Primitives.Signals.Signal.Sequence(int start, int count, ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> System.IObservable<int>!
 static ReactiveUI.Primitives.Signals.Signal.Silent<T>() -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net48/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net48/PublicAPI.Shipped.txt
@@ -378,6 +378,7 @@ ReactiveUI.Primitives.Signals.ScheduledSignal<T>.OnError(System.Exception! error
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.OnNext(T value) -> void
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> void
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler, System.IObserver<T>? defaultObserver) -> void
+ReactiveUI.Primitives.Signals.ScheduledSignal<T>.ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler, System.IObserver<T>? defaultObserver, ReactiveUI.Primitives.Signals.ISignal<T>? defaultSubject) -> void
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Signals.Signal
 ReactiveUI.Primitives.Signals.SignalExtensions
@@ -642,6 +643,7 @@ static ReactiveUI.Primitives.Signals.Signal.CreateSafe<T>(System.Func<System.IOb
 static ReactiveUI.Primitives.Signals.Signal.CreateWithState<T, TState>(TState state, System.Func<TState, System.IObserver<T>!, System.IDisposable!>! subscribe) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Signals.Signal.CreateWithState<T, TState>(TState state, System.Func<TState, System.IObserver<T>!, System.IDisposable!>! subscribe, bool isRequiredSubscribeOnCurrentThread) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Signals.Signal.Defer<T>(System.Func<System.IObservable<T>!>! observableFactory) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Delayable<T>(System.Func<bool>! isDelayed, System.Func<System.Collections.Generic.IList<T>!, System.Collections.Generic.IEnumerable<T>!>! flushDistinct) -> ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>!
 static ReactiveUI.Primitives.Signals.Signal.Emit(ReactiveUI.Primitives.RxVoid value) -> System.IObservable<ReactiveUI.Primitives.RxVoid>!
 static ReactiveUI.Primitives.Signals.Signal.Emit(bool value) -> System.IObservable<bool>!
 static ReactiveUI.Primitives.Signals.Signal.Emit(int value) -> System.IObservable<int>!
@@ -684,6 +686,8 @@ static ReactiveUI.Primitives.Signals.Signal.Pulse(System.TimeSpan period) -> Sys
 static ReactiveUI.Primitives.Signals.Signal.Pulse(System.TimeSpan period, ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> System.IObservable<long>!
 static ReactiveUI.Primitives.Signals.Signal.Race<T>(params System.IObservable<T>![]! sources) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Signals.Signal.Recover<TSource>(params System.IObservable<TSource>![]! sources) -> System.IObservable<TSource>!
+static ReactiveUI.Primitives.Signals.Signal.Scheduled<T>(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> ReactiveUI.Primitives.Signals.ScheduledSignal<T>!
+static ReactiveUI.Primitives.Signals.Signal.Scheduled<T>(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler, System.IObserver<T>? defaultObserver) -> ReactiveUI.Primitives.Signals.ScheduledSignal<T>!
 static ReactiveUI.Primitives.Signals.Signal.Sequence(int start, int count) -> System.IObservable<int>!
 static ReactiveUI.Primitives.Signals.Signal.Sequence(int start, int count, ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> System.IObservable<int>!
 static ReactiveUI.Primitives.Signals.Signal.Silent<T>() -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net481/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net481/PublicAPI.Shipped.txt
@@ -378,6 +378,7 @@ ReactiveUI.Primitives.Signals.ScheduledSignal<T>.OnError(System.Exception! error
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.OnNext(T value) -> void
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> void
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler, System.IObserver<T>? defaultObserver) -> void
+ReactiveUI.Primitives.Signals.ScheduledSignal<T>.ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler, System.IObserver<T>? defaultObserver, ReactiveUI.Primitives.Signals.ISignal<T>? defaultSubject) -> void
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Signals.Signal
 ReactiveUI.Primitives.Signals.SignalExtensions
@@ -642,6 +643,7 @@ static ReactiveUI.Primitives.Signals.Signal.CreateSafe<T>(System.Func<System.IOb
 static ReactiveUI.Primitives.Signals.Signal.CreateWithState<T, TState>(TState state, System.Func<TState, System.IObserver<T>!, System.IDisposable!>! subscribe) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Signals.Signal.CreateWithState<T, TState>(TState state, System.Func<TState, System.IObserver<T>!, System.IDisposable!>! subscribe, bool isRequiredSubscribeOnCurrentThread) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Signals.Signal.Defer<T>(System.Func<System.IObservable<T>!>! observableFactory) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Delayable<T>(System.Func<bool>! isDelayed, System.Func<System.Collections.Generic.IList<T>!, System.Collections.Generic.IEnumerable<T>!>! flushDistinct) -> ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>!
 static ReactiveUI.Primitives.Signals.Signal.Emit(ReactiveUI.Primitives.RxVoid value) -> System.IObservable<ReactiveUI.Primitives.RxVoid>!
 static ReactiveUI.Primitives.Signals.Signal.Emit(bool value) -> System.IObservable<bool>!
 static ReactiveUI.Primitives.Signals.Signal.Emit(int value) -> System.IObservable<int>!
@@ -684,6 +686,8 @@ static ReactiveUI.Primitives.Signals.Signal.Pulse(System.TimeSpan period) -> Sys
 static ReactiveUI.Primitives.Signals.Signal.Pulse(System.TimeSpan period, ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> System.IObservable<long>!
 static ReactiveUI.Primitives.Signals.Signal.Race<T>(params System.IObservable<T>![]! sources) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Signals.Signal.Recover<TSource>(params System.IObservable<TSource>![]! sources) -> System.IObservable<TSource>!
+static ReactiveUI.Primitives.Signals.Signal.Scheduled<T>(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> ReactiveUI.Primitives.Signals.ScheduledSignal<T>!
+static ReactiveUI.Primitives.Signals.Signal.Scheduled<T>(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler, System.IObserver<T>? defaultObserver) -> ReactiveUI.Primitives.Signals.ScheduledSignal<T>!
 static ReactiveUI.Primitives.Signals.Signal.Sequence(int start, int count) -> System.IObservable<int>!
 static ReactiveUI.Primitives.Signals.Signal.Sequence(int start, int count, ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> System.IObservable<int>!
 static ReactiveUI.Primitives.Signals.Signal.Silent<T>() -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -378,6 +378,7 @@ ReactiveUI.Primitives.Signals.ScheduledSignal<T>.OnError(System.Exception! error
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.OnNext(T value) -> void
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> void
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler, System.IObserver<T>? defaultObserver) -> void
+ReactiveUI.Primitives.Signals.ScheduledSignal<T>.ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler, System.IObserver<T>? defaultObserver, ReactiveUI.Primitives.Signals.ISignal<T>? defaultSubject) -> void
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Signals.Signal
 ReactiveUI.Primitives.Signals.SignalExtensions
@@ -642,6 +643,7 @@ static ReactiveUI.Primitives.Signals.Signal.CreateSafe<T>(System.Func<System.IOb
 static ReactiveUI.Primitives.Signals.Signal.CreateWithState<T, TState>(TState state, System.Func<TState, System.IObserver<T>!, System.IDisposable!>! subscribe) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Signals.Signal.CreateWithState<T, TState>(TState state, System.Func<TState, System.IObserver<T>!, System.IDisposable!>! subscribe, bool isRequiredSubscribeOnCurrentThread) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Signals.Signal.Defer<T>(System.Func<System.IObservable<T>!>! observableFactory) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Delayable<T>(System.Func<bool>! isDelayed, System.Func<System.Collections.Generic.IList<T>!, System.Collections.Generic.IEnumerable<T>!>! flushDistinct) -> ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>!
 static ReactiveUI.Primitives.Signals.Signal.Emit(ReactiveUI.Primitives.RxVoid value) -> System.IObservable<ReactiveUI.Primitives.RxVoid>!
 static ReactiveUI.Primitives.Signals.Signal.Emit(bool value) -> System.IObservable<bool>!
 static ReactiveUI.Primitives.Signals.Signal.Emit(int value) -> System.IObservable<int>!
@@ -686,6 +688,8 @@ static ReactiveUI.Primitives.Signals.Signal.Pulse(System.TimeSpan period) -> Sys
 static ReactiveUI.Primitives.Signals.Signal.Pulse(System.TimeSpan period, ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> System.IObservable<long>!
 static ReactiveUI.Primitives.Signals.Signal.Race<T>(params System.IObservable<T>![]! sources) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Signals.Signal.Recover<TSource>(params System.IObservable<TSource>![]! sources) -> System.IObservable<TSource>!
+static ReactiveUI.Primitives.Signals.Signal.Scheduled<T>(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> ReactiveUI.Primitives.Signals.ScheduledSignal<T>!
+static ReactiveUI.Primitives.Signals.Signal.Scheduled<T>(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler, System.IObserver<T>? defaultObserver) -> ReactiveUI.Primitives.Signals.ScheduledSignal<T>!
 static ReactiveUI.Primitives.Signals.Signal.Sequence(int start, int count) -> System.IObservable<int>!
 static ReactiveUI.Primitives.Signals.Signal.Sequence(int start, int count, ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> System.IObservable<int>!
 static ReactiveUI.Primitives.Signals.Signal.Silent<T>() -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net9.0/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net9.0/PublicAPI.Shipped.txt
@@ -378,6 +378,7 @@ ReactiveUI.Primitives.Signals.ScheduledSignal<T>.OnError(System.Exception! error
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.OnNext(T value) -> void
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> void
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler, System.IObserver<T>? defaultObserver) -> void
+ReactiveUI.Primitives.Signals.ScheduledSignal<T>.ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler, System.IObserver<T>? defaultObserver, ReactiveUI.Primitives.Signals.ISignal<T>? defaultSubject) -> void
 ReactiveUI.Primitives.Signals.ScheduledSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Signals.Signal
 ReactiveUI.Primitives.Signals.SignalExtensions
@@ -642,6 +643,7 @@ static ReactiveUI.Primitives.Signals.Signal.CreateSafe<T>(System.Func<System.IOb
 static ReactiveUI.Primitives.Signals.Signal.CreateWithState<T, TState>(TState state, System.Func<TState, System.IObserver<T>!, System.IDisposable!>! subscribe) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Signals.Signal.CreateWithState<T, TState>(TState state, System.Func<TState, System.IObserver<T>!, System.IDisposable!>! subscribe, bool isRequiredSubscribeOnCurrentThread) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Signals.Signal.Defer<T>(System.Func<System.IObservable<T>!>! observableFactory) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Delayable<T>(System.Func<bool>! isDelayed, System.Func<System.Collections.Generic.IList<T>!, System.Collections.Generic.IEnumerable<T>!>! flushDistinct) -> ReactiveUI.Primitives.Signals.DelayableNotificationSignal<T>!
 static ReactiveUI.Primitives.Signals.Signal.Emit(ReactiveUI.Primitives.RxVoid value) -> System.IObservable<ReactiveUI.Primitives.RxVoid>!
 static ReactiveUI.Primitives.Signals.Signal.Emit(bool value) -> System.IObservable<bool>!
 static ReactiveUI.Primitives.Signals.Signal.Emit(int value) -> System.IObservable<int>!
@@ -686,6 +688,8 @@ static ReactiveUI.Primitives.Signals.Signal.Pulse(System.TimeSpan period) -> Sys
 static ReactiveUI.Primitives.Signals.Signal.Pulse(System.TimeSpan period, ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> System.IObservable<long>!
 static ReactiveUI.Primitives.Signals.Signal.Race<T>(params System.IObservable<T>![]! sources) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Signals.Signal.Recover<TSource>(params System.IObservable<TSource>![]! sources) -> System.IObservable<TSource>!
+static ReactiveUI.Primitives.Signals.Signal.Scheduled<T>(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> ReactiveUI.Primitives.Signals.ScheduledSignal<T>!
+static ReactiveUI.Primitives.Signals.Signal.Scheduled<T>(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler, System.IObserver<T>? defaultObserver) -> ReactiveUI.Primitives.Signals.ScheduledSignal<T>!
 static ReactiveUI.Primitives.Signals.Signal.Sequence(int start, int count) -> System.IObservable<int>!
 static ReactiveUI.Primitives.Signals.Signal.Sequence(int start, int count, ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> System.IObservable<int>!
 static ReactiveUI.Primitives.Signals.Signal.Silent<T>() -> System.IObservable<T>!

--- a/src/tests/ReactiveUI.Primitives.Tests/DelayableNotificationSignalTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/DelayableNotificationSignalTests.cs
@@ -1,0 +1,252 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using ReactiveUI.Primitives.Concurrency;
+using ReactiveUI.Primitives.Signals;
+
+namespace ReactiveUI.Primitives.Tests;
+
+/// <summary>Tests for <see cref="DelayableNotificationSignal{T}"/>.</summary>
+public sealed class DelayableNotificationSignalTests
+{
+    /// <summary>A buffered notification value used across tests.</summary>
+    private const string Buffered = "buffered";
+
+    /// <summary>Constructor validates its delegate arguments.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task ConstructorRejectsNullDelegates()
+    {
+        await Assert.That(() => new DelayableNotificationSignal<string>(null!, static items => items)).ThrowsExactly<ArgumentNullException>();
+        await Assert.That(() => new DelayableNotificationSignal<string>(static () => false, null!)).ThrowsExactly<ArgumentNullException>();
+    }
+
+    /// <summary>Notifications are buffered while delayed and emitted as a de-duplicated batch on flush.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task BuffersThenFlushes()
+    {
+        var delayed = true;
+        var signal = new DelayableNotificationSignal<string>(() => delayed, static items => items);
+        var recorder = new RecordingObserver<string>();
+        using var subscription = signal.Subscribe(recorder);
+
+        signal.OnNext(Buffered);
+        await Assert.That(recorder.Values.Length).IsEqualTo(0);
+
+        delayed = false;
+        signal.Flush();
+
+        await Assert.That(recorder.Values.Contains(Buffered)).IsTrue();
+    }
+
+    /// <summary>The flush delegate de-duplicates the buffered batch before emission.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task FlushDeDuplicatesBatch()
+    {
+        var signal = new DelayableNotificationSignal<string>(static () => true, static items => items.Distinct());
+        var recorder = new RecordingObserver<string>();
+        using var subscription = signal.Subscribe(recorder);
+
+        signal.OnNext("a");
+        signal.OnNext("a");
+        signal.OnNext("b");
+        signal.Flush();
+
+        await Assert.That(recorder.Values.SequenceEqual(["a", "b"])).IsTrue();
+    }
+
+    /// <summary>Notifications pass through immediately when not delayed and terminal events stop further emission.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task ImmediateAndTerminal()
+    {
+        var immediate = new DelayableNotificationSignal<string>(static () => false, static items => items);
+        var recorder = new RecordingObserver<string>();
+        using var subscription = immediate.Subscribe(recorder);
+        immediate.OnNext("now");
+        immediate.OnCompleted();
+        immediate.OnNext("ignored");
+
+        var errored = new DelayableNotificationSignal<string>(static () => false, static items => items);
+        var error = new InvalidOperationException("delayable-error");
+        errored.OnError(error);
+        var afterError = new RecordingObserver<string>();
+        errored.Subscribe(afterError);
+
+        await Assert.That(recorder.Values.Contains("now")).IsTrue();
+        await Assert.That(recorder.Completed).IsEqualTo(1);
+        await Assert.That(afterError.Errors.Contains(error)).IsTrue();
+    }
+
+    /// <summary>HasObservers reflects subscription state and IsDisposed flips on disposal.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task ObserverStateAndDisposal()
+    {
+        var signal = new DelayableNotificationSignal<string>(static () => false, static items => items);
+        await Assert.That(signal.HasObservers).IsFalse();
+        await Assert.That(signal.IsDisposed).IsFalse();
+
+        var subscription = signal.Subscribe(new RecordingObserver<string>());
+        await Assert.That(signal.HasObservers).IsTrue();
+
+        subscription.Dispose();
+        await Assert.That(signal.HasObservers).IsFalse();
+
+        signal.Dispose();
+        await Assert.That(signal.IsDisposed).IsTrue();
+    }
+
+    /// <summary>The factory helpers build working signal instances.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task FactoryHelpersBuildWorkingSignals()
+    {
+        var delayed = true;
+        var signal = Signal.Delayable<string>(() => delayed, static items => items);
+        var recorder = new RecordingObserver<string>();
+        using var subscription = signal.Subscribe(recorder);
+
+        signal.OnNext(Buffered);
+        await Assert.That(recorder.Values.Length).IsEqualTo(0);
+
+        delayed = false;
+        signal.Flush();
+        await Assert.That(recorder.Values.Contains(Buffered)).IsTrue();
+
+        using var scheduled = Signal.Scheduled<int>(Sequencer.Immediate);
+        await Assert.That(scheduled.HasObservers).IsFalse();
+    }
+
+    /// <summary>A factory-built signal de-duplicates the buffered batch via the flush delegate.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task FactoryFlushDeDuplicatesBatch()
+    {
+        var signal = Signal.Delayable<string>(static () => true, static items => items.Distinct());
+        var recorder = new RecordingObserver<string>();
+        using var subscription = signal.Subscribe(recorder);
+
+        signal.OnNext("a");
+        signal.OnNext("a");
+        signal.OnNext("b");
+        signal.Flush();
+
+        await Assert.That(recorder.Values.SequenceEqual(["a", "b"])).IsTrue();
+    }
+
+    /// <summary>A factory-built signal passes notifications through immediately when not delayed and stops after completion.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task FactoryImmediatePassthroughAndTerminal()
+    {
+        var signal = Signal.Delayable<string>(static () => false, static items => items);
+        var recorder = new RecordingObserver<string>();
+        using var subscription = signal.Subscribe(recorder);
+
+        signal.OnNext("now");
+        signal.OnCompleted();
+        signal.OnNext("ignored");
+
+        await Assert.That(recorder.Values.SequenceEqual(["now"])).IsTrue();
+        await Assert.That(recorder.Completed).IsEqualTo(1);
+    }
+
+    /// <summary>A factory-built signal replays its terminal error to a subscriber that arrives after the error.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task FactoryReplaysErrorToLateSubscriber()
+    {
+        var signal = Signal.Delayable<string>(static () => false, static items => items);
+        var error = new InvalidOperationException("delayable-error");
+        signal.OnError(error);
+
+        var recorder = new RecordingObserver<string>();
+        signal.Subscribe(recorder);
+
+        await Assert.That(recorder.Errors.Contains(error)).IsTrue();
+    }
+
+    /// <summary>A factory-built signal reports observer state and flips IsDisposed on disposal.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task FactoryObserverStateAndDisposal()
+    {
+        var signal = Signal.Delayable<string>(static () => false, static items => items);
+        await Assert.That(signal.HasObservers).IsFalse();
+        await Assert.That(signal.IsDisposed).IsFalse();
+
+        var subscription = signal.Subscribe(new RecordingObserver<string>());
+        await Assert.That(signal.HasObservers).IsTrue();
+
+        subscription.Dispose();
+        await Assert.That(signal.HasObservers).IsFalse();
+
+        signal.Dispose();
+        await Assert.That(signal.IsDisposed).IsTrue();
+    }
+
+    /// <summary>Records the notifications delivered to an observer.</summary>
+    /// <typeparam name="T">The notification type.</typeparam>
+    private sealed class RecordingObserver<T> : IObserver<T>
+    {
+        /// <summary>The values delivered via OnNext.</summary>
+        private readonly List<T> _values = [];
+
+        /// <summary>The errors delivered via OnError.</summary>
+        private readonly List<Exception> _errors = [];
+
+        /// <summary>The number of times OnCompleted was called.</summary>
+        private int _completed;
+
+        /// <summary>Gets the values delivered via <see cref="OnNext"/>.</summary>
+        public T[] Values
+        {
+            get
+            {
+                lock (_values)
+                {
+                    return [.. _values];
+                }
+            }
+        }
+
+        /// <summary>Gets the errors delivered via <see cref="OnError"/>.</summary>
+        public Exception[] Errors
+        {
+            get
+            {
+                lock (_errors)
+                {
+                    return [.. _errors];
+                }
+            }
+        }
+
+        /// <summary>Gets the number of times <see cref="OnCompleted"/> was invoked.</summary>
+        public int Completed => Volatile.Read(ref _completed);
+
+        /// <inheritdoc/>
+        public void OnCompleted() => Interlocked.Increment(ref _completed);
+
+        /// <inheritdoc/>
+        public void OnError(Exception error)
+        {
+            lock (_errors)
+            {
+                _errors.Add(error);
+            }
+        }
+
+        /// <inheritdoc/>
+        public void OnNext(T value)
+        {
+            lock (_values)
+            {
+                _values.Add(value);
+            }
+        }
+    }
+}

--- a/src/tests/ReactiveUI.Primitives.Tests/PriorityQueueTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/PriorityQueueTests.cs
@@ -9,22 +9,31 @@ namespace ReactiveUI.Primitives.Tests;
 /// <summary>Verifies <see cref="PriorityQueue{T}"/> indexed-item equality contracts.</summary>
 public class PriorityQueueTests
 {
+    /// <summary>The second test value enqueued.</summary>
     private const int SecondValue = 2;
 
+    /// <summary>The third test value enqueued.</summary>
     private const int ThirdValue = 3;
 
+    /// <summary>The fourth test value enqueued.</summary>
     private const int FourthValue = 4;
 
+    /// <summary>The fifth test value enqueued.</summary>
     private const int FifthValue = 5;
 
+    /// <summary>The sixth test value enqueued.</summary>
     private const int SixthValue = 6;
 
+    /// <summary>The seventh test value enqueued.</summary>
     private const int SeventhValue = 7;
 
+    /// <summary>The eighth test value enqueued.</summary>
     private const int EighthValue = 8;
 
+    /// <summary>The length of the destination buffer used when copying.</summary>
     private const int DestinationLength = 2;
 
+    /// <summary>The number of items to dequeue in the test.</summary>
     private const int DequeueLimit = 2;
 
     /// <summary>Verifies public helper methods preserve priority order.</summary>

--- a/src/tests/ReactiveUI.Primitives.Tests/SignalTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/SignalTests.cs
@@ -573,6 +573,7 @@ public class SignalTests
     /// <typeparam name="T">The type of the signal sequence elements.</typeparam>
     private sealed class SignalsBaseProbe<T> : IRequireCurrentThread<T>
     {
+        /// <summary>Whether subscription must occur on the current thread.</summary>
         private readonly bool _currentThreadRequired;
 
         /// <summary>Initializes a new instance of the <see cref="SignalsBaseProbe{T}"/> class.</summary>

--- a/src/tests/ReactiveUI.Primitives.Tests/SinkTerminalTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/SinkTerminalTests.cs
@@ -9,6 +9,7 @@ namespace ReactiveUI.Primitives.Tests;
 /// <summary>Direct tests for the <see cref = "SinkTerminal"/> terminal-forwarding helper.</summary>
 public class SinkTerminalTests
 {
+    /// <summary>The value pushed through the sink under test.</summary>
     private const int Value = 7;
 
     /// <summary>Verifies <see cref = "SinkTerminal.Fault{TResult}(IObserver{TResult}, Exception, IDisposable)"/> forwards the error downstream and disposes the sink.</summary>

--- a/src/tests/ReactiveUI.Primitives.Tests/SynchronizeTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/SynchronizeTests.cs
@@ -171,6 +171,7 @@ public class SynchronizeTests
     /// <summary>A downstream observer that flags any re-entrant (overlapping) notification and counts deliveries.</summary>
     private sealed class ConcurrencyProbe : IObserver<int>
     {
+        /// <summary>Non-zero while a notification is in flight, used to detect re-entrancy.</summary>
         private int _inside;
 
         /// <summary>Gets the number of values delivered.</summary>


### PR DESCRIPTION
## What kind of change does this PR introduce?
Feature

## What is the new behavior?
This PR introduces a new signal implementation, `DelayableNotificationSignal<T>`, which offers functionality for delaying, buffering, de-duplicating, and batch-emitting notifications. It also adds a factory helper method, `Signal.Delayable<T>`, and updates the existing `ScheduledSignal<T>` to optionally support backing signals. Comprehensive tests are included to ensure the implementation's reliability.

## What is the current behavior?
Current implementation lacks the ability to handle notification delay, buffering, de-duplication, and batch-emission in a unified way.

## What might this PR break?
None

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [x] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information
N/A