### PR TITLE
feat(primitives): add Rx parity APIs and event handler support

### DIFF
--- a/src/Primitives.Shared/Advanced/AutoConnectSignal{T}.cs
+++ b/src/Primitives.Shared/Advanced/AutoConnectSignal{T}.cs
@@ -22,6 +22,15 @@ public sealed class AutoConnectSignal<T> : IObservable<T>
     /// <param name="source">Connectable signal being auto-connected.</param>
     /// <param name="subscriberCount">Number of observers required before connecting.</param>
     public AutoConnectSignal(ConnectableSignal<T> source, int subscriberCount)
+        : this(source, subscriberCount, null)
+    {
+    }
+
+    /// <summary>Initializes a new instance of the <see cref="AutoConnectSignal{T}"/> class.</summary>
+    /// <param name="source">Connectable signal being auto-connected.</param>
+    /// <param name="subscriberCount">Number of observers required before connecting.</param>
+    /// <param name="onConnect">Action invoked with the connection disposable when the source connects.</param>
+    public AutoConnectSignal(ConnectableSignal<T> source, int subscriberCount, Action<IDisposable>? onConnect)
     {
         ArgumentExceptionHelper.ThrowIfNull(source);
 
@@ -29,6 +38,7 @@ public sealed class AutoConnectSignal<T> : IObservable<T>
 
         Source = source;
         SubscriberCount = subscriberCount;
+        OnConnect = onConnect;
     }
 
     /// <summary>Gets the connectable signal being auto-connected.</summary>
@@ -36,6 +46,9 @@ public sealed class AutoConnectSignal<T> : IObservable<T>
 
     /// <summary>Gets the number of observers required before connecting.</summary>
     private int SubscriberCount { get; }
+
+    /// <summary>Gets the callback invoked with the connection disposable.</summary>
+    private Action<IDisposable>? OnConnect { get; }
 
     /// <summary>Subscribes an observer and connects when the threshold is reached.</summary>
     /// <param name="observer">Observer to subscribe.</param>
@@ -51,7 +64,8 @@ public sealed class AutoConnectSignal<T> : IObservable<T>
         var count = Interlocked.Increment(ref _count);
         if (count >= SubscriberCount && Interlocked.CompareExchange(ref _connected, 1, 0) == 0)
         {
-            _ = Source.Connect();
+            var connection = Source.Connect();
+            OnConnect?.Invoke(connection);
         }
 
         return subscription;

--- a/src/Primitives.Shared/Advanced/FromEventPatternSignal{TEventHandler,TEventArgs}.cs
+++ b/src/Primitives.Shared/Advanced/FromEventPatternSignal{TEventHandler,TEventArgs}.cs
@@ -78,6 +78,38 @@ public sealed class FromEventPatternSignal<TEventHandler, TEventArgs> : IObserva
             return (TEventHandler)(object)typed;
         }
 
-        throw new NotSupportedException($"Event handler type '{typeof(TEventHandler)}' is not supported.");
+        return CreateCompatibleHandler(observer);
+    }
+
+    /// <summary>Creates a delegate for event handler shapes compatible with <c>void Handler(object, TEventArgs)</c>.</summary>
+    /// <param name="observer">The downstream observer.</param>
+    /// <returns>The generated event handler.</returns>
+    private static TEventHandler CreateCompatibleHandler(IObserver<EventPattern<TEventArgs>> observer)
+    {
+        var forwarder = new Forwarder(observer);
+        var method = typeof(Forwarder).GetMethod(nameof(Forwarder.OnEvent))!;
+
+        try
+        {
+#if NET8_0_OR_GREATER
+            return method.CreateDelegate<TEventHandler>(forwarder);
+#else
+            return (TEventHandler)Delegate.CreateDelegate(typeof(TEventHandler), forwarder, method);
+#endif
+        }
+        catch (ArgumentException ex)
+        {
+            throw new NotSupportedException($"Event handler type '{typeof(TEventHandler)}' is not supported.", ex);
+        }
+    }
+
+    /// <summary>Forwards compatible delegate invocations to the subscribed observer.</summary>
+    /// <param name="observer">The downstream observer.</param>
+    private sealed class Forwarder(IObserver<EventPattern<TEventArgs>> observer)
+    {
+        /// <summary>Forwards event arguments to the observer.</summary>
+        /// <param name="sender">The event sender.</param>
+        /// <param name="args">The event arguments.</param>
+        public void OnEvent(object? sender, TEventArgs args) => observer.OnNext(new(sender, args));
     }
 }

--- a/src/Primitives.Shared/Advanced/FromEventPatternSignal{TEventHandler,TEventArgs}.cs
+++ b/src/Primitives.Shared/Advanced/FromEventPatternSignal{TEventHandler,TEventArgs}.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Specialized;
 using System.ComponentModel;
+using System.Reflection;
 
 #if REACTIVE_SHIM
 namespace ReactiveUI.Primitives.Reactive.Advanced;
@@ -18,6 +19,9 @@ public sealed class FromEventPatternSignal<TEventHandler, TEventArgs> : IObserva
     where TEventHandler : Delegate
     where TEventArgs : EventArgs
 {
+    /// <summary>The compatible handler forwarder method for this closed generic signal.</summary>
+    private static readonly MethodInfo ForwarderOnEvent = typeof(Forwarder).GetMethod(nameof(Forwarder.OnEvent))!;
+
     /// <summary>Initializes a new instance of the <see cref="FromEventPatternSignal{TEventHandler, TEventArgs}"/> class.</summary>
     /// <param name="addHandler">The action that attaches the generated handler.</param>
     /// <param name="removeHandler">The action that detaches the generated handler.</param>
@@ -87,14 +91,13 @@ public sealed class FromEventPatternSignal<TEventHandler, TEventArgs> : IObserva
     private static TEventHandler CreateCompatibleHandler(IObserver<EventPattern<TEventArgs>> observer)
     {
         var forwarder = new Forwarder(observer);
-        var method = typeof(Forwarder).GetMethod(nameof(Forwarder.OnEvent))!;
 
         try
         {
 #if NET8_0_OR_GREATER
-            return method.CreateDelegate<TEventHandler>(forwarder);
+            return ForwarderOnEvent.CreateDelegate<TEventHandler>(forwarder);
 #else
-            return (TEventHandler)Delegate.CreateDelegate(typeof(TEventHandler), forwarder, method);
+            return (TEventHandler)Delegate.CreateDelegate(typeof(TEventHandler), forwarder, ForwarderOnEvent);
 #endif
         }
         catch (ArgumentException ex)

--- a/src/Primitives.Shared/Advanced/OnErrorResumeNextSignal{T}.cs
+++ b/src/Primitives.Shared/Advanced/OnErrorResumeNextSignal{T}.cs
@@ -1,0 +1,98 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+#if REACTIVE_SHIM
+namespace ReactiveUI.Primitives.Reactive.Advanced;
+#else
+namespace ReactiveUI.Primitives.Advanced;
+#endif
+
+/// <summary>Continues through observable sources after either completion or error.</summary>
+/// <typeparam name="T">The value type.</typeparam>
+internal sealed class OnErrorResumeNextSignal<T> : IObservable<T>
+{
+    /// <summary>The sources to subscribe in order.</summary>
+    private readonly IEnumerable<IObservable<T>> _sources;
+
+    /// <summary>Initializes a new instance of the <see cref="OnErrorResumeNextSignal{T}"/> class.</summary>
+    /// <param name="sources">The sources to subscribe in order.</param>
+    internal OnErrorResumeNextSignal(IEnumerable<IObservable<T>> sources) => _sources = sources;
+
+    /// <inheritdoc/>
+    public IDisposable Subscribe(IObserver<T> observer)
+    {
+        ArgumentExceptionHelper.ThrowIfNull(observer);
+
+        return new Coordinator(observer).Run(_sources);
+    }
+
+    /// <summary>Coordinates ordered subscriptions while swallowing source errors.</summary>
+    private sealed class Coordinator : IDisposable
+    {
+        /// <summary>The downstream observer.</summary>
+        private readonly IObserver<T> _observer;
+
+        /// <summary>Subscriptions created while walking the source list.</summary>
+        private readonly MultipleDisposable _subscriptions = [];
+
+        /// <summary>The active source enumerator.</summary>
+        private IEnumerator<IObservable<T>>? _enumerator;
+
+        /// <summary>Initializes a new instance of the <see cref="Coordinator"/> class.</summary>
+        /// <param name="observer">The downstream observer.</param>
+        internal Coordinator(IObserver<T> observer) => _observer = observer;
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            _enumerator?.Dispose();
+            _subscriptions.Dispose();
+        }
+
+        /// <summary>Starts iterating and subscribing to sources.</summary>
+        /// <param name="sources">The sources to subscribe in order.</param>
+        /// <returns>The coordinator that owns the subscriptions.</returns>
+        internal Coordinator Run(IEnumerable<IObservable<T>> sources)
+        {
+            try
+            {
+                _enumerator = sources.GetEnumerator();
+            }
+            catch (Exception error)
+            {
+                _observer.OnError(error);
+                return this;
+            }
+
+            SubscribeNext();
+            return this;
+        }
+
+        /// <summary>Subscribes to the next source or completes when the sequence is exhausted.</summary>
+        private void SubscribeNext()
+        {
+            IObservable<T> source;
+            try
+            {
+                var enumerator = _enumerator;
+                if (enumerator?.MoveNext() != true)
+                {
+                    _observer.OnCompleted();
+                    Dispose();
+                    return;
+                }
+
+                source = enumerator.Current ?? throw new InvalidOperationException("OnErrorResumeNext source contained null.");
+            }
+            catch (Exception error)
+            {
+                _observer.OnError(error);
+                Dispose();
+                return;
+            }
+
+            _subscriptions.Add(source.Subscribe(_observer.OnNext, _ => SubscribeNext(), SubscribeNext));
+        }
+    }
+}

--- a/src/Primitives.Shared/Advanced/OnErrorResumeNextSignal{T}.cs
+++ b/src/Primitives.Shared/Advanced/OnErrorResumeNextSignal{T}.cs
@@ -10,7 +10,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Continues through observable sources after either completion or error.</summary>
 /// <typeparam name="T">The value type.</typeparam>
-internal sealed class OnErrorResumeNextSignal<T> : IObservable<T>
+internal sealed class OnErrorResumeNextSignal<T> : IRequireCurrentThread<T>
 {
     /// <summary>The sources to subscribe in order.</summary>
     private readonly IEnumerable<IObservable<T>> _sources;
@@ -18,6 +18,9 @@ internal sealed class OnErrorResumeNextSignal<T> : IObservable<T>
     /// <summary>Initializes a new instance of the <see cref="OnErrorResumeNextSignal{T}"/> class.</summary>
     /// <param name="sources">The sources to subscribe in order.</param>
     internal OnErrorResumeNextSignal(IEnumerable<IObservable<T>> sources) => _sources = sources;
+
+    /// <inheritdoc/>
+    public bool IsRequiredSubscribeOnCurrentThread() => true;
 
     /// <inheritdoc/>
     public IDisposable Subscribe(IObserver<T> observer)
@@ -33,11 +36,23 @@ internal sealed class OnErrorResumeNextSignal<T> : IObservable<T>
         /// <summary>The downstream observer.</summary>
         private readonly IObserver<T> _observer;
 
-        /// <summary>Subscriptions created while walking the source list.</summary>
-        private readonly MultipleDisposable _subscriptions = [];
+        /// <summary>Serializes enumeration, terminal rescheduling, and disposal.</summary>
+        private readonly Lock _gate = new();
+
+        /// <summary>The active source subscription.</summary>
+        private readonly SwapDisposable _subscription = new();
 
         /// <summary>The active source enumerator.</summary>
         private IEnumerator<IObservable<T>>? _enumerator;
+
+        /// <summary>The recursive current-thread rescheduler.</summary>
+        private Action? _nextSelf;
+
+        /// <summary>The active recursive schedule.</summary>
+        private IDisposable _schedule = EmptyDisposable.Instance;
+
+        /// <summary>Disposed latch; 0 when alive, 1 once disposed.</summary>
+        private int _disposed;
 
         /// <summary>Initializes a new instance of the <see cref="Coordinator"/> class.</summary>
         /// <param name="observer">The downstream observer.</param>
@@ -46,8 +61,12 @@ internal sealed class OnErrorResumeNextSignal<T> : IObservable<T>
         /// <inheritdoc/>
         public void Dispose()
         {
-            _enumerator?.Dispose();
-            _subscriptions.Dispose();
+            if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            {
+                return;
+            }
+
+            Dispose(disposing: true);
         }
 
         /// <summary>Starts iterating and subscribing to sources.</summary>
@@ -61,38 +80,155 @@ internal sealed class OnErrorResumeNextSignal<T> : IObservable<T>
             }
             catch (Exception error)
             {
-                _observer.OnError(error);
+                Fail(error);
                 return this;
             }
 
-            SubscribeNext();
+            var schedule = Sequencer.CurrentThread.Schedule(SubscribeNext);
+            _schedule = schedule;
+            if (Volatile.Read(ref _disposed) != 0)
+            {
+                schedule.Dispose();
+            }
+
             return this;
         }
 
         /// <summary>Subscribes to the next source or completes when the sequence is exhausted.</summary>
-        private void SubscribeNext()
+        /// <param name="self">The current-thread recursive scheduler.</param>
+        private void SubscribeNext(Action self)
         {
-            IObservable<T> source;
+            IObservable<T>? source = null;
+            Exception? error = null;
+            var completed = false;
+            var disposed = false;
+
+            lock (_gate)
+            {
+                _nextSelf = self;
+                disposed = Volatile.Read(ref _disposed) != 0;
+                if (!disposed)
+                {
+                    ReadNextSource(out source, out error, out completed);
+                }
+            }
+
+            if (disposed)
+            {
+                return;
+            }
+
+            if (error is not null)
+            {
+                Fail(error);
+                return;
+            }
+
+            if (completed)
+            {
+                Complete();
+                return;
+            }
+
+            _subscription.Disposable = source!.Subscribe(_observer.OnNext, _ => ScheduleNext(), ScheduleNext);
+        }
+
+        /// <summary>Reads the next source from the active enumerator.</summary>
+        /// <param name="source">The next source when available.</param>
+        /// <param name="error">The enumeration error when reading fails.</param>
+        /// <param name="completed">Whether enumeration has completed.</param>
+        private void ReadNextSource(out IObservable<T>? source, out Exception? error, out bool completed)
+        {
+            source = null;
+            error = null;
+            completed = false;
+
             try
             {
                 var enumerator = _enumerator;
                 if (enumerator?.MoveNext() != true)
                 {
-                    _observer.OnCompleted();
-                    Dispose();
+                    completed = true;
                     return;
                 }
 
                 source = enumerator.Current ?? throw new InvalidOperationException("OnErrorResumeNext source contained null.");
             }
-            catch (Exception error)
+            catch (Exception exception)
             {
-                _observer.OnError(error);
-                Dispose();
-                return;
+                error = exception;
+            }
+        }
+
+        /// <summary>Schedules the next source without re-entering the current source terminal callback.</summary>
+        private void ScheduleNext()
+        {
+            Action? next;
+            lock (_gate)
+            {
+                if (Volatile.Read(ref _disposed) != 0)
+                {
+                    return;
+                }
+
+                next = _nextSelf;
             }
 
-            _subscriptions.Add(source.Subscribe(_observer.OnNext, _ => SubscribeNext(), SubscribeNext));
+            next?.Invoke();
+        }
+
+        /// <summary>Forwards an error and releases owned resources.</summary>
+        /// <param name="error">The error to forward.</param>
+        private void Fail(Exception error)
+        {
+            switch (Interlocked.Exchange(ref _disposed, 1))
+            {
+                case 0:
+                {
+                    try
+                    {
+                        _observer.OnError(error);
+                    }
+                    finally
+                    {
+                        Dispose(disposing: true);
+                    }
+
+                    break;
+                }
+            }
+        }
+
+        /// <summary>Forwards completion and releases owned resources.</summary>
+        private void Complete()
+        {
+            switch (Interlocked.Exchange(ref _disposed, 1))
+            {
+                case 0:
+                {
+                    try
+                    {
+                        _observer.OnCompleted();
+                    }
+                    finally
+                    {
+                        Dispose(disposing: true);
+                    }
+
+                    break;
+                }
+            }
+        }
+
+        /// <summary>Releases managed resources.</summary>
+        /// <param name="disposing">Whether managed resources should be released.</param>
+        private void Dispose(bool disposing)
+        {
+            _ = disposing;
+            _schedule.Dispose();
+            _subscription.Dispose();
+            _enumerator?.Dispose();
+            _enumerator = null;
         }
     }
 }

--- a/src/Primitives.Shared/ConnectableSignalExtensions.cs
+++ b/src/Primitives.Shared/ConnectableSignalExtensions.cs
@@ -54,6 +54,21 @@ public static class ConnectableSignalExtensions
 
             return new AutoConnectSignal<T>(source, subscriberCount);
         }
+
+        /// <summary>Connects after <paramref name="subscriberCount"/> observers have subscribed and reports the connection.</summary>
+        /// <param name="subscriberCount">Number of observers required before connecting.</param>
+        /// <param name="onConnect">Action invoked with the connection disposable when the source connects.</param>
+        /// <returns>A sequence that connects after the requested number of subscriptions.</returns>
+        public IObservable<T> AutoConnect(int subscriberCount, Action<IDisposable> onConnect)
+        {
+            ArgumentExceptionHelper.ThrowIfNull(source);
+
+            ArgumentExceptionHelper.ThrowIfNull(onConnect);
+
+            ArgumentOutOfRangeExceptionHelper.ThrowIfNegative(subscriberCount);
+
+            return new AutoConnectSignal<T>(source, subscriberCount, onConnect);
+        }
     }
 
     /// <summary>Hot-sharing operators for an observable source sequence.</summary>

--- a/src/Primitives.Shared/SignalOperatorMixins.SchedulerSignals.cs
+++ b/src/Primitives.Shared/SignalOperatorMixins.SchedulerSignals.cs
@@ -116,6 +116,45 @@ public static partial class LinqExtensions
         }
     }
 
+    /// <summary>Dedicated signal for absolute <c>Shift</c> overloads.</summary>
+    /// <typeparam name="T">The value type.</typeparam>
+    private sealed class AbsoluteShiftSignal<T> : IRequireCurrentThread<T>
+    {
+        /// <summary>The source observable.</summary>
+        private readonly IObservable<T> _source;
+
+        /// <summary>The absolute time at which notifications may be forwarded.</summary>
+        private readonly DateTimeOffset _dueTime;
+
+        /// <summary>The sequencer used to schedule delayed notifications.</summary>
+        private readonly ISequencer _scheduler;
+
+        /// <summary>Initializes a new instance of the <see cref="AbsoluteShiftSignal{T}"/> class.</summary>
+        /// <param name="source">The source observable.</param>
+        /// <param name="dueTime">The absolute time at which notifications may be forwarded.</param>
+        /// <param name="scheduler">The sequencer used to schedule delayed notifications.</param>
+        internal AbsoluteShiftSignal(IObservable<T> source, DateTimeOffset dueTime, ISequencer scheduler)
+        {
+            _source = source;
+            _dueTime = dueTime;
+            _scheduler = scheduler;
+        }
+
+        /// <inheritdoc/>
+        public bool IsRequiredSubscribeOnCurrentThread() => _scheduler == Sequencer.CurrentThread;
+
+        /// <inheritdoc/>
+        public IDisposable Subscribe(IObserver<T> observer)
+        {
+            ArgumentExceptionHelper.ThrowIfNull(observer);
+
+            var dueTime = Sequencer.Normalize(_dueTime - _scheduler.Now);
+            return _source is RangeSignal range && CanReadRangeAs(typeof(T))
+                ? new ShiftedRangeSignal<T>(range, dueTime, _scheduler).Subscribe(observer)
+                : new ShiftSignal<T>(_source, dueTime, _scheduler).Subscribe(observer);
+        }
+    }
+
     /// <summary>Dedicated signal for <c>SubscribeOn</c> (defer subscription to a sequencer).</summary>
     /// <typeparam name="T">The value type.</typeparam>
     private sealed class SubscribeOnSignal<T> : IObservable<T>
@@ -178,6 +217,81 @@ public static partial class LinqExtensions
             MultipleDisposable pocket = [];
             pocket.Add(_scheduler.Schedule(Sequencer.Normalize(_dueTime), () => pocket.Add(_source.Subscribe(observer))));
             return pocket;
