### PR TITLE
fix(operators): serialize switch inner notifications

### DIFF
--- a/src/Primitives.Shared/Advanced/SwitchWitness{T}.cs
+++ b/src/Primitives.Shared/Advanced/SwitchWitness{T}.cs
@@ -37,6 +37,9 @@ public sealed class SwitchWitness<T> : IDisposable
     /// <summary>Gets or sets a value indicating whether an inner source is active.</summary>
     private bool IsInnerActive { get; set; }
 
+    /// <summary>Gets or sets a value indicating whether a terminal notification has been emitted.</summary>
+    private bool IsDone { get; set; }
+
     /// <inheritdoc/>
     public void Dispose()
     {
@@ -50,7 +53,7 @@ public sealed class SwitchWitness<T> : IDisposable
     public SwitchWitness<T> Run(IObservable<IObservable<T>> sources)
     {
         Subscriptions.Add(InnerSlot);
-        Subscriptions.Add(sources.Subscribe(OnSource, Observer.OnError, OnOuterCompleted));
+        Subscriptions.Add(sources.Subscribe(OnSource, OnOuterError, OnOuterCompleted));
         return this;
     }
 
@@ -61,6 +64,11 @@ public sealed class SwitchWitness<T> : IDisposable
         int current;
         lock (_gate)
         {
+            if (IsDone)
+            {
+                return;
+            }
+
             current = _version + 1;
             Volatile.Write(ref _version, current);
             IsInnerActive = true;
@@ -77,10 +85,30 @@ public sealed class SwitchWitness<T> : IDisposable
     {
         lock (_gate)
         {
-            IsOuterCompleted = true;
-        }
+            if (IsDone)
+            {
+                return;
+            }
 
-        TryComplete();
+            IsOuterCompleted = true;
+            TryComplete();
+        }
+    }
+
+    /// <summary>Forwards the outer source error once.</summary>
+    /// <param name="error">The error to forward.</param>
+    private void OnOuterError(Exception error)
+    {
+        lock (_gate)
+        {
+            if (IsDone)
+            {
+                return;
+            }
+
+            IsDone = true;
+            Observer.OnError(error);
+        }
     }
 
     /// <summary>Forwards a current inner value.</summary>
@@ -88,12 +116,15 @@ public sealed class SwitchWitness<T> : IDisposable
     /// <param name="value">The value to forward.</param>
     private void OnNext(int version, T value)
     {
-        if (!IsCurrent(version))
+        lock (_gate)
         {
-            return;
-        }
+            if (IsDone || version != _version)
+            {
+                return;
+            }
 
-        Observer.OnNext(value);
+            Observer.OnNext(value);
+        }
     }
 
     /// <summary>Forwards a current inner error.</summary>
@@ -101,12 +132,16 @@ public sealed class SwitchWitness<T> : IDisposable
     /// <param name="error">The error to forward.</param>
     private void OnError(int version, Exception error)
     {
-        if (!IsCurrent(version))
+        lock (_gate)
         {
-            return;
-        }
+            if (IsDone || version != _version)
+            {
+                return;
+            }
 
-        Observer.OnError(error);
+            IsDone = true;
+            Observer.OnError(error);
+        }
     }
 
     /// <summary>Marks a current inner source complete.</summary>
@@ -115,29 +150,25 @@ public sealed class SwitchWitness<T> : IDisposable
     {
         lock (_gate)
         {
-            if (version == _version)
+            if (IsDone || version != _version)
             {
-                IsInnerActive = false;
+                return;
             }
+
+            IsInnerActive = false;
+            TryComplete();
         }
-
-        TryComplete();
     }
-
-    /// <summary>Determines whether a version is current.</summary>
-    /// <param name="version">The candidate version.</param>
-    /// <returns><see langword="true"/> when the version is current.</returns>
-    private bool IsCurrent(int version) => version == Volatile.Read(ref _version);
 
     /// <summary>Completes once the outer source and current inner source are done.</summary>
     private void TryComplete()
     {
-        lock (_gate)
+        if (IsDone || !IsOuterCompleted || IsInnerActive)
         {
-            if (IsOuterCompleted && !IsInnerActive)
-            {
-                Observer.OnCompleted();
-            }
+            return;
         }
+
+        IsDone = true;
+        Observer.OnCompleted();
     }
 }

--- a/src/Primitives.Shared/SignalOperatorMixins.Coordinators.cs
+++ b/src/Primitives.Shared/SignalOperatorMixins.Coordinators.cs
@@ -1008,7 +1008,7 @@ public static partial class LinqExtensions
 
                 current = _version + 1;
 
