### PR TITLE
fix(primitives-core): ship Optional public API updates

### DIFF
--- a/src/ReactiveUI.Primitives.Core/Optional.cs
+++ b/src/ReactiveUI.Primitives.Core/Optional.cs
@@ -54,4 +54,40 @@ public readonly record struct Optional<T>
     /// <param name="value">The contained value.</param>
     /// <returns>The optional value.</returns>
     public static Optional<T> Some(T value) => new(value, hasValue: true);
+
+    /// <summary>Implicit cast from the value to the optional.</summary>
+    /// <param name="value">The value.</param>
+    /// <returns>The optional value.</returns>
+    public static implicit operator Optional<T>(T value) => ToOptional(value);
+
+    /// <summary>Explicit cast from option to value.</summary>
+    /// <param name="value">The value.</param>
+    /// <returns>The optional value.</returns>
+    public static explicit operator T?(in Optional<T> value) => FromOptional(value);
+
+    /// <summary>Creates the specified value.</summary>
+    /// <param name="value">The value.</param>
+    /// <returns>The optional value.</returns>
+    public static Optional<T> Create(T value) => new(value);
+
+    /// <summary>Gets the value from the optional value.</summary>
+    /// <param name="value">The optional value.</param>
+    /// <returns>The value.</returns>
+    public static T? FromOptional(in Optional<T> value) => value.Value;
+
+    /// <summary>Gets the optional from a value.</summary>
+    /// <param name="value">The value to get the optional for.</param>
+    /// <returns>The optional.</returns>
+    public static Optional<T> ToOptional(T value) => new(value);
+
+    /// <inheritdoc />
+    public override string? ToString()
+    {
+        if (_value is null)
+        {
+            return "<None>";
+        }
+
+        return !HasValue ? "<None>" : _value.ToString();
+    }
 }

--- a/src/ReactiveUI.Primitives.Core/PublicAPI/net10.0/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Core/PublicAPI/net10.0/PublicAPI.Shipped.txt
@@ -628,6 +628,7 @@ override ReactiveUI.Primitives.Core.TimeInterval<T>.Equals(object? obj) -> bool
 override ReactiveUI.Primitives.Core.TimeInterval<T>.GetHashCode() -> int
 override ReactiveUI.Primitives.Core.TimeInterval<T>.ToString() -> string!
 override ReactiveUI.Primitives.Optional<T>.GetHashCode() -> int
+override ReactiveUI.Primitives.Optional<T>.ToString() -> string?
 override ReactiveUI.Primitives.Result.GetHashCode() -> int
 override ReactiveUI.Primitives.Result.ToString() -> string!
 override ReactiveUI.Primitives.Signals.Broadcaster<T>.Equals(object? obj) -> bool