+        }
+    }
+
+    /// <summary>Dedicated signal for absolute <c>DelayStart</c>/<c>DelaySubscription</c> overloads.</summary>
+    /// <typeparam name="T">The value type.</typeparam>
+    private sealed class AbsoluteDelayStartSignal<T> : IObservable<T>
+    {
+        /// <summary>The source observable.</summary>
+        private readonly IObservable<T> _source;
+
+        /// <summary>The absolute time at which to subscribe to the source.</summary>
+        private readonly DateTimeOffset _dueTime;
+
+        /// <summary>The sequencer used to schedule the delayed subscription.</summary>
+        private readonly ISequencer _scheduler;
+
+        /// <summary>Initializes a new instance of the <see cref="AbsoluteDelayStartSignal{T}"/> class.</summary>
+        /// <param name="source">The source observable.</param>
+        /// <param name="dueTime">The absolute time at which to subscribe to the source.</param>
+        /// <param name="scheduler">The sequencer used to schedule the delayed subscription.</param>
+        internal AbsoluteDelayStartSignal(IObservable<T> source, DateTimeOffset dueTime, ISequencer scheduler)
+        {
+            _source = source;
+            _dueTime = dueTime;
+            _scheduler = scheduler;
+        }
+
+        /// <inheritdoc/>
+        public IDisposable Subscribe(IObserver<T> observer)
+        {
+            ArgumentExceptionHelper.ThrowIfNull(observer);
+
+            var dueTime = Sequencer.Normalize(_dueTime - _scheduler.Now);
+            return _source is RangeSignal range && CanReadRangeAs(typeof(T))
+                ? new ShiftedRangeSignal<T>(range, dueTime, _scheduler).Subscribe(observer)
+                : new DelayStartSignal<T>(_source, dueTime, _scheduler).Subscribe(observer);
+        }
+    }
+
+    /// <summary>Dedicated signal for absolute <c>Expire</c>/<c>Timeout</c> overloads.</summary>
+    /// <typeparam name="T">The value type.</typeparam>
+    private sealed class AbsoluteExpireSignal<T> : IRequireCurrentThread<T>
+    {
+        /// <summary>The source observable.</summary>
+        private readonly IObservable<T> _source;
+
+        /// <summary>The absolute timeout time.</summary>
+        private readonly DateTimeOffset _dueTime;
+
+        /// <summary>The sequencer used to schedule the timeout.</summary>
+        private readonly ISequencer _scheduler;
+
+        /// <summary>Initializes a new instance of the <see cref="AbsoluteExpireSignal{T}"/> class.</summary>
+        /// <param name="source">The source observable.</param>
+        /// <param name="dueTime">The absolute timeout time.</param>
+        /// <param name="scheduler">The sequencer used to schedule the timeout.</param>
+        internal AbsoluteExpireSignal(IObservable<T> source, DateTimeOffset dueTime, ISequencer scheduler)
+        {
+            _source = source;
+            _dueTime = dueTime;
+            _scheduler = scheduler;
+        }
+
+        /// <inheritdoc/>
+        public bool IsRequiredSubscribeOnCurrentThread() =>
+            _scheduler == Sequencer.CurrentThread ||
+            (_source is IRequireCurrentThread<T> currentThread && currentThread.IsRequiredSubscribeOnCurrentThread());
+
+        /// <inheritdoc/>
+        public IDisposable Subscribe(IObserver<T> observer)
+        {
+            ArgumentExceptionHelper.ThrowIfNull(observer);
+
+            var dueTime = Sequencer.Normalize(_dueTime - _scheduler.Now);
+            return new ExpireSignal<T>(_source, dueTime, _scheduler).Subscribe(observer);
         }
     }
 

--- a/src/Primitives.Shared/SignalOperatorParityMixins.RxNames.cs
+++ b/src/Primitives.Shared/SignalOperatorParityMixins.RxNames.cs
@@ -727,11 +727,7 @@ public static partial class LinqExtensions
         {
             ArgumentExceptionHelper.ThrowIfNull(left);
 
-            var scheduler = ThreadPoolSequencer.Instance;
-            var normalizedDueTime = Sequencer.Normalize(dueTime - scheduler.Now);
-            return left is RangeSignal range && CanReadRangeAs(typeof(TLeft))
-                ? new ShiftedRangeSignal<TLeft>(range, normalizedDueTime, scheduler)
-                : new ShiftSignal<TLeft>(left, normalizedDueTime, scheduler);
+            return new AbsoluteShiftSignal<TLeft>(left, dueTime, ThreadPoolSequencer.Instance);
         }
 
         /// <summary>Delays source notifications until the specified absolute due time on a sequencer.</summary>
@@ -743,10 +739,7 @@ public static partial class LinqExtensions
             ArgumentExceptionHelper.ThrowIfNull(left);
 
             scheduler ??= ThreadPoolSequencer.Instance;
-            var normalizedDueTime = Sequencer.Normalize(dueTime - scheduler.Now);
-            return left is RangeSignal range && CanReadRangeAs(typeof(TLeft))
-                ? new ShiftedRangeSignal<TLeft>(range, normalizedDueTime, scheduler)
-                : new ShiftSignal<TLeft>(left, normalizedDueTime, scheduler);
+            return new AbsoluteShiftSignal<TLeft>(left, dueTime, scheduler);
         }
 
         /// <summary>Fails the sequence if it does not terminate before the timeout. System.Reactive name for <c>Expire</c>.</summary>
@@ -778,8 +771,7 @@ public static partial class LinqExtensions
         {
             ArgumentExceptionHelper.ThrowIfNull(left);
 
-            var scheduler = ThreadPoolSequencer.Instance;
-            return new ExpireSignal<TLeft>(left, Sequencer.Normalize(dueTime - scheduler.Now), scheduler);
+            return new AbsoluteExpireSignal<TLeft>(left, dueTime, ThreadPoolSequencer.Instance);
         }
 
         /// <summary>Fails the sequence if it does not terminate before the absolute sequencer timeout.</summary>
@@ -791,7 +783,7 @@ public static partial class LinqExtensions
             ArgumentExceptionHelper.ThrowIfNull(left);
 
             scheduler ??= ThreadPoolSequencer.Instance;
-            return new ExpireSignal<TLeft>(left, Sequencer.Normalize(dueTime - scheduler.Now), scheduler);
+            return new AbsoluteExpireSignal<TLeft>(left, dueTime, scheduler);
         }
 
         /// <summary>Emits the most recent value at the end of each sampling period. System.Reactive name for <c>Probe</c>.</summary>

--- a/src/Primitives.Shared/SignalOperatorParityMixins.RxNames.cs
+++ b/src/Primitives.Shared/SignalOperatorParityMixins.RxNames.cs
@@ -588,6 +588,19 @@ public static partial class LinqExtensions
 
             return new ChainSignal<T>(source, second);
         }
+
+        /// <summary>Continues with <paramref name="second"/> after this sequence completes or errors.</summary>
+        /// <param name="second">The second sequence.</param>
+        /// <returns>A sequence that forwards both sources in order, ignoring errors from the first.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="second"/> is <see langword="null"/>.</exception>
+        public IObservable<T> OnErrorResumeNext(IObservable<T> second)
+        {
+            ArgumentExceptionHelper.ThrowIfNull(source);
+
+            ArgumentExceptionHelper.ThrowIfNull(second);
+
+            return new OnErrorResumeNextSignal<T>([source, second]);
+        }
     }
 
     /// <summary>Null-filtering operator using System.Reactive vocabulary for an observable source of nullable reference values.</summary>
@@ -707,6 +720,35 @@ public static partial class LinqExtensions
                 : new ShiftSignal<TLeft>(left, dueTime, scheduler);
         }
 
+        /// <summary>Delays source notifications until the specified absolute due time.</summary>
+        /// <param name="dueTime">The absolute time at which notifications may be forwarded.</param>
+        /// <returns>A sequence that forwards source notifications after the due time.</returns>
+        public IObservable<TLeft> Delay(DateTimeOffset dueTime)
+        {
+            ArgumentExceptionHelper.ThrowIfNull(left);
+
+            var scheduler = ThreadPoolSequencer.Instance;
+            var normalizedDueTime = Sequencer.Normalize(dueTime - scheduler.Now);
+            return left is RangeSignal range && CanReadRangeAs(typeof(TLeft))
+                ? new ShiftedRangeSignal<TLeft>(range, normalizedDueTime, scheduler)
+                : new ShiftSignal<TLeft>(left, normalizedDueTime, scheduler);
+        }
+
+        /// <summary>Delays source notifications until the specified absolute due time on a sequencer.</summary>
+        /// <param name="dueTime">The absolute time at which notifications may be forwarded.</param>
+        /// <param name="scheduler">The sequencer used to schedule delayed notifications.</param>
+        /// <returns>A sequence that forwards source notifications after the due time.</returns>
+        public IObservable<TLeft> Delay(DateTimeOffset dueTime, ISequencer? scheduler)
+        {
+            ArgumentExceptionHelper.ThrowIfNull(left);
+
+            scheduler ??= ThreadPoolSequencer.Instance;
+            var normalizedDueTime = Sequencer.Normalize(dueTime - scheduler.Now);
+            return left is RangeSignal range && CanReadRangeAs(typeof(TLeft))
+                ? new ShiftedRangeSignal<TLeft>(range, normalizedDueTime, scheduler)
+                : new ShiftSignal<TLeft>(left, normalizedDueTime, scheduler);
+        }
+
         /// <summary>Fails the sequence if it does not terminate before the timeout. System.Reactive name for <c>Expire</c>.</summary>
         /// <param name="dueTime">The timeout duration.</param>
         /// <returns>A sequence that errors with <see cref="TimeoutException"/> when the timeout elapses first.</returns>
@@ -727,6 +769,29 @@ public static partial class LinqExtensions
 
             scheduler ??= ThreadPoolSequencer.Instance;
             return new ExpireSignal<TLeft>(left, dueTime, scheduler);
+        }
+
+        /// <summary>Fails the sequence if it does not terminate before the absolute timeout.</summary>
+        /// <param name="dueTime">The absolute timeout time.</param>
+        /// <returns>A sequence that errors with <see cref="TimeoutException"/> when the timeout elapses first.</returns>
+        public IObservable<TLeft> Timeout(DateTimeOffset dueTime)
+        {
+            ArgumentExceptionHelper.ThrowIfNull(left);
+
+            var scheduler = ThreadPoolSequencer.Instance;
+            return new ExpireSignal<TLeft>(left, Sequencer.Normalize(dueTime - scheduler.Now), scheduler);
+        }
+
+        /// <summary>Fails the sequence if it does not terminate before the absolute sequencer timeout.</summary>
+        /// <param name="dueTime">The absolute timeout time.</param>
+        /// <param name="scheduler">The sequencer used to schedule the timeout.</param>
+        /// <returns>A sequence that errors with <see cref="TimeoutException"/> when the timeout elapses first.</returns>
+        public IObservable<TLeft> Timeout(DateTimeOffset dueTime, ISequencer? scheduler)
+        {
+            ArgumentExceptionHelper.ThrowIfNull(left);
+
+            scheduler ??= ThreadPoolSequencer.Instance;
+            return new ExpireSignal<TLeft>(left, Sequencer.Normalize(dueTime - scheduler.Now), scheduler);
         }
 
         /// <summary>Emits the most recent value at the end of each sampling period. System.Reactive name for <c>Probe</c>.</summary>
@@ -873,6 +938,41 @@ public static partial class LinqExtensions
             ArgumentExceptionHelper.ThrowIfNull(sources);
 
             return new TaskChainSignal<T>(sources);
+        }
+    }
+
+    /// <summary>System.Reactive-named type filtering and casting operators for an untyped observable source.</summary>
+    /// <param name="source">The source sequence.</param>
+    extension(IObservable<object?> source)
+    {
+        /// <summary>Filters values to those assignable to <typeparamref name="TResult"/>. System.Reactive name for <c>KeepType</c>.</summary>
+        /// <typeparam name="TResult">The result value type.</typeparam>
+        /// <returns>A sequence containing only values assignable to <typeparamref name="TResult"/>.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage(
+            "Major Code Smell",
+            "S4018:Generic methods should provide type parameters",
+            Justification = "The type parameter defines the element type for this Rx-style operator and cannot be inferred from the arguments.")]
+        public IObservable<TResult> OfType<TResult>()
+        {
+            ArgumentExceptionHelper.ThrowIfNull(source);
+
+            return new KeepTypeSignal<TResult>(source);
+        }
+
+        /// <summary>Casts each source value to <typeparamref name="TResult"/>. System.Reactive name for <c>CastTo</c>.</summary>
+        /// <typeparam name="TResult">The result value type.</typeparam>
+        /// <returns>A sequence containing each value cast to <typeparamref name="TResult"/>.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage(
+            "Major Code Smell",
+            "S4018:Generic methods should provide type parameters",
+            Justification = "The type parameter defines the element type for this Rx-style operator and cannot be inferred from the arguments.")]
+        public IObservable<TResult> Cast<TResult>()
+        {
+            ArgumentExceptionHelper.ThrowIfNull(source);
+
+            return new CastSignal<TResult>(source);
         }
     }
 }

--- a/src/Primitives.Shared/SignalOperatorParityMixins.cs
+++ b/src/Primitives.Shared/SignalOperatorParityMixins.cs
@@ -175,11 +175,7 @@ public static partial class LinqExtensions
         {
             ArgumentExceptionHelper.ThrowIfNull(source);
 
-            var scheduler = ThreadPoolSequencer.Instance;
-            var normalizedDueTime = Sequencer.Normalize(dueTime - scheduler.Now);
-            return source is RangeSignal range && CanReadRangeAs(typeof(T))
-                ? new ShiftedRangeSignal<T>(range, normalizedDueTime, scheduler)
-                : new DelayStartSignal<T>(source, normalizedDueTime, scheduler);
+            return new AbsoluteDelayStartSignal<T>(source, dueTime, ThreadPoolSequencer.Instance);
         }
 
         /// <summary>Alias for <c>DelayStart</c> using the System.Reactive operator name.</summary>
@@ -207,10 +203,7 @@ public static partial class LinqExtensions
             ArgumentExceptionHelper.ThrowIfNull(source);
 
             scheduler ??= ThreadPoolSequencer.Instance;
-            var normalizedDueTime = Sequencer.Normalize(dueTime - scheduler.Now);
-            return source is RangeSignal range && CanReadRangeAs(typeof(T))
-                ? new ShiftedRangeSignal<T>(range, normalizedDueTime, scheduler)
-                : new DelayStartSignal<T>(source, normalizedDueTime, scheduler);
+            return new AbsoluteDelayStartSignal<T>(source, dueTime, scheduler);
         }
 
         /// <summary>Invokes actions for each element in the observable sequence, for error notifications, and for successful completion.</summary>

--- a/src/Primitives.Shared/SignalOperatorParityMixins.cs
+++ b/src/Primitives.Shared/SignalOperatorParityMixins.cs
@@ -167,6 +167,21 @@ public static partial class LinqExtensions
                 : new DelayStartSignal<T>(source, dueTime, ThreadPoolSequencer.Instance);
         }
 
+        /// <summary>Alias for <c>DelayStart</c> using an absolute due time.</summary>
+        /// <param name="dueTime">The absolute time at which to subscribe to the source.</param>
+        /// <returns>A sequence that subscribes to the source at <paramref name="dueTime"/>.</returns>
+        /// <exception cref="ArgumentNullException">The receiver sequence is <see langword="null"/>.</exception>
+        public IObservable<T> DelaySubscription(DateTimeOffset dueTime)
+        {
+            ArgumentExceptionHelper.ThrowIfNull(source);
+
+            var scheduler = ThreadPoolSequencer.Instance;
+            var normalizedDueTime = Sequencer.Normalize(dueTime - scheduler.Now);
+            return source is RangeSignal range && CanReadRangeAs(typeof(T))
+                ? new ShiftedRangeSignal<T>(range, normalizedDueTime, scheduler)
+                : new DelayStartSignal<T>(source, normalizedDueTime, scheduler);
+        }
+
         /// <summary>Alias for <c>DelayStart</c> using the System.Reactive operator name.</summary>
         /// <param name="dueTime">The delay before subscribing to the source.</param>
         /// <param name="scheduler">The sequencer used to schedule the delayed subscription.</param>
@@ -180,6 +195,22 @@ public static partial class LinqExtensions
             return source is RangeSignal range && CanReadRangeAs(typeof(T))
                 ? new ShiftedRangeSignal<T>(range, Sequencer.Normalize(dueTime), scheduler)
                 : new DelayStartSignal<T>(source, dueTime, scheduler);
+        }
+
+        /// <summary>Alias for <c>DelayStart</c> using an absolute due time.</summary>
+        /// <param name="dueTime">The absolute time at which to subscribe to the source.</param>
+        /// <param name="scheduler">The sequencer used to schedule the delayed subscription.</param>
+        /// <returns>A sequence that subscribes to the source at <paramref name="dueTime"/>.</returns>
+        /// <exception cref="ArgumentNullException">The receiver sequence is <see langword="null"/>.</exception>
+        public IObservable<T> DelaySubscription(DateTimeOffset dueTime, ISequencer? scheduler)
+        {
+            ArgumentExceptionHelper.ThrowIfNull(source);
+
+            scheduler ??= ThreadPoolSequencer.Instance;
+            var normalizedDueTime = Sequencer.Normalize(dueTime - scheduler.Now);
+            return source is RangeSignal range && CanReadRangeAs(typeof(T))
+                ? new ShiftedRangeSignal<T>(range, normalizedDueTime, scheduler)
+                : new DelayStartSignal<T>(source, normalizedDueTime, scheduler);
         }
 
         /// <summary>Invokes actions for each element in the observable sequence, for error notifications, and for successful completion.</summary>

--- a/src/Primitives.Shared/Signals/Signal{RxAliases}.cs
+++ b/src/Primitives.Shared/Signals/Signal{RxAliases}.cs
@@ -27,6 +27,63 @@ public static partial class Signal
         return new DeferSignal<T>(observableFactory);
     }
 
+    /// <summary>Returns the source selected by the condition for each subscription.</summary>
+    /// <typeparam name="T">The value type.</typeparam>
+    /// <param name="condition">The condition used to choose the source.</param>
+    /// <param name="thenSource">The source used when <paramref name="condition"/> returns <see langword="true"/>.</param>
+    /// <returns>A deferred conditional observable sequence.</returns>
+    public static IObservable<T> If<T>(Func<bool> condition, IObservable<T> thenSource) =>
+        If(condition, thenSource, Empty<T>());
+
+    /// <summary>Returns the source selected by the condition for each subscription.</summary>
+    /// <typeparam name="T">The value type.</typeparam>
+    /// <param name="condition">The condition used to choose the source.</param>
+    /// <param name="thenSource">The source used when <paramref name="condition"/> returns <see langword="true"/>.</param>
+    /// <param name="elseSource">The source used when <paramref name="condition"/> returns <see langword="false"/>.</param>
+    /// <returns>A deferred conditional observable sequence.</returns>
+    public static IObservable<T> If<T>(Func<bool> condition, IObservable<T> thenSource, IObservable<T> elseSource)
+    {
+        ArgumentExceptionHelper.ThrowIfNull(condition);
+
+        ArgumentExceptionHelper.ThrowIfNull(thenSource);
+
+        ArgumentExceptionHelper.ThrowIfNull(elseSource);
+
+        return new DeferSignal<T>(() => condition() ? thenSource : elseSource);
+    }
+
+    /// <summary>Returns the source selected by the dictionary key for each subscription.</summary>
+    /// <typeparam name="TKey">The key type.</typeparam>
+    /// <typeparam name="T">The value type.</typeparam>
+    /// <param name="selector">The selector used to choose the source key.</param>
+    /// <param name="sources">The keyed source map.</param>
+    /// <returns>A deferred conditional observable sequence.</returns>
+    public static IObservable<T> Case<TKey, T>(Func<TKey> selector, IDictionary<TKey, IObservable<T>> sources)
+        where TKey : notnull =>
+        Case(selector, sources, Empty<T>());
+
+    /// <summary>Returns the source selected by the dictionary key for each subscription.</summary>
+    /// <typeparam name="TKey">The key type.</typeparam>
+    /// <typeparam name="T">The value type.</typeparam>
+    /// <param name="selector">The selector used to choose the source key.</param>
+    /// <param name="sources">The keyed source map.</param>
+    /// <param name="defaultSource">The source used when the selected key is not present.</param>
+    /// <returns>A deferred conditional observable sequence.</returns>
+    public static IObservable<T> Case<TKey, T>(
+        Func<TKey> selector,
+        IDictionary<TKey, IObservable<T>> sources,
+        IObservable<T> defaultSource)
+        where TKey : notnull
+    {
+        ArgumentExceptionHelper.ThrowIfNull(selector);
+
+        ArgumentExceptionHelper.ThrowIfNull(sources);
+
+        ArgumentExceptionHelper.ThrowIfNull(defaultSource);
+
+        return new DeferSignal<T>(() => sources.TryGetValue(selector(), out var source) ? source : defaultSource);
+    }
+
     /// <summary>Returns an observable sequence that contains a single value.</summary>
     /// <typeparam name="T">The value type.</typeparam>
     /// <param name="value">The value to emit.</param>
@@ -44,6 +101,25 @@ public static partial class Signal
         ArgumentExceptionHelper.ThrowIfNull(scheduler);
 
         return scheduler == Sequencer.Immediate ? new ImmediateReturnSignal<T>(value) : new ReturnSignal<T>(value, scheduler);
+    }
+
+    /// <summary>Returns an observable sequence that repeats a value indefinitely.</summary>
+    /// <typeparam name="T">The value type.</typeparam>
+    /// <param name="value">The value to repeat.</param>
+    /// <returns>An observable sequence that repeats <paramref name="value"/> indefinitely.</returns>
+    public static IObservable<T> Repeat<T>(T value) =>
+        new LoopSignal<T>(value);
+
+    /// <summary>Returns an observable sequence that repeats a value a fixed number of times.</summary>
+    /// <typeparam name="T">The value type.</typeparam>
+    /// <param name="value">The value to repeat.</param>
+    /// <param name="repeatCount">The number of times to repeat the value.</param>
+    /// <returns>An observable sequence that repeats <paramref name="value"/> <paramref name="repeatCount"/> times.</returns>
+    public static IObservable<T> Repeat<T>(T value, int repeatCount)
+    {
+        ArgumentOutOfRangeExceptionHelper.ThrowIfNegative(repeatCount);
+
+        return repeatCount == 0 ? ImmutableEmptySignal<T>.Instance : new RepeatSignal<T>(value, repeatCount);
     }
 
     /// <summary>Returns an empty observable sequence.</summary>
@@ -135,6 +211,29 @@ public static partial class Signal
         return scheduler == Sequencer.Immediate || scheduler == Sequencer.CurrentThread
             ? new RangeSignal(start, count)
             : new SequenceSignal(start, count, scheduler);