-                // Publish the new version so the lock-free reader in IsCurrent observes it.
+                // Publish the new version so readers in gated operations observe it.
                 Volatile.Write(ref _version, current);
                 _innerActive = true;
             }

--- a/src/Primitives.Shared/SignalOperatorMixins.Coordinators.cs
+++ b/src/Primitives.Shared/SignalOperatorMixins.Coordinators.cs
@@ -970,6 +970,9 @@ public static partial class LinqExtensions
         /// <summary>The current inner source version.</summary>
         private int _version;
 
+        /// <summary>A value indicating whether a terminal notification has been emitted.</summary>
+        private bool _done;
+
         /// <summary>Initializes a new instance of the <see cref="SwitchCoordinator{T}"/> class.</summary>
         /// <param name="observer">The downstream observer.</param>
         internal SwitchCoordinator(IObserver<T> observer) => _observer = observer;
@@ -987,7 +990,7 @@ public static partial class LinqExtensions
         internal SwitchCoordinator<T> Run(IObservable<IObservable<T>> sources)
         {
             _subscriptions.Add(_innerSlot);
-            _subscriptions.Add(sources.Subscribe(OnSource, _observer.OnError, OnOuterCompleted));
+            _subscriptions.Add(sources.Subscribe(OnSource, OnOuterError, OnOuterCompleted));
             return this;
         }
 
@@ -998,6 +1001,11 @@ public static partial class LinqExtensions
             int current;
             lock (_gate)
             {
+                if (_done)
+                {
+                    return;
+                }
+
                 current = _version + 1;
 
                 // Publish the new version so the lock-free reader in IsCurrent observes it.
@@ -1016,10 +1024,30 @@ public static partial class LinqExtensions
         {
             lock (_gate)
             {
-                _outerCompleted = true;
-            }
+                if (_done)
+                {
+                    return;
+                }
 
-            TryComplete();
+                _outerCompleted = true;
+                TryComplete();
+            }
+        }
+
+        /// <summary>Forwards an outer source error once.</summary>
+        /// <param name="error">The error to forward.</param>
+        private void OnOuterError(Exception error)
+        {
+            lock (_gate)
+            {
+                if (_done)
+                {
+                    return;
+                }
+
+                _done = true;
+                _observer.OnError(error);
+            }
         }
 
         /// <summary>Forwards an inner value when it belongs to the current source.</summary>
@@ -1027,12 +1055,15 @@ public static partial class LinqExtensions
         /// <param name="value">The value to forward.</param>
         private void OnNext(int version, T value)
         {
-            if (!IsCurrent(version))
+            lock (_gate)
             {
-                return;
-            }
+                if (_done || version != _version)
+                {
+                    return;
+                }
 
-            _observer.OnNext(value);
+                _observer.OnNext(value);
+            }
         }
 
         /// <summary>Forwards an inner error when it belongs to the current source.</summary>
@@ -1040,12 +1071,16 @@ public static partial class LinqExtensions
         /// <param name="error">The error to forward.</param>
         private void OnError(int version, Exception error)
         {
-            if (!IsCurrent(version))
+            lock (_gate)
             {
-                return;
-            }
+                if (_done || version != _version)
+                {
+                    return;
+                }
 
-            _observer.OnError(error);
+                _done = true;
+                _observer.OnError(error);
+            }
         }
 
         /// <summary>Completes an inner source when it belongs to the current source.</summary>
@@ -1054,30 +1089,26 @@ public static partial class LinqExtensions
         {
             lock (_gate)
             {
-                if (version == _version)
+                if (_done || version != _version)
                 {
-                    _innerActive = false;
+                    return;
                 }
+
+                _innerActive = false;
+                TryComplete();
             }
-
-            TryComplete();
         }
-
-        /// <summary>Determines whether a version is the current inner source.</summary>
-        /// <param name="version">The candidate version.</param>
-        /// <returns><c>true</c> if the version is current; otherwise, <c>false</c>.</returns>
-        private bool IsCurrent(int version) => version == Volatile.Read(ref _version);
 
         /// <summary>Completes the observer when both outer and inner sources are complete.</summary>
         private void TryComplete()
         {
-            lock (_gate)
+            if (_done || !_outerCompleted || _innerActive)
             {
-                if (_outerCompleted && !_innerActive)
-                {
-                    _observer.OnCompleted();
-                }
+                return;
             }
+
+            _done = true;
+            _observer.OnCompleted();
         }
     }
 }

--- a/src/tests/ReactiveUI.Primitives.Tests/SignalOperatorMixinsTests.Deterministic.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/SignalOperatorMixinsTests.Deterministic.cs
@@ -621,6 +621,38 @@ public partial class SignalOperatorMixinsTests
         }
 
         await Assert.That(staleCompleted.Completed).IsEqualTo(1);
