### PR TITLE
docs: document Scheduled and Delayable signal factories

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,6 +445,8 @@ Creation APIs live on `ReactiveUI.Primitives.Signals.Signal`.
 | `Signal.After(...)`                                                                            | One-shot and periodic timer overloads.                                                     |
 | `Signal.Chain(...)`, `Signal.Blend(...)`, `Signal.Race(...)`                                   | Compose multiple sources.                                                                  |
 | `Signal.Pair(...)`, `Signal.SyncLatest(...)`, `Signal.PairLatest(...)`, `Signal.ForkJoin(...)` | Pairwise combination helpers.                                                              |
+| `Signal.Scheduled<T>(ISequencer)` / `Signal.Scheduled<T>(ISequencer, IObserver<T>?)`           | Multicast signal that dispatches notifications on a sequencer, with an optional default observer active while no other subscribers are present. |
+| `Signal.Delayable<T>(Func<bool>, Func<IList<T>, IEnumerable<T>>)`                               | Multicast signal that buffers notifications while delayed and emits a de-duplicated batch when `Flush` is called. |
 
 Example:
 
@@ -873,6 +875,8 @@ ReactiveUI.Primitives uses explicit names instead of cloning every System.Reacti
 | `ReplaySubject<T>`                   | `ReplaySignal<T>`                        | Replays buffered values by size and/or time window.                                      |
 | `AsyncSubject<T>`                    | `FinalSignal<T>`                         | Awaitable subject-like signal; also implements `IAwaitSignal<T>`.                        |
 | `ReactiveProperty<T>` / state holder | `StateSignal<T>` plus `ReadOnlyState<T>` | Mutable state and read-only projected state.                                             |
+| `Subject<T>.ObserveOn(scheduler)`    | `ScheduledSignal<T>`                     | Multicast signal that dispatches its notifications on an `ISequencer`, with an optional default observer active while no other subscribers are present. |
+| `Buffer(boundary).SelectMany(distinct)` pipeline | `DelayableNotificationSignal<T>`     | Passes notifications through immediately while not delayed, buffers them while delayed, and emits a de-duplicated batch on `Flush`. |
 
 State example:
 
@@ -902,6 +906,22 @@ history.OnNext("B");
 history.OnNext("C");
 
 using var subscription = history.Subscribe(Console.WriteLine); // replays B, C
+```
+
+Delayable example:
+
+```csharp
+using ReactiveUI.Primitives.Signals;
+
+var delayed = true;
+var notifications = Signal.Delayable<string>(() => delayed, items => items.Distinct());
+
+using var subscription = notifications.Subscribe(Console.WriteLine);
+
+notifications.OnNext("A");
+notifications.OnNext("A"); // buffered while delayed
+delayed = false;
+notifications.Flush();     // emits the de-duplicated batch: A
 ```
 
 Error and completion example:


### PR DESCRIPTION
## What kind of change does this PR introduce?
Docs update.

## What is the new behavior?
Documents the `Signal.Scheduled` and `Signal.Delayable` creation factories (and their `ScheduledSignal<T>` / `DelayableNotificationSignal<T>` signal types) that are being added in the more-operators work:

- Adds `Signal.Scheduled<T>` and `Signal.Delayable<T>` to the **Creation factories** table.
- Adds `ScheduledSignal<T>` and `DelayableNotificationSignal<T>` to the **Stateful signals and subject-like types** mapping, against their closest System.Reactive patterns.
- Adds a short delayable buffer/flush example.

> Note: the operators themselves land in a separate branch; this PR only touches `README.md` so the docs are ready when they merge.

## What is the current behavior?
The README documents the existing factories and subject-like types but not the new scheduled/delayable signals.

## What might this PR break?
None — documentation only.

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [ ] Tests have been added or updated (for bug fixes / features)
- [x] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information
Documents the `Signal.Delayable` / `Signal.Scheduled` operators from the `glennawatson/more-operators` work.