### PR TITLE
fix(operators): dispose losing race subscriptions

### DIFF
--- a/src/Primitives.Shared/Advanced/RaceArms{T}.cs
+++ b/src/Primitives.Shared/Advanced/RaceArms{T}.cs
@@ -1,0 +1,167 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+#if REACTIVE_SHIM
+namespace ReactiveUI.Primitives.Reactive.Advanced;
+#else
+namespace ReactiveUI.Primitives.Advanced;
+#endif
+
+/// <summary>Shared race-arm bookkeeping: tracks candidate subscriptions, elects a winner, and disposes losers.</summary>
+/// <typeparam name="T">The source value type.</typeparam>
+internal sealed class RaceArms<T> : IDisposable
+{
+    /// <summary>Serializes source registration and winner finalization.</summary>
+    private readonly Lock _gate = new();
+
+    /// <summary>Active source subscriptions by source index.</summary>
+    private readonly Dictionary<int, IDisposable> _sourceSubscriptions = [];
+
+    /// <summary>The active subscriptions.</summary>
+    private readonly MultipleDisposable _subscriptions = [];
+
+    /// <summary>The downstream observer.</summary>
+    private readonly IObserver<T> _observer;
+
+    /// <summary>The winning source index, or -1 before a source wins.</summary>
+    private int _winner = -1;
+
+    /// <summary>The next source index.</summary>
+    private int _index;
+
+    /// <summary>Initializes a new instance of the <see cref="RaceArms{T}"/> class.</summary>
+    /// <param name="observer">The downstream observer.</param>
+    internal RaceArms(IObserver<T> observer) => _observer = observer;
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        _subscriptions.Dispose();
+        lock (_gate)
+        {
+            _sourceSubscriptions.Clear();
+        }
+    }
+
+    /// <summary>Adds a disposable that should be released with the arms.</summary>
+    /// <param name="disposable">The disposable to track.</param>
+    internal void Add(IDisposable disposable) => _subscriptions.Add(disposable);
+
+    /// <summary>Forwards a terminal error from the outer source to the downstream observer.</summary>
+    /// <param name="error">The error to forward.</param>
+    internal void OnOuterError(Exception error) => _observer.OnError(error);
+
+    /// <summary>Subscribes to a candidate source and registers it for winner bookkeeping.</summary>
+    /// <param name="source">The candidate source.</param>
+    internal void OnSource(IObservable<T> source)
+    {
+        var current = Interlocked.Increment(ref _index) - 1;
+        var subscription = source.Subscribe(
+            value => OnNext(current, value),
+            error => OnError(current, error),
+            () => OnCompleted(current));
+        _subscriptions.Add(subscription);
+
+        lock (_gate)
+        {
+            if (_winner < 0 || _winner == current)
+            {
+                _sourceSubscriptions[current] = subscription;
+                return;
+            }
+
+            _ = _subscriptions.Remove(subscription);
+        }
+    }
+
+    /// <summary>Forwards a value from the winning candidate.</summary>
+    /// <param name="candidate">The candidate index.</param>
+    /// <param name="value">The value to forward.</param>
+    private void OnNext(int candidate, T value)
+    {
+        if (!Win(candidate))
+        {
+            return;
+        }
+
+        _observer.OnNext(value);
+    }
+
+    /// <summary>Forwards an error from the winning candidate.</summary>
+    /// <param name="candidate">The candidate index.</param>
+    /// <param name="error">The error to forward.</param>
+    private void OnError(int candidate, Exception error)
+    {
+        if (!Win(candidate))
+        {
+            return;
+        }
+
+        _observer.OnError(error);
+    }
+
+    /// <summary>Forwards completion from the winning candidate.</summary>
+    /// <param name="candidate">The candidate index.</param>
+    private void OnCompleted(int candidate)
+    {
+        if (!Win(candidate))
+        {
+            return;
+        }
+
+        _observer.OnCompleted();
+    }
+
+    /// <summary>Attempts to make a candidate the winner, disposing the losers when it wins.</summary>
+    /// <param name="candidate">The candidate index.</param>
+    /// <returns><see langword="true"/> when the candidate is the winner.</returns>
+    private bool Win(int candidate)
+    {
+        var current = Volatile.Read(ref _winner);
+        if (current == candidate)
+        {
+            return true;
+        }
+
+        if (current >= 0)
+        {
+            return false;
+        }
+
+        if (Interlocked.CompareExchange(ref _winner, candidate, -1) != -1)
+        {
+            return false;
+        }
+
+        DiscardLosers(candidate);
+        return true;
+    }
+
+    /// <summary>Disposes all inner subscriptions except the winner.</summary>
+    /// <param name="winner">The winning source index.</param>
+    private void DiscardLosers(int winner)
+    {
+        List<(int Candidate, IDisposable Subscription)> losers = [];
+        lock (_gate)
+        {
+            foreach (var pair in _sourceSubscriptions)
+            {
+                if (pair.Key != winner)
+                {
+                    losers.Add((pair.Key, pair.Value));
+                }
+            }
+
+            for (var i = 0; i < losers.Count; i++)
+            {
+                _ = _sourceSubscriptions.Remove(losers[i].Candidate);
+            }
+        }
+
+        for (var i = 0; i < losers.Count; i++)
+        {
+            _ = _subscriptions.Remove(losers[i].Subscription);
+        }
+    }
+}