+
+        // An inner error makes the coordinator terminal while the outer source stays live, so a
+        // later source switch and a later outer error are both gated.
+        Signal<IObservable<int>> innerErrorOuter = new();
+        CapturingObservable<int> innerErrorFirst = new();
+        CapturingObservable<int> innerErrorLate = new();
+        RecordingWitness<int> innerErrored = new();
+        using (innerErrorOuter.SwitchTo().Subscribe(innerErrored))
+        {
+            innerErrorOuter.OnNext(innerErrorFirst);
+            innerErrorFirst.Observer!.OnError(new InvalidOperationException("inner-switch"));
+            innerErrorOuter.OnNext(innerErrorLate);
+            innerErrorOuter.OnError(new InvalidOperationException("ignored"));
+        }
+
+        await Assert.That(innerErrored.Errors.Count).IsEqualTo(1);
+        await Assert.That(innerErrored.Errors[0].Message).IsEqualTo("inner-switch");
+        await Assert.That(innerErrorLate.Observer).IsNull();
+
+        // A terminal coordinator also gates a later outer completion (outer source still live).
+        Signal<IObservable<int>> innerErrorCompleteOuter = new();
+        CapturingObservable<int> innerErrorCompleteInner = new();
+        RecordingWitness<int> innerErrorCompleted = new();
+        using (innerErrorCompleteOuter.SwitchTo().Subscribe(innerErrorCompleted))
+        {
+            innerErrorCompleteOuter.OnNext(innerErrorCompleteInner);
+            innerErrorCompleteInner.Observer!.OnError(new InvalidOperationException("inner-complete-gate"));
+            innerErrorCompleteOuter.OnCompleted();
+        }
+
+        await Assert.That(innerErrorCompleted.Errors.Count).IsEqualTo(1);
+        await Assert.That(innerErrorCompleted.Completed).IsEqualTo(0);
     }
 
     /// <summary>Verifies the probe operator error, disposal, and completion branches.</summary>

--- a/src/tests/ReactiveUI.Primitives.Tests/SignalOperatorMixinsTests.Deterministic.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/SignalOperatorMixinsTests.Deterministic.cs
@@ -552,6 +552,62 @@ public partial class SignalOperatorMixinsTests
 
         await Assert.That(switched.Values.Count).IsEqualTo(0);
         await Assert.That(switched.Errors[0].Message).IsEqualTo("current-switch");
+
+        await VerifySwitchTerminalGatingBranches();
+    }
+
+    /// <summary>Verifies switch outer-error, deferred-completion, and post-terminal gating branches.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    private static async Task VerifySwitchTerminalGatingBranches()
+    {
+        // Outer error is forwarded once and gates all subsequent notifications.
+        Signal<IObservable<int>> outerErrorOuter = new();
+        CapturingObservable<int> outerErrorInner = new();
+        RecordingWitness<int> outerErrored = new();
+        using (outerErrorOuter.SwitchTo().Subscribe(outerErrored))
+        {
+            outerErrorOuter.OnNext(outerErrorInner);
+            outerErrorOuter.OnError(new InvalidOperationException("outer-switch"));
+            outerErrorInner.Observer!.OnNext(One);
+            outerErrorInner.Observer.OnCompleted();
+            outerErrorOuter.OnNext(outerErrorInner);
+        }
+
+        await Assert.That(outerErrored.Errors[0].Message).IsEqualTo("outer-switch");
+        await Assert.That(outerErrored.Errors.Count).IsEqualTo(1);
+        await Assert.That(outerErrored.Values.Count).IsEqualTo(0);
+
+        // Outer completes while the inner is still active: completion is deferred until the inner finishes.
+        Signal<IObservable<int>> deferredOuter = new();
+        CapturingObservable<int> deferredInner = new();
+        RecordingWitness<int> deferred = new();
+        using (deferredOuter.SwitchTo().Subscribe(deferred))
+        {
+            deferredOuter.OnNext(deferredInner);
+            deferredOuter.OnCompleted();
+            await Assert.That(deferred.Completed).IsEqualTo(0);
+            deferredInner.Observer!.OnCompleted();
+        }
+
+        await Assert.That(deferred.Completed).IsEqualTo(1);
+
+        // A stale inner completion (superseded version) does not complete the observer.
+        Signal<IObservable<int>> staleCompleteOuter = new();
+        CapturingObservable<int> staleCompleteFirst = new();
+        CapturingObservable<int> staleCompleteSecond = new();
+        RecordingWitness<int> staleCompleted = new();
+        using (staleCompleteOuter.SwitchTo().Subscribe(staleCompleted))
+        {
+            staleCompleteOuter.OnNext(staleCompleteFirst);
+            var staleObserver = staleCompleteFirst.Observer!;
+            staleCompleteOuter.OnNext(staleCompleteSecond);
+            staleCompleteOuter.OnCompleted();
+            staleObserver.OnCompleted();
+            await Assert.That(staleCompleted.Completed).IsEqualTo(0);
+            staleCompleteSecond.Observer!.OnCompleted();
+        }
+
+        await Assert.That(staleCompleted.Completed).IsEqualTo(1);
     }
 
     /// <summary>Verifies the probe operator error, disposal, and completion branches.</summary>