@@ -677,9 +678,14 @@ static ReactiveUI.Primitives.Core.Moment<T>.operator ==(ReactiveUI.Primitives.Co
 static ReactiveUI.Primitives.Core.TimeInterval<T>.operator !=(ReactiveUI.Primitives.Core.TimeInterval<T> first, ReactiveUI.Primitives.Core.TimeInterval<T> second) -> bool
 static ReactiveUI.Primitives.Core.TimeInterval<T>.operator ==(ReactiveUI.Primitives.Core.TimeInterval<T> first, ReactiveUI.Primitives.Core.TimeInterval<T> second) -> bool
 static ReactiveUI.Primitives.ExceptionExtensions.Throw(this System.Exception! exception) -> void
+static ReactiveUI.Primitives.Optional<T>.Create(T value) -> ReactiveUI.Primitives.Optional<T>
 static ReactiveUI.Primitives.Optional<T>.Empty.get -> ReactiveUI.Primitives.Optional<T>
+static ReactiveUI.Primitives.Optional<T>.FromOptional(in ReactiveUI.Primitives.Optional<T> value) -> T?
 static ReactiveUI.Primitives.Optional<T>.None.get -> ReactiveUI.Primitives.Optional<T>
 static ReactiveUI.Primitives.Optional<T>.Some(T value) -> ReactiveUI.Primitives.Optional<T>
+static ReactiveUI.Primitives.Optional<T>.ToOptional(T value) -> ReactiveUI.Primitives.Optional<T>
+static ReactiveUI.Primitives.Optional<T>.explicit operator T?(in ReactiveUI.Primitives.Optional<T> value) -> T?
+static ReactiveUI.Primitives.Optional<T>.implicit operator ReactiveUI.Primitives.Optional<T>(T value) -> ReactiveUI.Primitives.Optional<T>
 static ReactiveUI.Primitives.Optional<T>.operator !=(ReactiveUI.Primitives.Optional<T> left, ReactiveUI.Primitives.Optional<T> right) -> bool
 static ReactiveUI.Primitives.Optional<T>.operator ==(ReactiveUI.Primitives.Optional<T> left, ReactiveUI.Primitives.Optional<T> right) -> bool
 static ReactiveUI.Primitives.Result.Failure(System.Exception! exception) -> ReactiveUI.Primitives.Result
@@ -731,7 +737,6 @@ virtual ReactiveUI.Primitives.Signals.Signal<T>.IsDisposed.get -> bool
 ~override ReactiveUI.Primitives.Advanced.LongCountPredicateAggregator<T>.Equals(object obj) -> bool
 ~override ReactiveUI.Primitives.Advanced.LongCountPredicateAggregator<T>.ToString() -> string
 ~override ReactiveUI.Primitives.Optional<T>.Equals(object obj) -> bool
-~override ReactiveUI.Primitives.Optional<T>.ToString() -> string
 ~override ReactiveUI.Primitives.Result.Equals(object obj) -> bool
 ~override ReactiveUI.Primitives.Signals.CommandExecution<TResult>.Awaiter.Equals(object obj) -> bool
 ~override ReactiveUI.Primitives.Signals.CommandExecution<TResult>.Awaiter.ToString() -> string

--- a/src/ReactiveUI.Primitives.Core/PublicAPI/net11.0/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Core/PublicAPI/net11.0/PublicAPI.Shipped.txt
@@ -628,6 +628,7 @@ override ReactiveUI.Primitives.Core.TimeInterval<T>.Equals(object? obj) -> bool
 override ReactiveUI.Primitives.Core.TimeInterval<T>.GetHashCode() -> int
 override ReactiveUI.Primitives.Core.TimeInterval<T>.ToString() -> string!
 override ReactiveUI.Primitives.Optional<T>.GetHashCode() -> int
+override ReactiveUI.Primitives.Optional<T>.ToString() -> string?
 override ReactiveUI.Primitives.Result.GetHashCode() -> int
 override ReactiveUI.Primitives.Result.ToString() -> string!
 override ReactiveUI.Primitives.Signals.Broadcaster<T>.Equals(object? obj) -> bool
@@ -677,9 +678,14 @@ static ReactiveUI.Primitives.Core.Moment<T>.operator ==(ReactiveUI.Primitives.Co
 static ReactiveUI.Primitives.Core.TimeInterval<T>.operator !=(ReactiveUI.Primitives.Core.TimeInterval<T> first, ReactiveUI.Primitives.Core.TimeInterval<T> second) -> bool
 static ReactiveUI.Primitives.Core.TimeInterval<T>.operator ==(ReactiveUI.Primitives.Core.TimeInterval<T> first, ReactiveUI.Primitives.Core.TimeInterval<T> second) -> bool
 static ReactiveUI.Primitives.ExceptionExtensions.Throw(this System.Exception! exception) -> void
+static ReactiveUI.Primitives.Optional<T>.Create(T value) -> ReactiveUI.Primitives.Optional<T>
 static ReactiveUI.Primitives.Optional<T>.Empty.get -> ReactiveUI.Primitives.Optional<T>
+static ReactiveUI.Primitives.Optional<T>.FromOptional(in ReactiveUI.Primitives.Optional<T> value) -> T?
 static ReactiveUI.Primitives.Optional<T>.None.get -> ReactiveUI.Primitives.Optional<T>
 static ReactiveUI.Primitives.Optional<T>.Some(T value) -> ReactiveUI.Primitives.Optional<T>
+static ReactiveUI.Primitives.Optional<T>.ToOptional(T value) -> ReactiveUI.Primitives.Optional<T>
+static ReactiveUI.Primitives.Optional<T>.explicit operator T?(in ReactiveUI.Primitives.Optional<T> value) -> T?
+static ReactiveUI.Primitives.Optional<T>.implicit operator ReactiveUI.Primitives.Optional<T>(T value) -> ReactiveUI.Primitives.Optional<T>
 static ReactiveUI.Primitives.Optional<T>.operator !=(ReactiveUI.Primitives.Optional<T> left, ReactiveUI.Primitives.Optional<T> right) -> bool
 static ReactiveUI.Primitives.Optional<T>.operator ==(ReactiveUI.Primitives.Optional<T> left, ReactiveUI.Primitives.Optional<T> right) -> bool
 static ReactiveUI.Primitives.Result.Failure(System.Exception! exception) -> ReactiveUI.Primitives.Result
@@ -731,7 +737,6 @@ virtual ReactiveUI.Primitives.Signals.Signal<T>.IsDisposed.get -> bool
 ~override ReactiveUI.Primitives.Advanced.LongCountPredicateAggregator<T>.Equals(object obj) -> bool
 ~override ReactiveUI.Primitives.Advanced.LongCountPredicateAggregator<T>.ToString() -> string
 ~override ReactiveUI.Primitives.Optional<T>.Equals(object obj) -> bool
-~override ReactiveUI.Primitives.Optional<T>.ToString() -> string
 ~override ReactiveUI.Primitives.Result.Equals(object obj) -> bool
 ~override ReactiveUI.Primitives.Signals.CommandExecution<TResult>.Awaiter.Equals(object obj) -> bool
 ~override ReactiveUI.Primitives.Signals.CommandExecution<TResult>.Awaiter.ToString() -> string

--- a/src/ReactiveUI.Primitives.Core/PublicAPI/net462/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Core/PublicAPI/net462/PublicAPI.Shipped.txt
@@ -620,6 +620,7 @@ override ReactiveUI.Primitives.Core.TimeInterval<T>.Equals(object? obj) -> bool
 override ReactiveUI.Primitives.Core.TimeInterval<T>.GetHashCode() -> int
 override ReactiveUI.Primitives.Core.TimeInterval<T>.ToString() -> string!
 override ReactiveUI.Primitives.Optional<T>.GetHashCode() -> int
+override ReactiveUI.Primitives.Optional<T>.ToString() -> string?
 override ReactiveUI.Primitives.Result.GetHashCode() -> int
 override ReactiveUI.Primitives.Result.ToString() -> string!
 override ReactiveUI.Primitives.Signals.Broadcaster<T>.Equals(object? obj) -> bool
@@ -669,9 +670,14 @@ static ReactiveUI.Primitives.Core.Moment<T>.operator ==(ReactiveUI.Primitives.Co
 static ReactiveUI.Primitives.Core.TimeInterval<T>.operator !=(ReactiveUI.Primitives.Core.TimeInterval<T> first, ReactiveUI.Primitives.Core.TimeInterval<T> second) -> bool
 static ReactiveUI.Primitives.Core.TimeInterval<T>.operator ==(ReactiveUI.Primitives.Core.TimeInterval<T> first, ReactiveUI.Primitives.Core.TimeInterval<T> second) -> bool
 static ReactiveUI.Primitives.ExceptionExtensions.Throw(this System.Exception! exception) -> void
+static ReactiveUI.Primitives.Optional<T>.Create(T value) -> ReactiveUI.Primitives.Optional<T>
 static ReactiveUI.Primitives.Optional<T>.Empty.get -> ReactiveUI.Primitives.Optional<T>
+static ReactiveUI.Primitives.Optional<T>.FromOptional(in ReactiveUI.Primitives.Optional<T> value) -> T?
 static ReactiveUI.Primitives.Optional<T>.None.get -> ReactiveUI.Primitives.Optional<T>
 static ReactiveUI.Primitives.Optional<T>.Some(T value) -> ReactiveUI.Primitives.Optional<T>
+static ReactiveUI.Primitives.Optional<T>.ToOptional(T value) -> ReactiveUI.Primitives.Optional<T>
+static ReactiveUI.Primitives.Optional<T>.explicit operator T?(in ReactiveUI.Primitives.Optional<T> value) -> T?
+static ReactiveUI.Primitives.Optional<T>.implicit operator ReactiveUI.Primitives.Optional<T>(T value) -> ReactiveUI.Primitives.Optional<T>
 static ReactiveUI.Primitives.Optional<T>.operator !=(ReactiveUI.Primitives.Optional<T> left, ReactiveUI.Primitives.Optional<T> right) -> bool
 static ReactiveUI.Primitives.Optional<T>.operator ==(ReactiveUI.Primitives.Optional<T> left, ReactiveUI.Primitives.Optional<T> right) -> bool
 static ReactiveUI.Primitives.Result.Failure(System.Exception! exception) -> ReactiveUI.Primitives.Result
@@ -723,7 +729,6 @@ virtual ReactiveUI.Primitives.Signals.Signal<T>.IsDisposed.get -> bool
 ~override ReactiveUI.Primitives.Advanced.LongCountPredicateAggregator<T>.Equals(object obj) -> bool
 ~override ReactiveUI.Primitives.Advanced.LongCountPredicateAggregator<T>.ToString() -> string
 ~override ReactiveUI.Primitives.Optional<T>.Equals(object obj) -> bool
-~override ReactiveUI.Primitives.Optional<T>.ToString() -> string
 ~override ReactiveUI.Primitives.Result.Equals(object obj) -> bool
 ~override ReactiveUI.Primitives.Signals.CommandExecution<TResult>.Awaiter.Equals(object obj) -> bool
 ~override ReactiveUI.Primitives.Signals.CommandExecution<TResult>.Awaiter.ToString() -> string

--- a/src/ReactiveUI.Primitives.Core/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Core/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -620,6 +620,7 @@ override ReactiveUI.Primitives.Core.TimeInterval<T>.Equals(object? obj) -> bool
 override ReactiveUI.Primitives.Core.TimeInterval<T>.GetHashCode() -> int
 override ReactiveUI.Primitives.Core.TimeInterval<T>.ToString() -> string!
 override ReactiveUI.Primitives.Optional<T>.GetHashCode() -> int
+override ReactiveUI.Primitives.Optional<T>.ToString() -> string?
 override ReactiveUI.Primitives.Result.GetHashCode() -> int
 override ReactiveUI.Primitives.Result.ToString() -> string!
 override ReactiveUI.Primitives.Signals.Broadcaster<T>.Equals(object? obj) -> bool
@@ -669,9 +670,14 @@ static ReactiveUI.Primitives.Core.Moment<T>.operator ==(ReactiveUI.Primitives.Co
 static ReactiveUI.Primitives.Core.TimeInterval<T>.operator !=(ReactiveUI.Primitives.Core.TimeInterval<T> first, ReactiveUI.Primitives.Core.TimeInterval<T> second) -> bool
 static ReactiveUI.Primitives.Core.TimeInterval<T>.operator ==(ReactiveUI.Primitives.Core.TimeInterval<T> first, ReactiveUI.Primitives.Core.TimeInterval<T> second) -> bool
 static ReactiveUI.Primitives.ExceptionExtensions.Throw(this System.Exception! exception) -> void
+static ReactiveUI.Primitives.Optional<T>.Create(T value) -> ReactiveUI.Primitives.Optional<T>
 static ReactiveUI.Primitives.Optional<T>.Empty.get -> ReactiveUI.Primitives.Optional<T>
+static ReactiveUI.Primitives.Optional<T>.FromOptional(in ReactiveUI.Primitives.Optional<T> value) -> T?
 static ReactiveUI.Primitives.Optional<T>.None.get -> ReactiveUI.Primitives.Optional<T>
 static ReactiveUI.Primitives.Optional<T>.Some(T value) -> ReactiveUI.Primitives.Optional<T>
+static ReactiveUI.Primitives.Optional<T>.ToOptional(T value) -> ReactiveUI.Primitives.Optional<T>
+static ReactiveUI.Primitives.Optional<T>.explicit operator T?(in ReactiveUI.Primitives.Optional<T> value) -> T?
+static ReactiveUI.Primitives.Optional<T>.implicit operator ReactiveUI.Primitives.Optional<T>(T value) -> ReactiveUI.Primitives.Optional<T>
 static ReactiveUI.Primitives.Optional<T>.operator !=(ReactiveUI.Primitives.Optional<T> left, ReactiveUI.Primitives.Optional<T> right) -> bool
 static ReactiveUI.Primitives.Optional<T>.operator ==(ReactiveUI.Primitives.Optional<T> left, ReactiveUI.Primitives.Optional<T> right) -> bool
 static ReactiveUI.Primitives.Result.Failure(System.Exception! exception) -> ReactiveUI.Primitives.Result
@@ -723,7 +729,6 @@ virtual ReactiveUI.Primitives.Signals.Signal<T>.IsDisposed.get -> bool
 ~override ReactiveUI.Primitives.Advanced.LongCountPredicateAggregator<T>.Equals(object obj) -> bool
 ~override ReactiveUI.Primitives.Advanced.LongCountPredicateAggregator<T>.ToString() -> string
 ~override ReactiveUI.Primitives.Optional<T>.Equals(object obj) -> bool
-~override ReactiveUI.Primitives.Optional<T>.ToString() -> string
 ~override ReactiveUI.Primitives.Result.Equals(object obj) -> bool
 ~override ReactiveUI.Primitives.Signals.CommandExecution<TResult>.Awaiter.Equals(object obj) -> bool
 ~override ReactiveUI.Primitives.Signals.CommandExecution<TResult>.Awaiter.ToString() -> string

--- a/src/ReactiveUI.Primitives.Core/PublicAPI/net48/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Core/PublicAPI/net48/PublicAPI.Shipped.txt
@@ -620,6 +620,7 @@ override ReactiveUI.Primitives.Core.TimeInterval<T>.Equals(object? obj) -> bool
 override ReactiveUI.Primitives.Core.TimeInterval<T>.GetHashCode() -> int
 override ReactiveUI.Primitives.Core.TimeInterval<T>.ToString() -> string!
 override ReactiveUI.Primitives.Optional<T>.GetHashCode() -> int
+override ReactiveUI.Primitives.Optional<T>.ToString() -> string?
 override ReactiveUI.Primitives.Result.GetHashCode() -> int
 override ReactiveUI.Primitives.Result.ToString() -> string!
 override ReactiveUI.Primitives.Signals.Broadcaster<T>.Equals(object? obj) -> bool
@@ -669,9 +670,14 @@ static ReactiveUI.Primitives.Core.Moment<T>.operator ==(ReactiveUI.Primitives.Co
 static ReactiveUI.Primitives.Core.TimeInterval<T>.operator !=(ReactiveUI.Primitives.Core.TimeInterval<T> first, ReactiveUI.Primitives.Core.TimeInterval<T> second) -> bool
 static ReactiveUI.Primitives.Core.TimeInterval<T>.operator ==(ReactiveUI.Primitives.Core.TimeInterval<T> first, ReactiveUI.Primitives.Core.TimeInterval<T> second) -> bool
 static ReactiveUI.Primitives.ExceptionExtensions.Throw(this System.Exception! exception) -> void
+static ReactiveUI.Primitives.Optional<T>.Create(T value) -> ReactiveUI.Primitives.Optional<T>
 static ReactiveUI.Primitives.Optional<T>.Empty.get -> ReactiveUI.Primitives.Optional<T>
+static ReactiveUI.Primitives.Optional<T>.FromOptional(in ReactiveUI.Primitives.Optional<T> value) -> T?
 static ReactiveUI.Primitives.Optional<T>.None.get -> ReactiveUI.Primitives.Optional<T>
 static ReactiveUI.Primitives.Optional<T>.Some(T value) -> ReactiveUI.Primitives.Optional<T>
+static ReactiveUI.Primitives.Optional<T>.ToOptional(T value) -> ReactiveUI.Primitives.Optional<T>
+static ReactiveUI.Primitives.Optional<T>.explicit operator T?(in ReactiveUI.Primitives.Optional<T> value) -> T?
+static ReactiveUI.Primitives.Optional<T>.implicit operator ReactiveUI.Primitives.Optional<T>(T value) -> ReactiveUI.Primitives.Optional<T>
 static ReactiveUI.Primitives.Optional<T>.operator !=(ReactiveUI.Primitives.Optional<T> left, ReactiveUI.Primitives.Optional<T> right) -> bool
 static ReactiveUI.Primitives.Optional<T>.operator ==(ReactiveUI.Primitives.Optional<T> left, ReactiveUI.Primitives.Optional<T> right) -> bool
 static ReactiveUI.Primitives.Result.Failure(System.Exception! exception) -> ReactiveUI.Primitives.Result
@@ -723,7 +729,6 @@ virtual ReactiveUI.Primitives.Signals.Signal<T>.IsDisposed.get -> bool
 ~override ReactiveUI.Primitives.Advanced.LongCountPredicateAggregator<T>.Equals(object obj) -> bool
 ~override ReactiveUI.Primitives.Advanced.LongCountPredicateAggregator<T>.ToString() -> string
 ~override ReactiveUI.Primitives.Optional<T>.Equals(object obj) -> bool
-~override ReactiveUI.Primitives.Optional<T>.ToString() -> string
 ~override ReactiveUI.Primitives.Result.Equals(object obj) -> bool
 ~override ReactiveUI.Primitives.Signals.CommandExecution<TResult>.Awaiter.Equals(object obj) -> bool
 ~override ReactiveUI.Primitives.Signals.CommandExecution<TResult>.Awaiter.ToString() -> string

--- a/src/ReactiveUI.Primitives.Core/PublicAPI/net481/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Core/PublicAPI/net481/PublicAPI.Shipped.txt
@@ -620,6 +620,7 @@ override ReactiveUI.Primitives.Core.TimeInterval<T>.Equals(object? obj) -> bool
 override ReactiveUI.Primitives.Core.TimeInterval<T>.GetHashCode() -> int
 override ReactiveUI.Primitives.Core.TimeInterval<T>.ToString() -> string!
 override ReactiveUI.Primitives.Optional<T>.GetHashCode() -> int
+override ReactiveUI.Primitives.Optional<T>.ToString() -> string?
 override ReactiveUI.Primitives.Result.GetHashCode() -> int
 override ReactiveUI.Primitives.Result.ToString() -> string!
 override ReactiveUI.Primitives.Signals.Broadcaster<T>.Equals(object? obj) -> bool
@@ -669,9 +670,14 @@ static ReactiveUI.Primitives.Core.Moment<T>.operator ==(ReactiveUI.Primitives.Co
 static ReactiveUI.Primitives.Core.TimeInterval<T>.operator !=(ReactiveUI.Primitives.Core.TimeInterval<T> first, ReactiveUI.Primitives.Core.TimeInterval<T> second) -> bool
 static ReactiveUI.Primitives.Core.TimeInterval<T>.operator ==(ReactiveUI.Primitives.Core.TimeInterval<T> first, ReactiveUI.Primitives.Core.TimeInterval<T> second) -> bool
 static ReactiveUI.Primitives.ExceptionExtensions.Throw(this System.Exception! exception) -> void
+static ReactiveUI.Primitives.Optional<T>.Create(T value) -> ReactiveUI.Primitives.Optional<T>
 static ReactiveUI.Primitives.Optional<T>.Empty.get -> ReactiveUI.Primitives.Optional<T>
+static ReactiveUI.Primitives.Optional<T>.FromOptional(in ReactiveUI.Primitives.Optional<T> value) -> T?
 static ReactiveUI.Primitives.Optional<T>.None.get -> ReactiveUI.Primitives.Optional<T>
 static ReactiveUI.Primitives.Optional<T>.Some(T value) -> ReactiveUI.Primitives.Optional<T>
+static ReactiveUI.Primitives.Optional<T>.ToOptional(T value) -> ReactiveUI.Primitives.Optional<T>
+static ReactiveUI.Primitives.Optional<T>.explicit operator T?(in ReactiveUI.Primitives.Optional<T> value) -> T?
+static ReactiveUI.Primitives.Optional<T>.implicit operator ReactiveUI.Primitives.Optional<T>(T value) -> ReactiveUI.Primitives.Optional<T>
 static ReactiveUI.Primitives.Optional<T>.operator !=(ReactiveUI.Primitives.Optional<T> left, ReactiveUI.Primitives.Optional<T> right) -> bool
 static ReactiveUI.Primitives.Optional<T>.operator ==(ReactiveUI.Primitives.Optional<T> left, ReactiveUI.Primitives.Optional<T> right) -> bool
 static ReactiveUI.Primitives.Result.Failure(System.Exception! exception) -> ReactiveUI.Primitives.Result
@@ -723,7 +729,6 @@ virtual ReactiveUI.Primitives.Signals.Signal<T>.IsDisposed.get -> bool
 ~override ReactiveUI.Primitives.Advanced.LongCountPredicateAggregator<T>.Equals(object obj) -> bool
 ~override ReactiveUI.Primitives.Advanced.LongCountPredicateAggregator<T>.ToString() -> string
 ~override ReactiveUI.Primitives.Optional<T>.Equals(object obj) -> bool
-~override ReactiveUI.Primitives.Optional<T>.ToString() -> string
 ~override ReactiveUI.Primitives.Result.Equals(object obj) -> bool
 ~override ReactiveUI.Primitives.Signals.CommandExecution<TResult>.Awaiter.Equals(object obj) -> bool
 ~override ReactiveUI.Primitives.Signals.CommandExecution<TResult>.Awaiter.ToString() -> string

--- a/src/ReactiveUI.Primitives.Core/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Core/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -628,6 +628,7 @@ override ReactiveUI.Primitives.Core.TimeInterval<T>.Equals(object? obj) -> bool
 override ReactiveUI.Primitives.Core.TimeInterval<T>.GetHashCode() -> int
 override ReactiveUI.Primitives.Core.TimeInterval<T>.ToString() -> string!
 override ReactiveUI.Primitives.Optional<T>.GetHashCode() -> int
+override ReactiveUI.Primitives.Optional<T>.ToString() -> string?
 override ReactiveUI.Primitives.Result.GetHashCode() -> int
 override ReactiveUI.Primitives.Result.ToString() -> string!
 override ReactiveUI.Primitives.Signals.Broadcaster<T>.Equals(object? obj) -> bool
@@ -677,9 +678,14 @@ static ReactiveUI.Primitives.Core.Moment<T>.operator ==(ReactiveUI.Primitives.Co
 static ReactiveUI.Primitives.Core.TimeInterval<T>.operator !=(ReactiveUI.Primitives.Core.TimeInterval<T> first, ReactiveUI.Primitives.Core.TimeInterval<T> second) -> bool
 static ReactiveUI.Primitives.Core.TimeInterval<T>.operator ==(ReactiveUI.Primitives.Core.TimeInterval<T> first, ReactiveUI.Primitives.Core.TimeInterval<T> second) -> bool
 static ReactiveUI.Primitives.ExceptionExtensions.Throw(this System.Exception! exception) -> void
+static ReactiveUI.Primitives.Optional<T>.Create(T value) -> ReactiveUI.Primitives.Optional<T>
 static ReactiveUI.Primitives.Optional<T>.Empty.get -> ReactiveUI.Primitives.Optional<T>
+static ReactiveUI.Primitives.Optional<T>.FromOptional(in ReactiveUI.Primitives.Optional<T> value) -> T?
 static ReactiveUI.Primitives.Optional<T>.None.get -> ReactiveUI.Primitives.Optional<T>
 static ReactiveUI.Primitives.Optional<T>.Some(T value) -> ReactiveUI.Primitives.Optional<T>
+static ReactiveUI.Primitives.Optional<T>.ToOptional(T value) -> ReactiveUI.Primitives.Optional<T>
+static ReactiveUI.Primitives.Optional<T>.explicit operator T?(in ReactiveUI.Primitives.Optional<T> value) -> T?
+static ReactiveUI.Primitives.Optional<T>.implicit operator ReactiveUI.Primitives.Optional<T>(T value) -> ReactiveUI.Primitives.Optional<T>
 static ReactiveUI.Primitives.Optional<T>.operator !=(ReactiveUI.Primitives.Optional<T> left, ReactiveUI.Primitives.Optional<T> right) -> bool
 static ReactiveUI.Primitives.Optional<T>.operator ==(ReactiveUI.Primitives.Optional<T> left, ReactiveUI.Primitives.Optional<T> right) -> bool
 static ReactiveUI.Primitives.Result.Failure(System.Exception! exception) -> ReactiveUI.Primitives.Result
@@ -731,7 +737,6 @@ virtual ReactiveUI.Primitives.Signals.Signal<T>.IsDisposed.get -> bool
 ~override ReactiveUI.Primitives.Advanced.LongCountPredicateAggregator<T>.Equals(object obj) -> bool
 ~override ReactiveUI.Primitives.Advanced.LongCountPredicateAggregator<T>.ToString() -> string
 ~override ReactiveUI.Primitives.Optional<T>.Equals(object obj) -> bool
-~override ReactiveUI.Primitives.Optional<T>.ToString() -> string
 ~override ReactiveUI.Primitives.Result.Equals(object obj) -> bool
 ~override ReactiveUI.Primitives.Signals.CommandExecution<TResult>.Awaiter.Equals(object obj) -> bool
 ~override ReactiveUI.Primitives.Signals.CommandExecution<TResult>.Awaiter.ToString() -> string

--- a/src/ReactiveUI.Primitives.Core/PublicAPI/net9.0/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Core/PublicAPI/net9.0/PublicAPI.Shipped.txt
@@ -628,6 +628,7 @@ override ReactiveUI.Primitives.Core.TimeInterval<T>.Equals(object? obj) -> bool
 override ReactiveUI.Primitives.Core.TimeInterval<T>.GetHashCode() -> int
 override ReactiveUI.Primitives.Core.TimeInterval<T>.ToString() -> string!
 override ReactiveUI.Primitives.Optional<T>.GetHashCode() -> int
+override ReactiveUI.Primitives.Optional<T>.ToString() -> string?
 override ReactiveUI.Primitives.Result.GetHashCode() -> int
 override ReactiveUI.Primitives.Result.ToString() -> string!
 override ReactiveUI.Primitives.Signals.Broadcaster<T>.Equals(object? obj) -> bool
@@ -677,9 +678,14 @@ static ReactiveUI.Primitives.Core.Moment<T>.operator ==(ReactiveUI.Primitives.Co
 static ReactiveUI.Primitives.Core.TimeInterval<T>.operator !=(ReactiveUI.Primitives.Core.TimeInterval<T> first, ReactiveUI.Primitives.Core.TimeInterval<T> second) -> bool
 static ReactiveUI.Primitives.Core.TimeInterval<T>.operator ==(ReactiveUI.Primitives.Core.TimeInterval<T> first, ReactiveUI.Primitives.Core.TimeInterval<T> second) -> bool
 static ReactiveUI.Primitives.ExceptionExtensions.Throw(this System.Exception! exception) -> void
+static ReactiveUI.Primitives.Optional<T>.Create(T value) -> ReactiveUI.Primitives.Optional<T>
 static ReactiveUI.Primitives.Optional<T>.Empty.get -> ReactiveUI.Primitives.Optional<T>
+static ReactiveUI.Primitives.Optional<T>.FromOptional(in ReactiveUI.Primitives.Optional<T> value) -> T?
 static ReactiveUI.Primitives.Optional<T>.None.get -> ReactiveUI.Primitives.Optional<T>
 static ReactiveUI.Primitives.Optional<T>.Some(T value) -> ReactiveUI.Primitives.Optional<T>
+static ReactiveUI.Primitives.Optional<T>.ToOptional(T value) -> ReactiveUI.Primitives.Optional<T>
+static ReactiveUI.Primitives.Optional<T>.explicit operator T?(in ReactiveUI.Primitives.Optional<T> value) -> T?
+static ReactiveUI.Primitives.Optional<T>.implicit operator ReactiveUI.Primitives.Optional<T>(T value) -> ReactiveUI.Primitives.Optional<T>
 static ReactiveUI.Primitives.Optional<T>.operator !=(ReactiveUI.Primitives.Optional<T> left, ReactiveUI.Primitives.Optional<T> right) -> bool
 static ReactiveUI.Primitives.Optional<T>.operator ==(ReactiveUI.Primitives.Optional<T> left, ReactiveUI.Primitives.Optional<T> right) -> bool
 static ReactiveUI.Primitives.Result.Failure(System.Exception! exception) -> ReactiveUI.Primitives.Result
@@ -731,7 +737,6 @@ virtual ReactiveUI.Primitives.Signals.Signal<T>.IsDisposed.get -> bool
 ~override ReactiveUI.Primitives.Advanced.LongCountPredicateAggregator<T>.Equals(object obj) -> bool
 ~override ReactiveUI.Primitives.Advanced.LongCountPredicateAggregator<T>.ToString() -> string
 ~override ReactiveUI.Primitives.Optional<T>.Equals(object obj) -> bool
-~override ReactiveUI.Primitives.Optional<T>.ToString() -> string
 ~override ReactiveUI.Primitives.Result.Equals(object obj) -> bool
 ~override ReactiveUI.Primitives.Signals.CommandExecution<TResult>.Awaiter.Equals(object obj) -> bool
 ~override ReactiveUI.Primitives.Signals.CommandExecution<TResult>.Awaiter.ToString() -> string

--- a/src/tests/ReactiveUI.Primitives.Tests/OptionalTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/OptionalTests.cs
@@ -30,4 +30,32 @@ public class OptionalTests
         await Assert.That(some.HasValue).IsTrue();
         await Assert.That(some.Value).IsEqualTo(Second);
     }
+
+    /// <summary>Covers optional conversion helpers and operators.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task OptionalSupportsConversionHelpers()
+    {
+        var created = Optional<int>.Create(First);
+        var converted = Optional<int>.ToOptional(Second);
+        Optional<int> implicitOptional = First;
+        var explicitValue = (int?)converted;
+
+        await Assert.That(created.HasValue).IsTrue();
+        await Assert.That(created.Value).IsEqualTo(First);
+        await Assert.That(Optional<int>.FromOptional(created)).IsEqualTo(First);
+        await Assert.That(converted.HasValue).IsTrue();
+        await Assert.That(explicitValue).IsEqualTo(Second);
+        await Assert.That(implicitOptional.Value).IsEqualTo(First);
+    }
+
+    /// <summary>Covers optional string formatting for values and empty values.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task OptionalToStringFormatsValueAndNone()
+    {
+        await Assert.That(Optional<int>.Some(First).ToString()).IsEqualTo("1");
+        await Assert.That(Optional<int>.None.ToString()).IsEqualTo("<None>");
+        await Assert.That(Optional<string?>.Some(null).ToString()).IsEqualTo("<None>");
+    }
 }

--- a/src/tests/ReactiveUI.Primitives.Tests/ResultTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/ResultTests.cs
@@ -1,0 +1,46 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace ReactiveUI.Primitives.Tests;
+
+/// <summary>Verifies <see cref="Result"/> success and failure contracts.</summary>
+public class ResultTests
+{
+    /// <summary>Failure message used by result tests.</summary>
+    private const string FailureMessage = "boom";
+
+    /// <summary>Covers the success result contract.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task ResultSuccessReportsStatusAndString()
+    {
+        var result = Result.Success;
+
+        await Assert.That(result.IsSuccess).IsTrue();
+        await Assert.That(result.IsFailure).IsFalse();
+        await Assert.That(result.Exception).IsNull();
+        await Assert.That(result.ToString()).IsEqualTo("Success");
+    }
+
+    /// <summary>Covers the failure result contract.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task ResultFailureReportsExceptionStatusAndString()
+    {
+        InvalidOperationException error = new(FailureMessage);
+        var constructed = new Result(error);
+        var created = Result.Failure(error);
+
+        await Assert.That(constructed.IsSuccess).IsFalse();
+        await Assert.That(constructed.IsFailure).IsTrue();
+        await Assert.That(constructed.Exception).IsSameReferenceAs(error);
+        await Assert.That(constructed.ToString()).IsEqualTo("Failure{boom}");
+        await Assert.That(created.Exception).IsSameReferenceAs(error);
+    }
+
+    /// <summary>Covers failure result argument validation.</summary>
+    [Test]
+    public void ResultRejectsNullException() =>
+        Assert.Throws<ArgumentNullException>(() => _ = new Result(null!));
+}

--- a/src/tests/ReactiveUI.Primitives.Tests/StateSignalTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/StateSignalTests.cs
@@ -109,6 +109,36 @@ public class StateSignalTests
         await Assert.That(readonlyValues.SequenceEqual(ExpectedReadOnlyValues)).IsTrue();
     }
 
+    /// <summary>Verifies mutable state reports observer state, value availability, terminal errors, and disposal.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task StatefulSignalsReportObserverValueErrorAndDisposalState()
+    {
+        StateSignal<int> state = new(InitialStateValue);
+        await Assert.That(state.HasObservers).IsFalse();
+        await Assert.That(state.IsDisposed).IsFalse();
+        await Assert.That(state.TryGetValue(out var current)).IsTrue();
+        await Assert.That(current).IsEqualTo(InitialStateValue);
+
+        Recorder<int> observer = new();
+        using var subscription = state.Subscribe(observer);
+        await Assert.That(state.HasObservers).IsTrue();
+        state.OnNext(UpdatedStateValue);
+        await Assert.That(observer.Values.SequenceEqual([InitialStateValue, UpdatedStateValue])).IsTrue();
+
+        subscription.Dispose();
+        await Assert.That(state.HasObservers).IsFalse();
+
+        var error = new InvalidOperationException("state-error");
+        state.OnError(error);
+        Recorder<int> lateObserver = new();
+        state.Subscribe(lateObserver);
+        await Assert.That(lateObserver.Errors.Single()).IsSameReferenceAs(error);
+
+        state.Dispose();
+        await Assert.That(state.IsDisposed).IsTrue();
+    }
+
     /// <summary>Records observer notifications.</summary>
     /// <typeparam name="T">The observed value type.</typeparam>
     private sealed class Recorder<T> : IObserver<T>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix / public API baseline update for `ReactiveUI.Primitives.Core`.

## What is the new behavior?

`Optional<T>` now has its newly added conversion helpers and nullable `ToString()` override represented in the shipped PublicAPI baselines for every `ReactiveUI.Primitives.Core` target framework.

The Core project analyzer ordering issue is also resolved by keeping the new static operators/helpers before the instance `ToString()` member.

## What is the current behavior?

The generated public API baselines were missing the new `Optional<T>` surface, and the full Core build failed analyzer ordering rules for the newly added members.

## Checklist

- [x] Tests have been added or updated (for bug fixes / features)
- [x] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the main branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information

Local validation completed:

- `./tools/generate-publicapi.ps1 -Filter ReactiveUI.Primitives.Core -Jobs 1`
- `dotnet restore ReactiveUI.Primitives.slnx`
- `dotnet build ReactiveUI.Primitives.Core/ReactiveUI.Primitives.Core.csproj --no-restore`
- `dotnet build ReactiveUI.Primitives.slnx --no-restore -p:AndroidPrimitivesTargetFrameworks=`

The default local solution build still requires Android API 37 to be installed in the local Android SDK for `net11.0-android` TFMs.