--- a/src/Primitives.Shared/Advanced/RaceWitness{T}.cs
+++ b/src/Primitives.Shared/Advanced/RaceWitness{T}.cs
@@ -12,44 +12,22 @@ namespace ReactiveUI.Primitives.Advanced;
 /// <typeparam name="T">The value type.</typeparam>
 public sealed class RaceWitness<T> : IDisposable
 {
-    /// <summary>Serializes source registration and winner finalization.</summary>
-    private readonly Lock _gate = new();
-
-    /// <summary>Active source subscriptions by source index.</summary>
-    private readonly Dictionary<int, IDisposable> _sourceSubscriptions = [];
-
-    /// <summary>The winning source index, or -1 before a source wins.</summary>
-    private int _winner = -1;
-
-    /// <summary>The next source index.</summary>
-    private int _index;
+    /// <summary>The shared race-arm bookkeeping.</summary>
+    private readonly RaceArms<T> _arms;
 
     /// <summary>Initializes a new instance of the <see cref="RaceWitness{T}"/> class.</summary>
     /// <param name="observer">The downstream observer.</param>
-    public RaceWitness(IObserver<T> observer) => Observer = observer;
-
-    /// <summary>Gets the downstream observer.</summary>
-    private IObserver<T> Observer { get; }
-
-    /// <summary>Gets the active subscriptions.</summary>
-    private MultipleDisposable Subscriptions { get; } = [];
+    public RaceWitness(IObserver<T> observer) => _arms = new(observer);
 
     /// <inheritdoc/>
-    public void Dispose()
-    {
-        Subscriptions.Dispose();
-        lock (_gate)
-        {
-            _sourceSubscriptions.Clear();
-        }
-    }
+    public void Dispose() => _arms.Dispose();
 
     /// <summary>Starts observing an outer observable of candidates.</summary>
     /// <param name="sources">The outer source.</param>
     /// <returns>The observer that owns the subscriptions.</returns>
     public RaceWitness<T> Run(IObservable<IObservable<T>> sources)
     {
-        Subscriptions.Add(sources.Subscribe(OnSource, Observer.OnError, OnOuterCompleted));
+        _arms.Add(sources.Subscribe(OnSource, _arms.OnOuterError, OnOuterCompleted));
         return this;
     }
 
@@ -79,122 +57,10 @@ public sealed class RaceWitness<T> : IDisposable
     {
         if (source is null)
         {
-            Observer.OnError(new InvalidOperationException("Race source contained null."));
+            _arms.OnOuterError(new InvalidOperationException("Race source contained null."));
             return;
         }
 
-        var current = Interlocked.Increment(ref _index) - 1;
-        var subscription = source.Subscribe(
-            value => OnNext(current, value),
-            error => OnError(current, error),
-            () => OnCompleted(current));
-        Subscriptions.Add(subscription);
-
-        lock (_gate)
-        {
-            if (_winner < 0)
-            {
-                _sourceSubscriptions[current] = subscription;
-                return;
-            }
-
-            if (_winner == current)
-            {
-                _sourceSubscriptions[current] = subscription;
-                return;
-            }
-
-            _ = Subscriptions.Remove(subscription);
-        }
-    }
-
-    /// <summary>Forwards a value from the winning candidate.</summary>
-    /// <param name="candidate">The candidate index.</param>
-    /// <param name="value">The value to forward.</param>
-    private void OnNext(int candidate, T value)
-    {
-        if (!Win(candidate))
-        {
-            return;
-        }
-
-        Observer.OnNext(value);
-    }
-
-    /// <summary>Forwards an error from the winning candidate.</summary>
-    /// <param name="candidate">The candidate index.</param>
-    /// <param name="error">The error to forward.</param>
-    private void OnError(int candidate, Exception error)
-    {
-        if (!Win(candidate))
-        {
-            return;
-        }
-
-        Observer.OnError(error);
-    }
-
-    /// <summary>Forwards completion from the winning candidate.</summary>
-    /// <param name="candidate">The candidate index.</param>
-    private void OnCompleted(int candidate)
-    {
-        if (!Win(candidate))
-        {
-            return;
-        }
-
-        Observer.OnCompleted();
-    }
-
-    /// <summary>Attempts to make a candidate the winner.</summary>
-    /// <param name="candidate">The candidate index.</param>
-    /// <returns><see langword="true"/> when the candidate is the winner.</returns>
-    private bool Win(int candidate)
-    {
-        var current = Volatile.Read(ref _winner);
-        if (current == candidate)
-        {
-            return true;
-        }
-
-        if (current >= 0)
-        {
-            return false;
-        }
-
-        if (Interlocked.CompareExchange(ref _winner, candidate, -1) != -1)
-        {
-            return false;
-        }
-
-        DiscardLosers(candidate);
-        return true;
-    }
-
-    /// <summary>Disposes all inner subscriptions except the winner.</summary>
-    /// <param name="winner">The winning source index.</param>
-    private void DiscardLosers(int winner)
-    {
-        List<(int Candidate, IDisposable Subscription)> losers = [];
-        lock (_gate)
-        {
-            foreach (var pair in _sourceSubscriptions)
-            {
-                if (pair.Key != winner)
-                {
-                    losers.Add((pair.Key, pair.Value));
-                }
-            }
-
-            for (var i = 0; i < losers.Count; i++)
-            {
-                _ = _sourceSubscriptions.Remove(losers[i].Candidate);
-            }
-        }
-
-        for (var i = 0; i < losers.Count; i++)
-        {
-            _ = Subscriptions.Remove(losers[i].Subscription);
-        }
+        _arms.OnSource(source);
     }
 }