+    }
+
+    /// <summary>Generates a finite observable sequence from state.</summary>
+    /// <typeparam name="TState">The state type.</typeparam>
+    /// <typeparam name="T">The value type.</typeparam>
+    /// <param name="initialState">The initial state.</param>
+    /// <param name="condition">The condition that determines whether to continue.</param>
+    /// <param name="iterate">The function that advances the state.</param>
+    /// <param name="resultSelector">The function that produces the result from the state.</param>
+    /// <returns>An observable sequence generated from state.</returns>
+    public static IObservable<T> Generate<TState, T>(
+        TState initialState,
+        Func<TState, bool> condition,
+        Func<TState, TState> iterate,
+        Func<TState, T> resultSelector)
+    {
+        ArgumentExceptionHelper.ThrowIfNull(condition);
+
+        ArgumentExceptionHelper.ThrowIfNull(iterate);
+
+        ArgumentExceptionHelper.ThrowIfNull(resultSelector);
+
+        return new UnfoldSignal<TState, T>(initialState, condition, iterate, resultSelector);
     }
 
     /// <summary>Returns an observable sequence that emits a single tick after the due time.</summary>
@@ -281,6 +380,59 @@ public static partial class Signal
         ArgumentExceptionHelper.ThrowIfNull(sources);
 
         return new EnumerableBlendSignal<T>(sources);
+    }
+
+    /// <summary>Continues with the second sequence after the first sequence completes or errors.</summary>
+    /// <typeparam name="T">The value type.</typeparam>
+    /// <param name="first">The first source.</param>
+    /// <param name="second">The second source.</param>
+    /// <returns>An observable sequence that forwards both sources in order.</returns>
+    public static IObservable<T> OnErrorResumeNext<T>(IObservable<T> first, IObservable<T> second)
+    {
+        ArgumentExceptionHelper.ThrowIfNull(first);
+
+        ArgumentExceptionHelper.ThrowIfNull(second);
+
+        return new OnErrorResumeNextSignal<T>([first, second]);
+    }
+
+    /// <summary>Continues through the supplied sequences after each sequence completes or errors.</summary>
+    /// <typeparam name="T">The value type.</typeparam>
+    /// <param name="sources">The sources to subscribe in order.</param>
+    /// <returns>An observable sequence that forwards every source in order.</returns>
+    public static IObservable<T> OnErrorResumeNext<T>(params IObservable<T>[] sources)
+    {
+        _ = ValidateSources(sources);
+        return new OnErrorResumeNextSignal<T>(sources);
+    }
+
+    /// <summary>Continues through the supplied sequences after each sequence completes or errors.</summary>
+    /// <typeparam name="T">The value type.</typeparam>
+    /// <param name="sources">The sources to subscribe in order.</param>
+    /// <returns>An observable sequence that forwards every source in order.</returns>
+    public static IObservable<T> OnErrorResumeNext<T>(IEnumerable<IObservable<T>> sources)
+    {
+        ArgumentExceptionHelper.ThrowIfNull(sources);
+
+        return new OnErrorResumeNextSignal<T>(sources);
+    }
+
+    /// <summary>Creates a signal whose subscription lifetime owns a resource.</summary>
+    /// <typeparam name="TResource">The type of the resource.</typeparam>
+    /// <typeparam name="T">The value type.</typeparam>
+    /// <param name="resourceFactory">The factory that creates the resource.</param>
+    /// <param name="observableFactory">The factory that creates the observable from the resource.</param>
+    /// <returns>An observable sequence that owns the resource for the subscription lifetime.</returns>
+    public static IObservable<T> Using<TResource, T>(
+        Func<TResource> resourceFactory,
+        Func<TResource, IObservable<T>> observableFactory)
+        where TResource : IDisposable
+    {
+        ArgumentExceptionHelper.ThrowIfNull(resourceFactory);
+
+        ArgumentExceptionHelper.ThrowIfNull(observableFactory);
+
+        return new UseSignal<TResource, T>(resourceFactory, observableFactory);
     }
 
     /// <summary>Switches to the most recent inner observable sequence.</summary>

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-android/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-android/PublicAPI.Unshipped.txt
@@ -1,1 +1,33 @@
 #nullable enable