--- a/src/tests/ReactiveUI.Primitives.Tests/SwitchWitnessTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/SwitchWitnessTests.cs
@@ -1,0 +1,143 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using ReactiveUI.Primitives.Advanced;
+using ReactiveUI.Primitives.Disposables;
+using ReactiveUI.Primitives.Signals;
+
+namespace ReactiveUI.Primitives.Tests;
+
+/// <summary>Tests for <see cref="SwitchWitness{T}"/>.</summary>
+public sealed class SwitchWitnessTests
+{
+    /// <summary>The integer constant one.</summary>
+    private const int One = 1;
+
+    /// <summary>The integer constant two.</summary>
+    private const int Two = 2;
+
+    /// <summary>Timeout used while waiting for background work in these tests.</summary>
+    private static readonly TimeSpan WaitTimeout = TimeSpan.FromSeconds(5);
+
+    /// <summary>Verifies direct switch witness completion is emitted once.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SwitchWitnessSuppressesDuplicateCompletionFromCurrentInner()
+    {
+        RecordingWitness<int> observer = new();
+        Signal<IObservable<int>> outer = new();
+        CapturingObservable<int> inner = new();
+        using var subscription = new SwitchWitness<int>(observer).Run(outer);
+
+        outer.OnNext(inner);
+        inner.Observer!.OnCompleted();
+        outer.OnCompleted();
+        inner.Observer.OnCompleted();
+
+        await Assert.That(observer.Completed).IsEqualTo(One);
+    }
+
+    /// <summary>Verifies the public switch operator serializes consecutive inner values through the same observer gate.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SwitchToDoesNotEnterObserverConcurrentlyWhenSwitchingInnerSources()
+    {
+        Signal<IObservable<int>> outer = new();
+        CapturingObservable<int> first = new();
+        CapturingObservable<int> second = new();
+        using BlockingObserver observer = new();
+        using var subscription = outer.SwitchTo().Subscribe(observer);
+
+        outer.OnNext(first);
+        var firstValueTask = Task.Run(() => first.Observer!.OnNext(One));
+        await Assert.That(observer.OnNextEntered.Wait(WaitTimeout)).IsTrue();
+
+        var switchTask = Task.Run(() => outer.OnNext(second));
+        await Task.Delay(TimeSpan.FromMilliseconds(50)).ConfigureAwait(false);
+        second.Observer?.OnNext(Two);
+
+        await Assert.That(observer.ConcurrentOnNext).IsFalse();
+        observer.ReleaseOnNext.Set();
+        await firstValueTask.WaitAsync(WaitTimeout).ConfigureAwait(false);
+        await switchTask.WaitAsync(WaitTimeout).ConfigureAwait(false);
+
+        if (observer.Values == One)
+        {
+            second.Observer!.OnNext(Two);
+        }
+
+        await Assert.That(observer.ConcurrentOnNext).IsFalse();
+        await Assert.That(observer.Values).IsEqualTo(Two);
+    }
+
+    /// <summary>An observable that captures its observer for manual notification.</summary>
+    /// <typeparam name="T">The value type.</typeparam>
+    private sealed class CapturingObservable<T> : IObservable<T>
+    {
+        /// <summary>Gets the captured observer.</summary>
+        public IObserver<T>? Observer { get; private set; }
+
+        /// <inheritdoc/>
+        public IDisposable Subscribe(IObserver<T> observer)
+        {
+            Observer = observer;
+            return EmptyDisposable.Instance;
+        }
+    }
+
+    /// <summary>Observer that blocks the first value so concurrent re-entry can be detected.</summary>
+    private sealed class BlockingObserver : IObserver<int>, IDisposable
+    {
+        /// <summary>Gets the event set when the first <see cref="OnNext"/> call is entered.</summary>
+        public ManualResetEventSlim OnNextEntered { get; } = new();
+
+        /// <summary>Gets the event released by the test to unblock the first <see cref="OnNext"/> call.</summary>
+        public ManualResetEventSlim ReleaseOnNext { get; } = new();
+
+        /// <summary>Gets the number of forwarded values.</summary>
+        public int Values { get; private set; }
+
+        /// <summary>Gets a value indicating whether <see cref="OnNext"/> was entered concurrently.</summary>
+        public bool ConcurrentOnNext { get; private set; }
+
+        /// <summary>Gets or sets a value indicating whether an <see cref="OnNext"/> call is active.</summary>
+        private bool IsInOnNext { get; set; }
+
+        /// <inheritdoc/>
+        public void OnCompleted()
+        {
+        }
+
+        /// <inheritdoc/>
+        public void OnError(Exception error)
+        {
+        }
+
+        /// <inheritdoc/>
+        public void OnNext(int value)
+        {
+            if (IsInOnNext)
+            {
+                ConcurrentOnNext = true;
+            }
+
+            Values++;
+            IsInOnNext = true;
+            OnNextEntered.Set();
+            if (value == One && !ReleaseOnNext.Wait(WaitTimeout))
+            {
+                throw new TimeoutException("Timed out waiting to release the blocked OnNext call.");
+            }
+
+            IsInOnNext = false;
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            OnNextEntered.Dispose();
+            ReleaseOnNext.Dispose();
+        }
+    }
+}