--- a/src/Primitives.Shared/Advanced/RaceWitness{T}.cs
+++ b/src/Primitives.Shared/Advanced/RaceWitness{T}.cs
@@ -12,6 +12,12 @@ namespace ReactiveUI.Primitives.Advanced;
 /// <typeparam name="T">The value type.</typeparam>
 public sealed class RaceWitness<T> : IDisposable
 {
+    /// <summary>Serializes source registration and winner finalization.</summary>
+    private readonly Lock _gate = new();
+
+    /// <summary>Active source subscriptions by source index.</summary>
+    private readonly Dictionary<int, IDisposable> _sourceSubscriptions = [];
+
     /// <summary>The winning source index, or -1 before a source wins.</summary>
     private int _winner = -1;
 
@@ -29,7 +35,14 @@ public sealed class RaceWitness<T> : IDisposable
     private MultipleDisposable Subscriptions { get; } = [];
 
     /// <inheritdoc/>
-    public void Dispose() => Subscriptions.Dispose();
+    public void Dispose()
+    {
+        Subscriptions.Dispose();
+        lock (_gate)
+        {
+            _sourceSubscriptions.Clear();
+        }
+    }
 
     /// <summary>Starts observing an outer observable of candidates.</summary>
     /// <param name="sources">The outer source.</param>
@@ -71,10 +84,28 @@ public sealed class RaceWitness<T> : IDisposable
         }
 
         var current = Interlocked.Increment(ref _index) - 1;