+ReactiveUI.Primitives.Reactive.Advanced.AutoConnectSignal<T>.AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>? onConnect) -> void
+ReactiveUI.Primitives.Reactive.ConnectableSignalExtensions.extension<T>(ReactiveUI.Primitives.ConnectableSignal<T>!).AutoConnect(int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension(System.IObservable<object?>!).Cast<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension(System.IObservable<object?>!).OfType<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.IObservable<T>!).OnErrorResumeNext(System.IObservable<T>! second) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.ConnectableSignalExtensions.AutoConnect<T>(this ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Cast<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources, System.IObservable<T>! defaultSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Generate<TState, T>(TState initialState, System.Func<TState, bool>! condition, System.Func<TState, TState>! iterate, System.Func<TState, T>! resultSelector) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource, System.IObservable<T>! elseSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.OnErrorResumeNext<T>(params System.IObservable<T>![]! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.OnErrorResumeNext<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.OnErrorResumeNext<T>(System.IObservable<T>! first, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Repeat<T>(T value) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Repeat<T>(T value, int repeatCount) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Using<TResource, T>(System.Func<TResource>! resourceFactory, System.Func<TResource, System.IObservable<T>!>! observableFactory) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-ios/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-ios/PublicAPI.Unshipped.txt
@@ -1,1 +1,33 @@
 #nullable enable
+ReactiveUI.Primitives.Reactive.Advanced.AutoConnectSignal<T>.AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>? onConnect) -> void
+ReactiveUI.Primitives.Reactive.ConnectableSignalExtensions.extension<T>(ReactiveUI.Primitives.ConnectableSignal<T>!).AutoConnect(int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension(System.IObservable<object?>!).Cast<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension(System.IObservable<object?>!).OfType<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.IObservable<T>!).OnErrorResumeNext(System.IObservable<T>! second) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.ConnectableSignalExtensions.AutoConnect<T>(this ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Cast<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources, System.IObservable<T>! defaultSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Generate<TState, T>(TState initialState, System.Func<TState, bool>! condition, System.Func<TState, TState>! iterate, System.Func<TState, T>! resultSelector) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource, System.IObservable<T>! elseSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.OnErrorResumeNext<T>(params System.IObservable<T>![]! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.OnErrorResumeNext<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.OnErrorResumeNext<T>(System.IObservable<T>! first, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Repeat<T>(T value) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Repeat<T>(T value, int repeatCount) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Using<TResource, T>(System.Func<TResource>! resourceFactory, System.Func<TResource, System.IObservable<T>!>! observableFactory) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,1 +1,33 @@
 #nullable enable
+ReactiveUI.Primitives.Reactive.Advanced.AutoConnectSignal<T>.AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>? onConnect) -> void
+ReactiveUI.Primitives.Reactive.ConnectableSignalExtensions.extension<T>(ReactiveUI.Primitives.ConnectableSignal<T>!).AutoConnect(int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension(System.IObservable<object?>!).Cast<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension(System.IObservable<object?>!).OfType<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.IObservable<T>!).OnErrorResumeNext(System.IObservable<T>! second) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.ConnectableSignalExtensions.AutoConnect<T>(this ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Cast<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources, System.IObservable<T>! defaultSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Generate<TState, T>(TState initialState, System.Func<TState, bool>! condition, System.Func<TState, TState>! iterate, System.Func<TState, T>! resultSelector) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource, System.IObservable<T>! elseSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.OnErrorResumeNext<T>(params System.IObservable<T>![]! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.OnErrorResumeNext<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.OnErrorResumeNext<T>(System.IObservable<T>! first, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Repeat<T>(T value) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Repeat<T>(T value, int repeatCount) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Using<TResource, T>(System.Func<TResource>! resourceFactory, System.Func<TResource, System.IObservable<T>!>! observableFactory) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-macos/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-macos/PublicAPI.Unshipped.txt
@@ -1,1 +1,33 @@
 #nullable enable
+ReactiveUI.Primitives.Reactive.Advanced.AutoConnectSignal<T>.AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>? onConnect) -> void
+ReactiveUI.Primitives.Reactive.ConnectableSignalExtensions.extension<T>(ReactiveUI.Primitives.ConnectableSignal<T>!).AutoConnect(int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension(System.IObservable<object?>!).Cast<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension(System.IObservable<object?>!).OfType<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.IObservable<T>!).OnErrorResumeNext(System.IObservable<T>! second) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.ConnectableSignalExtensions.AutoConnect<T>(this ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Cast<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources, System.IObservable<T>! defaultSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Generate<TState, T>(TState initialState, System.Func<TState, bool>! condition, System.Func<TState, TState>! iterate, System.Func<TState, T>! resultSelector) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource, System.IObservable<T>! elseSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.OnErrorResumeNext<T>(params System.IObservable<T>![]! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.OnErrorResumeNext<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.OnErrorResumeNext<T>(System.IObservable<T>! first, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Repeat<T>(T value) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Repeat<T>(T value, int repeatCount) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Using<TResource, T>(System.Func<TResource>! resourceFactory, System.Func<TResource, System.IObservable<T>!>! observableFactory) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-tvos/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-tvos/PublicAPI.Unshipped.txt
@@ -1,1 +1,33 @@
 #nullable enable
+ReactiveUI.Primitives.Reactive.Advanced.AutoConnectSignal<T>.AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>? onConnect) -> void
+ReactiveUI.Primitives.Reactive.ConnectableSignalExtensions.extension<T>(ReactiveUI.Primitives.ConnectableSignal<T>!).AutoConnect(int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension(System.IObservable<object?>!).Cast<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension(System.IObservable<object?>!).OfType<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.IObservable<T>!).OnErrorResumeNext(System.IObservable<T>! second) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.ConnectableSignalExtensions.AutoConnect<T>(this ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Cast<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources, System.IObservable<T>! defaultSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Generate<TState, T>(TState initialState, System.Func<TState, bool>! condition, System.Func<TState, TState>! iterate, System.Func<TState, T>! resultSelector) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource, System.IObservable<T>! elseSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.OnErrorResumeNext<T>(params System.IObservable<T>![]! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.OnErrorResumeNext<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.OnErrorResumeNext<T>(System.IObservable<T>! first, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Repeat<T>(T value) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Repeat<T>(T value, int repeatCount) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Using<TResource, T>(System.Func<TResource>! resourceFactory, System.Func<TResource, System.IObservable<T>!>! observableFactory) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,33 @@
 #nullable enable
+ReactiveUI.Primitives.Reactive.Advanced.AutoConnectSignal<T>.AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>? onConnect) -> void
+ReactiveUI.Primitives.Reactive.ConnectableSignalExtensions.extension<T>(ReactiveUI.Primitives.ConnectableSignal<T>!).AutoConnect(int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension(System.IObservable<object?>!).Cast<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension(System.IObservable<object?>!).OfType<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.IObservable<T>!).OnErrorResumeNext(System.IObservable<T>! second) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.ConnectableSignalExtensions.AutoConnect<T>(this ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Cast<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources, System.IObservable<T>! defaultSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Generate<TState, T>(TState initialState, System.Func<TState, bool>! condition, System.Func<TState, TState>! iterate, System.Func<TState, T>! resultSelector) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource, System.IObservable<T>! elseSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.OnErrorResumeNext<T>(params System.IObservable<T>![]! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.OnErrorResumeNext<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.OnErrorResumeNext<T>(System.IObservable<T>! first, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Repeat<T>(T value) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Repeat<T>(T value, int repeatCount) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Using<TResource, T>(System.Func<TResource>! resourceFactory, System.Func<TResource, System.IObservable<T>!>! observableFactory) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-android/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-android/PublicAPI.Unshipped.txt
@@ -1,1 +1,33 @@
 #nullable enable
+ReactiveUI.Primitives.Reactive.Advanced.AutoConnectSignal<T>.AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>? onConnect) -> void
+ReactiveUI.Primitives.Reactive.ConnectableSignalExtensions.extension<T>(ReactiveUI.Primitives.ConnectableSignal<T>!).AutoConnect(int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension(System.IObservable<object?>!).Cast<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension(System.IObservable<object?>!).OfType<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.IObservable<T>!).OnErrorResumeNext(System.IObservable<T>! second) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.ConnectableSignalExtensions.AutoConnect<T>(this ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Cast<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources, System.IObservable<T>! defaultSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Generate<TState, T>(TState initialState, System.Func<TState, bool>! condition, System.Func<TState, TState>! iterate, System.Func<TState, T>! resultSelector) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource, System.IObservable<T>! elseSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.OnErrorResumeNext<T>(params System.IObservable<T>![]! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.OnErrorResumeNext<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.OnErrorResumeNext<T>(System.IObservable<T>! first, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Repeat<T>(T value) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Repeat<T>(T value, int repeatCount) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Using<TResource, T>(System.Func<TResource>! resourceFactory, System.Func<TResource, System.IObservable<T>!>! observableFactory) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-ios/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-ios/PublicAPI.Unshipped.txt
@@ -1,1 +1,33 @@
 #nullable enable
+ReactiveUI.Primitives.Reactive.Advanced.AutoConnectSignal<T>.AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>? onConnect) -> void
+ReactiveUI.Primitives.Reactive.ConnectableSignalExtensions.extension<T>(ReactiveUI.Primitives.ConnectableSignal<T>!).AutoConnect(int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension(System.IObservable<object?>!).Cast<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension(System.IObservable<object?>!).OfType<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.IObservable<T>!).OnErrorResumeNext(System.IObservable<T>! second) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.ConnectableSignalExtensions.AutoConnect<T>(this ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Cast<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources, System.IObservable<T>! defaultSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Generate<TState, T>(TState initialState, System.Func<TState, bool>! condition, System.Func<TState, TState>! iterate, System.Func<TState, T>! resultSelector) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource, System.IObservable<T>! elseSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.OnErrorResumeNext<T>(params System.IObservable<T>![]! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.OnErrorResumeNext<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.OnErrorResumeNext<T>(System.IObservable<T>! first, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Repeat<T>(T value) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Repeat<T>(T value, int repeatCount) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Using<TResource, T>(System.Func<TResource>! resourceFactory, System.Func<TResource, System.IObservable<T>!>! observableFactory) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,1 +1,33 @@
 #nullable enable
+ReactiveUI.Primitives.Reactive.Advanced.AutoConnectSignal<T>.AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>? onConnect) -> void
+ReactiveUI.Primitives.Reactive.ConnectableSignalExtensions.extension<T>(ReactiveUI.Primitives.ConnectableSignal<T>!).AutoConnect(int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension(System.IObservable<object?>!).Cast<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension(System.IObservable<object?>!).OfType<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.IObservable<T>!).OnErrorResumeNext(System.IObservable<T>! second) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.ConnectableSignalExtensions.AutoConnect<T>(this ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Cast<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources, System.IObservable<T>! defaultSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Generate<TState, T>(TState initialState, System.Func<TState, bool>! condition, System.Func<TState, TState>! iterate, System.Func<TState, T>! resultSelector) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource, System.IObservable<T>! elseSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.OnErrorResumeNext<T>(params System.IObservable<T>![]! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.OnErrorResumeNext<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.OnErrorResumeNext<T>(System.IObservable<T>! first, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Repeat<T>(T value) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Repeat<T>(T value, int repeatCount) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Using<TResource, T>(System.Func<TResource>! resourceFactory, System.Func<TResource, System.IObservable<T>!>! observableFactory) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-macos/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-macos/PublicAPI.Unshipped.txt
@@ -1,1 +1,33 @@
 #nullable enable
+ReactiveUI.Primitives.Reactive.Advanced.AutoConnectSignal<T>.AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>? onConnect) -> void
+ReactiveUI.Primitives.Reactive.ConnectableSignalExtensions.extension<T>(ReactiveUI.Primitives.ConnectableSignal<T>!).AutoConnect(int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension(System.IObservable<object?>!).Cast<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension(System.IObservable<object?>!).OfType<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.IObservable<T>!).OnErrorResumeNext(System.IObservable<T>! second) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.ConnectableSignalExtensions.AutoConnect<T>(this ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Cast<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources, System.IObservable<T>! defaultSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Generate<TState, T>(TState initialState, System.Func<TState, bool>! condition, System.Func<TState, TState>! iterate, System.Func<TState, T>! resultSelector) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource, System.IObservable<T>! elseSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.OnErrorResumeNext<T>(params System.IObservable<T>![]! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.OnErrorResumeNext<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.OnErrorResumeNext<T>(System.IObservable<T>! first, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Repeat<T>(T value) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Repeat<T>(T value, int repeatCount) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Using<TResource, T>(System.Func<TResource>! resourceFactory, System.Func<TResource, System.IObservable<T>!>! observableFactory) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-tvos/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-tvos/PublicAPI.Unshipped.txt
@@ -1,1 +1,33 @@
 #nullable enable
+ReactiveUI.Primitives.Reactive.Advanced.AutoConnectSignal<T>.AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>? onConnect) -> void
+ReactiveUI.Primitives.Reactive.ConnectableSignalExtensions.extension<T>(ReactiveUI.Primitives.ConnectableSignal<T>!).AutoConnect(int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension(System.IObservable<object?>!).Cast<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension(System.IObservable<object?>!).OfType<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.IObservable<T>!).OnErrorResumeNext(System.IObservable<T>! second) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.ConnectableSignalExtensions.AutoConnect<T>(this ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Cast<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources, System.IObservable<T>! defaultSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Generate<TState, T>(TState initialState, System.Func<TState, bool>! condition, System.Func<TState, TState>! iterate, System.Func<TState, T>! resultSelector) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource, System.IObservable<T>! elseSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.OnErrorResumeNext<T>(params System.IObservable<T>![]! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.OnErrorResumeNext<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.OnErrorResumeNext<T>(System.IObservable<T>! first, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Repeat<T>(T value) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Repeat<T>(T value, int repeatCount) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Using<TResource, T>(System.Func<TResource>! resourceFactory, System.Func<TResource, System.IObservable<T>!>! observableFactory) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,33 @@
 #nullable enable
+ReactiveUI.Primitives.Reactive.Advanced.AutoConnectSignal<T>.AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>? onConnect) -> void
+ReactiveUI.Primitives.Reactive.ConnectableSignalExtensions.extension<T>(ReactiveUI.Primitives.ConnectableSignal<T>!).AutoConnect(int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension(System.IObservable<object?>!).Cast<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension(System.IObservable<object?>!).OfType<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.IObservable<T>!).OnErrorResumeNext(System.IObservable<T>! second) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.ConnectableSignalExtensions.AutoConnect<T>(this ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Cast<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources, System.IObservable<T>! defaultSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Generate<TState, T>(TState initialState, System.Func<TState, bool>! condition, System.Func<TState, TState>! iterate, System.Func<TState, T>! resultSelector) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource, System.IObservable<T>! elseSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.OnErrorResumeNext<T>(params System.IObservable<T>![]! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.OnErrorResumeNext<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.OnErrorResumeNext<T>(System.IObservable<T>! first, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Repeat<T>(T value) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Repeat<T>(T value, int repeatCount) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Using<TResource, T>(System.Func<TResource>! resourceFactory, System.Func<TResource, System.IObservable<T>!>! observableFactory) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net462/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net462/PublicAPI.Unshipped.txt
@@ -1,1 +1,33 @@
 #nullable enable
+ReactiveUI.Primitives.Reactive.Advanced.AutoConnectSignal<T>.AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>? onConnect) -> void
+ReactiveUI.Primitives.Reactive.ConnectableSignalExtensions.extension<T>(ReactiveUI.Primitives.ConnectableSignal<T>!).AutoConnect(int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension(System.IObservable<object?>!).Cast<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension(System.IObservable<object?>!).OfType<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.IObservable<T>!).OnErrorResumeNext(System.IObservable<T>! second) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.ConnectableSignalExtensions.AutoConnect<T>(this ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Cast<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources, System.IObservable<T>! defaultSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Generate<TState, T>(TState initialState, System.Func<TState, bool>! condition, System.Func<TState, TState>! iterate, System.Func<TState, T>! resultSelector) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource, System.IObservable<T>! elseSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.OnErrorResumeNext<T>(params System.IObservable<T>![]! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.OnErrorResumeNext<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.OnErrorResumeNext<T>(System.IObservable<T>! first, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Repeat<T>(T value) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Repeat<T>(T value, int repeatCount) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Using<TResource, T>(System.Func<TResource>! resourceFactory, System.Func<TResource, System.IObservable<T>!>! observableFactory) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,1 +1,33 @@
 #nullable enable
+ReactiveUI.Primitives.Reactive.Advanced.AutoConnectSignal<T>.AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>? onConnect) -> void
+ReactiveUI.Primitives.Reactive.ConnectableSignalExtensions.extension<T>(ReactiveUI.Primitives.ConnectableSignal<T>!).AutoConnect(int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension(System.IObservable<object?>!).Cast<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension(System.IObservable<object?>!).OfType<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.IObservable<T>!).OnErrorResumeNext(System.IObservable<T>! second) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.ConnectableSignalExtensions.AutoConnect<T>(this ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Cast<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources, System.IObservable<T>! defaultSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Generate<TState, T>(TState initialState, System.Func<TState, bool>! condition, System.Func<TState, TState>! iterate, System.Func<TState, T>! resultSelector) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource, System.IObservable<T>! elseSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.OnErrorResumeNext<T>(params System.IObservable<T>![]! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.OnErrorResumeNext<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.OnErrorResumeNext<T>(System.IObservable<T>! first, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Repeat<T>(T value) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Repeat<T>(T value, int repeatCount) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Using<TResource, T>(System.Func<TResource>! resourceFactory, System.Func<TResource, System.IObservable<T>!>! observableFactory) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net48/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net48/PublicAPI.Unshipped.txt
@@ -1,1 +1,33 @@
 #nullable enable
+ReactiveUI.Primitives.Reactive.Advanced.AutoConnectSignal<T>.AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>? onConnect) -> void
+ReactiveUI.Primitives.Reactive.ConnectableSignalExtensions.extension<T>(ReactiveUI.Primitives.ConnectableSignal<T>!).AutoConnect(int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension(System.IObservable<object?>!).Cast<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension(System.IObservable<object?>!).OfType<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.IObservable<T>!).OnErrorResumeNext(System.IObservable<T>! second) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.ConnectableSignalExtensions.AutoConnect<T>(this ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Cast<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources, System.IObservable<T>! defaultSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Generate<TState, T>(TState initialState, System.Func<TState, bool>! condition, System.Func<TState, TState>! iterate, System.Func<TState, T>! resultSelector) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource, System.IObservable<T>! elseSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.OnErrorResumeNext<T>(params System.IObservable<T>![]! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.OnErrorResumeNext<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.OnErrorResumeNext<T>(System.IObservable<T>! first, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Repeat<T>(T value) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Repeat<T>(T value, int repeatCount) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Using<TResource, T>(System.Func<TResource>! resourceFactory, System.Func<TResource, System.IObservable<T>!>! observableFactory) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net481/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net481/PublicAPI.Unshipped.txt
@@ -1,1 +1,33 @@
 #nullable enable
+ReactiveUI.Primitives.Reactive.Advanced.AutoConnectSignal<T>.AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>? onConnect) -> void
+ReactiveUI.Primitives.Reactive.ConnectableSignalExtensions.extension<T>(ReactiveUI.Primitives.ConnectableSignal<T>!).AutoConnect(int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension(System.IObservable<object?>!).Cast<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension(System.IObservable<object?>!).OfType<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.IObservable<T>!).OnErrorResumeNext(System.IObservable<T>! second) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.ConnectableSignalExtensions.AutoConnect<T>(this ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Cast<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources, System.IObservable<T>! defaultSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Generate<TState, T>(TState initialState, System.Func<TState, bool>! condition, System.Func<TState, TState>! iterate, System.Func<TState, T>! resultSelector) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource, System.IObservable<T>! elseSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.OnErrorResumeNext<T>(params System.IObservable<T>![]! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.OnErrorResumeNext<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.OnErrorResumeNext<T>(System.IObservable<T>! first, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Repeat<T>(T value) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Repeat<T>(T value, int repeatCount) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Using<TResource, T>(System.Func<TResource>! resourceFactory, System.Func<TResource, System.IObservable<T>!>! observableFactory) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,33 @@
 #nullable enable
+ReactiveUI.Primitives.Reactive.Advanced.AutoConnectSignal<T>.AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>? onConnect) -> void
+ReactiveUI.Primitives.Reactive.ConnectableSignalExtensions.extension<T>(ReactiveUI.Primitives.ConnectableSignal<T>!).AutoConnect(int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension(System.IObservable<object?>!).Cast<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension(System.IObservable<object?>!).OfType<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.IObservable<T>!).OnErrorResumeNext(System.IObservable<T>! second) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.ConnectableSignalExtensions.AutoConnect<T>(this ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Cast<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources, System.IObservable<T>! defaultSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Generate<TState, T>(TState initialState, System.Func<TState, bool>! condition, System.Func<TState, TState>! iterate, System.Func<TState, T>! resultSelector) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource, System.IObservable<T>! elseSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.OnErrorResumeNext<T>(params System.IObservable<T>![]! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.OnErrorResumeNext<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.OnErrorResumeNext<T>(System.IObservable<T>! first, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Repeat<T>(T value) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Repeat<T>(T value, int repeatCount) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Using<TResource, T>(System.Func<TResource>! resourceFactory, System.Func<TResource, System.IObservable<T>!>! observableFactory) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net9.0/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net9.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,33 @@
 #nullable enable
+ReactiveUI.Primitives.Reactive.Advanced.AutoConnectSignal<T>.AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>? onConnect) -> void
+ReactiveUI.Primitives.Reactive.ConnectableSignalExtensions.extension<T>(ReactiveUI.Primitives.ConnectableSignal<T>!).AutoConnect(int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension(System.IObservable<object?>!).Cast<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension(System.IObservable<object?>!).OfType<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.IObservable<T>!).OnErrorResumeNext(System.IObservable<T>! second) -> System.IObservable<T>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.ConnectableSignalExtensions.AutoConnect<T>(this ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Cast<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources, System.IObservable<T>! defaultSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Generate<TState, T>(TState initialState, System.Func<TState, bool>! condition, System.Func<TState, TState>! iterate, System.Func<TState, T>! resultSelector) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource, System.IObservable<T>! elseSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.OnErrorResumeNext<T>(params System.IObservable<T>![]! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.OnErrorResumeNext<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.OnErrorResumeNext<T>(System.IObservable<T>! first, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Repeat<T>(T value) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Repeat<T>(T value, int repeatCount) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.Signals.Signal.Using<TResource, T>(System.Func<TResource>! resourceFactory, System.Func<TResource, System.IObservable<T>!>! observableFactory) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net10.0-android/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net10.0-android/PublicAPI.Unshipped.txt
@@ -1,1 +1,33 @@
 #nullable enable
+ReactiveUI.Primitives.Advanced.AutoConnectSignal<T>.AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>? onConnect) -> void
+ReactiveUI.Primitives.ConnectableSignalExtensions.extension<T>(ReactiveUI.Primitives.ConnectableSignal<T>!).AutoConnect(int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension(System.IObservable<object?>!).Cast<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.LinqExtensions.extension(System.IObservable<object?>!).OfType<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<T>!).OnErrorResumeNext(System.IObservable<T>! second) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.ConnectableSignalExtensions.AutoConnect<T>(this ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.Cast<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources, System.IObservable<T>! defaultSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Generate<TState, T>(TState initialState, System.Func<TState, bool>! condition, System.Func<TState, TState>! iterate, System.Func<TState, T>! resultSelector) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource, System.IObservable<T>! elseSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.OnErrorResumeNext<T>(params System.IObservable<T>![]! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.OnErrorResumeNext<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.OnErrorResumeNext<T>(System.IObservable<T>! first, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Repeat<T>(T value) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Repeat<T>(T value, int repeatCount) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Using<TResource, T>(System.Func<TResource>! resourceFactory, System.Func<TResource, System.IObservable<T>!>! observableFactory) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net10.0-ios/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net10.0-ios/PublicAPI.Unshipped.txt
@@ -1,1 +1,33 @@
 #nullable enable
+ReactiveUI.Primitives.Advanced.AutoConnectSignal<T>.AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>? onConnect) -> void
+ReactiveUI.Primitives.ConnectableSignalExtensions.extension<T>(ReactiveUI.Primitives.ConnectableSignal<T>!).AutoConnect(int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension(System.IObservable<object?>!).Cast<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.LinqExtensions.extension(System.IObservable<object?>!).OfType<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<T>!).OnErrorResumeNext(System.IObservable<T>! second) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.ConnectableSignalExtensions.AutoConnect<T>(this ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.Cast<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources, System.IObservable<T>! defaultSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Generate<TState, T>(TState initialState, System.Func<TState, bool>! condition, System.Func<TState, TState>! iterate, System.Func<TState, T>! resultSelector) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource, System.IObservable<T>! elseSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.OnErrorResumeNext<T>(params System.IObservable<T>![]! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.OnErrorResumeNext<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.OnErrorResumeNext<T>(System.IObservable<T>! first, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Repeat<T>(T value) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Repeat<T>(T value, int repeatCount) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Using<TResource, T>(System.Func<TResource>! resourceFactory, System.Func<TResource, System.IObservable<T>!>! observableFactory) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net10.0-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net10.0-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,1 +1,33 @@
 #nullable enable
+ReactiveUI.Primitives.Advanced.AutoConnectSignal<T>.AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>? onConnect) -> void
+ReactiveUI.Primitives.ConnectableSignalExtensions.extension<T>(ReactiveUI.Primitives.ConnectableSignal<T>!).AutoConnect(int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension(System.IObservable<object?>!).Cast<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.LinqExtensions.extension(System.IObservable<object?>!).OfType<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<T>!).OnErrorResumeNext(System.IObservable<T>! second) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.ConnectableSignalExtensions.AutoConnect<T>(this ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.Cast<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources, System.IObservable<T>! defaultSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Generate<TState, T>(TState initialState, System.Func<TState, bool>! condition, System.Func<TState, TState>! iterate, System.Func<TState, T>! resultSelector) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource, System.IObservable<T>! elseSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.OnErrorResumeNext<T>(params System.IObservable<T>![]! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.OnErrorResumeNext<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.OnErrorResumeNext<T>(System.IObservable<T>! first, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Repeat<T>(T value) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Repeat<T>(T value, int repeatCount) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Using<TResource, T>(System.Func<TResource>! resourceFactory, System.Func<TResource, System.IObservable<T>!>! observableFactory) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net10.0-macos/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net10.0-macos/PublicAPI.Unshipped.txt
@@ -1,1 +1,33 @@
 #nullable enable
+ReactiveUI.Primitives.Advanced.AutoConnectSignal<T>.AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>? onConnect) -> void
+ReactiveUI.Primitives.ConnectableSignalExtensions.extension<T>(ReactiveUI.Primitives.ConnectableSignal<T>!).AutoConnect(int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension(System.IObservable<object?>!).Cast<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.LinqExtensions.extension(System.IObservable<object?>!).OfType<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<T>!).OnErrorResumeNext(System.IObservable<T>! second) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.ConnectableSignalExtensions.AutoConnect<T>(this ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.Cast<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources, System.IObservable<T>! defaultSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Generate<TState, T>(TState initialState, System.Func<TState, bool>! condition, System.Func<TState, TState>! iterate, System.Func<TState, T>! resultSelector) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource, System.IObservable<T>! elseSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.OnErrorResumeNext<T>(params System.IObservable<T>![]! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.OnErrorResumeNext<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.OnErrorResumeNext<T>(System.IObservable<T>! first, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Repeat<T>(T value) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Repeat<T>(T value, int repeatCount) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Using<TResource, T>(System.Func<TResource>! resourceFactory, System.Func<TResource, System.IObservable<T>!>! observableFactory) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net10.0-tvos/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net10.0-tvos/PublicAPI.Unshipped.txt
@@ -1,1 +1,33 @@
 #nullable enable
+ReactiveUI.Primitives.Advanced.AutoConnectSignal<T>.AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>? onConnect) -> void
+ReactiveUI.Primitives.ConnectableSignalExtensions.extension<T>(ReactiveUI.Primitives.ConnectableSignal<T>!).AutoConnect(int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension(System.IObservable<object?>!).Cast<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.LinqExtensions.extension(System.IObservable<object?>!).OfType<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<T>!).OnErrorResumeNext(System.IObservable<T>! second) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.ConnectableSignalExtensions.AutoConnect<T>(this ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.Cast<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources, System.IObservable<T>! defaultSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Generate<TState, T>(TState initialState, System.Func<TState, bool>! condition, System.Func<TState, TState>! iterate, System.Func<TState, T>! resultSelector) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource, System.IObservable<T>! elseSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.OnErrorResumeNext<T>(params System.IObservable<T>![]! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.OnErrorResumeNext<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.OnErrorResumeNext<T>(System.IObservable<T>! first, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Repeat<T>(T value) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Repeat<T>(T value, int repeatCount) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Using<TResource, T>(System.Func<TResource>! resourceFactory, System.Func<TResource, System.IObservable<T>!>! observableFactory) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net10.0/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net10.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,33 @@
 #nullable enable
+ReactiveUI.Primitives.Advanced.AutoConnectSignal<T>.AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>? onConnect) -> void
+ReactiveUI.Primitives.ConnectableSignalExtensions.extension<T>(ReactiveUI.Primitives.ConnectableSignal<T>!).AutoConnect(int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension(System.IObservable<object?>!).Cast<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.LinqExtensions.extension(System.IObservable<object?>!).OfType<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<T>!).OnErrorResumeNext(System.IObservable<T>! second) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.ConnectableSignalExtensions.AutoConnect<T>(this ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.Cast<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources, System.IObservable<T>! defaultSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Generate<TState, T>(TState initialState, System.Func<TState, bool>! condition, System.Func<TState, TState>! iterate, System.Func<TState, T>! resultSelector) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource, System.IObservable<T>! elseSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.OnErrorResumeNext<T>(params System.IObservable<T>![]! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.OnErrorResumeNext<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.OnErrorResumeNext<T>(System.IObservable<T>! first, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Repeat<T>(T value) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Repeat<T>(T value, int repeatCount) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Using<TResource, T>(System.Func<TResource>! resourceFactory, System.Func<TResource, System.IObservable<T>!>! observableFactory) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net11.0-android/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net11.0-android/PublicAPI.Unshipped.txt
@@ -1,1 +1,33 @@
 #nullable enable
+ReactiveUI.Primitives.Advanced.AutoConnectSignal<T>.AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>? onConnect) -> void
+ReactiveUI.Primitives.ConnectableSignalExtensions.extension<T>(ReactiveUI.Primitives.ConnectableSignal<T>!).AutoConnect(int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension(System.IObservable<object?>!).Cast<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.LinqExtensions.extension(System.IObservable<object?>!).OfType<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<T>!).OnErrorResumeNext(System.IObservable<T>! second) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.ConnectableSignalExtensions.AutoConnect<T>(this ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.Cast<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources, System.IObservable<T>! defaultSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Generate<TState, T>(TState initialState, System.Func<TState, bool>! condition, System.Func<TState, TState>! iterate, System.Func<TState, T>! resultSelector) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource, System.IObservable<T>! elseSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.OnErrorResumeNext<T>(params System.IObservable<T>![]! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.OnErrorResumeNext<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.OnErrorResumeNext<T>(System.IObservable<T>! first, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Repeat<T>(T value) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Repeat<T>(T value, int repeatCount) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Using<TResource, T>(System.Func<TResource>! resourceFactory, System.Func<TResource, System.IObservable<T>!>! observableFactory) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net11.0-ios/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net11.0-ios/PublicAPI.Unshipped.txt
@@ -1,1 +1,33 @@
 #nullable enable
+ReactiveUI.Primitives.Advanced.AutoConnectSignal<T>.AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>? onConnect) -> void
+ReactiveUI.Primitives.ConnectableSignalExtensions.extension<T>(ReactiveUI.Primitives.ConnectableSignal<T>!).AutoConnect(int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension(System.IObservable<object?>!).Cast<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.LinqExtensions.extension(System.IObservable<object?>!).OfType<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<T>!).OnErrorResumeNext(System.IObservable<T>! second) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.ConnectableSignalExtensions.AutoConnect<T>(this ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.Cast<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources, System.IObservable<T>! defaultSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Generate<TState, T>(TState initialState, System.Func<TState, bool>! condition, System.Func<TState, TState>! iterate, System.Func<TState, T>! resultSelector) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource, System.IObservable<T>! elseSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.OnErrorResumeNext<T>(params System.IObservable<T>![]! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.OnErrorResumeNext<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.OnErrorResumeNext<T>(System.IObservable<T>! first, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Repeat<T>(T value) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Repeat<T>(T value, int repeatCount) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Using<TResource, T>(System.Func<TResource>! resourceFactory, System.Func<TResource, System.IObservable<T>!>! observableFactory) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net11.0-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net11.0-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,1 +1,33 @@
 #nullable enable
+ReactiveUI.Primitives.Advanced.AutoConnectSignal<T>.AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>? onConnect) -> void
+ReactiveUI.Primitives.ConnectableSignalExtensions.extension<T>(ReactiveUI.Primitives.ConnectableSignal<T>!).AutoConnect(int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension(System.IObservable<object?>!).Cast<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.LinqExtensions.extension(System.IObservable<object?>!).OfType<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<T>!).OnErrorResumeNext(System.IObservable<T>! second) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.ConnectableSignalExtensions.AutoConnect<T>(this ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.Cast<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources, System.IObservable<T>! defaultSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Generate<TState, T>(TState initialState, System.Func<TState, bool>! condition, System.Func<TState, TState>! iterate, System.Func<TState, T>! resultSelector) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource, System.IObservable<T>! elseSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.OnErrorResumeNext<T>(params System.IObservable<T>![]! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.OnErrorResumeNext<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.OnErrorResumeNext<T>(System.IObservable<T>! first, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Repeat<T>(T value) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Repeat<T>(T value, int repeatCount) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Using<TResource, T>(System.Func<TResource>! resourceFactory, System.Func<TResource, System.IObservable<T>!>! observableFactory) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net11.0-macos/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net11.0-macos/PublicAPI.Unshipped.txt
@@ -1,1 +1,33 @@
 #nullable enable
+ReactiveUI.Primitives.Advanced.AutoConnectSignal<T>.AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>? onConnect) -> void
+ReactiveUI.Primitives.ConnectableSignalExtensions.extension<T>(ReactiveUI.Primitives.ConnectableSignal<T>!).AutoConnect(int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension(System.IObservable<object?>!).Cast<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.LinqExtensions.extension(System.IObservable<object?>!).OfType<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<T>!).OnErrorResumeNext(System.IObservable<T>! second) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.ConnectableSignalExtensions.AutoConnect<T>(this ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.Cast<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources, System.IObservable<T>! defaultSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Generate<TState, T>(TState initialState, System.Func<TState, bool>! condition, System.Func<TState, TState>! iterate, System.Func<TState, T>! resultSelector) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource, System.IObservable<T>! elseSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.OnErrorResumeNext<T>(params System.IObservable<T>![]! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.OnErrorResumeNext<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.OnErrorResumeNext<T>(System.IObservable<T>! first, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Repeat<T>(T value) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Repeat<T>(T value, int repeatCount) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Using<TResource, T>(System.Func<TResource>! resourceFactory, System.Func<TResource, System.IObservable<T>!>! observableFactory) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net11.0-tvos/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net11.0-tvos/PublicAPI.Unshipped.txt
@@ -1,1 +1,33 @@
 #nullable enable
+ReactiveUI.Primitives.Advanced.AutoConnectSignal<T>.AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>? onConnect) -> void
+ReactiveUI.Primitives.ConnectableSignalExtensions.extension<T>(ReactiveUI.Primitives.ConnectableSignal<T>!).AutoConnect(int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension(System.IObservable<object?>!).Cast<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.LinqExtensions.extension(System.IObservable<object?>!).OfType<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<T>!).OnErrorResumeNext(System.IObservable<T>! second) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.ConnectableSignalExtensions.AutoConnect<T>(this ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.Cast<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources, System.IObservable<T>! defaultSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Generate<TState, T>(TState initialState, System.Func<TState, bool>! condition, System.Func<TState, TState>! iterate, System.Func<TState, T>! resultSelector) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource, System.IObservable<T>! elseSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.OnErrorResumeNext<T>(params System.IObservable<T>![]! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.OnErrorResumeNext<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.OnErrorResumeNext<T>(System.IObservable<T>! first, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Repeat<T>(T value) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Repeat<T>(T value, int repeatCount) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Using<TResource, T>(System.Func<TResource>! resourceFactory, System.Func<TResource, System.IObservable<T>!>! observableFactory) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net11.0/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net11.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,33 @@
 #nullable enable
+ReactiveUI.Primitives.Advanced.AutoConnectSignal<T>.AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>? onConnect) -> void
+ReactiveUI.Primitives.ConnectableSignalExtensions.extension<T>(ReactiveUI.Primitives.ConnectableSignal<T>!).AutoConnect(int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension(System.IObservable<object?>!).Cast<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.LinqExtensions.extension(System.IObservable<object?>!).OfType<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<T>!).OnErrorResumeNext(System.IObservable<T>! second) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.ConnectableSignalExtensions.AutoConnect<T>(this ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.Cast<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources, System.IObservable<T>! defaultSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Generate<TState, T>(TState initialState, System.Func<TState, bool>! condition, System.Func<TState, TState>! iterate, System.Func<TState, T>! resultSelector) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource, System.IObservable<T>! elseSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.OnErrorResumeNext<T>(params System.IObservable<T>![]! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.OnErrorResumeNext<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.OnErrorResumeNext<T>(System.IObservable<T>! first, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Repeat<T>(T value) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Repeat<T>(T value, int repeatCount) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Using<TResource, T>(System.Func<TResource>! resourceFactory, System.Func<TResource, System.IObservable<T>!>! observableFactory) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net462/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net462/PublicAPI.Unshipped.txt
@@ -1,1 +1,33 @@
 #nullable enable
+ReactiveUI.Primitives.Advanced.AutoConnectSignal<T>.AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>? onConnect) -> void
+ReactiveUI.Primitives.ConnectableSignalExtensions.extension<T>(ReactiveUI.Primitives.ConnectableSignal<T>!).AutoConnect(int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension(System.IObservable<object?>!).Cast<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.LinqExtensions.extension(System.IObservable<object?>!).OfType<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<T>!).OnErrorResumeNext(System.IObservable<T>! second) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.ConnectableSignalExtensions.AutoConnect<T>(this ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.Cast<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources, System.IObservable<T>! defaultSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Generate<TState, T>(TState initialState, System.Func<TState, bool>! condition, System.Func<TState, TState>! iterate, System.Func<TState, T>! resultSelector) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource, System.IObservable<T>! elseSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.OnErrorResumeNext<T>(params System.IObservable<T>![]! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.OnErrorResumeNext<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.OnErrorResumeNext<T>(System.IObservable<T>! first, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Repeat<T>(T value) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Repeat<T>(T value, int repeatCount) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Using<TResource, T>(System.Func<TResource>! resourceFactory, System.Func<TResource, System.IObservable<T>!>! observableFactory) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,1 +1,33 @@
 #nullable enable
+ReactiveUI.Primitives.Advanced.AutoConnectSignal<T>.AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>? onConnect) -> void
+ReactiveUI.Primitives.ConnectableSignalExtensions.extension<T>(ReactiveUI.Primitives.ConnectableSignal<T>!).AutoConnect(int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension(System.IObservable<object?>!).Cast<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.LinqExtensions.extension(System.IObservable<object?>!).OfType<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<T>!).OnErrorResumeNext(System.IObservable<T>! second) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.ConnectableSignalExtensions.AutoConnect<T>(this ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.Cast<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources, System.IObservable<T>! defaultSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Generate<TState, T>(TState initialState, System.Func<TState, bool>! condition, System.Func<TState, TState>! iterate, System.Func<TState, T>! resultSelector) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource, System.IObservable<T>! elseSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.OnErrorResumeNext<T>(params System.IObservable<T>![]! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.OnErrorResumeNext<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.OnErrorResumeNext<T>(System.IObservable<T>! first, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Repeat<T>(T value) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Repeat<T>(T value, int repeatCount) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Using<TResource, T>(System.Func<TResource>! resourceFactory, System.Func<TResource, System.IObservable<T>!>! observableFactory) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net48/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net48/PublicAPI.Unshipped.txt
@@ -1,1 +1,33 @@
 #nullable enable
+ReactiveUI.Primitives.Advanced.AutoConnectSignal<T>.AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>? onConnect) -> void
+ReactiveUI.Primitives.ConnectableSignalExtensions.extension<T>(ReactiveUI.Primitives.ConnectableSignal<T>!).AutoConnect(int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension(System.IObservable<object?>!).Cast<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.LinqExtensions.extension(System.IObservable<object?>!).OfType<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<T>!).OnErrorResumeNext(System.IObservable<T>! second) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.ConnectableSignalExtensions.AutoConnect<T>(this ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.Cast<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources, System.IObservable<T>! defaultSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Generate<TState, T>(TState initialState, System.Func<TState, bool>! condition, System.Func<TState, TState>! iterate, System.Func<TState, T>! resultSelector) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource, System.IObservable<T>! elseSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.OnErrorResumeNext<T>(params System.IObservable<T>![]! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.OnErrorResumeNext<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.OnErrorResumeNext<T>(System.IObservable<T>! first, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Repeat<T>(T value) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Repeat<T>(T value, int repeatCount) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Using<TResource, T>(System.Func<TResource>! resourceFactory, System.Func<TResource, System.IObservable<T>!>! observableFactory) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net481/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net481/PublicAPI.Unshipped.txt
@@ -1,1 +1,33 @@
 #nullable enable
+ReactiveUI.Primitives.Advanced.AutoConnectSignal<T>.AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>? onConnect) -> void
+ReactiveUI.Primitives.ConnectableSignalExtensions.extension<T>(ReactiveUI.Primitives.ConnectableSignal<T>!).AutoConnect(int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension(System.IObservable<object?>!).Cast<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.LinqExtensions.extension(System.IObservable<object?>!).OfType<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<T>!).OnErrorResumeNext(System.IObservable<T>! second) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.ConnectableSignalExtensions.AutoConnect<T>(this ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.Cast<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources, System.IObservable<T>! defaultSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Generate<TState, T>(TState initialState, System.Func<TState, bool>! condition, System.Func<TState, TState>! iterate, System.Func<TState, T>! resultSelector) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource, System.IObservable<T>! elseSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.OnErrorResumeNext<T>(params System.IObservable<T>![]! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.OnErrorResumeNext<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.OnErrorResumeNext<T>(System.IObservable<T>! first, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Repeat<T>(T value) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Repeat<T>(T value, int repeatCount) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Using<TResource, T>(System.Func<TResource>! resourceFactory, System.Func<TResource, System.IObservable<T>!>! observableFactory) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,33 @@
 #nullable enable
+ReactiveUI.Primitives.Advanced.AutoConnectSignal<T>.AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>? onConnect) -> void
+ReactiveUI.Primitives.ConnectableSignalExtensions.extension<T>(ReactiveUI.Primitives.ConnectableSignal<T>!).AutoConnect(int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension(System.IObservable<object?>!).Cast<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.LinqExtensions.extension(System.IObservable<object?>!).OfType<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<T>!).OnErrorResumeNext(System.IObservable<T>! second) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.ConnectableSignalExtensions.AutoConnect<T>(this ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.Cast<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources, System.IObservable<T>! defaultSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Generate<TState, T>(TState initialState, System.Func<TState, bool>! condition, System.Func<TState, TState>! iterate, System.Func<TState, T>! resultSelector) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource, System.IObservable<T>! elseSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.OnErrorResumeNext<T>(params System.IObservable<T>![]! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.OnErrorResumeNext<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.OnErrorResumeNext<T>(System.IObservable<T>! first, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Repeat<T>(T value) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Repeat<T>(T value, int repeatCount) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Using<TResource, T>(System.Func<TResource>! resourceFactory, System.Func<TResource, System.IObservable<T>!>! observableFactory) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net9.0/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net9.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,33 @@
 #nullable enable
+ReactiveUI.Primitives.Advanced.AutoConnectSignal<T>.AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>? onConnect) -> void
+ReactiveUI.Primitives.ConnectableSignalExtensions.extension<T>(ReactiveUI.Primitives.ConnectableSignal<T>!).AutoConnect(int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension(System.IObservable<object?>!).Cast<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.LinqExtensions.extension(System.IObservable<object?>!).OfType<TResult>() -> System.IObservable<TResult>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<T>!).DelaySubscription(System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<T>(System.IObservable<T>!).OnErrorResumeNext(System.IObservable<T>! second) -> System.IObservable<T>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Timeout(System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.ConnectableSignalExtensions.AutoConnect<T>(this ReactiveUI.Primitives.ConnectableSignal<T>! source, int subscriberCount, System.Action<System.IDisposable!>! onConnect) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.Cast<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.LinqExtensions.Delay<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
+static ReactiveUI.Primitives.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
+static ReactiveUI.Primitives.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources, System.IObservable<T>! defaultSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Generate<TState, T>(TState initialState, System.Func<TState, bool>! condition, System.Func<TState, TState>! iterate, System.Func<TState, T>! resultSelector) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.If<T>(System.Func<bool>! condition, System.IObservable<T>! thenSource, System.IObservable<T>! elseSource) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.OnErrorResumeNext<T>(params System.IObservable<T>![]! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.OnErrorResumeNext<T>(System.Collections.Generic.IEnumerable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.OnErrorResumeNext<T>(System.IObservable<T>! first, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Repeat<T>(T value) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Repeat<T>(T value, int repeatCount) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Signals.Signal.Using<TResource, T>(System.Func<TResource>! resourceFactory, System.Func<TResource, System.IObservable<T>!>! observableFactory) -> System.IObservable<T>!

--- a/src/tests/ReactiveUI.Primitives.Tests/ConnectableSignalTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/ConnectableSignalTests.cs
@@ -107,6 +107,48 @@ public sealed class ConnectableSignalTests
         await Assert.That(replayValues.SequenceEqual(ExpectedReplayValues[..1])).IsTrue();
     }
 
+    /// <summary>Verifies AutoConnect reports the connection disposable once the subscriber threshold is reached.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task AutoConnectReportsConnectionDisposableAtThreshold()
+    {
+        Signal<int> source = new();
+        var sourceSubscriptions = 0;
+        var sourceDisposals = 0;
+        var cold = Signal.Create<int>(observer =>
+        {
+            sourceSubscriptions++;
+            var inner = source.Subscribe(observer);
+            return new ActionDisposable(() =>
+            {
+                sourceDisposals++;
+                inner.Dispose();
+            });
+        });
+
+        List<IDisposable> connections = [];
+        var auto = cold.Publish().AutoConnect(2, connections.Add);
+        List<int> first = [];
+        List<int> second = [];
+        using var firstSubscription = auto.Subscribe(first.Add);
+        source.OnNext(FirstSharedValue);
+        using var secondSubscription = auto.Subscribe(second.Add);
+        source.OnNext(SecondSharedValue);
+
+        await Assert.That(connections.Count).IsEqualTo(1);
+        await Assert.That(sourceSubscriptions).IsEqualTo(1);
+        await Assert.That(first.SequenceEqual(ExpectedSecondSharedValues[1..])).IsTrue();
+        await Assert.That(second.SequenceEqual(ExpectedSecondSharedValues[1..])).IsTrue();
+
+        connections[0].Dispose();
+        source.OnNext(UnobservedSharedValue);
+
+        await Assert.That(sourceDisposals).IsEqualTo(1);
+        await Assert.That(first.SequenceEqual(ExpectedSecondSharedValues[1..])).IsTrue();
+        await Assert.That(second.SequenceEqual(ExpectedSecondSharedValues[1..])).IsTrue();
+        _ = Assert.Throws<ArgumentNullException>(() => cold.Publish().AutoConnect(1, null!));
+    }
+
     /// <summary>Verifies direct connect handles reuse, terminate, and dispose idempotently.</summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Test]

--- a/src/tests/ReactiveUI.Primitives.Tests/EventPatternTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/EventPatternTests.cs
@@ -70,6 +70,29 @@ public class EventPatternTests
             Signal.FromEventPattern<Action, EventArgs>(_ => { }, _ => { }).Subscribe(_ => { }));
     }
 
+    /// <summary>Verifies generic event factories support WPF-style non-generic event handler shapes.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task GenericFromEventPatternSupportsCompatibleNonGenericHandlerShape()
+    {
+        AssemblyLoadEventSource source = new();
+        var assembly = typeof(EventPatternTests).Assembly;
+        List<EventPattern<AssemblyLoadEventArgs>> events = [];
+        using (Signal.FromEventPattern<AssemblyLoadEventHandler, AssemblyLoadEventArgs>(
+                   handler => source.AssemblyLoaded += handler,
+                   handler => source.AssemblyLoaded -= handler).Subscribe(events.Add))
+        {
+            source.Raise(assembly);
+        }
+
+        source.Raise(typeof(string).Assembly);
+
+        await Assert.That(events).Count().IsEqualTo(1);
+        await Assert.That(events[0].Sender!).IsSameReferenceAs(source);
+        await Assert.That(events[0].EventArgs.LoadedAssembly).IsSameReferenceAs(assembly);
+        await Assert.That(source.SubscriberCount).IsEqualTo(0);
+    }
+
     /// <summary>Verifies generic event factories support collection and list event handlers used by binding sources.</summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Test]
@@ -146,6 +169,32 @@ public class EventPatternTests
         /// <summary>Raises <see cref="Changed"/> with the supplied value.</summary>
         /// <param name="value">The value supplied to the event arguments.</param>
         public void Raise(int value) => Changed?.Invoke(this, new(value));
+    }
+
+    /// <summary>Source used to exercise a WPF-style non-generic event handler shape.</summary>
+    private sealed class AssemblyLoadEventSource
+    {
+        /// <summary>Raised by the test source.</summary>
+        [SuppressMessage(
+            "Roslynator",
+            "RCS1159:Use EventHandler<T>",
+            Justification = "This test deliberately covers WPF-style non-generic event handler delegates.")]
+        [SuppressMessage(
+            "Major Code Smell",
+            "S3908:Refactor this delegate to use 'System.EventHandler<TEventArgs>'.",
+            Justification = "This test deliberately covers WPF-style non-generic event handler delegates.")]
+        [SuppressMessage(
+            "Major Code Smell",
+            "S3906:Event Handlers should have the correct signature",
+            Justification = "This test deliberately covers WPF-style non-generic event handler delegates.")]
+        public event AssemblyLoadEventHandler? AssemblyLoaded;
+
+        /// <summary>Gets the current subscriber count.</summary>
+        public int SubscriberCount => AssemblyLoaded?.GetInvocationList().Length ?? 0;
+
+        /// <summary>Raises <see cref="AssemblyLoaded"/> with the supplied assembly.</summary>
+        /// <param name="assembly">The assembly supplied to the event arguments.</param>
+        public void Raise(System.Reflection.Assembly assembly) => AssemblyLoaded?.Invoke(this, new(assembly));
     }
 
     /// <summary>Source used to exercise <see cref="PropertyChangedEventHandler"/> event conversion.</summary>

--- a/src/tests/ReactiveUI.Primitives.Tests/OnErrorResumeNextSignalTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/OnErrorResumeNextSignalTests.cs
@@ -1,0 +1,78 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using ReactiveUI.Primitives.Signals;
+
+namespace ReactiveUI.Primitives.Tests;
+
+/// <summary>Focused coverage for the Rx-style on-error resume sequence coordinator.</summary>
+public sealed class OnErrorResumeNextSignalTests
+{
+    /// <summary>The integer constant one.</summary>
+    private const int One = 1;
+
+    /// <summary>Verifies enumerable creation failures are reported to the observer.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task OnErrorResumeNextReportsEnumeratorCreationFailure()
+    {
+        InvalidOperationException expected = new("enumerator");
+        Exception? error = null;
+        using var subscription = Signal.OnErrorResumeNext(new ThrowingEnumerable<int>(expected))
+            .Subscribe(static _ => { }, captured => error = captured);
+
+        await Assert.That(error).IsSameReferenceAs(expected);
+    }
+
+    /// <summary>Verifies a null enumerator is treated as an empty source list.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task OnErrorResumeNextCompletesWhenEnumeratorIsNull()
+    {
+        var completed = 0;
+        using var subscription = Signal.OnErrorResumeNext(new NullEnumeratorEnumerable<int>(returnsNull: true))
+            .Subscribe(static _ => { }, error => throw error, () => completed++);
+
+        await Assert.That(completed).IsEqualTo(One);
+    }
+
+    /// <summary>Verifies a null source inside the list is reported as an invalid sequence.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task OnErrorResumeNextReportsNullSourceEntry()
+    {
+        List<int> values = [];
+        Exception? error = null;
+        List<IObservable<int>> sources = [Signal.Emit(One), null!];
+        using var subscription = Signal.OnErrorResumeNext(sources)
+            .Subscribe(values.Add, captured => error = captured);
+
+        await Assert.That(values.SequenceEqual([One])).IsTrue();
+        await Assert.That(error).IsTypeOf<InvalidOperationException>();
+    }
+
+    /// <summary>Enumerable that throws when asked for an enumerator.</summary>
+    /// <param name="error">The error to throw.</param>
+    /// <typeparam name="T">The source value type.</typeparam>
+    private sealed class ThrowingEnumerable<T>(Exception error) : IEnumerable<IObservable<T>>
+    {
+        /// <inheritdoc/>
+        public IEnumerator<IObservable<T>> GetEnumerator() => throw error;
+
+        /// <inheritdoc/>
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    /// <summary>Enumerable that returns a null enumerator to cover the defensive null path.</summary>
+    /// <param name="returnsNull">Whether <see cref="IEnumerable{T}.GetEnumerator"/> returns null.</param>
+    /// <typeparam name="T">The source value type.</typeparam>
+    private sealed class NullEnumeratorEnumerable<T>(bool returnsNull) : IEnumerable<IObservable<T>>
+    {
+        /// <inheritdoc/>
+        public IEnumerator<IObservable<T>> GetEnumerator() => returnsNull ? null! : throw new InvalidOperationException();
+
+        /// <inheritdoc/>
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+}

--- a/src/tests/ReactiveUI.Primitives.Tests/OnErrorResumeNextSignalTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/OnErrorResumeNextSignalTests.cs
@@ -2,6 +2,8 @@
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using ReactiveUI.Primitives.Advanced;
+using ReactiveUI.Primitives.Disposables;
 using ReactiveUI.Primitives.Signals;
 
 namespace ReactiveUI.Primitives.Tests;
@@ -11,6 +13,16 @@ public sealed class OnErrorResumeNextSignalTests
 {
     /// <summary>The integer constant one.</summary>
     private const int One = 1;
+
+    /// <summary>Verifies the coordinator advertises current-thread subscription requirements.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task OnErrorResumeNextRequiresCurrentThread()
+    {
+        OnErrorResumeNextSignal<int> signal = new([]);
+
+        await Assert.That(signal.IsRequiredSubscribeOnCurrentThread()).IsTrue();
+    }
 
     /// <summary>Verifies enumerable creation failures are reported to the observer.</summary>
     /// <returns>A task representing the asynchronous operation.</returns>
@@ -52,6 +64,109 @@ public sealed class OnErrorResumeNextSignalTests
         await Assert.That(error).IsTypeOf<InvalidOperationException>();
     }
 
+    /// <summary>Verifies move-next failures after an active source are reported once through the observer.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task OnErrorResumeNextReportsMoveNextFailureAfterActiveSource()
+    {
+        InvalidOperationException expected = new("move-next");
+        ManualSource<int> first = new();
+        Exception? error = null;
+        using var subscription = Signal.OnErrorResumeNext(new ThrowingAfterFirstEnumerable<int>(first, expected))
+            .Subscribe(static _ => { }, captured => error = captured);
+
+        first.Complete();
+
+        await Assert.That(error).IsSameReferenceAs(expected);
+    }
+
+    /// <summary>Verifies active-source completion releases the coordinator after the source list is exhausted.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task OnErrorResumeNextCompletesAfterActiveSourceCompletes()
+    {
+        ManualSource<int> first = new();
+        var completed = 0;
+        using var subscription = Signal.OnErrorResumeNext(first)
+            .Subscribe(static _ => { }, error => throw error, () => completed++);
+
+        first.Complete();
+
+        await Assert.That(completed).IsEqualTo(One);
+    }
+
+    /// <summary>Verifies synchronous terminal sources advance through the current-thread trampoline.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task OnErrorResumeNextDoesNotReenterSynchronousSources()
+    {
+        SubscriptionDepth depth = new();
+        List<IObservable<int>> sources =
+        [
+            new DepthTrackingSource<int>(depth),
+            new DepthTrackingSource<int>(depth),
+            new DepthTrackingSource<int>(depth),
+            Signal.Emit(One)
+        ];
+        List<int> values = [];
+
+        using var subscription = Signal.OnErrorResumeNext(sources)
+            .Subscribe(values.Add);
+
+        await Assert.That(depth.MaxDepth).IsEqualTo(One);
+        await Assert.That(values.SequenceEqual([One])).IsTrue();
+    }
+
+    /// <summary>Verifies duplicate terminal callbacks cannot advance the chain after it has completed.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task OnErrorResumeNextIgnoresDuplicateTerminalReschedules()
+    {
+        List<int> values = [];
+        var completed = 0;
+
+        using var subscription = Signal.OnErrorResumeNext(new DuplicateCompleteSource<int>(), Signal.Emit(One))
+            .Subscribe(values.Add, error => throw error, () => completed++);
+
+        await Assert.That(values.SequenceEqual([One])).IsTrue();
+        await Assert.That(completed).IsEqualTo(One);
+    }
+
+    /// <summary>Verifies a completed source subscription is released once the chain advances to the next source.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task OnErrorResumeNextDisposesCompletedSubscriptionWhenAdvancing()
+    {
+        CompletingSource<int> first = new();
+        ManualSource<int> second = new();
+
+        using var subscription = Signal.OnErrorResumeNext(first, second)
+            .Subscribe(static _ => { });
+
+        await Assert.That(first.Subscription?.IsDisposed).IsTrue();
+        await Assert.That(second.Subscription?.IsDisposed).IsFalse();
+    }
+
+    /// <summary>Verifies late terminal callbacks from a disposed source do not reach the observer.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task OnErrorResumeNextIgnoresTerminalAfterDispose()
+    {
+        ManualSource<int> first = new();
+        List<int> values = [];
+        Exception? error = null;
+        var completed = 0;
+        var subscription = Signal.OnErrorResumeNext(first, Signal.Emit(One))
+            .Subscribe(values.Add, captured => error = captured, () => completed++);
+
+        subscription.Dispose();
+        first.Fail(new InvalidOperationException("late"));
+
+        await Assert.That(values.Count).IsEqualTo(0);
+        await Assert.That(error).IsNull();
+        await Assert.That(completed).IsEqualTo(0);
+    }
+
     /// <summary>Enumerable that throws when asked for an enumerator.</summary>
     /// <param name="error">The error to throw.</param>
     /// <typeparam name="T">The source value type.</typeparam>
@@ -74,5 +189,119 @@ public sealed class OnErrorResumeNextSignalTests
 
         /// <inheritdoc/>
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    /// <summary>Enumerable that returns one source and then throws when asked for the next source.</summary>
+    /// <param name="first">The first source to return.</param>
+    /// <param name="error">The error to throw on the second move.</param>
+    /// <typeparam name="T">The source value type.</typeparam>
+    private sealed class ThrowingAfterFirstEnumerable<T>(IObservable<T> first, Exception error) : IEnumerable<IObservable<T>>
+    {
+        /// <inheritdoc/>
+        public IEnumerator<IObservable<T>> GetEnumerator()
+        {
+            yield return first;
+            throw error;
+        }
+
+        /// <inheritdoc/>
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    /// <summary>Tracks nested synchronous subscriptions.</summary>
+    private sealed class SubscriptionDepth
+    {
+        /// <summary>The current subscription depth.</summary>
+        private int _depth;
+
+        /// <summary>Gets the maximum observed subscription depth.</summary>
+        internal int MaxDepth { get; private set; }
+
+        /// <summary>Enters a source subscription.</summary>
+        internal void Enter()
+        {
+            _depth++;
+            MaxDepth = Math.Max(MaxDepth, _depth);
+        }
+
+        /// <summary>Exits a source subscription.</summary>
+        internal void Exit() => _depth--;
+    }
+
+    /// <summary>Observable that completes synchronously while recording subscription nesting.</summary>
+    /// <param name="depth">The shared depth tracker.</param>
+    /// <typeparam name="T">The source value type.</typeparam>
+    private sealed class DepthTrackingSource<T>(SubscriptionDepth depth) : IObservable<T>
+    {
+        /// <inheritdoc/>
+        public IDisposable Subscribe(IObserver<T> observer)
+        {
+            depth.Enter();
+            try
+            {
+                observer.OnCompleted();
+            }
+            finally
+            {
+                depth.Exit();
+            }
+
+            return EmptyDisposable.Instance;
+        }
+    }
+
+    /// <summary>Observable that raises completion twice from one subscription.</summary>
+    /// <typeparam name="T">The source value type.</typeparam>
+    private sealed class DuplicateCompleteSource<T> : IObservable<T>
+    {
+        /// <inheritdoc/>
+        public IDisposable Subscribe(IObserver<T> observer)
+        {
+            observer.OnCompleted();
+            observer.OnCompleted();
+            return EmptyDisposable.Instance;
+        }
+    }
+
+    /// <summary>Observable that completes synchronously and exposes its returned subscription.</summary>
+    /// <typeparam name="T">The source value type.</typeparam>
+    private sealed class CompletingSource<T> : IObservable<T>
+    {
+        /// <summary>Gets the subscription returned to the caller.</summary>
+        internal BooleanDisposable? Subscription { get; private set; }
+
+        /// <inheritdoc/>
+        public IDisposable Subscribe(IObserver<T> observer)
+        {
+            Subscription = new();
+            observer.OnCompleted();
+            return Subscription;
+        }
+    }
+
+    /// <summary>Observable that keeps the observer available for manual terminal callbacks.</summary>
+    /// <typeparam name="T">The source value type.</typeparam>
+    private sealed class ManualSource<T> : IObservable<T>
+    {
+        /// <summary>The subscribed observer.</summary>
+        private IObserver<T>? _observer;
+
+        /// <summary>Gets the subscription returned to the caller.</summary>
+        internal BooleanDisposable? Subscription { get; private set; }
+
+        /// <inheritdoc/>
+        public IDisposable Subscribe(IObserver<T> observer)
+        {
+            _observer = observer;
+            Subscription = new();
+            return Subscription;
+        }
+
+        /// <summary>Manually raises an error.</summary>
+        /// <param name="error">The error to raise.</param>
+        internal void Fail(Exception error) => _observer?.OnError(error);
+
+        /// <summary>Manually completes the source.</summary>
+        internal void Complete() => _observer?.OnCompleted();
     }
 }

--- a/src/tests/ReactiveUI.Primitives.Tests/RxNamesTests.Helpers.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/RxNamesTests.Helpers.cs
@@ -1,0 +1,569 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+using ReactiveUI.Primitives.Advanced;
+using ReactiveUI.Primitives.Concurrency;
+using ReactiveUI.Primitives.Disposables;
+using ReactiveUI.Primitives.Signals;
+
+namespace ReactiveUI.Primitives.Tests;
+
+/// <summary>Helper methods and case records for Rx-name parity tests.</summary>
+public partial class RxNamesTests
+{
+    /// <summary>Runs a unary operator over a cold source and collects the forwarded values.</summary>
+    /// <param name = "op">The operator under test.</param>
+    /// <param name = "input">The source values.</param>
+    /// <returns>The forwarded values.</returns>
+    private static List<int> RunUnary(Func<IObservable<int>, IObservable<int>> op, int[] input)
+    {
+        List<int> values = [];
+        _ = op(Signal.FromEnumerable(input)).Subscribe(values.Add);
+        return values;
+    }
+
+    /// <summary>Runs a higher-order operator over a source of cold inner sources and collects the forwarded values.</summary>
+    /// <param name = "op">The operator under test.</param>
+    /// <param name = "inners">The inner source values.</param>
+    /// <returns>The forwarded values.</returns>
+    private static List<int> RunHigherOrder(Func<IObservable<IObservable<int>>, IObservable<int>> op, int[][] inners)
+    {
+        var outer = Signal.FromEnumerable(Array.ConvertAll(inners, ToSource));
+        List<int> values = [];
+        _ = op(outer).Subscribe(values.Add);
+        return values;
+    }
+
+    /// <summary>Wraps an inner value array in a cold source.</summary>
+    /// <param name = "inner">The inner values.</param>
+    /// <returns>A cold source over the inner values.</returns>
+    private static IObservable<int> ToSource(int[] inner) => Signal.FromEnumerable(inner);
+
+    /// <summary>Runs a binary operator over two manual subjects driven by a script and collects the forwarded values.</summary>
+    /// <param name = "op">The operator under test.</param>
+    /// <param name = "drive">The script that pushes values into the subjects.</param>
+    /// <returns>The forwarded values.</returns>
+    private static List<int> RunBinary(
+        Func<IObservable<int>, IObservable<int>, IObservable<int>> op,
+        Action<Signal<int>, Signal<int>> drive)
+    {
+        Signal<int> left = new();
+        Signal<int> right = new();
+        List<int> values = [];
+        using var subscription = op(left, right).Subscribe(values.Add);
+        drive(left, right);
+        return values;
+    }
+
+    /// <summary>Runs a time-based operator against a virtual clock and collects the forwarded values and any error.</summary>
+    /// <param name = "op">The operator under test.</param>
+    /// <param name = "source">The source factory.</param>
+    /// <returns>The forwarded values and any terminal error.</returns>
+    private static (List<int> Values, Exception? Error) RunTimed(
+        Func<IObservable<int>, ISequencer, IObservable<int>> op,
+        Func<IObservable<int>> source)
+    {
+        VirtualClock clock = new(DateTimeOffset.UnixEpoch);
+        List<int> values = [];
+        Exception? error = null;
+        using var subscription = op(source(), clock).Subscribe(values.Add, captured => error = captured, () => { });
+        clock.AdvanceBy(TimeSpan.FromTicks(AdvanceTicks));
+        return (values, error);
+    }
+
+    /// <summary>Pushes one value then an error through a stateful sink and reports whether both were forwarded.</summary>
+    /// <param name = "op">The stateful operator under test.</param>
+    /// <returns><see langword="true"/> when one value and the error were forwarded.</returns>
+    private static bool RunStatefulError(Func<IObservable<int>, IObservable<int>> op)
+    {
+        Signal<int> source = new();
+        List<int> values = [];
+        Exception? error = null;
+        using var subscription = op(source).Subscribe(values.Add, captured => error = captured, () => { });
+        source.OnNext(Two);
+        source.OnError(new InvalidOperationException(Boom));
+        return values.Count == One && error is InvalidOperationException;
+    }
+
+    /// <summary>Pushes a value through a sink whose projection throws and reports whether the error was forwarded.</summary>
+    /// <param name = "op">The stateful operator under test.</param>
+    /// <returns><see langword="true"/> when the thrown error was forwarded downstream.</returns>
+    private static bool RunStatefulThrow(Func<IObservable<int>, IObservable<int>> op)
+    {
+        Signal<int> source = new();
+        Exception? error = null;
+        using var subscription = op(source).Subscribe(
+            static _ => { },
+            captured => error = captured,
+            () => { });
+        source.OnNext(One);
+        return error is InvalidOperationException;
+    }
+
+    /// <summary>A stateful projection that always throws (drives the sink catch path).</summary>
+    /// <param name = "state">The unused state.</param>
+    /// <param name = "value">The unused value.</param>
+    /// <returns>Never returns; always throws.</returns>
+    private static int ThrowProjection(int state, int value) => throw new InvalidOperationException(Boom);
+
+    /// <summary>A stateful predicate that always throws (drives the sink catch path).</summary>
+    /// <param name = "state">The unused state.</param>
+    /// <param name = "value">The unused value.</param>
+    /// <returns>Never returns; always throws.</returns>
+    private static bool ThrowPredicate(int state, int value) => throw new InvalidOperationException(Boom);
+
+    /// <summary>Runs a sampling operator against a virtual clock with a fixed drive and collects the sampled values.</summary>
+    /// <param name = "op">The sampling operator under test.</param>
+    /// <returns>The sampled values.</returns>
+    private static List<int> RunSampling(Func<IObservable<int>, ISequencer, IObservable<int>> op)
+    {
+        VirtualClock clock = new(DateTimeOffset.UnixEpoch);
+        Signal<int> source = new();
+        List<int> values = [];
+        using var subscription = op(source, clock).Subscribe(values.Add);
+        source.OnNext(One);
+        clock.AdvanceBy(TimeSpan.FromTicks(Two));
+        source.OnNext(Three);
+        clock.AdvanceBy(TimeSpan.FromTicks(Two));
+        return values;
+    }
+
+    /// <summary>Combines a source value with an inner value (result selector for the 3-arg SelectMany/FlatMap).</summary>
+    /// <param name = "source">The source value.</param>
+    /// <param name = "inner">The inner value.</param>
+    /// <returns>The combined value.</returns>
+    private static int AddPair(int source, int inner) => source + inner;
+
+    /// <summary>Creates the requested multi-source CombineLatest overload.</summary>
+    /// <param name="arity">The arity to create.</param>
+    /// <param name="sources">The source signals.</param>
+    /// <returns>The combined observable.</returns>
+    [SuppressMessage(
+        "Style",
+        "S1541:Methods and properties should not be too complex",
+        Justification = "Compile-time overload coverage intentionally invokes each generated arity.")]
+    [SuppressMessage(
+        "Major Code Smell",
+        "S107:Methods should not have too many parameters",
+        Justification = "Compile-time overload coverage intentionally invokes high-arity selector lambdas.")]
+    [SuppressMessage(
+        "Major Code Smell",
+        "S109:Magic numbers should not be used",
+        Justification = "Compile-time overload coverage indexes each source slot by arity.")]
+    [SuppressMessage(
+        "Major Code Smell",
+        "S138:Functions should not have too many lines of code",
+        Justification = "Compile-time overload coverage keeps the arity switch in one audited helper.")]
+    private static IObservable<int> CreateCombineLatest(int arity, Signal<int>[] sources) =>
+        arity switch
+        {
+            4 => sources[0].CombineLatest(
+                sources[1],
+                sources[2],
+                sources[3],
+                static (value1, value2, value3, value4) =>
+                    value1 + value2 + value3 + value4),
+            5 => sources[0].CombineLatest(
+                sources[1],
+                sources[2],
+                sources[3],
+                sources[4],
+                static (value1, value2, value3, value4, value5) =>
+                    value1 + value2 + value3 + value4 + value5),
+            6 => sources[0].CombineLatest(
+                sources[1],
+                sources[2],
+                sources[3],
+                sources[4],
+                sources[5],
+                static (value1, value2, value3, value4, value5, value6) =>
+                    value1 + value2 + value3 + value4 + value5 + value6),
+            7 => sources[0].CombineLatest(
+                sources[1],
+                sources[2],
+                sources[3],
+                sources[4],
+                sources[5],
+                sources[6],
+                static (value1, value2, value3, value4, value5, value6, value7) =>
+                    value1 + value2 + value3 + value4 + value5 + value6 + value7),
+            8 => sources[0].CombineLatest(
+                sources[1],
+                sources[2],
+                sources[3],
+                sources[4],
+                sources[5],
+                sources[6],
+                sources[7],
+                static (value1, value2, value3, value4, value5, value6, value7, value8) =>
+                    value1 + value2 + value3 + value4 + value5 + value6 + value7 + value8),
+            9 => sources[0].CombineLatest(
+                sources[1],
+                sources[2],
+                sources[3],
+                sources[4],
+                sources[5],
+                sources[6],
+                sources[7],
+                sources[8],
+                static (value1, value2, value3, value4, value5, value6, value7, value8, value9) =>
+                    value1 + value2 + value3 + value4 + value5 + value6 + value7 + value8 + value9),
+            10 => sources[0].CombineLatest(
+                sources[1],
+                sources[2],
+                sources[3],
+                sources[4],
+                sources[5],
+                sources[6],
+                sources[7],
+                sources[8],
+                sources[9],
+                static (value1, value2, value3, value4, value5, value6, value7, value8, value9, value10) =>
+                    value1 + value2 + value3 + value4 + value5 + value6 + value7 + value8 + value9 + value10),
+            11 => sources[0].CombineLatest(
+                sources[1],
+                sources[2],
+                sources[3],
+                sources[4],
+                sources[5],
+                sources[6],
+                sources[7],
+                sources[8],
+                sources[9],
+                sources[10],
+                static (value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11) =>
+                    value1 + value2 + value3 + value4 + value5 + value6 + value7 + value8 + value9 + value10 +
+                    value11),
+            12 => sources[0].CombineLatest(
+                sources[1],
+                sources[2],
+                sources[3],
+                sources[4],
+                sources[5],
+                sources[6],
+                sources[7],
+                sources[8],
+                sources[9],
+                sources[10],
+                sources[11],
+                static (
+                    value1,
+                    value2,
+                    value3,
+                    value4,
+                    value5,
+                    value6,
+                    value7,
+                    value8,
+                    value9,
+                    value10,
+                    value11,
+                    value12) =>
+                    value1 + value2 + value3 + value4 + value5 + value6 + value7 + value8 + value9 + value10 +
+                    value11 + value12),
+            13 => sources[0].CombineLatest(
+                sources[1],
+                sources[2],
+                sources[3],
+                sources[4],
+                sources[5],
+                sources[6],
+                sources[7],
+                sources[8],
+                sources[9],
+                sources[10],
+                sources[11],
+                sources[12],
+                static (
+                    value1,
+                    value2,
+                    value3,
+                    value4,
+                    value5,
+                    value6,
+                    value7,
+                    value8,
+                    value9,
+                    value10,
+                    value11,
+                    value12,
+                    value13) =>
+                    value1 + value2 + value3 + value4 + value5 + value6 + value7 + value8 + value9 + value10 +
+                    value11 + value12 + value13),
+            14 => sources[0].CombineLatest(
+                sources[1],
+                sources[2],
+                sources[3],
+                sources[4],
+                sources[5],
+                sources[6],
+                sources[7],
+                sources[8],
+                sources[9],
+                sources[10],
+                sources[11],
+                sources[12],
+                sources[13],
+                static (
+                    value1,
+                    value2,
+                    value3,
+                    value4,
+                    value5,
+                    value6,
+                    value7,
+                    value8,
+                    value9,
+                    value10,
+                    value11,
+                    value12,
+                    value13,
+                    value14) =>
+                    value1 + value2 + value3 + value4 + value5 + value6 + value7 + value8 + value9 + value10 +
+                    value11 + value12 + value13 + value14),
+            15 => sources[0].CombineLatest(
+                sources[1],
+                sources[2],
+                sources[3],
+                sources[4],
+                sources[5],
+                sources[6],
+                sources[7],
+                sources[8],
+                sources[9],
+                sources[10],
+                sources[11],
+                sources[12],
+                sources[13],
+                sources[14],
+                static (
+                    value1,
+                    value2,
+                    value3,
+                    value4,
+                    value5,
+                    value6,
+                    value7,
+                    value8,
+                    value9,
+                    value10,
+                    value11,
+                    value12,
+                    value13,
+                    value14,
+                    value15) =>
+                    value1 + value2 + value3 + value4 + value5 + value6 + value7 + value8 + value9 + value10 +
+                    value11 + value12 + value13 + value14 + value15),
+            _ => throw new ArgumentOutOfRangeException(nameof(arity), arity, null)
+        };
+
+    /// <summary>Sums sixteen values for the widest CombineLatest overload.</summary>
+    /// <param name="value1">Value 1.</param>
+    /// <param name="value2">Value 2.</param>
+    /// <param name="value3">Value 3.</param>
+    /// <param name="value4">Value 4.</param>
+    /// <param name="value5">Value 5.</param>
+    /// <param name="value6">Value 6.</param>
+    /// <param name="value7">Value 7.</param>
+    /// <param name="value8">Value 8.</param>
+    /// <param name="value9">Value 9.</param>
+    /// <param name="value10">Value 10.</param>
+    /// <param name="value11">Value 11.</param>
+    /// <param name="value12">Value 12.</param>
+    /// <param name="value13">Value 13.</param>
+    /// <param name="value14">Value 14.</param>
+    /// <param name="value15">Value 15.</param>
+    /// <param name="value16">Value 16.</param>
+    /// <returns>The sum of all values.</returns>
+    [SuppressMessage(
+        "Major Code Smell",
+        "S107:Methods should not have too many parameters",
+        Justification = "Has more than 7 parameters - required to exercise the arity-16 CombineLatest selector.")]
+    private static int SumSixteen(
+        int value1,
+        int value2,
+        int value3,
+        int value4,
+        int value5,
+        int value6,
+        int value7,
+        int value8,
+        int value9,
+        int value10,
+        int value11,
+        int value12,
+        int value13,
+        int value14,
+        int value15,
+        int value16) =>
+        value1 +
+        value2 +
+        value3 +
+        value4 +
+        value5 +
+        value6 +
+        value7 +
+        value8 +
+        value9 +
+        value10 +
+        value11 +
+        value12 +
+        value13 +
+        value14 +
+        value15 +
+        value16;
+
+    /// <summary>Subscribes to a source and collects its forwarded values.</summary>
+    /// <param name = "source">The source sequence.</param>
+    /// <returns>The forwarded values.</returns>
+    private static List<int> Collect(IObservable<int> source)
+    {
+        List<int> values = [];
+        _ = source.Subscribe(values.Add);
+        return values;
+    }
+
+    /// <summary>Builds a source of two int-range inner sources (exercises the synchronous Switch range fast path).</summary>
+    /// <returns>An outer source of two range inners.</returns>
+    private static IObservable<IObservable<int>> RangeInners() =>
+        Signal.FromEnumerable([Signal.Sequence(One, Two), Signal.Sequence(Three, Two)]);
+
+    /// <summary>
+    /// Drives a stateful sink through a value, a terminal completion, and then further notifications, reporting
+    /// whether the post-terminal notifications were dropped (exactly one completion, no leaked error).
+    /// </summary>
+    /// <param name = "op">The stateful operator under test.</param>
+    /// <returns><see langword="true"/> when notifications after the terminal were dropped.</returns>
+    private static bool RunStopGuards(Func<IObservable<int>, IObservable<int>> op)
+    {
+        ManualSource<int> source = new();
+        var completed = 0;
+        Exception? error = null;
+        using var subscription = op(source).Subscribe(
+            static _ => { },
+            captured => error = captured,
+            () => completed++);
+        source.Next(Two);
+        source.Complete();
+        source.Next(Three);
+        source.Error(new InvalidOperationException(Boom));
+        source.Complete();
+        return completed == One && error is null;
+    }
+
+    /// <summary>
+    /// An observable whose subscription retains its observer and ignores disposal, letting a test push raw
+    /// notifications (including ones after a terminal notification) to exercise a sink's terminal guards.
+    /// </summary>
+    /// <typeparam name = "T">The element type.</typeparam>
+    private sealed class ManualSource<T> : IObservable<T>
+    {
+        /// <summary>The observer retained from the most recent subscription.</summary>
+        private IObserver<T>? _observer;
+
+        /// <inheritdoc/>
+        public IDisposable Subscribe(IObserver<T> observer)
+        {
+            _observer = observer;
+            return EmptyDisposable.Instance;
+        }
+
+        /// <summary>Pushes a value to the retained observer.</summary>
+        /// <param name = "value">The value to push.</param>
+        public void Next(T value) => _observer?.OnNext(value);
+
+        /// <summary>Pushes an error to the retained observer.</summary>
+        /// <param name = "exception">The error to push.</param>
+        public void Error(Exception exception) => _observer?.OnError(exception);
+
+        /// <summary>Pushes completion to the retained observer.</summary>
+        public void Complete() => _observer?.OnCompleted();
+    }
+
+    /// <summary>A source that reports it requires current-thread subscription (drives the sink's propagation check).</summary>
+    /// <typeparam name = "T">The element type.</typeparam>
+    private sealed class CurrentThreadSource<T> : IRequireCurrentThread<T>
+    {
+        /// <inheritdoc/>
+        public bool IsRequiredSubscribeOnCurrentThread() => true;
+
+        /// <inheritdoc/>
+        public IDisposable Subscribe(IObserver<T> observer) => EmptyDisposable.Instance;
+    }
+
+    /// <summary>A unary parity case: a Primitives-named builder and its Rx-named twin over one source.</summary>
+    /// <param name = "Name">The pair name.</param>
+    /// <param name = "Deviant">The Primitives-named builder.</param>
+    /// <param name = "Rx">The Rx/LINQ-named builder.</param>
+    /// <param name = "Input">The source values.</param>
+    /// <param name = "Expected">The expected forwarded values.</param>
+    public sealed record UnaryCase(
+        string Name,
+        Func<IObservable<int>, IObservable<int>> Deviant,
+        Func<IObservable<int>, IObservable<int>> Rx,
+        int[] Input,
+        int[] Expected)
+    {
+        /// <inheritdoc/>
+        public override string ToString() => Name;
+    }
+
+    /// <summary>A higher-order parity case operating over a source of inner sources.</summary>
+    /// <param name = "Name">The pair name.</param>
+    /// <param name = "Deviant">The Primitives-named builder.</param>
+    /// <param name = "Rx">The Rx/LINQ-named builder.</param>
+    /// <param name = "Inners">The inner source values.</param>
+    /// <param name = "Expected">The expected forwarded values.</param>
+    [SuppressMessage(
+        "Major Code Smell",
+        "S2368:Public methods should not have multidimensional array parameters",
+        Justification = "The jagged array is the public TUnit method-data shape for higher-order parity cases.")]
+    public sealed record HigherOrderCase(
+        string Name,
+        Func<IObservable<IObservable<int>>, IObservable<int>> Deviant,
+        Func<IObservable<IObservable<int>>, IObservable<int>> Rx,
+        int[][] Inners,
+        int[] Expected)
+    {
+        /// <inheritdoc/>
+        public override string ToString() => Name;
+    }
+
+    /// <summary>A binary parity case driven by a scripted interleaving of two manual subjects.</summary>
+    /// <param name = "Name">The pair name.</param>
+    /// <param name = "Deviant">The Primitives-named builder.</param>
+    /// <param name = "Rx">The Rx/LINQ-named builder.</param>
+    /// <param name = "Drive">The script that pushes values into the left and right subjects.</param>
+    /// <param name = "Expected">The expected forwarded values.</param>
+    public sealed record BinaryCase(
+        string Name,
+        Func<IObservable<int>, IObservable<int>, IObservable<int>> Deviant,
+        Func<IObservable<int>, IObservable<int>, IObservable<int>> Rx,
+        Action<Signal<int>, Signal<int>> Drive,
+        int[] Expected)
+    {
+        /// <inheritdoc/>
+        public override string ToString() => Name;
+    }
+
+    /// <summary>A time-based parity case driven by a virtual clock.</summary>
+    /// <param name = "Name">The pair name.</param>
+    /// <param name = "Deviant">The Primitives-named builder.</param>
+    /// <param name = "Rx">The Rx/LINQ-named builder.</param>
+    /// <param name = "Source">The source factory.</param>
+    /// <param name = "Expected">The expected forwarded values.</param>
+    /// <param name = "ExpectsTimeout">Whether a <see cref = "TimeoutException"/> is expected.</param>
+    public sealed record TimeCase(
+        string Name,
+        Func<IObservable<int>, ISequencer, IObservable<int>> Deviant,
+        Func<IObservable<int>, ISequencer, IObservable<int>> Rx,
+        Func<IObservable<int>> Source,
+        int[] Expected,
+        bool ExpectsTimeout)
+    {
+        /// <inheritdoc/>
+        public override string ToString() => Name;
+    }
+}

--- a/src/tests/ReactiveUI.Primitives.Tests/RxNamesTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/RxNamesTests.cs
@@ -382,6 +382,48 @@ public partial class RxNamesTests
         await Assert.That(timeout).IsTypeOf<TimeoutException>();
     }
 
+    /// <summary>Verifies absolute-time operators resolve scheduler time when subscribed, not when constructed.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task AbsoluteTimeOperatorsUseSchedulerNowAtSubscription()
+    {
+        const long RelativeTicks = 5;
+        const long ConstructionAdvanceTicks = 3;
+        const long RemainingTicks = RelativeTicks - ConstructionAdvanceTicks;
+
+        VirtualClock delayClock = new(DateTimeOffset.UnixEpoch);
+        var delayDueTime = delayClock.Now.AddTicks(RelativeTicks);
+        var delayedSignal = Signal.Emit(One).Delay(delayDueTime, delayClock);
+        delayClock.AdvanceBy(TimeSpan.FromTicks(ConstructionAdvanceTicks));
+        List<int> delayed = [];
+        _ = delayedSignal.Subscribe(delayed.Add);
+        delayClock.AdvanceBy(TimeSpan.FromTicks(RemainingTicks));
+        await Assert.That(delayed.SequenceEqual([One])).IsTrue();
+
+        VirtualClock subscriptionClock = new(DateTimeOffset.UnixEpoch);
+        var subscriptionDueTime = subscriptionClock.Now.AddTicks(RelativeTicks);
+        var delayedSubscriptionSignal = Signal.Emit(Two).DelaySubscription(subscriptionDueTime, subscriptionClock);
+        subscriptionClock.AdvanceBy(TimeSpan.FromTicks(ConstructionAdvanceTicks));
+        List<int> delayedSubscription = [];
+        _ = delayedSubscriptionSignal.Subscribe(delayedSubscription.Add);
+        subscriptionClock.AdvanceBy(TimeSpan.FromTicks(RemainingTicks));
+        await Assert.That(delayedSubscription.SequenceEqual([Two])).IsTrue();
+
+        VirtualClock timeoutClock = new(DateTimeOffset.UnixEpoch);
+        var timeoutDueTime = timeoutClock.Now.AddTicks(RelativeTicks);
+        var timeoutSignal = Signal.Silent<int>().Timeout(timeoutDueTime, timeoutClock);
+        timeoutClock.AdvanceBy(TimeSpan.FromTicks(ConstructionAdvanceTicks));
+        Exception? timeout = null;
+        _ = timeoutSignal.Subscribe(static _ => { }, error => timeout = error);
+        timeoutClock.AdvanceBy(TimeSpan.FromTicks(RemainingTicks));
+        await Assert.That(timeout).IsTypeOf<TimeoutException>();
+
+        await Assert.That(((IRequireCurrentThread<int>)Signal.Emit(One).Delay(delayDueTime, Sequencer.CurrentThread)).IsRequiredSubscribeOnCurrentThread()).IsTrue();
+        await Assert.That(((IRequireCurrentThread<int>)Signal.Silent<int>().Timeout(timeoutDueTime, Sequencer.CurrentThread)).IsRequiredSubscribeOnCurrentThread()).IsTrue();
+        await Assert.That(((IRequireCurrentThread<int>)Signal.OnErrorResumeNext(Signal.Silent<int>()).Timeout(timeoutDueTime, Sequencer.Immediate)).IsRequiredSubscribeOnCurrentThread()).IsTrue();
+        await Assert.That(((IRequireCurrentThread<int>)new ManualSource<int>().Timeout(timeoutDueTime, Sequencer.Immediate)).IsRequiredSubscribeOnCurrentThread()).IsFalse();
+    }
+
     /// <summary>Verifies absolute-time overloads use the default scheduler when no scheduler is supplied.</summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Test]

--- a/src/tests/ReactiveUI.Primitives.Tests/RxNamesTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/RxNamesTests.cs
@@ -2,11 +2,9 @@
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Diagnostics.CodeAnalysis;
 using ReactiveUI.Primitives.Advanced;
 using ReactiveUI.Primitives.Concurrency;
 using ReactiveUI.Primitives.Core;
-using ReactiveUI.Primitives.Disposables;
 using ReactiveUI.Primitives.Signals;
 
 namespace ReactiveUI.Primitives.Tests;
@@ -59,6 +57,9 @@ public partial class RxNamesTests
 
     /// <summary>The amount the virtual clock is advanced, comfortably past <see cref = "DueTicks"/>.</summary>
     private const long AdvanceTicks = 5;
+
+    /// <summary>The timeout in seconds used while waiting for ThreadPool-scheduled coverage branches.</summary>
+    private const int PollTimeoutSeconds = 2;
 
     /// <summary>Source values 1..5.</summary>
     private static readonly int[] _oneToFive = [1, 2, 3, 4, 5];
@@ -306,6 +307,144 @@ public partial class RxNamesTests
         await Assert.That(where.Count).IsEqualTo(Two);
     }
 
+    /// <summary>Verifies the Rx type-filtering names match the existing KeepType and CastTo operators.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task CastAndOfTypeMatchTypeFilteringAliases()
+    {
+        List<string> keepType = [];
+        List<string> ofType = [];
+        _ = Signal.FromEnumerable<object?>(["a", null, Two, "b"]).KeepType<string>().Subscribe(keepType.Add);
+        _ = Signal.FromEnumerable<object?>(["a", null, Two, "b"]).OfType<string>().Subscribe(ofType.Add);
+
+        List<string> castValues = [];
+        Exception? castError = null;
+        _ = Signal.FromEnumerable<object?>(["a", Two]).Cast<string>().Subscribe(castValues.Add, error => castError = error);
+
+        await Assert.That(ofType).IsEquivalentTo(keepType, EqualityComparer<string>.Default);
+        await Assert.That(ofType.SequenceEqual(["a", "b"])).IsTrue();
+        await Assert.That(castValues.SequenceEqual(["a"])).IsTrue();
+        await Assert.That(castError).IsTypeOf<InvalidCastException>();
+    }
+
+    /// <summary>Verifies OnErrorResumeNext continues after both normal completion and errors.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task OnErrorResumeNextContinuesAfterCompletionAndError()
+    {
+        List<int> binary = [];
+        var binaryCompleted = 0;
+        _ = Signal.Emit(Ten)
+            .OnErrorResumeNext(Signal.FromEnumerable(_oneToThree))
+            .Subscribe(binary.Add, ex => throw ex, () => binaryCompleted++);
+
+        List<int> staticValues = [];
+        var staticCompleted = 0;
+        _ = Signal.OnErrorResumeNext(
+            Signal.FromEnumerable([One]),
+            Signal.Fail<int>(new InvalidOperationException(Boom)),
+            Signal.FromEnumerable([Two, Three]))
+            .Subscribe(staticValues.Add, ex => throw ex, () => staticCompleted++);
+
+        await Assert.That(binary.SequenceEqual(_tenThenFallback)).IsTrue();
+        await Assert.That(binaryCompleted).IsEqualTo(1);
+        await Assert.That(staticValues.SequenceEqual(_oneToThree)).IsTrue();
+        await Assert.That(staticCompleted).IsEqualTo(1);
+    }
+
+    /// <summary>Verifies absolute-time Delay, DelaySubscription, and Timeout overloads use scheduler time.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task AbsoluteTimeOperatorsUseSchedulerNow()
+    {
+        VirtualClock delayClock = new(DateTimeOffset.UnixEpoch);
+        List<int> delayed = [];
+        _ = Signal.Emit(One).Delay(delayClock.Now.AddTicks(DueTicks), delayClock).Subscribe(delayed.Add);
+        await Assert.That(delayed.Count).IsEqualTo(0);
+        delayClock.AdvanceBy(TimeSpan.FromTicks(DueTicks));
+        await Assert.That(delayed.SequenceEqual([One])).IsTrue();
+
+        VirtualClock subscriptionClock = new(DateTimeOffset.UnixEpoch);
+        List<int> delayedSubscription = [];
+        _ = Signal.Emit(Two)
+            .DelaySubscription(subscriptionClock.Now.AddTicks(DueTicks), subscriptionClock)
+            .Subscribe(delayedSubscription.Add);
+        await Assert.That(delayedSubscription.Count).IsEqualTo(0);
+        subscriptionClock.AdvanceBy(TimeSpan.FromTicks(DueTicks));
+        await Assert.That(delayedSubscription.SequenceEqual([Two])).IsTrue();
+
+        VirtualClock timeoutClock = new(DateTimeOffset.UnixEpoch);
+        Exception? timeout = null;
+        _ = Signal.Silent<int>()
+            .Timeout(timeoutClock.Now.AddTicks(DueTicks), timeoutClock)
+            .Subscribe(static _ => { }, error => timeout = error);
+        timeoutClock.AdvanceBy(TimeSpan.FromTicks(DueTicks));
+        await Assert.That(timeout).IsTypeOf<TimeoutException>();
+    }
+
+    /// <summary>Verifies absolute-time overloads use the default scheduler when no scheduler is supplied.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task AbsoluteTimeOperatorsUseDefaultScheduler()
+    {
+        var dueTime = ThreadPoolSequencer.Instance.Now.AddSeconds(-PollTimeoutSeconds);
+        List<int> delayedScalar = [];
+        List<int> delayedRange = [];
+        List<int> delayedSubscriptionScalar = [];
+        List<int> delayedSubscriptionRange = [];
+        List<int> delayedExplicitRange = [];
+        List<int> delayedSubscriptionExplicitRange = [];
+        Exception? timeout = null;
+        Exception? explicitTimeout = null;
+        const ISequencer? defaultScheduler = null;
+
+        using var delayScalarSubscription = Signal.Emit(One)
+            .Delay(dueTime)
+            .Subscribe(delayedScalar.Add);
+        using var delayRangeSubscription = Signal.Sequence(Two, Two)
+            .Delay(dueTime)
+            .Subscribe(delayedRange.Add);
+        using var delayExplicitRangeSubscription = Signal.Sequence(Two, Two)
+            .Delay(dueTime, defaultScheduler)
+            .Subscribe(delayedExplicitRange.Add);
+        using var subscriptionScalarSubscription = Signal.Emit(One)
+            .DelaySubscription(dueTime)
+            .Subscribe(delayedSubscriptionScalar.Add);
+        using var subscriptionRangeSubscription = Signal.Sequence(Two, Two)
+            .DelaySubscription(dueTime)
+            .Subscribe(delayedSubscriptionRange.Add);
+        using var subscriptionExplicitRangeSubscription = Signal.Sequence(Two, Two)
+            .DelaySubscription(dueTime, defaultScheduler)
+            .Subscribe(delayedSubscriptionExplicitRange.Add);
+        using var timeoutSubscription = Signal.Silent<int>()
+            .Timeout(dueTime)
+            .Subscribe(static _ => { }, captured => timeout = captured);
+        using var explicitTimeoutSubscription = Signal.Silent<int>()
+            .Timeout(dueTime, defaultScheduler)
+            .Subscribe(static _ => { }, captured => explicitTimeout = captured);
+
+        await TestPolling.SpinUntil(
+            () =>
+                delayedScalar.Count == One &&
+                delayedRange.Count == Two &&
+                delayedExplicitRange.Count == Two &&
+                delayedSubscriptionScalar.Count == One &&
+                delayedSubscriptionRange.Count == Two &&
+                delayedSubscriptionExplicitRange.Count == Two &&
+                timeout is not null &&
+                explicitTimeout is not null,
+            TimeSpan.FromSeconds(PollTimeoutSeconds));
+
+        await Assert.That(delayedScalar.SequenceEqual([One])).IsTrue();
+        await Assert.That(delayedRange.SequenceEqual([Two, Three])).IsTrue();
+        await Assert.That(delayedExplicitRange.SequenceEqual([Two, Three])).IsTrue();
+        await Assert.That(delayedSubscriptionScalar.SequenceEqual([One])).IsTrue();
+        await Assert.That(delayedSubscriptionRange.SequenceEqual([Two, Three])).IsTrue();
+        await Assert.That(delayedSubscriptionExplicitRange.SequenceEqual([Two, Three])).IsTrue();
+        await Assert.That(timeout).IsTypeOf<TimeoutException>();
+        await Assert.That(explicitTimeout).IsTypeOf<TimeoutException>();
+    }
+
     /// <summary>Verifies the binary <c>Concat</c>/<c>Chain</c> overload concatenates two sequences identically.</summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Test]
@@ -477,15 +616,22 @@ public partial class RxNamesTests
         _ = Assert.Throws<ArgumentNullException>(() => default(IObservable<int>)!.CombineLatest(other, Add));
         _ = Assert.Throws<ArgumentNullException>(() => default(IObservable<int>)!.WithLatestFrom(other, Add));
         _ = Assert.Throws<ArgumentNullException>(() => default(IObservable<int>)!.Delay(TimeSpan.FromTicks(DueTicks)));
+        _ = Assert.Throws<ArgumentNullException>(() => default(IObservable<int>)!.Delay(DateTimeOffset.UnixEpoch));
         _ = Assert.Throws<ArgumentNullException>(() => default(IObservable<int>)!.Timeout(TimeSpan.FromTicks(DueTicks)));
+        _ = Assert.Throws<ArgumentNullException>(() => default(IObservable<int>)!.Timeout(DateTimeOffset.UnixEpoch));
         _ = Assert.Throws<ArgumentNullException>(() => default(IObservable<int>)!.Sample(TimeSpan.FromTicks(DueTicks)));
         _ = Assert.Throws<ArgumentNullException>(() => default(IObservable<int>)!.Retry(Two));
         _ = Assert.Throws<ArgumentNullException>(() => default(IObservable<int>)!.Materialize());
         _ = Assert.Throws<ArgumentNullException>(() => default(IObservable<Spark<int>>)!.Dematerialize());
         _ = Assert.Throws<ArgumentNullException>(() => default(IObservable<int>)!.Resume(other));
         _ = Assert.Throws<ArgumentNullException>(() => other.Resume(null!));
+        _ = Assert.Throws<ArgumentNullException>(() => default(IObservable<int>)!.OnErrorResumeNext(other));
+        _ = Assert.Throws<ArgumentNullException>(() => other.OnErrorResumeNext(null!));
         _ = Assert.Throws<ArgumentNullException>(() => default(IObservable<int>)!.Chain(other));
         _ = Assert.Throws<ArgumentNullException>(() => other.Chain((IObservable<int>)null!));
+        _ = Assert.Throws<ArgumentNullException>(() => default(IObservable<object?>)!.OfType<string>());
+        _ = Assert.Throws<ArgumentNullException>(() => default(IObservable<object?>)!.Cast<string>());
+        _ = Assert.Throws<ArgumentNullException>(() => default(IObservable<int>)!.DelaySubscription(DateTimeOffset.UnixEpoch));
     }
 
     /// <summary>Verifies the Rx names throw <see cref = "ArgumentNullException"/> for a null projection/predicate.</summary>
@@ -809,559 +955,5 @@ public partial class RxNamesTests
         left.OnNext(Two);
         right.OnNext(Twenty);
         left.OnNext(Three);
-    }
-
-    /// <summary>Runs a unary operator over a cold source and collects the forwarded values.</summary>
-    /// <param name = "op">The operator under test.</param>
-    /// <param name = "input">The source values.</param>
-    /// <returns>The forwarded values.</returns>
-    private static List<int> RunUnary(Func<IObservable<int>, IObservable<int>> op, int[] input)
-    {
-        List<int> values = [];
-        _ = op(Signal.FromEnumerable(input)).Subscribe(values.Add);
-        return values;
-    }
-
-    /// <summary>Runs a higher-order operator over a source of cold inner sources and collects the forwarded values.</summary>
-    /// <param name = "op">The operator under test.</param>
-    /// <param name = "inners">The inner source values.</param>
-    /// <returns>The forwarded values.</returns>
-    private static List<int> RunHigherOrder(Func<IObservable<IObservable<int>>, IObservable<int>> op, int[][] inners)
-    {
-        var outer = Signal.FromEnumerable(Array.ConvertAll(inners, ToSource));
-        List<int> values = [];
-        _ = op(outer).Subscribe(values.Add);
-        return values;
-    }
-
-    /// <summary>Wraps an inner value array in a cold source.</summary>
-    /// <param name = "inner">The inner values.</param>
-    /// <returns>A cold source over the inner values.</returns>
-    private static IObservable<int> ToSource(int[] inner) => Signal.FromEnumerable(inner);
-
-    /// <summary>Runs a binary operator over two manual subjects driven by a script and collects the forwarded values.</summary>
-    /// <param name = "op">The operator under test.</param>
-    /// <param name = "drive">The script that pushes values into the subjects.</param>
-    /// <returns>The forwarded values.</returns>
-    private static List<int> RunBinary(
-        Func<IObservable<int>, IObservable<int>, IObservable<int>> op,
-        Action<Signal<int>, Signal<int>> drive)
-    {
-        Signal<int> left = new();
-        Signal<int> right = new();
-        List<int> values = [];
-        using var subscription = op(left, right).Subscribe(values.Add);
-        drive(left, right);
-        return values;
-    }
-
-    /// <summary>Runs a time-based operator against a virtual clock and collects the forwarded values and any error.</summary>
-    /// <param name = "op">The operator under test.</param>
-    /// <param name = "source">The source factory.</param>
-    /// <returns>The forwarded values and any terminal error.</returns>
-    private static (List<int> Values, Exception? Error) RunTimed(
-        Func<IObservable<int>, ISequencer, IObservable<int>> op,
-        Func<IObservable<int>> source)
-    {
-        VirtualClock clock = new(DateTimeOffset.UnixEpoch);
-        List<int> values = [];
-        Exception? error = null;
-        using var subscription = op(source(), clock).Subscribe(values.Add, captured => error = captured, () => { });
-        clock.AdvanceBy(TimeSpan.FromTicks(AdvanceTicks));
-        return (values, error);
-    }
-
-    /// <summary>Pushes one value then an error through a stateful sink and reports whether both were forwarded.</summary>
-    /// <param name = "op">The stateful operator under test.</param>
-    /// <returns><see langword="true"/> when one value and the error were forwarded.</returns>
-    private static bool RunStatefulError(Func<IObservable<int>, IObservable<int>> op)
-    {
-        Signal<int> source = new();
-        List<int> values = [];
-        Exception? error = null;
-        using var subscription = op(source).Subscribe(values.Add, captured => error = captured, () => { });
-        source.OnNext(Two);
-        source.OnError(new InvalidOperationException(Boom));
-        return values.Count == One && error is InvalidOperationException;
-    }
-
-    /// <summary>Pushes a value through a sink whose projection throws and reports whether the error was forwarded.</summary>
-    /// <param name = "op">The stateful operator under test.</param>
-    /// <returns><see langword="true"/> when the thrown error was forwarded downstream.</returns>
-    private static bool RunStatefulThrow(Func<IObservable<int>, IObservable<int>> op)
-    {
-        Signal<int> source = new();
-        Exception? error = null;
-        using var subscription = op(source).Subscribe(
-            static _ => { },
-            captured => error = captured,
-            () => { });
-        source.OnNext(One);
-        return error is InvalidOperationException;
-    }
-
-    /// <summary>A stateful projection that always throws (drives the sink catch path).</summary>
-    /// <param name = "state">The unused state.</param>
-    /// <param name = "value">The unused value.</param>
-    /// <returns>Never returns; always throws.</returns>
-    private static int ThrowProjection(int state, int value) => throw new InvalidOperationException(Boom);
-
-    /// <summary>A stateful predicate that always throws (drives the sink catch path).</summary>
-    /// <param name = "state">The unused state.</param>
-    /// <param name = "value">The unused value.</param>
-    /// <returns>Never returns; always throws.</returns>
-    private static bool ThrowPredicate(int state, int value) => throw new InvalidOperationException(Boom);
-
-    /// <summary>Runs a sampling operator against a virtual clock with a fixed drive and collects the sampled values.</summary>
-    /// <param name = "op">The sampling operator under test.</param>
-    /// <returns>The sampled values.</returns>
-    private static List<int> RunSampling(Func<IObservable<int>, ISequencer, IObservable<int>> op)
-    {
-        VirtualClock clock = new(DateTimeOffset.UnixEpoch);
-        Signal<int> source = new();
-        List<int> values = [];
-        using var subscription = op(source, clock).Subscribe(values.Add);
-        source.OnNext(One);
-        clock.AdvanceBy(TimeSpan.FromTicks(Two));
-        source.OnNext(Three);
-        clock.AdvanceBy(TimeSpan.FromTicks(Two));
-        return values;
-    }
-
-    /// <summary>Combines a source value with an inner value (result selector for the 3-arg SelectMany/FlatMap).</summary>
-    /// <param name = "source">The source value.</param>
-    /// <param name = "inner">The inner value.</param>
-    /// <returns>The combined value.</returns>
-    private static int AddPair(int source, int inner) => source + inner;
-
-    /// <summary>Creates the requested multi-source CombineLatest overload.</summary>
-    /// <param name="arity">The arity to create.</param>
-    /// <param name="sources">The source signals.</param>
-    /// <returns>The combined observable.</returns>
-    [SuppressMessage(
-        "Style",
-        "S1541:Methods and properties should not be too complex",
-        Justification = "Compile-time overload coverage intentionally invokes each generated arity.")]
-    [SuppressMessage(
-        "Major Code Smell",
-        "S107:Methods should not have too many parameters",
-        Justification = "Compile-time overload coverage intentionally invokes high-arity selector lambdas.")]
-    [SuppressMessage(
-        "Major Code Smell",
-        "S109:Magic numbers should not be used",
-        Justification = "Compile-time overload coverage indexes each source slot by arity.")]
-    [SuppressMessage(
-        "Major Code Smell",
-        "S138:Functions should not have too many lines of code",
-        Justification = "Compile-time overload coverage keeps the arity switch in one audited helper.")]
-    private static IObservable<int> CreateCombineLatest(int arity, Signal<int>[] sources) =>
-        arity switch
-        {
-            4 => sources[0].CombineLatest(
-                sources[1],
-                sources[2],
-                sources[3],
-                static (value1, value2, value3, value4) =>
-                    value1 + value2 + value3 + value4),
-            5 => sources[0].CombineLatest(
-                sources[1],
-                sources[2],
-                sources[3],
-                sources[4],
-                static (value1, value2, value3, value4, value5) =>
-                    value1 + value2 + value3 + value4 + value5),
-            6 => sources[0].CombineLatest(
-                sources[1],
-                sources[2],
-                sources[3],
-                sources[4],
-                sources[5],
-                static (value1, value2, value3, value4, value5, value6) =>
-                    value1 + value2 + value3 + value4 + value5 + value6),
-            7 => sources[0].CombineLatest(
-                sources[1],
-                sources[2],
-                sources[3],
-                sources[4],
-                sources[5],
-                sources[6],
-                static (value1, value2, value3, value4, value5, value6, value7) =>
-                    value1 + value2 + value3 + value4 + value5 + value6 + value7),
-            8 => sources[0].CombineLatest(
-                sources[1],
-                sources[2],
-                sources[3],
-                sources[4],
-                sources[5],
-                sources[6],
-                sources[7],
-                static (value1, value2, value3, value4, value5, value6, value7, value8) =>
-                    value1 + value2 + value3 + value4 + value5 + value6 + value7 + value8),
-            9 => sources[0].CombineLatest(
-                sources[1],
-                sources[2],
-                sources[3],
-                sources[4],
-                sources[5],
-                sources[6],
-                sources[7],
-                sources[8],
-                static (value1, value2, value3, value4, value5, value6, value7, value8, value9) =>
-                    value1 + value2 + value3 + value4 + value5 + value6 + value7 + value8 + value9),
-            10 => sources[0].CombineLatest(
-                sources[1],
-                sources[2],
-                sources[3],
-                sources[4],
-                sources[5],
-                sources[6],
-                sources[7],
-                sources[8],
-                sources[9],
-                static (value1, value2, value3, value4, value5, value6, value7, value8, value9, value10) =>
-                    value1 + value2 + value3 + value4 + value5 + value6 + value7 + value8 + value9 + value10),
-            11 => sources[0].CombineLatest(
-                sources[1],
-                sources[2],
-                sources[3],
-                sources[4],
-                sources[5],
-                sources[6],
-                sources[7],
-                sources[8],
-                sources[9],
-                sources[10],
-                static (value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11) =>
-                    value1 + value2 + value3 + value4 + value5 + value6 + value7 + value8 + value9 + value10 +
-                    value11),
-            12 => sources[0].CombineLatest(
-                sources[1],
-                sources[2],
-                sources[3],
-                sources[4],
-                sources[5],
-                sources[6],
-                sources[7],
-                sources[8],
-                sources[9],
-                sources[10],
-                sources[11],
-                static (
-                    value1,
-                    value2,
-                    value3,
-                    value4,
-                    value5,
-                    value6,
-                    value7,
-                    value8,
-                    value9,
-                    value10,
-                    value11,
-                    value12) =>
-                    value1 + value2 + value3 + value4 + value5 + value6 + value7 + value8 + value9 + value10 +
-                    value11 + value12),
-            13 => sources[0].CombineLatest(
-                sources[1],
-                sources[2],
-                sources[3],
-                sources[4],
-                sources[5],
-                sources[6],
-                sources[7],
-                sources[8],
-                sources[9],
-                sources[10],
-                sources[11],
-                sources[12],
-                static (
-                    value1,
-                    value2,
-                    value3,
-                    value4,
-                    value5,
-                    value6,
-                    value7,
-                    value8,
-                    value9,
-                    value10,
-                    value11,
-                    value12,
-                    value13) =>
-                    value1 + value2 + value3 + value4 + value5 + value6 + value7 + value8 + value9 + value10 +
-                    value11 + value12 + value13),
-            14 => sources[0].CombineLatest(
-                sources[1],
-                sources[2],
-                sources[3],
-                sources[4],
-                sources[5],
-                sources[6],
-                sources[7],
-                sources[8],
-                sources[9],
-                sources[10],
-                sources[11],
-                sources[12],
-                sources[13],
-                static (
-                    value1,
-                    value2,
-                    value3,
-                    value4,
-                    value5,
-                    value6,
-                    value7,
-                    value8,
-                    value9,
-                    value10,
-                    value11,
-                    value12,
-                    value13,
-                    value14) =>
-                    value1 + value2 + value3 + value4 + value5 + value6 + value7 + value8 + value9 + value10 +
-                    value11 + value12 + value13 + value14),
-            15 => sources[0].CombineLatest(
-                sources[1],
-                sources[2],
-                sources[3],
-                sources[4],
-                sources[5],
-                sources[6],
-                sources[7],
-                sources[8],
-                sources[9],
-                sources[10],
-                sources[11],
-                sources[12],
-                sources[13],
-                sources[14],
-                static (
-                    value1,
-                    value2,
-                    value3,
-                    value4,
-                    value5,
-                    value6,
-                    value7,
-                    value8,
-                    value9,
-                    value10,
-                    value11,
-                    value12,
-                    value13,
-                    value14,
-                    value15) =>
-                    value1 + value2 + value3 + value4 + value5 + value6 + value7 + value8 + value9 + value10 +
-                    value11 + value12 + value13 + value14 + value15),
-            _ => throw new ArgumentOutOfRangeException(nameof(arity), arity, null)
-        };
-
-    /// <summary>Sums sixteen values for the widest CombineLatest overload.</summary>
-    /// <param name="value1">Value 1.</param>
-    /// <param name="value2">Value 2.</param>
-    /// <param name="value3">Value 3.</param>
-    /// <param name="value4">Value 4.</param>
-    /// <param name="value5">Value 5.</param>
-    /// <param name="value6">Value 6.</param>
-    /// <param name="value7">Value 7.</param>
-    /// <param name="value8">Value 8.</param>
-    /// <param name="value9">Value 9.</param>
-    /// <param name="value10">Value 10.</param>
-    /// <param name="value11">Value 11.</param>
-    /// <param name="value12">Value 12.</param>
-    /// <param name="value13">Value 13.</param>
-    /// <param name="value14">Value 14.</param>
-    /// <param name="value15">Value 15.</param>
-    /// <param name="value16">Value 16.</param>
-    /// <returns>The sum of all values.</returns>
-    [SuppressMessage(
-        "Major Code Smell",
-        "S107:Methods should not have too many parameters",
-        Justification = "Has more than 7 parameters - required to exercise the arity-16 CombineLatest selector.")]
-    private static int SumSixteen(
-        int value1,
-        int value2,
-        int value3,
-        int value4,
-        int value5,
-        int value6,
-        int value7,
-        int value8,
-        int value9,
-        int value10,
-        int value11,
-        int value12,
-        int value13,
-        int value14,
-        int value15,
-        int value16) =>
-        value1 +
-        value2 +
-        value3 +
-        value4 +
-        value5 +
-        value6 +
-        value7 +
-        value8 +
-        value9 +
-        value10 +
-        value11 +
-        value12 +
-        value13 +
-        value14 +
-        value15 +
-        value16;
-
-    /// <summary>Subscribes to a source and collects its forwarded values.</summary>
-    /// <param name = "source">The source sequence.</param>
-    /// <returns>The forwarded values.</returns>
-    private static List<int> Collect(IObservable<int> source)
-    {
-        List<int> values = [];
-        _ = source.Subscribe(values.Add);
-        return values;
-    }
-
-    /// <summary>Builds a source of two int-range inner sources (exercises the synchronous Switch range fast path).</summary>
-    /// <returns>An outer source of two range inners.</returns>
-    private static IObservable<IObservable<int>> RangeInners() =>
-        Signal.FromEnumerable([Signal.Sequence(One, Two), Signal.Sequence(Three, Two)]);
-
-    /// <summary>
-    /// Drives a stateful sink through a value, a terminal completion, and then further notifications, reporting
-    /// whether the post-terminal notifications were dropped (exactly one completion, no leaked error).
-    /// </summary>
-    /// <param name = "op">The stateful operator under test.</param>
-    /// <returns><see langword="true"/> when notifications after the terminal were dropped.</returns>
-    private static bool RunStopGuards(Func<IObservable<int>, IObservable<int>> op)
-    {
-        ManualSource<int> source = new();
-        var completed = 0;
-        Exception? error = null;
-        using var subscription = op(source).Subscribe(
-            static _ => { },
-            captured => error = captured,
-            () => completed++);
-        source.Next(Two);
-        source.Complete();
-        source.Next(Three);
-        source.Error(new InvalidOperationException(Boom));
-        source.Complete();
-        return completed == One && error is null;
-    }
-
-    /// <summary>
-    /// An observable whose subscription retains its observer and ignores disposal, letting a test push raw
-    /// notifications (including ones after a terminal notification) to exercise a sink's terminal guards.
-    /// </summary>
-    /// <typeparam name = "T">The element type.</typeparam>
-    private sealed class ManualSource<T> : IObservable<T>
-    {
-        /// <summary>The observer retained from the most recent subscription.</summary>
-        private IObserver<T>? _observer;
-
-        /// <inheritdoc/>
-        public IDisposable Subscribe(IObserver<T> observer)
-        {
-            _observer = observer;
-            return EmptyDisposable.Instance;
-        }
-
-        /// <summary>Pushes a value to the retained observer.</summary>
-        /// <param name = "value">The value to push.</param>
-        public void Next(T value) => _observer?.OnNext(value);
-
-        /// <summary>Pushes an error to the retained observer.</summary>
-        /// <param name = "exception">The error to push.</param>
-        public void Error(Exception exception) => _observer?.OnError(exception);
-
-        /// <summary>Pushes completion to the retained observer.</summary>
-        public void Complete() => _observer?.OnCompleted();
-    }
-
-    /// <summary>A source that reports it requires current-thread subscription (drives the sink's propagation check).</summary>
-    /// <typeparam name = "T">The element type.</typeparam>
-    private sealed class CurrentThreadSource<T> : IRequireCurrentThread<T>
-    {
-        /// <inheritdoc/>
-        public bool IsRequiredSubscribeOnCurrentThread() => true;
-
-        /// <inheritdoc/>
-        public IDisposable Subscribe(IObserver<T> observer) => EmptyDisposable.Instance;
-    }
-
-    /// <summary>A unary parity case: a Primitives-named builder and its Rx-named twin over one source.</summary>
-    /// <param name = "Name">The pair name.</param>
-    /// <param name = "Deviant">The Primitives-named builder.</param>
-    /// <param name = "Rx">The Rx/LINQ-named builder.</param>
-    /// <param name = "Input">The source values.</param>
-    /// <param name = "Expected">The expected forwarded values.</param>
-    public sealed record UnaryCase(
-        string Name,
-        Func<IObservable<int>, IObservable<int>> Deviant,
-        Func<IObservable<int>, IObservable<int>> Rx,
-        int[] Input,
-        int[] Expected)
-    {
-        /// <inheritdoc/>
-        public override string ToString() => Name;
-    }
-
-    /// <summary>A higher-order parity case operating over a source of inner sources.</summary>
-    /// <param name = "Name">The pair name.</param>
-    /// <param name = "Deviant">The Primitives-named builder.</param>
-    /// <param name = "Rx">The Rx/LINQ-named builder.</param>
-    /// <param name = "Inners">The inner source values.</param>
-    /// <param name = "Expected">The expected forwarded values.</param>
-    [SuppressMessage(
-        "Major Code Smell",
-        "S2368:Public methods should not have multidimensional array parameters",
-        Justification = "The jagged array is the public TUnit method-data shape for higher-order parity cases.")]
-    public sealed record HigherOrderCase(
-        string Name,
-        Func<IObservable<IObservable<int>>, IObservable<int>> Deviant,
-        Func<IObservable<IObservable<int>>, IObservable<int>> Rx,
-        int[][] Inners,
-        int[] Expected)
-    {
-        /// <inheritdoc/>
-        public override string ToString() => Name;
-    }
-
-    /// <summary>A binary parity case driven by a scripted interleaving of two manual subjects.</summary>
-    /// <param name = "Name">The pair name.</param>
-    /// <param name = "Deviant">The Primitives-named builder.</param>
-    /// <param name = "Rx">The Rx/LINQ-named builder.</param>
-    /// <param name = "Drive">The script that pushes values into the left and right subjects.</param>
-    /// <param name = "Expected">The expected forwarded values.</param>
-    public sealed record BinaryCase(
-        string Name,
-        Func<IObservable<int>, IObservable<int>, IObservable<int>> Deviant,
-        Func<IObservable<int>, IObservable<int>, IObservable<int>> Rx,
-        Action<Signal<int>, Signal<int>> Drive,
-        int[] Expected)
-    {
-        /// <inheritdoc/>
-        public override string ToString() => Name;
-    }
-
-    /// <summary>A time-based parity case driven by a virtual clock.</summary>
-    /// <param name = "Name">The pair name.</param>
-    /// <param name = "Deviant">The Primitives-named builder.</param>
-    /// <param name = "Rx">The Rx/LINQ-named builder.</param>
-    /// <param name = "Source">The source factory.</param>
-    /// <param name = "Expected">The expected forwarded values.</param>
-    /// <param name = "ExpectsTimeout">Whether a <see cref = "TimeoutException"/> is expected.</param>
-    public sealed record TimeCase(
-        string Name,
-        Func<IObservable<int>, ISequencer, IObservable<int>> Deviant,
-        Func<IObservable<int>, ISequencer, IObservable<int>> Rx,
-        Func<IObservable<int>> Source,
-        int[] Expected,
-        bool ExpectsTimeout)
-    {
-        /// <inheritdoc/>
-        public override string ToString() => Name;
     }
 }

--- a/src/tests/ReactiveUI.Primitives.Tests/SignalFactoriesTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/SignalFactoriesTests.cs
@@ -4,6 +4,7 @@
 
 using ReactiveUI.Primitives.Advanced;
 using ReactiveUI.Primitives.Concurrency;
+using ReactiveUI.Primitives.Disposables;
 using ReactiveUI.Primitives.Signals;
 
 namespace ReactiveUI.Primitives.Tests;
@@ -25,6 +26,9 @@ public partial class SignalFactoriesTests
 
     /// <summary>The integer constant five.</summary>
     private const int Five = 5;
+
+    /// <summary>The integer constant six.</summary>
+    private const int Six = 6;
 
     /// <summary>The integer constant seven.</summary>
     private const int Seven = 7;
@@ -500,5 +504,84 @@ public partial class SignalFactoriesTests
         List<int> values = [];
         _ = Signal.Timeout(Signal.FromEnumerable(ExpectedOneTwoThree), TimeSpan.FromTicks(One), clock).Subscribe(values.Add);
         await Assert.That(values.SequenceEqual(ExpectedOneTwoThree)).IsTrue();
+    }
+
+    /// <summary>Verifies Rx-named factory aliases delegate to the matching Primitives factories.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task RxFactoryAliasesRepeatGenerateUsingIfAndCase()
+    {
+        List<int> repeated = [];
+        List<int> repeatedCount = [];
+        List<int> repeatedZero = [];
+        List<int> generated = [];
+        List<int> conditional = [];
+        List<int> selectedCase = [];
+        List<int> defaultCase = [];
+        List<int> resumedPair = [];
+        var disposed = 0;
+        var useCompleted = 0;
+        var repeatedZeroCompleted = 0;
+
+        _ = Signal.Repeat(Seven).Take(Three).Subscribe(repeated.Add);
+        _ = Signal.Repeat(Five, Two).Subscribe(repeatedCount.Add);
+        _ = Signal.Repeat(Five, 0).Subscribe(repeatedZero.Add, ex => throw ex, () => repeatedZeroCompleted++);
+        _ = Signal.Generate(One, value => value <= Three, value => value + One, value => value * Two)
+            .Subscribe(generated.Add);
+        _ = Signal.OnErrorResumeNext(
+            Signal.Fail<int>(new InvalidOperationException("resume")),
+            Signal.Emit(Four))
+            .Subscribe(resumedPair.Add);
+
+        var chooseThen = true;
+        var conditionalSource = Signal.If(() => chooseThen, Signal.Emit(One), Signal.Emit(Two));
+        _ = conditionalSource.Subscribe(conditional.Add);
+        chooseThen = false;
+        _ = conditionalSource.Subscribe(conditional.Add);
+
+        Dictionary<string, IObservable<int>> cases = new(StringComparer.Ordinal)
+        {
+            ["one"] = Signal.Emit(One)
+        };
+        _ = Signal.Case(() => "one", cases, Signal.Emit(Two)).Subscribe(selectedCase.Add);
+        _ = Signal.Case(() => "missing", cases, Signal.Emit(Two)).Subscribe(defaultCase.Add);
+        _ = Signal.Using(
+            () => new TrackedDisposable(() => disposed++),
+            _ => Signal.Emit(Three))
+            .Subscribe(static _ => { }, ex => throw ex, () => useCompleted++);
+
+        await Assert.That(repeated.SequenceEqual(ExpectedSevenSevenSeven)).IsTrue();
+        await Assert.That(repeatedCount.SequenceEqual(ExpectedFiveFive)).IsTrue();
+        await Assert.That(repeatedZero).IsEmpty();
+        await Assert.That(repeatedZeroCompleted).IsEqualTo(One);
+        await Assert.That(generated.SequenceEqual([Two, Four, Six])).IsTrue();
+        await Assert.That(conditional.SequenceEqual([One, Two])).IsTrue();
+        await Assert.That(selectedCase.SequenceEqual([One])).IsTrue();
+        await Assert.That(defaultCase.SequenceEqual([Two])).IsTrue();
+        await Assert.That(resumedPair.SequenceEqual([Four])).IsTrue();
+        await Assert.That(disposed).IsEqualTo(One);
+        await Assert.That(useCompleted).IsEqualTo(One);
+
+        _ = Assert.Throws<ArgumentOutOfRangeException>(() => Signal.Repeat(One, -1));
+        _ = Assert.Throws<ArgumentNullException>(() => Signal.Generate<int, int>(One, null!, value => value, value => value));
+        _ = Assert.Throws<ArgumentNullException>(() => Signal.Generate<int, int>(One, _ => true, null!, value => value));
+        _ = Assert.Throws<ArgumentNullException>(() => Signal.Generate<int, int>(One, _ => true, value => value, null!));
+        _ = Assert.Throws<ArgumentNullException>(() => Signal.If<int>(null!, Signal.Emit(One)));
+        _ = Assert.Throws<ArgumentNullException>(() => Signal.If(() => true, null!, Signal.Emit(One)));
+        _ = Assert.Throws<ArgumentNullException>(() => Signal.If(() => true, Signal.Emit(One), null!));
+        _ = Assert.Throws<ArgumentNullException>(() => Signal.Case<string, int>(null!, cases));
+        _ = Assert.Throws<ArgumentNullException>(() => Signal.Case<string, int>(() => "one", null!));
+        _ = Assert.Throws<ArgumentNullException>(() => Signal.Case(() => "one", cases, null!));
+        _ = Assert.Throws<ArgumentNullException>(() => Signal.Using<IDisposable, int>(null!, _ => Signal.Emit(One)));
+        _ = Assert.Throws<ArgumentNullException>(() =>
+            Signal.Using(() => EmptyDisposable.Instance, (Func<IDisposable, IObservable<int>>)null!));
+    }
+
+    /// <summary>Disposable used by factory alias tests.</summary>
+    /// <param name="onDispose">Action invoked when disposed.</param>
+    private sealed class TrackedDisposable(Action onDispose) : IDisposable
+    {
+        /// <inheritdoc/>
+        public void Dispose() => onDispose();
     }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature: adds non-generic event handler support and fills missing System.Reactive parity APIs for ReactiveUI.Primitives and ReactiveUI.Primitives.Reactive.

## What is the new behavior?

- Supports non-generic event handler patterns in event pattern signals.
- Adds Rx-style factory aliases for If, Case, Repeat, Generate, OnErrorResumeNext, and Using.
- Adds AutoConnect callback support, Cast/OfType aliases, OnErrorResumeNext instance overload, and DateTimeOffset timing overloads.
- Adds TUnit coverage for the new event handler and parity paths and updates public API baselines.

## What is the current behavior?

Several System.Reactive-compatible entry points are missing from the Primitives API surface, and non-generic event handler patterns are not covered by the event pattern implementation.

## Checklist
- [x] Tests have been added or updated (for bug fixes / features) 
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the main branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) 

## Additional information

Local validation:
- `dotnet build "ReactiveUI.Primitives.slnx" /clp:ErrorsOnly -v:minimal`
- `dotnet test "ReactiveUI.Primitives.slnx" -- --output Detailed`
- `dotnet test "tests/ReactiveUI.Primitives.Tests/ReactiveUI.Primitives.Tests.csproj" -f net8.0 -- --coverage --output Detailed`
- MTP coverage MCP reports no missed coverage for `OnErrorResumeNextSignal{T}.cs` and `AutoConnectSignal{T}.cs`.