### PR TITLE
fix(disposables): hide OnceDisposable disposed sentinel

### DIFF
--- a/src/ReactiveUI.Disposables/Disposables/OnceDisposable.cs
+++ b/src/ReactiveUI.Disposables/Disposables/OnceDisposable.cs
@@ -14,7 +14,7 @@ namespace ReactiveUI.Primitives.Disposables;
 public sealed class OnceDisposable : IsDisposed
 {
     /// <summary>Sentinel value indicating the object has been disposed.</summary>
-    private static readonly IDisposable DisposedSentinel = EmptyDisposable.Instance;
+    private static readonly IDisposable DisposedSentinel = new DisposedMarker();
 
     /// <summary>The current inner disposable.</summary>
     private IDisposable? _current;
@@ -67,5 +67,15 @@ public sealed class OnceDisposable : IsDisposed
         }
 
         previous.Dispose();
+    }
+
+    /// <summary>Disposable marker for disposed instances.</summary>
+    private sealed class DisposedMarker : IDisposable
+    {
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            // Intentionally empty.
+        }
     }
 }

--- a/src/tests/ReactiveUI.Disposables.Tests/InternalDisposablesTests.cs
+++ b/src/tests/ReactiveUI.Disposables.Tests/InternalDisposablesTests.cs
@@ -116,6 +116,23 @@ public class InternalDisposablesTests
         await Assert.That(ex).IsNotNull();
     }
 
+    /// <summary>Verifies assigning <see cref="EmptyDisposable.Instance"/> does not mark disposed and does not drop a later real assignment.</summary>
+    /// <returns>A <see cref = "Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenOnceDisposableAssignedEmptyDisposable_ThenNotDisposedAndLaterRealAssignmentNotDropped()
+    {
+        OnceDisposable holder = new();
+        holder.Disposable = EmptyDisposable.Instance;
+
+        await Assert.That(holder.IsDisposed).IsFalse();
+        await Assert.That(holder.Disposable).IsSameReferenceAs(EmptyDisposable.Instance);
+
+        CountingDisposable late = new();
+        var ex = Assert.Throws<InvalidOperationException>(() => holder.Disposable = late);
+        await Assert.That(ex).IsNotNull();
+        await Assert.That(late.DisposeCount).IsEqualTo(0);
+    }
+
     /// <summary>Verifies that assigning after dispose disposes the supplied value and reports null via the getter.</summary>
     /// <returns>A <see cref = "Task"/> representing the asynchronous test operation.</returns>
     [Test]


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix for `OnceDisposable` disposed-state tracking.

## What is the new behavior?

`OnceDisposable` uses a private sentinel instance for its disposed marker, so callers cannot spoof the disposed state by assigning the public `EmptyDisposable.Instance` singleton.

## What is the current behavior?

`OnceDisposable` uses `EmptyDisposable.Instance` as its disposed sentinel. Since that singleton is public, assigning it as a normal disposable makes the instance appear disposed and causes later assignments to be treated as post-dispose assignments.

## Checklist
- [x] Tests have been added or updated (for bug fixes / features) 
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the main branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) 

## Additional information

Fixes #78.

Validation run from `src`:

- `dotnet test "tests/ReactiveUI.Disposables.Tests/ReactiveUI.Disposables.Tests.csproj" -- --treenode-filter "/*/ReactiveUI.Disposables.Tests/InternalDisposablesTests/WhenOnceDisposableAssignedEmptyDisposable_ThenNotDisposedAndLaterRealAssignmentNotDropped"` passed across net8.0, net9.0, net10.0, and net11.0
- `dotnet build "tests/ReactiveUI.Disposables.Tests/ReactiveUI.Disposables.Tests.csproj"` succeeded
- `dotnet test "tests/ReactiveUI.Disposables.Tests/ReactiveUI.Disposables.Tests.csproj"` passed 192 total, 0 failed

Full solution build was attempted by the worker but timed out in this local environment.