-        Subscriptions.Add(source.Subscribe(
+        var subscription = source.Subscribe(
             value => OnNext(current, value),
             error => OnError(current, error),
-            () => OnCompleted(current)));
+            () => OnCompleted(current));
+        Subscriptions.Add(subscription);
+
+        lock (_gate)
+        {
+            if (_winner < 0)
+            {
+                _sourceSubscriptions[current] = subscription;
+                return;
+            }
+
+            if (_winner == current)
+            {
+                _sourceSubscriptions[current] = subscription;
+                return;
+            }
+
+            _ = Subscriptions.Remove(subscription);
+        }
     }
 
     /// <summary>Forwards a value from the winning candidate.</summary>
@@ -126,6 +157,44 @@ public sealed class RaceWitness<T> : IDisposable
             return true;
         }
 
-        return current >= 0 ? false : Interlocked.CompareExchange(ref _winner, candidate, -1) == -1;
+        if (current >= 0)
+        {
+            return false;
+        }
+
+        if (Interlocked.CompareExchange(ref _winner, candidate, -1) != -1)
+        {
+            return false;
+        }
+
+        DiscardLosers(candidate);
+        return true;
+    }
+
+    /// <summary>Disposes all inner subscriptions except the winner.</summary>
+    /// <param name="winner">The winning source index.</param>
+    private void DiscardLosers(int winner)
+    {
+        List<(int Candidate, IDisposable Subscription)> losers = [];
+        lock (_gate)
+        {
+            foreach (var pair in _sourceSubscriptions)
+            {
+                if (pair.Key != winner)
+                {
+                    losers.Add((pair.Key, pair.Value));
+                }
+            }
+
+            for (var i = 0; i < losers.Count; i++)
+            {
+                _ = _sourceSubscriptions.Remove(losers[i].Candidate);
+            }
+        }
+
+        for (var i = 0; i < losers.Count; i++)
+        {
+            _ = Subscriptions.Remove(losers[i].Subscription);
+        }
     }
 }