--- a/src/tests/ReactiveUI.Primitives.Tests/SwitchWitnessTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/SwitchWitnessTests.cs
@@ -71,6 +71,208 @@ public sealed class SwitchWitnessTests
         await Assert.That(observer.Values).IsEqualTo(Two);
     }
 
+    /// <summary>Verifies switching inner sources forwards only the latest source's values.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SwitchWitnessForwardsOnlyLatestInnerValues()
+    {
+        RecordingWitness<int> observer = new();
+        Signal<IObservable<int>> outer = new();
+        CapturingObservable<int> first = new();
+        CapturingObservable<int> second = new();
+        using var subscription = new SwitchWitness<int>(observer).Run(outer);
+
+        outer.OnNext(first);
+        first.Observer!.OnNext(One);
+
+        outer.OnNext(second);
+
+        // The stale first inner is now superseded; its values must be dropped.
+        first.Observer.OnNext(One);
+        second.Observer!.OnNext(Two);
+
+        await Assert.That(observer.Values.Count).IsEqualTo(Two);
+        await Assert.That(observer.Values[0]).IsEqualTo(One);
+        await Assert.That(observer.Values[1]).IsEqualTo(Two);
+    }
+
+    /// <summary>Verifies a stale inner completion does not complete the witness.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SwitchWitnessIgnoresStaleInnerCompletion()
+    {
+        RecordingWitness<int> observer = new();
+        Signal<IObservable<int>> outer = new();
+        CapturingObservable<int> first = new();
+        CapturingObservable<int> second = new();
+        using var subscription = new SwitchWitness<int>(observer).Run(outer);
+
+        outer.OnNext(first);
+        var staleFirst = first.Observer!;
+        outer.OnNext(second);
+        outer.OnCompleted();
+
+        // Stale inner completion (wrong version) must not complete the witness.
+        staleFirst.OnCompleted();
+        await Assert.That(observer.Completed).IsEqualTo(0);
+
+        // Current inner completion plus outer-complete completes once.
+        second.Observer!.OnCompleted();
+        await Assert.That(observer.Completed).IsEqualTo(One);
+    }
+
+    /// <summary>Verifies outer completion before the inner finishes defers completion.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SwitchWitnessDefersCompletionUntilActiveInnerCompletes()
+    {
+        RecordingWitness<int> observer = new();
+        Signal<IObservable<int>> outer = new();
+        CapturingObservable<int> inner = new();
+        using var subscription = new SwitchWitness<int>(observer).Run(outer);
+
+        outer.OnNext(inner);
+        outer.OnCompleted();
+
+        // Outer done but inner still active: no completion yet.
+        await Assert.That(observer.Completed).IsEqualTo(0);
+
+        inner.Observer!.OnCompleted();
+        await Assert.That(observer.Completed).IsEqualTo(One);
+    }
+
+    /// <summary>Verifies completion when the outer finishes with no inner ever active.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SwitchWitnessCompletesWhenOuterCompletesWithNoInner()
+    {
+        RecordingWitness<int> observer = new();
+        Signal<IObservable<int>> outer = new();
+        using var subscription = new SwitchWitness<int>(observer).Run(outer);
+
+        outer.OnCompleted();
+
+        await Assert.That(observer.Completed).IsEqualTo(One);
+    }
+
+    /// <summary>Verifies an outer error is forwarded once and gates later notifications.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SwitchWitnessForwardsOuterErrorAndGatesAfterwards()
+    {
+        RecordingWitness<int> observer = new();
+        Signal<IObservable<int>> outer = new();
+        CapturingObservable<int> inner = new();
+        InvalidOperationException error = new("outer");
+        using var subscription = new SwitchWitness<int>(observer).Run(outer);
+
+        outer.OnNext(inner);
+        outer.OnError(error);
+
+        await Assert.That(observer.Errors).HasSingleItem();
+        await Assert.That(observer.Errors[0]).IsSameReferenceAs(error);
+
+        // Everything is gated after the terminal error.
+        inner.Observer!.OnNext(One);
+        inner.Observer.OnCompleted();
+        outer.OnNext(inner);
+        outer.OnCompleted();
+
+        await Assert.That(observer.Values).IsEmpty();
+        await Assert.That(observer.Completed).IsEqualTo(0);
+        await Assert.That(observer.Errors).HasSingleItem();
+    }
+
+    /// <summary>Verifies an inner error is forwarded once and gates later notifications.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SwitchWitnessForwardsInnerErrorAndGatesAfterwards()
+    {
+        RecordingWitness<int> observer = new();
+        Signal<IObservable<int>> outer = new();
+        CapturingObservable<int> inner = new();
+        InvalidOperationException error = new("inner");
+        using var subscription = new SwitchWitness<int>(observer).Run(outer);
+
+        outer.OnNext(inner);
+        inner.Observer!.OnError(error);
+
+        await Assert.That(observer.Errors).HasSingleItem();
+        await Assert.That(observer.Errors[0]).IsSameReferenceAs(error);
+
+        // Subsequent inner/outer notifications are gated.
+        inner.Observer.OnNext(One);
+        outer.OnCompleted();
+
+        await Assert.That(observer.Values).IsEmpty();
+        await Assert.That(observer.Completed).IsEqualTo(0);
+        await Assert.That(observer.Errors).HasSingleItem();
+    }
+
+    /// <summary>Verifies a stale inner error (wrong version) is dropped.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SwitchWitnessDropsStaleInnerError()
+    {
+        RecordingWitness<int> observer = new();
+        Signal<IObservable<int>> outer = new();
+        CapturingObservable<int> first = new();
+        CapturingObservable<int> second = new();
+        using var subscription = new SwitchWitness<int>(observer).Run(outer);
+
+        outer.OnNext(first);
+        var staleFirst = first.Observer!;
+        outer.OnNext(second);
+
+        // Error from the superseded inner is dropped, not forwarded.
+        staleFirst.OnError(new InvalidOperationException("stale"));
+
+        await Assert.That(observer.Errors).IsEmpty();
+
+        second.Observer!.OnNext(Two);
+        await Assert.That(observer.Values).HasSingleItem();
+        await Assert.That(observer.Values[0]).IsEqualTo(Two);
+    }
+
+    /// <summary>Verifies a new source arriving after a terminal is ignored.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SwitchWitnessIgnoresSourceAfterTerminal()
+    {
+        RecordingWitness<int> observer = new();
+        Signal<IObservable<int>> outer = new();
+        CapturingObservable<int> inner = new();
+        using var subscription = new SwitchWitness<int>(observer).Run(outer);
+
+        outer.OnCompleted();
+        await Assert.That(observer.Completed).IsEqualTo(One);
+
+        // A late source must be ignored; its observer is never captured.
+        outer.OnNext(inner);
+        await Assert.That(inner.Observer).IsNull();
+    }
+
+    /// <summary>Verifies disposal mid-switch disposes the active inner subscription.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SwitchWitnessDisposesActiveInnerOnDispose()
+    {
+        RecordingWitness<int> observer = new();
+        Signal<IObservable<int>> outer = new();
+        DisposalObservable<int> inner = new();
+        var subscription = new SwitchWitness<int>(observer).Run(outer);
+
+        outer.OnNext(inner);
+        inner.Observer!.OnNext(One);
+        await Assert.That(observer.Values).HasSingleItem();
+        await Assert.That(observer.Values[0]).IsEqualTo(One);
+
+        subscription.Dispose();
+
+        // The inner subscription is disposed by the witness.
+        await Assert.That(inner.Disposed).IsTrue();
+    }
+
     /// <summary>An observable that captures its observer for manual notification.</summary>
     /// <typeparam name="T">The value type.</typeparam>
     private sealed class CapturingObservable<T> : IObservable<T>
