### PR TITLE
fix(scheduling): dispose SequencerWorkItem action resource

### DIFF
--- a/src/Primitives.Shared/Concurrency/SequencerWorkItem.cs
+++ b/src/Primitives.Shared/Concurrency/SequencerWorkItem.cs
@@ -72,6 +72,11 @@ internal sealed class SequencerWorkItem<TSequencer, TState> : IDisposable
             return;
         }
 
+        if (!ReferenceEquals(Interlocked.CompareExchange(ref _disposable, EmptyDisposable.Instance, disposable), disposable))
+        {
+            return;
+        }
+
         disposable.Dispose();
     }
 }

--- a/src/Primitives.Shared/Concurrency/SequencerWorkItem.cs
+++ b/src/Primitives.Shared/Concurrency/SequencerWorkItem.cs
@@ -23,6 +23,9 @@ internal sealed class SequencerWorkItem<TSequencer, TState> : IDisposable
     /// <summary>Action invoked when the scheduled item runs.</summary>
     private readonly Func<ISequencer, TState, IDisposable> _action;
 
+    /// <summary>Disposable returned by the scheduled action after it starts.</summary>
+    private IDisposable? _disposable;
+
     /// <summary>Tracks cancellation.</summary>
     private int _isDisposed;
 
@@ -38,7 +41,15 @@ internal sealed class SequencerWorkItem<TSequencer, TState> : IDisposable
     }
 
     /// <summary>Cancels the work item.</summary>
-    public void Dispose() => Interlocked.Exchange(ref _isDisposed, 1);
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _isDisposed, 1) != 0)
+        {
+            return;
+        }
+
+        Interlocked.Exchange(ref _disposable, EmptyDisposable.Instance)?.Dispose();
+    }
 
     /// <summary>Invokes the scheduled action if it has not been cancelled.</summary>
     public void Invoke()
@@ -48,6 +59,19 @@ internal sealed class SequencerWorkItem<TSequencer, TState> : IDisposable
             return;
         }
 
-        _ = _action(_sequencer, _state);
+        var disposable = _action(_sequencer, _state) ?? EmptyDisposable.Instance;
+        var previous = Interlocked.CompareExchange(ref _disposable, disposable, null);
+        if (previous is not null)
+        {
+            disposable.Dispose();
+            return;
+        }
+
+        if (Volatile.Read(ref _isDisposed) == 0)
+        {
+            return;
+        }
+
+        disposable.Dispose();
     }
 }

--- a/src/Primitives.Shared/Concurrency/SequencerWorkItem.cs
+++ b/src/Primitives.Shared/Concurrency/SequencerWorkItem.cs
@@ -60,23 +60,6 @@ internal sealed class SequencerWorkItem<TSequencer, TState> : IDisposable
         }
 
         var disposable = _action(_sequencer, _state) ?? EmptyDisposable.Instance;
-        var previous = Interlocked.CompareExchange(ref _disposable, disposable, null);
-        if (previous is not null)
-        {
-            disposable.Dispose();
-            return;
-        }
-
-        if (Volatile.Read(ref _isDisposed) == 0)
-        {
-            return;
-        }
-
-        if (!ReferenceEquals(Interlocked.CompareExchange(ref _disposable, EmptyDisposable.Instance, disposable), disposable))
-        {
-            return;
-        }
-
-        disposable.Dispose();
+        SequencerWorkItemDisposal.Publish(ref _disposable, disposable);
     }
 }

--- a/src/Primitives.Shared/Concurrency/SequencerWorkItemDisposal.cs
+++ b/src/Primitives.Shared/Concurrency/SequencerWorkItemDisposal.cs
@@ -1,0 +1,32 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+#if REACTIVE_SHIM
+namespace ReactiveUI.Primitives.Reactive.Concurrency;
+#else
+namespace ReactiveUI.Primitives.Concurrency;
+#endif
+
+/// <summary>Disposal helpers shared by sequencer work items.</summary>
+internal static class SequencerWorkItemDisposal
+{
+    /// <summary>Publishes the action's disposable into the shared slot, disposing it when disposal won the race.</summary>
+    /// <param name="slot">The disposable slot shared with the work item's disposal.</param>
+    /// <param name="disposable">The disposable returned by the scheduled action.</param>
+    /// <remarks>
+    /// Disposal swaps a non-null sentinel into the slot, so a non-null exchange result means disposal already
+    /// owns (or will own) the slot and the freshly produced disposable must be released here. A null result
+    /// means this caller published first and disposal releases the slot later. This keeps the in-flight dispose
+    /// race correct with a single compare-exchange instead of a re-check loop.
+    /// </remarks>
+    internal static void Publish(ref IDisposable? slot, IDisposable disposable)
+    {
+        if (Interlocked.CompareExchange(ref slot, disposable, null) is null)
+        {
+            return;
+        }
+
+        disposable.Dispose();
+    }
+}