--- a/src/Primitives.Shared/SignalOperatorMixins.Coordinators.cs
+++ b/src/Primitives.Shared/SignalOperatorMixins.Coordinators.cs
@@ -585,170 +585,29 @@ public static partial class LinqExtensions
     /// <typeparam name="T">The source value type.</typeparam>
     private sealed class RaceCoordinator<T> : IDisposable
     {
-        /// <summary>The downstream observer.</summary>
-        private readonly IObserver<T> _observer;
-
-        /// <summary>The active subscriptions.</summary>
-        private readonly MultipleDisposable _subscriptions = [];
-
-        /// <summary>Serializes source registration and winner finalization.</summary>
-        private readonly Lock _gate = new();
-
-        /// <summary>Active source subscriptions by source index.</summary>
-        private readonly Dictionary<int, IDisposable> _sourceSubscriptions = [];
-
-        /// <summary>The winning source index.</summary>
-        private int _winner = -1;
-
-        /// <summary>The next source index.</summary>
-        private int _index;
+        /// <summary>The shared race-arm bookkeeping.</summary>
+        private readonly RaceArms<T> _arms;
 
         /// <summary>Initializes a new instance of the <see cref="RaceCoordinator{T}"/> class.</summary>
         /// <param name="observer">The downstream observer.</param>
-        internal RaceCoordinator(IObserver<T> observer) => _observer = observer;
+        internal RaceCoordinator(IObserver<T> observer) => _arms = new(observer);
 
         /// <summary>Releases the active subscriptions.</summary>
-        public void Dispose()
-        {
-            _subscriptions.Dispose();
-            lock (_gate)
-            {
-                _sourceSubscriptions.Clear();
-            }
-        }
+        public void Dispose() => _arms.Dispose();
 
         /// <summary>Starts observing the candidate source streams.</summary>
         /// <param name="sources">The candidate source streams.</param>
         /// <returns>The coordinator that owns the subscription cleanup.</returns>
         internal RaceCoordinator<T> Run(IObservable<IObservable<T>> sources)
         {
-            _subscriptions.Add(sources.Subscribe(OnSource, _observer.OnError, OnOuterCompleted));
+            _arms.Add(sources.Subscribe(_arms.OnSource, _arms.OnOuterError, OnOuterCompleted));
             return this;
         }
 
-        /// <summary>Forwards a value from a candidate source.</summary>
-        /// <param name="candidate">The candidate source index.</param>
-        /// <param name="value">The value to forward.</param>
-        private void OnNext(int candidate, T value)
-        {
-            if (!Win(candidate))
-            {
-                return;
-            }
-
-            _observer.OnNext(value);
-        }
-
-        /// <summary>Forwards an error from a candidate source.</summary>
-        /// <param name="candidate">The candidate source index.</param>
-        /// <param name="error">The error to forward.</param>
-        private void OnError(int candidate, Exception error)
-        {
-            if (!Win(candidate))
-            {
-                return;
-            }
-
-            _observer.OnError(error);
-        }
-
-        /// <summary>Forwards completion from a candidate source.</summary>
-        /// <param name="candidate">The candidate source index.</param>
-        private void OnCompleted(int candidate)
-        {
-            if (!Win(candidate))
-            {
-                return;
-            }
-
-            _observer.OnCompleted();
-        }
-
         /// <summary>Handles completion of the outer sequence.</summary>
-        private void OnOuterCompleted()
+        private static void OnOuterCompleted()
         {
             // Race completion is controlled by the first inner source to win.
-        }
-
-        /// <summary>Subscribes to a candidate source.</summary>
-        /// <param name="source">The source to observe.</param>
-        private void OnSource(IObservable<T> source)
-        {
-            var current = Interlocked.Increment(ref _index) - 1;
-            var subscription = source.Subscribe(
-                value => OnNext(current, value),
-                error => OnError(current, error),
-                () => OnCompleted(current));
-            _subscriptions.Add(subscription);
-
-            lock (_gate)
-            {
-                if (_winner < 0)
-                {
-                    _sourceSubscriptions[current] = subscription;
-                    return;
-                }
-
-                if (_winner == current)
-                {
-                    _sourceSubscriptions[current] = subscription;
-                    return;
-                }
-
-                _ = _subscriptions.Remove(subscription);
-            }
-        }
-
-        /// <summary>Attempts to make a candidate source the winner.</summary>
-        /// <param name="candidate">The candidate source index.</param>
-        /// <returns><c>true</c> when the candidate is the winning source; otherwise, <c>false</c>.</returns>
-        private bool Win(int candidate)
-        {
-            var current = Volatile.Read(ref _winner);
-            if (current == candidate)
-            {
-                return true;
-            }
-
-            if (current >= 0)
-            {
-                return false;
-            }
-
-            if (Interlocked.CompareExchange(ref _winner, candidate, -1) != -1)
-            {
-                return false;
-            }
-
-            DiscardLosers(candidate);
-            return true;
-        }
-
-        /// <summary>Disposes all inner subscriptions except the winner.</summary>
-        /// <param name="winner">The winning source index.</param>
-        private void DiscardLosers(int winner)
-        {
-            List<(int Candidate, IDisposable Subscription)> losers = [];
-            lock (_gate)
-            {
-                foreach (var pair in _sourceSubscriptions)
-                {
-                    if (pair.Key != winner)
-                    {
-                        losers.Add((pair.Key, pair.Value));
-                    }
-                }
-
-                for (var i = 0; i < losers.Count; i++)
-                {
-                    _ = _sourceSubscriptions.Remove(losers[i].Candidate);
-                }
-            }
-
-            for (var i = 0; i < losers.Count; i++)
-            {
-                _ = _subscriptions.Remove(losers[i].Subscription);
-            }
         }
     }
 

--- a/src/Primitives.Shared/SignalOperatorMixins.Coordinators.cs
+++ b/src/Primitives.Shared/SignalOperatorMixins.Coordinators.cs
@@ -591,6 +591,12 @@ public static partial class LinqExtensions
         /// <summary>The active subscriptions.</summary>
         private readonly MultipleDisposable _subscriptions = [];
 
+        /// <summary>Serializes source registration and winner finalization.</summary>
+        private readonly Lock _gate = new();
+
+        /// <summary>Active source subscriptions by source index.</summary>
+        private readonly Dictionary<int, IDisposable> _sourceSubscriptions = [];
+
         /// <summary>The winning source index.</summary>
         private int _winner = -1;
 
