### PR TITLE
fix(operators): serialize timeout terminal delivery

### DIFF
--- a/src/Primitives.Shared/Advanced/ExpireCoordinator{T}.cs
+++ b/src/Primitives.Shared/Advanced/ExpireCoordinator{T}.cs
@@ -12,6 +12,9 @@ namespace ReactiveUI.Primitives.Advanced;
 /// <typeparam name="T">The source value type.</typeparam>
 public sealed class ExpireCoordinator<T> : IObserver<T>, IDisposable
 {
+    /// <summary>The synchronization gate for downstream observer calls.</summary>
+    private readonly Lock _gate = new();
+
     /// <summary>The source observable.</summary>
     private readonly IObservable<T> _source;
 
@@ -71,48 +74,69 @@ public sealed class ExpireCoordinator<T> : IObserver<T>, IDisposable
     /// <inheritdoc/>
     public void OnCompleted()
     {
-        if (Interlocked.Exchange(ref _done, 1) != 0)
-        {
-            return;
-        }
-
+        var shouldDispose = false;
         try
         {
-            _observer.OnCompleted();
+            lock (_gate)
+            {
+                if (_done != 0)
+                {
+                    return;
+                }
+
+                _done = 1;
+                shouldDispose = true;
+                _observer.OnCompleted();
+            }
         }
         finally
         {
-            Dispose();
+            if (shouldDispose)
+            {
+                Dispose();
+            }
         }
     }
 
     /// <inheritdoc/>
     public void OnError(Exception error)
     {
-        if (Interlocked.Exchange(ref _done, 1) != 0)
-        {
-            return;
-        }
-
+        var shouldDispose = false;
         try
         {
-            _observer.OnError(error);
+            lock (_gate)
+            {
+                if (_done != 0)
+                {
+                    return;
+                }
+
+                _done = 1;
+                shouldDispose = true;
+                _observer.OnError(error);
+            }
         }
         finally
         {
-            Dispose();
+            if (shouldDispose)
+            {
+                Dispose();
+            }
         }
     }
 
     /// <inheritdoc/>
     public void OnNext(T value)
     {
-        if (Volatile.Read(ref _done) != 0)
+        lock (_gate)
         {
-            return;
-        }
+            if (_done != 0)
+            {
+                return;
+            }
 
-        _observer.OnNext(value);
+            _observer.OnNext(value);
+        }
     }
 
     /// <summary>Starts observing the source and timeout timer.</summary>