@@ -83,6 +285,24 @@ public sealed class SwitchWitnessTests
         {
             Observer = observer;
             return EmptyDisposable.Instance;
+        }
+    }
+
+    /// <summary>An observable that captures its observer and records subscription disposal.</summary>
+    /// <typeparam name="T">The value type.</typeparam>
+    private sealed class DisposalObservable<T> : IObservable<T>
+    {
+        /// <summary>Gets the captured observer.</summary>
+        public IObserver<T>? Observer { get; private set; }
+
+        /// <summary>Gets a value indicating whether the subscription was disposed.</summary>
+        public bool Disposed { get; private set; }
+
+        /// <inheritdoc/>
+        public IDisposable Subscribe(IObserver<T> observer)
+        {
+            Observer = observer;
+            return new ActionDisposable(() => Disposed = true);
         }
     }
 

--- a/src/tests/ReactiveUI.Primitives.Tests/SwitchWitnessTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/SwitchWitnessTests.cs
@@ -255,6 +255,31 @@ public sealed class SwitchWitnessTests
         await Assert.That(inner.Observer).IsNull();
     }
 
+    /// <summary>Verifies a terminal witness gates a later source switch and outer error while the outer source stays live.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SwitchWitnessGatesLateNotificationsAfterInnerError()
+    {
+        RecordingWitness<int> observer = new();
+        Signal<IObservable<int>> outer = new();
+        CapturingObservable<int> first = new();
+        CapturingObservable<int> late = new();
+        using var subscription = new SwitchWitness<int>(observer).Run(outer);
+
+        outer.OnNext(first);
+
+        // An inner error makes the witness terminal without stopping the outer source.
+        first.Observer!.OnError(new InvalidOperationException("boom"));
+        await Assert.That(observer.Errors).HasSingleItem();
+
+        // Subsequent source switches and outer errors are gated: nothing more is forwarded.
+        outer.OnNext(late);
+        outer.OnError(new InvalidOperationException("late"));
+
+        await Assert.That(late.Observer).IsNull();
+        await Assert.That(observer.Errors).HasSingleItem();
+    }
+
     /// <summary>Verifies disposal mid-switch disposes the active inner subscription.</summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Test]