@@ -602,7 +608,14 @@ public static partial class LinqExtensions
         internal RaceCoordinator(IObserver<T> observer) => _observer = observer;
 
         /// <summary>Releases the active subscriptions.</summary>
-        public void Dispose() => _subscriptions.Dispose();
+        public void Dispose()
+        {
+            _subscriptions.Dispose();
+            lock (_gate)
+            {
+                _sourceSubscriptions.Clear();
+            }
+        }
 
         /// <summary>Starts observing the candidate source streams.</summary>
         /// <param name="sources">The candidate source streams.</param>
@@ -662,10 +675,28 @@ public static partial class LinqExtensions
         private void OnSource(IObservable<T> source)
         {
             var current = Interlocked.Increment(ref _index) - 1;
-            _subscriptions.Add(source.Subscribe(
+            var subscription = source.Subscribe(
                 value => OnNext(current, value),
                 error => OnError(current, error),
-                () => OnCompleted(current)));
+                () => OnCompleted(current));
+            _subscriptions.Add(subscription);
+
+            lock (_gate)
+            {
+                if (_winner < 0)
+                {
+                    _sourceSubscriptions[current] = subscription;
+                    return;
+                }
+
+                if (_winner == current)
+                {
+                    _sourceSubscriptions[current] = subscription;
+                    return;
+                }
+
+                _ = _subscriptions.Remove(subscription);
+            }
         }
 
         /// <summary>Attempts to make a candidate source the winner.</summary>
@@ -679,7 +710,45 @@ public static partial class LinqExtensions
                 return true;
             }
 
-            return current >= 0 ? false : Interlocked.CompareExchange(ref _winner, candidate, -1) == -1;
+            if (current >= 0)
+            {
+                return false;
+            }
+
+            if (Interlocked.CompareExchange(ref _winner, candidate, -1) != -1)
+            {
+                return false;
+            }
+
+            DiscardLosers(candidate);
+            return true;
+        }
+
+        /// <summary>Disposes all inner subscriptions except the winner.</summary>
+        /// <param name="winner">The winning source index.</param>
+        private void DiscardLosers(int winner)
+        {
+            List<(int Candidate, IDisposable Subscription)> losers = [];
+            lock (_gate)
+            {
+                foreach (var pair in _sourceSubscriptions)
+                {
+                    if (pair.Key != winner)
+                    {
+                        losers.Add((pair.Key, pair.Value));
+                    }
+                }
+
+                for (var i = 0; i < losers.Count; i++)
+                {
+                    _ = _sourceSubscriptions.Remove(losers[i].Candidate);
+                }
+            }
+
+            for (var i = 0; i < losers.Count; i++)
+            {
+                _ = _subscriptions.Remove(losers[i].Subscription);
+            }
         }
     }
 

--- a/src/tests/ReactiveUI.Primitives.Tests/SignalOperatorMixinsTests.Deterministic.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/SignalOperatorMixinsTests.Deterministic.cs
@@ -508,6 +508,19 @@ public partial class SignalOperatorMixinsTests
         int[] expectedRace = [One];
         await Assert.That(race.Values.SequenceEqual(expectedRace)).IsTrue();
         await Assert.That(race.Errors.Count).IsEqualTo(0);
+
+        TrackingDisposableObservable<int> raceLosing = new();
+        TrackingDisposableObservable<int> raceWinning = new();
+        RecordingWitness<int> raceWithDisposables = new();
+        using (Signal.Race(raceWinning, raceLosing).Subscribe(raceWithDisposables))
+        {
+            raceWinning.Observer!.OnNext(Three);
+            await Assert.That(raceLosing.DisposeCount).IsEqualTo(1);
+            await Assert.That(raceWinning.DisposeCount).IsEqualTo(0);
+            await Assert.That(raceWithDisposables.Values.SequenceEqual([Three])).IsTrue();
+        }
+
+        await Assert.That(raceWinning.DisposeCount).IsEqualTo(1);
         Signal<IObservable<int>> raceCompletionOuter = new();
         Signal<int> raceCompletionWinner = new();
         CapturingObservable<int> raceCompletionLoser = new();