--- a/src/tests/ReactiveUI.Primitives.Tests/SignalOperatorMixinsTests.Deterministic.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/SignalOperatorMixinsTests.Deterministic.cs
@@ -795,13 +795,14 @@ public partial class SignalOperatorMixinsTests
         SequencerWorkItem<ISequencer, int> helper = new(Sequencer.Immediate, One, (_, state) =>
         {
             helperValues.Add(state);
-            return EmptyDisposable.Instance;
+            return new ActionDisposable(() => { });
         });
         helper.Invoke();
         helper.Dispose();
         helper.Invoke();
         int[] expectedHelperValues = [One];
         await Assert.That(helperValues.SequenceEqual(expectedHelperValues)).IsTrue();
+        await VerifySequencerWorkItemDisposalBranches();
         ScheduledItem<int> unusedScheduled =
             ScheduledItem.Create(Sequencer.Immediate, "unused", (_, _) => EmptyDisposable.Instance, One);
         await Assert.That(new SequencerQueue<int>().Remove(unusedScheduled)).IsFalse();
@@ -816,6 +817,35 @@ public partial class SignalOperatorMixinsTests
         {
             await Assert.That(shrink.Dequeue()).IsEqualTo(i);
         }
+    }
+
+    /// <summary>Verifies the sequencer work item disposes returned disposables on disposal race paths.</summary>
+    /// <returns>A task representing the asynchronous verification.</returns>
+    private static async Task VerifySequencerWorkItemDisposalBranches()
+    {
+        const int DelayForRaceMilliseconds = 1000;
+        int beforeInvokeDisposed = 0;
+        using ManualResetEventSlim started = new();
+        using ManualResetEventSlim release = new();
+        SequencerWorkItem<ISequencer, int> before = new(Sequencer.Immediate, One, (_, _) =>
+        {
+            started.Set();
+            _ = release.Wait(DelayForRaceMilliseconds);
+            return new ActionDisposable(() => Interlocked.Increment(ref beforeInvokeDisposed));
+        });
+        Task invoke = Task.Run(before.Invoke);
+        await Assert.That(started.Wait(DelayForRaceMilliseconds)).IsTrue();
+        before.Dispose();
+        release.Set();
+        await invoke;
+        await Assert.That(beforeInvokeDisposed).IsEqualTo(1);
+
+        int afterInvokeDisposed = 0;
+        SequencerWorkItem<ISequencer, int> after = new(Sequencer.Immediate, One, (_, _) =>
+            new ActionDisposable(() => Interlocked.Increment(ref afterInvokeDisposed)));
+        after.Invoke();
+        after.Dispose();
+        await Assert.That(afterInvokeDisposed).IsEqualTo(1);
     }
 
     /// <summary>Verifies the thread pool absolute scheduling and scheduled work item disposal branches.</summary>

--- a/src/tests/ReactiveUI.Primitives.Tests/SignalOperatorMixinsTests.Deterministic.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/SignalOperatorMixinsTests.Deterministic.cs
@@ -840,6 +840,23 @@ public partial class SignalOperatorMixinsTests
         await invoke;
         await Assert.That(beforeInvokeDisposed).IsEqualTo(1);
 
+        int invokeFirstDisposed = 0;
+        using ManualResetEventSlim startedFirst = new();
+        using ManualResetEventSlim releaseFirst = new();
+        SequencerWorkItem<ISequencer, int> invokeFirst = new(Sequencer.Immediate, One, (_, _) =>
+        {
+            startedFirst.Set();
+            _ = releaseFirst.Wait(DelayForRaceMilliseconds);
+            return new ActionDisposable(() => Interlocked.Increment(ref invokeFirstDisposed));
+        });
+        Task invokeFirstTask = Task.Run(invokeFirst.Invoke);
+        await Assert.That(startedFirst.Wait(DelayForRaceMilliseconds)).IsTrue();
+        releaseFirst.Set();
+        await Task.Yield();
+        invokeFirst.Dispose();
+        await invokeFirstTask;
+        await Assert.That(invokeFirstDisposed).IsEqualTo(1);
+
         int afterInvokeDisposed = 0;
         SequencerWorkItem<ISequencer, int> after = new(Sequencer.Immediate, One, (_, _) =>
             new ActionDisposable(() => Interlocked.Increment(ref afterInvokeDisposed)));

