### PR TITLE
fix(disposables): keep SingleDisposable action single-shot

### DIFF
--- a/src/ReactiveUI.Disposables/Disposables/SingleDisposable.cs
+++ b/src/ReactiveUI.Disposables/Disposables/SingleDisposable.cs
@@ -62,7 +62,6 @@ public class SingleDisposable : IsDisposed
 
         if (ReferenceEquals(current, DisposedSentinel))
         {
-            _action?.Invoke();
             disposable.Dispose();
             return;
         }

--- a/src/tests/ReactiveUI.Disposables.Tests/DisposableTests.cs
+++ b/src/tests/ReactiveUI.Disposables.Tests/DisposableTests.cs
@@ -76,6 +76,23 @@ public class DisposableTests
         await Assert.That(disposed).IsEqualTo(1);
     }
 
+    /// <summary>Verifies action runs once and late assigned disposable is still disposed.</summary>
+    /// <returns>A <see cref = "Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task SingleDisposableDisposeThenCreateRunsActionOnce()
+    {
+        var disposed = 0;
+        var created = 0;
+        SingleDisposable disposable = new(EmptyDisposable.Instance, () => disposed++);
+
+        disposable.Dispose();
+        disposable.Create(new ActionDisposable(() => created++));
+
+        await Assert.That(disposable.IsDisposed).IsTrue();
+        await Assert.That(disposed).IsEqualTo(1);
+        await Assert.That(created).IsEqualTo(1);
+    }
+
     /// <summary>Multiples the disposable dispose.</summary>
     /// <returns>A <see cref = "Task"/> representing the asynchronous test operation.</returns>
     [Test]

--- a/src/tests/ReactiveUI.Primitives.Tests/DisposableTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/DisposableTests.cs
@@ -107,7 +107,7 @@ public class DisposableTests
         SingleDisposable lateSingle = new(() => disposedBeforeAssign++);
         lateSingle.Dispose();
         lateSingle.Create(new ActionDisposable(() => disposedBeforeAssign++));
-        await Assert.That(disposedBeforeAssign).IsEqualTo(DoubleDisposalCount);
+        await Assert.That(disposedBeforeAssign).IsEqualTo(1);
         _ = Assert.Throws<ArgumentNullException>(() => lateSingle.Create(null!));
         var replaced = 0;
         SingleReplaceableDisposable replaceable = new(


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix for `SingleDisposable` disposal callback semantics.

## What is the new behavior?

Calling `Create` after `SingleDisposable` has already been disposed now disposes the late assigned disposable without invoking the pre-dispose action again. The action remains single-shot.

## What is the current behavior?

`Dispose()` invokes the action, and a later `Create(...)` on the already-disposed slot invokes the same action again before disposing the incoming disposable.

## Checklist
- [x] Tests have been added or updated (for bug fixes / features) 
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the main branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) 

## Additional information

Fixes #80.

Validation run from `src`:

- `dotnet restore "ReactiveUI.Primitives.slnx"` succeeded
- `dotnet build "ReactiveUI.Disposables/ReactiveUI.Disposables.csproj"` succeeded
- `dotnet build "tests/ReactiveUI.Disposables.Tests/ReactiveUI.Disposables.Tests.csproj"` succeeded
- `dotnet test "tests/ReactiveUI.Disposables.Tests/ReactiveUI.Disposables.Tests.csproj" -- --treenode-filter "/*/*/DisposableTests/SingleDisposableDisposeThenCreateRunsActionOnce"` passed 4/4 target-framework instances

Full solution build was attempted by the worker but timed out in this local environment.