@@ -948,6 +961,24 @@ public partial class SignalOperatorMixinsTests
         {
             Observer = observer;
             return EmptyDisposable.Instance;
+        }
+    }
+
+    /// <summary>Observable with a tracked disposable subscription and captured observer.</summary>
+    /// <typeparam name="T">The source value type.</typeparam>
+    private sealed class TrackingDisposableObservable<T> : IObservable<T>
+    {
+        /// <summary>Gets the captured observer.</summary>
+        public IObserver<T>? Observer { get; private set; }
+
+        /// <summary>Gets the number of times this subscription was disposed.</summary>
+        public int DisposeCount { get; private set; }
+
+        /// <inheritdoc/>
+        public IDisposable Subscribe(IObserver<T> observer)
+        {
+            Observer = observer;
+            return new ActionDisposable(() => DisposeCount++);
         }
     }
 }

--- a/src/tests/ReactiveUI.Primitives.Tests/WitnessTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/WitnessTests.cs
@@ -814,6 +814,27 @@ public class WitnessTests
         }
     }
 
+    /// <summary>Verifies race witnesses dispose losing source subscriptions once a winner emerges.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task RaceWitnessDisposesLosingSubscriptionAfterWinnerEmerges()
+    {
+        RecordingDisposableObservable<int> winner = new();
+        RecordingDisposableObservable<int> loser = new();
+        RecordingWitness<int> observer = new();
+        using (new RaceWitness<int>(observer).Run([winner, loser]))
+        {
+            winner.Observer!.OnNext(One);
+            await Assert.That(loser.DisposeCount).IsEqualTo(1);
+            await Assert.That(winner.DisposeCount).IsEqualTo(0);
+            await Assert.That(observer.Values.SequenceEqual([One])).IsTrue();
+            await Assert.That(observer.Errors.Count).IsEqualTo(0);
+        }
+
+        await Assert.That(winner.DisposeCount).IsEqualTo(1);
+        await Assert.That(loser.DisposeCount).IsEqualTo(1);
+    }
+
     /// <summary>Verifies publish selector witnesses dispose cancellation resources on terminal and disposal.</summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Test]
@@ -1006,5 +1027,23 @@ public class WitnessTests
 
         /// <inheritdoc/>
         public void OnNext(T value) => Values.Add(value);
+    }
+
+    /// <summary>Observable with a disposable subscription tracker and captured observer.</summary>
+    /// <typeparam name="T">The source value type.</typeparam>
+    private sealed class RecordingDisposableObservable<T> : IObservable<T>
+    {
+        /// <summary>Gets the captured observer.</summary>
+        public IObserver<T>? Observer { get; private set; }
+
+        /// <summary>Gets the number of times the source subscription was disposed.</summary>
+        public int DisposeCount { get; private set; }
+
+        /// <inheritdoc/>
+        public IDisposable Subscribe(IObserver<T> observer)
+        {
+            Observer = observer;
+            return new ActionDisposable(() => DisposeCount++);
+        }
     }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix for race/amb subscription disposal.

## What is the new behavior?

`RaceWitness<T>` and the internal `Signal.Race` coordinator now dispose non-winning source subscriptions immediately after a winner is selected while keeping the winning subscription alive.

Fixes #79.

## What is the current behavior?

Losing race sources are suppressed from forwarding notifications, but their subscriptions remain active until the whole coordinator is disposed.

## Checklist
- [x] Tests have been added or updated (for bug fixes / features) 
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the main branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) 

## Additional information

Validation:
- `dotnet build src/tests/ReactiveUI.Primitives.Tests/ReactiveUI.Primitives.Tests.csproj`
- `dotnet test "tests/ReactiveUI.Primitives.Tests/ReactiveUI.Primitives.Tests.csproj" -- --treenode-filter "/*/ReactiveUI.Primitives.Tests/WitnessTests/RaceWitnessDisposesLosingSubscriptionAfterWinnerEmerges"`
- `dotnet test "tests/ReactiveUI.Primitives.Tests/ReactiveUI.Primitives.Tests.csproj" -- --treenode-filter "/*/ReactiveUI.Primitives.Tests/SignalOperatorMixinsTests/OptimizedCoordinatorAndAsyncEnumerableBranchesCoverRemainingGaps"`