--- a/src/tests/ReactiveUI.Primitives.Tests/SwitchWitnessTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/SwitchWitnessTests.cs
@@ -17,6 +17,9 @@ public sealed class SwitchWitnessTests
     /// <summary>The integer constant two.</summary>
     private const int Two = 2;
 
+    /// <summary>Window used to confirm a gated operation stays blocked while a delivery is in flight.</summary>
+    private const int GateProbeMilliseconds = 200;
+
     /// <summary>Timeout used while waiting for background work in these tests.</summary>
     private static readonly TimeSpan WaitTimeout = TimeSpan.FromSeconds(5);
 
@@ -38,7 +41,7 @@ public sealed class SwitchWitnessTests
         await Assert.That(observer.Completed).IsEqualTo(One);
     }
 
-    /// <summary>Verifies the public switch operator serializes consecutive inner values through the same observer gate.</summary>
+    /// <summary>Verifies the public switch operator serializes a source switch against an in-flight inner delivery.</summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Test]
     public async Task SwitchToDoesNotEnterObserverConcurrentlyWhenSwitchingInnerSources()
@@ -46,26 +49,26 @@ public sealed class SwitchWitnessTests
         Signal<IObservable<int>> outer = new();
         CapturingObservable<int> first = new();
         CapturingObservable<int> second = new();
-        using BlockingObserver observer = new();
+        using GatedObserver observer = new();
         using var subscription = outer.SwitchTo().Subscribe(observer);
 
         outer.OnNext(first);
-        var firstValueTask = Task.Run(() => first.Observer!.OnNext(One));
-        await Assert.That(observer.OnNextEntered.Wait(WaitTimeout)).IsTrue();
 
-        var switchTask = Task.Run(() => outer.OnNext(second));
-        await Task.Delay(TimeSpan.FromMilliseconds(50)).ConfigureAwait(false);
-        second.Observer?.OnNext(Two);
+        // The first inner value enters the observer and blocks while the coordinator holds its gate.
+        Task firstDelivery = Task.Run(() => first.Observer!.OnNext(One));
+        await Assert.That(observer.FirstEntered.Wait(WaitTimeout)).IsTrue();
 
+        // Switching sources is gated too: OnSource cannot subscribe the new inner until the delivery releases.
+        Task switchTask = Task.Run(() => outer.OnNext(second));
+        await Assert.That(SpinWait.SpinUntil(() => second.Observer is not null, GateProbeMilliseconds)).IsFalse();
         await Assert.That(observer.ConcurrentOnNext).IsFalse();
-        observer.ReleaseOnNext.Set();
-        await firstValueTask.WaitAsync(WaitTimeout).ConfigureAwait(false);
+
+        observer.ReleaseFirst.Set();
+        await firstDelivery.WaitAsync(WaitTimeout).ConfigureAwait(false);
         await switchTask.WaitAsync(WaitTimeout).ConfigureAwait(false);
 