@@ -134,18 +158,27 @@ public sealed class ExpireCoordinator<T> : IObserver<T>, IDisposable
     /// <returns>An empty disposable.</returns>
     private EmptyDisposable EmitTimeout()
     {
-        if (Interlocked.Exchange(ref _done, 1) != 0)
-        {
-            return EmptyDisposable.Instance;
-        }
-
+        var shouldDispose = false;
         try
         {
-            _observer.OnError(new TimeoutException());
+            lock (_gate)
+            {
+                if (_done != 0)
+                {
+                    return EmptyDisposable.Instance;
+                }
+
+                _done = 1;
+                shouldDispose = true;
+                _observer.OnError(new TimeoutException());
+            }
         }
         finally
         {
-            Dispose();
+            if (shouldDispose)
+            {
+                Dispose();
+            }
         }
 
         return EmptyDisposable.Instance;

--- a/src/tests/ReactiveUI.Primitives.Tests/ExpireCoordinatorTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/ExpireCoordinatorTests.cs
@@ -1,0 +1,93 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using ReactiveUI.Primitives.Advanced;
+using ReactiveUI.Primitives.Concurrency;
+using ReactiveUI.Primitives.Signals;
+
+namespace ReactiveUI.Primitives.Tests;
+
+/// <summary>Tests for <see cref="ExpireCoordinator{T}"/>.</summary>
+public sealed class ExpireCoordinatorTests
+{
+    /// <summary>The integer constant one.</summary>
+    private const int One = 1;
+
+    /// <summary>Timeout used while waiting for background work in this test.</summary>
+    private static readonly TimeSpan WaitTimeout = TimeSpan.FromSeconds(5);
+
+    /// <summary>Verifies timeout delivery is serialized behind an in-flight source value.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task TimeoutDoesNotEnterObserverWhileOnNextIsInFlight()
+    {
+        VirtualClock clock = new(DateTimeOffset.UnixEpoch);
+        Signal<int> source = new();
+        BlockingObserver observer = new();
+        using var subscription = source.Expire(TimeSpan.FromTicks(One), clock).Subscribe(observer);
+
+        var onNextTask = Task.Run(() => source.OnNext(One));
+        await observer.OnNextEntered.Task.WaitAsync(WaitTimeout).ConfigureAwait(false);
+
+        var timeoutTask = Task.Run(() => clock.AdvanceBy(TimeSpan.FromTicks(One)));
+        await Task.Delay(TimeSpan.FromMilliseconds(50)).ConfigureAwait(false);
+
+        await Assert.That(observer.ErrorEnteredDuringOnNext).IsFalse();
+
+        observer.ReleaseOnNext.Set();
+        await onNextTask.WaitAsync(WaitTimeout).ConfigureAwait(false);
+        await timeoutTask.WaitAsync(WaitTimeout).ConfigureAwait(false);
+
+        await Assert.That(observer.Errors).IsEqualTo(One);
+        await Assert.That(observer.Values).IsEqualTo(One);
+    }
+
+    /// <summary>Observer that blocks source value handling so timeout serialization can be observed.</summary>
+    private sealed class BlockingObserver : IObserver<int>
+    {
+        /// <summary>Gets the task completed when <see cref="OnNext"/> is entered.</summary>
+        public TaskCompletionSource OnNextEntered { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        /// <summary>Gets the event released by the test to unblock <see cref="OnNext"/>.</summary>
+        public ManualResetEventSlim ReleaseOnNext { get; } = new();
+
+        /// <summary>Gets the number of forwarded values.</summary>
+        public int Values { get; private set; }
+
+        /// <summary>Gets the number of forwarded errors.</summary>
+        public int Errors { get; private set; }
+
+        /// <summary>Gets a value indicating whether an error entered while <see cref="OnNext"/> was active.</summary>
+        public bool ErrorEnteredDuringOnNext { get; private set; }
+
+        /// <summary>Gets or sets a value indicating whether <see cref="OnNext"/> is active.</summary>
+        private bool IsInOnNext { get; set; }
+
+        /// <inheritdoc/>
+        public void OnCompleted()
+        {
+        }
+
+        /// <inheritdoc/>
+        public void OnError(Exception error)
+        {
+            if (IsInOnNext)
+            {
+                ErrorEnteredDuringOnNext = true;
+            }
+
+            Errors++;
+        }
+
+        /// <inheritdoc/>
+        public void OnNext(int value)
+        {
+            Values++;
+            IsInOnNext = true;
+            OnNextEntered.SetResult();
+            _ = ReleaseOnNext.Wait(WaitTimeout);
+            IsInOnNext = false;
+        }
+    }
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix for timeout operator concurrency.

## What is the new behavior?

Timeout terminal delivery is serialized with source notifications so a timeout `OnError` cannot enter an observer concurrently with an in-flight `OnNext`.

Fixes #68.

## What is the current behavior?

A timeout timer can emit `OnError` while the upstream `OnNext` path is still inside the downstream observer, allowing observer calls to overlap.

## Checklist
- [x] Tests have been added or updated (for bug fixes / features) 
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the main branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) 

## Additional information

Validation:
- `dotnet build "tests/ReactiveUI.Primitives.Tests/ReactiveUI.Primitives.Tests.csproj" -f net10.0 --no-restore -v minimal`
- `dotnet test "tests/ReactiveUI.Primitives.Tests/ReactiveUI.Primitives.Tests.csproj" -f net10.0 --no-build -- --treenode-filter "/*/*/ExpireCoordinatorTests/*" --output Detailed`
- `mcp__mtpunittestmcp.get_solution_coverage` was run, but no Cobertura coverage data was present under the solution directory.

A full multi-target test command was attempted first but exceeded the local timeout while the repository was under parallel issue validation load.