--- a/src/tests/ReactiveUI.Primitives.Tests/SignalOperatorMixinsTests.Deterministic.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/SignalOperatorMixinsTests.Deterministic.cs
@@ -35,6 +35,9 @@ public partial class SignalOperatorMixinsTests
     /// <summary>The integer constant thirty-two.</summary>
     private const int ThirtyTwo = 32;
 
+    /// <summary>Iterations used to stress the work item invoke/dispose race.</summary>
+    private const int RaceIterations = 256;
+
     /// <summary>The long constant two.</summary>
     private const long TwoLong = 2L;
 
@@ -832,58 +835,87 @@ public partial class SignalOperatorMixinsTests
         }
     }
 
-    /// <summary>Verifies the sequencer work item disposes returned disposables on disposal race paths.</summary>
+    /// <summary>Verifies the sequencer work item disposes the action's disposable across invoke and dispose orderings.</summary>
     /// <returns>A task representing the asynchronous verification.</returns>
     private static async Task VerifySequencerWorkItemDisposalBranches()
     {
-        const int DelayForRaceMilliseconds = 1000;
-        int beforeInvokeDisposed = 0;
-        using ManualResetEventSlim started = new();
-        using ManualResetEventSlim release = new();
-        SequencerWorkItem<ISequencer, int> before = new(Sequencer.Immediate, One, (_, _) =>
-        {
-            started.Set();
-            _ = release.Wait(DelayForRaceMilliseconds);
-            return new ActionDisposable(() => Interlocked.Increment(ref beforeInvokeDisposed));
-        });
-        Task invoke = Task.Factory.StartNew(
-            before.Invoke,
-            CancellationToken.None,
-            TaskCreationOptions.LongRunning,
-            TaskScheduler.Default);
-        await Assert.That(started.Wait(DelayForRaceMilliseconds)).IsTrue();
-        before.Dispose();
-        release.Set();
-        await invoke;
-        await Assert.That(beforeInvokeDisposed).IsEqualTo(1);
+        // Invoke then dispose: the published disposable is released by Dispose exactly once,
+        // and a redundant second Dispose is a no-op.
+        var invokeThenDisposeReleased = 0;
+        SequencerWorkItem<ISequencer, int> invokeThenDispose = new(Sequencer.Immediate, One, (_, _) =>
+            new ActionDisposable(() => Interlocked.Increment(ref invokeThenDisposeReleased)));
+        invokeThenDispose.Invoke();
+        invokeThenDispose.Dispose();
+        invokeThenDispose.Dispose();
+        await Assert.That(invokeThenDisposeReleased).IsEqualTo(1);
 
-        int invokeFirstDisposed = 0;
-        using ManualResetEventSlim startedFirst = new();
-        using ManualResetEventSlim releaseFirst = new();
-        SequencerWorkItem<ISequencer, int> invokeFirst = new(Sequencer.Immediate, One, (_, _) =>
+        // A null action result is coalesced to an empty disposable and never throws.
+        var nullActionRan = false;
+        SequencerWorkItem<ISequencer, int> nullAction = new(Sequencer.Immediate, One, (_, _) =>
         {
-            startedFirst.Set();
-            _ = releaseFirst.Wait(DelayForRaceMilliseconds);
-            return new ActionDisposable(() => Interlocked.Increment(ref invokeFirstDisposed));
+            nullActionRan = true;
+            return null!;
         });
-        Task invokeFirstTask = Task.Factory.StartNew(
-            invokeFirst.Invoke,
-            CancellationToken.None,
-            TaskCreationOptions.LongRunning,
-            TaskScheduler.Default);
-        await Assert.That(startedFirst.Wait(DelayForRaceMilliseconds)).IsTrue();
-        releaseFirst.Set();
-        await Task.Yield();
-        invokeFirst.Dispose();
-        await invokeFirstTask;
-        await Assert.That(invokeFirstDisposed).IsEqualTo(1);
+        nullAction.Invoke();
+        nullAction.Dispose();
+        await Assert.That(nullActionRan).IsTrue();
 
-        int afterInvokeDisposed = 0;
-        SequencerWorkItem<ISequencer, int> after = new(Sequencer.Immediate, One, (_, _) =>
-            new ActionDisposable(() => Interlocked.Increment(ref afterInvokeDisposed)));
-        after.Invoke();
-        after.Dispose();
-        await Assert.That(afterInvokeDisposed).IsEqualTo(1);
+        await VerifySequencerWorkItemPublishBranches();
+        await VerifySequencerWorkItemDisposeRaceInvariant();
+    }
+
+    /// <summary>Verifies both compare-exchange outcomes of <c>SequencerWorkItem.Publish</c>.</summary>
+    /// <returns>A task representing the asynchronous verification.</returns>
+    private static async Task VerifySequencerWorkItemPublishBranches()
+    {
+        // Publish wins the empty slot: the disposable is stored and left alive for Dispose.
+        var stored = 0;
+        ActionDisposable storedDisposable = new(() => Interlocked.Increment(ref stored));
+        IDisposable? winSlot = null;
+        SequencerWorkItemDisposal.Publish(ref winSlot, storedDisposable);
+        await Assert.That(ReferenceEquals(winSlot, storedDisposable)).IsTrue();
+        await Assert.That(stored).IsEqualTo(0);
+
+        // Publish loses to disposal (slot already claimed): the disposable is released immediately.
+        var loserDisposed = 0;
+        ActionDisposable loser = new(() => Interlocked.Increment(ref loserDisposed));
+        IDisposable? loseSlot = EmptyDisposable.Instance;
+        SequencerWorkItemDisposal.Publish(ref loseSlot, loser);
+        await Assert.That(loserDisposed).IsEqualTo(1);
+        await Assert.That(ReferenceEquals(loseSlot, EmptyDisposable.Instance)).IsTrue();
+    }
+
+    /// <summary>Verifies the action's disposable is released exactly once when invoke and dispose race.</summary>
+    /// <returns>A task representing the asynchronous verification.</returns>
+    private static async Task VerifySequencerWorkItemDisposeRaceInvariant()
+    {
+        for (var iteration = 0; iteration < RaceIterations; iteration++)
+        {
+            var created = 0;
+            var disposed = 0;
+            SequencerWorkItem<ISequencer, int> item = new(Sequencer.Immediate, One, (_, _) =>
+            {
+                _ = Interlocked.Increment(ref created);
+                return new ActionDisposable(() => Interlocked.Increment(ref disposed));
+            });
+
+            using Barrier barrier = new(2);
+            Task invoke = Task.Run(() =>
+            {
+                barrier.SignalAndWait();
+                item.Invoke();
+            });
+            Task dispose = Task.Run(() =>
+            {
+                barrier.SignalAndWait();
+                item.Dispose();
+            });
+            await Task.WhenAll(invoke, dispose);
+
+            // Whenever the action produced a disposable it is released once; otherwise nothing leaks.
+            await Assert.That(disposed).IsEqualTo(created);
+            await Assert.That(created <= 1).IsTrue();
+        }
     }
 
     /// <summary>Verifies the thread pool absolute scheduling and scheduled work item disposal branches.</summary>

--- a/src/tests/ReactiveUI.Primitives.Tests/SignalOperatorMixinsTests.Deterministic.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/SignalOperatorMixinsTests.Deterministic.cs
@@ -833,7 +833,11 @@ public partial class SignalOperatorMixinsTests
             _ = release.Wait(DelayForRaceMilliseconds);
             return new ActionDisposable(() => Interlocked.Increment(ref beforeInvokeDisposed));
         });