-        if (observer.Values == One)
-        {
-            second.Observer!.OnNext(Two);
-        }
+        // Once the switch completes the new inner delivers serially behind the first value.
+        second.Observer!.OnNext(Two);
 
         await Assert.That(observer.ConcurrentOnNext).IsFalse();
         await Assert.That(observer.Values).IsEqualTo(Two);
@@ -306,23 +309,29 @@ public sealed class SwitchWitnessTests
         }
     }
 
-    /// <summary>Observer that blocks the first value so concurrent re-entry can be detected.</summary>
-    private sealed class BlockingObserver : IObserver<int>, IDisposable
+    /// <summary>Observer that blocks its first value so any concurrent re-entry is detected with thread-safe state.</summary>
+    private sealed class GatedObserver : IObserver<int>, IDisposable
     {
+        /// <summary>Tracks how many threads are currently inside <see cref="OnNext"/>.</summary>
+        private int _inOnNext;
+
+        /// <summary>Counts forwarded values.</summary>
+        private int _values;
+
+        /// <summary>Set when more than one thread is inside <see cref="OnNext"/> at once.</summary>
+        private int _concurrent;
+
         /// <summary>Gets the event set when the first <see cref="OnNext"/> call is entered.</summary>
-        public ManualResetEventSlim OnNextEntered { get; } = new();
+        public ManualResetEventSlim FirstEntered { get; } = new();
 
         /// <summary>Gets the event released by the test to unblock the first <see cref="OnNext"/> call.</summary>
-        public ManualResetEventSlim ReleaseOnNext { get; } = new();
+        public ManualResetEventSlim ReleaseFirst { get; } = new();
 
         /// <summary>Gets the number of forwarded values.</summary>
-        public int Values { get; private set; }
+        public int Values => Volatile.Read(ref _values);
 
         /// <summary>Gets a value indicating whether <see cref="OnNext"/> was entered concurrently.</summary>
-        public bool ConcurrentOnNext { get; private set; }
-
-        /// <summary>Gets or sets a value indicating whether an <see cref="OnNext"/> call is active.</summary>
-        private bool IsInOnNext { get; set; }
+        public bool ConcurrentOnNext => Volatile.Read(ref _concurrent) != 0;
 
         /// <inheritdoc/>
         public void OnCompleted()
@@ -337,27 +346,29 @@ public sealed class SwitchWitnessTests
         /// <inheritdoc/>
         public void OnNext(int value)
         {
-            if (IsInOnNext)
+            if (Interlocked.Increment(ref _inOnNext) != 1)
             {
-                ConcurrentOnNext = true;
+                _ = Interlocked.Exchange(ref _concurrent, 1);
             }
 
-            Values++;
-            IsInOnNext = true;
-            OnNextEntered.Set();
-            if (value == One && !ReleaseOnNext.Wait(WaitTimeout))
+            var index = Interlocked.Increment(ref _values);
+            if (index == 1)
             {
-                throw new TimeoutException("Timed out waiting to release the blocked OnNext call.");
+                FirstEntered.Set();
+                if (!ReleaseFirst.Wait(WaitTimeout))
+                {
+                    throw new TimeoutException("Timed out waiting to release the blocked OnNext call.");
+                }
             }
 
-            IsInOnNext = false;
+            _ = Interlocked.Decrement(ref _inOnNext);
         }
 
         /// <inheritdoc/>
         public void Dispose()
         {
-            OnNextEntered.Dispose();
-            ReleaseOnNext.Dispose();
+            FirstEntered.Dispose();
+            ReleaseFirst.Dispose();
         }
     }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix for switch operator synchronization and terminal delivery.

## What is the new behavior?

`SwitchWitness<T>` and the internal switch coordinator now check the active inner version and forward downstream notifications under the same gate. They also latch terminal delivery so completion and errors are emitted once.

Fixes #69.

## What is the current behavior?

Inner switch notifications are checked outside the downstream gate, allowing stale or concurrent observer calls, and completion can be emitted more than once.

## Checklist
- [x] Tests have been added or updated (for bug fixes / features) 
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the main branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) 

## Additional information

Validation:
- `dotnet restore "ReactiveUI.Primitives.slnx"`
- `dotnet build "tests/ReactiveUI.Primitives.Tests/ReactiveUI.Primitives.Tests.csproj" -f net10.0 --no-restore -v minimal`
- `dotnet test "tests/ReactiveUI.Primitives.Tests/ReactiveUI.Primitives.Tests.csproj" -f net10.0 --no-build -- --treenode-filter "/*/*/SwitchWitnessTests/*" --output Detailed`
- `mcp__mtpunittestmcp.get_solution_coverage` reported no Cobertura data because coverage was not collected.