-        Task invoke = Task.Run(before.Invoke);
+        Task invoke = Task.Factory.StartNew(
+            before.Invoke,
+            CancellationToken.None,
+            TaskCreationOptions.LongRunning,
+            TaskScheduler.Default);
         await Assert.That(started.Wait(DelayForRaceMilliseconds)).IsTrue();
         before.Dispose();
         release.Set();
@@ -849,7 +853,11 @@ public partial class SignalOperatorMixinsTests
             _ = releaseFirst.Wait(DelayForRaceMilliseconds);
             return new ActionDisposable(() => Interlocked.Increment(ref invokeFirstDisposed));
         });
-        Task invokeFirstTask = Task.Run(invokeFirst.Invoke);
+        Task invokeFirstTask = Task.Factory.StartNew(
+            invokeFirst.Invoke,
+            CancellationToken.None,
+            TaskCreationOptions.LongRunning,
+            TaskScheduler.Default);
         await Assert.That(startedFirst.Wait(DelayForRaceMilliseconds)).IsTrue();
         releaseFirst.Set();
         await Task.Yield();


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix for scheduled work item resource disposal.

## What is the new behavior?

`SequencerWorkItem` now stores the `IDisposable` returned by its action and disposes it when cancellation wins before, during, or after invocation.

Fixes #81.

## What is the current behavior?

`SequencerWorkItem.Invoke` discards the returned disposable, so an action-created resource can be leaked when cancellation races with execution.

## Checklist
- [x] Tests have been added or updated (for bug fixes / features) 
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the main branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) 

## Additional information

Validation:
- `dotnet restore "ReactiveUI.Primitives.slnx"`
- `dotnet build "ReactiveUI.Primitives.slnx"`
- `dotnet test tests/ReactiveUI.Primitives.Tests/ReactiveUI.Primitives.Tests.csproj`