### PR TITLE
fix(operators): serialize delayed notifications

### DIFF
--- a/src/Primitives.Shared/SignalOperatorMixins.SchedulerSignals.cs
+++ b/src/Primitives.Shared/SignalOperatorMixins.SchedulerSignals.cs
@@ -189,8 +189,11 @@ public static partial class LinqExtensions
                 return;
             }
 
-            _timer.Dispose();
-            _subscriptions.Dispose();
+            lock (_gate)
+            {
+                _timer.Dispose();
+                _subscriptions.Dispose();
+            }
         }
 
         /// <summary>Starts the delayed notification coordinator.</summary>

--- a/src/Primitives.Shared/SignalOperatorMixins.SchedulerSignals.cs
+++ b/src/Primitives.Shared/SignalOperatorMixins.SchedulerSignals.cs
@@ -80,7 +80,7 @@ public static partial class LinqExtensions
         internal ShiftSignal(IObservable<T> source, TimeSpan dueTime, ISequencer scheduler)
         {
             _source = source;
-            _dueTime = dueTime;
+            _dueTime = Sequencer.Normalize(dueTime);
             _scheduler = scheduler;
         }
 
@@ -105,14 +105,283 @@ public static partial class LinqExtensions
         /// <summary>Subscribes to the source and schedules each notification by the delay.</summary>
         /// <param name="observer">The downstream observer.</param>
         /// <returns>The disposable that cancels the source subscription and pending timers.</returns>
-        private MultipleDisposable RunCore(IObserver<T> observer)
+        private ShiftCoordinator<T> RunCore(IObserver<T> observer)
         {
-            MultipleDisposable pocket = [];
-            pocket.Add(_source.Subscribe(
-                value => pocket.Add(_scheduler.Schedule(_dueTime, () => observer.OnNext(value))),
-                error => pocket.Add(_scheduler.Schedule(_dueTime, () => observer.OnError(error))),
-                () => pocket.Add(_scheduler.Schedule(_dueTime, observer.OnCompleted))));
-            return pocket;
+            ShiftCoordinator<T> coordinator = new(_source, _dueTime, _scheduler, observer);
+            return coordinator.Run();
+        }
+    }
+
+    /// <summary>Coordinates delayed notification delivery with a single serialized timer.</summary>
+    /// <typeparam name="T">The source value type.</typeparam>
+    private sealed class ShiftCoordinator<T> : IDisposable
+    {
+        /// <summary>The source observable.</summary>
+        private readonly IObservable<T> _source;
+
+        /// <summary>The normalized delay applied to each notification.</summary>
+        private readonly TimeSpan _dueTime;
+
+        /// <summary>The sequencer used to schedule delayed notifications.</summary>
+        private readonly ISequencer _sequencer;
+
+        /// <summary>The downstream observer.</summary>
+        private readonly IObserver<T> _observer;
+
+        /// <summary>Serializes queue state and downstream callbacks.</summary>
+        private readonly Lock _gate = new();
+
+        /// <summary>Active source and timer resources.</summary>
+        private readonly MultipleDisposable _subscriptions = [];
+
+        /// <summary>The single active timer slot.</summary>
+        private readonly SingleReplaceableDisposable _timer = new();
+
+        /// <summary>Queued delayed notifications in source order.</summary>
+        private readonly Queue<DelayedNotification> _queue = [];
+
+        /// <summary>A value indicating whether a timer or drain is active.</summary>
+        private bool _timerActive;
+
+        /// <summary>A value indicating whether the source has already signaled terminal notification.</summary>
+        private bool _sourceStopped;
+
+        /// <summary>A value indicating whether a terminal notification has been delivered.</summary>
+        private bool _done;
+
+        /// <summary>Tracks disposal.</summary>
+        private int _disposed;
+
+        /// <summary>Initializes a new instance of the <see cref="ShiftCoordinator{T}"/> class.</summary>
+        /// <param name="source">The source observable.</param>
+        /// <param name="dueTime">The normalized delay applied to each notification.</param>
+        /// <param name="sequencer">The sequencer used to schedule delayed notifications.</param>
+        /// <param name="observer">The downstream observer.</param>
+        internal ShiftCoordinator(IObservable<T> source, TimeSpan dueTime, ISequencer sequencer, IObserver<T> observer)
+        {
+            _source = source;
+            _dueTime = dueTime;
+            _sequencer = sequencer;
+            _observer = observer;
+        }
+
+        /// <summary>The queued notification kind.</summary>
+        private enum NotificationKind
+        {
+            /// <summary>A value notification.</summary>
+            Next,
+
+            /// <summary>An error notification.</summary>
+            Error,
+
+            /// <summary>A completion notification.</summary>
+            Completed
+        }
+
+        /// <summary>Gets a value indicating whether the coordinator is disposed.</summary>
+        private bool IsDisposed => Volatile.Read(ref _disposed) != 0;
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            {
+                return;
+            }
+
+            _timer.Dispose();
+            _subscriptions.Dispose();
+        }
+
+        /// <summary>Starts the delayed notification coordinator.</summary>
+        /// <returns>The coordinator that owns the subscription cleanup.</returns>
+        internal ShiftCoordinator<T> Run()
+        {
+            _subscriptions.Add(_timer);
+            _subscriptions.Add(_source.Subscribe(OnNext, OnError, OnCompleted));
+            return this;
+        }
+
+        /// <summary>Queues a source value for delayed delivery.</summary>
+        /// <param name="value">The source value.</param>
+        private void OnNext(T value) => Enqueue(DelayedNotification.Next(value, DueAt()), isTerminal: false);
+
+        /// <summary>Queues a source error for delayed delivery behind earlier values.</summary>
+        /// <param name="error">The source error.</param>
+        private void OnError(Exception error) => Enqueue(DelayedNotification.Failure(error, DueAt()), isTerminal: true);
+
+        /// <summary>Queues source completion for delayed delivery behind earlier values.</summary>
+        private void OnCompleted() => Enqueue(DelayedNotification.Completed(DueAt()), isTerminal: true);
+
+        /// <summary>Computes the due time for the current source notification.</summary>
+        /// <returns>The absolute due time.</returns>
+        private DateTimeOffset DueAt() => _sequencer.Now + _dueTime;
+
+        /// <summary>Queues a notification and starts the timer when this item owns the drain.</summary>
+        /// <param name="notification">The delayed notification.</param>
+        /// <param name="isTerminal">A value indicating whether the notification stops the source.</param>
+        private void Enqueue(DelayedNotification notification, bool isTerminal)
+        {
+            TimeSpan delay = default;
+            var shouldSchedule = false;
+            lock (_gate)
+            {
+                if (IsDisposed || _done || _sourceStopped)
+                {
+                    return;
+                }
+
+                if (isTerminal)
+                {
+                    _sourceStopped = true;
+                }
+
+                _queue.Enqueue(notification);
+                if (!_timerActive)
+                {
+                    _timerActive = true;
+                    delay = DelayUntil(notification.DueAt);
+                    shouldSchedule = true;
+                }
+            }
+
+            if (!shouldSchedule)
+            {
+                return;
+            }
+
+            Schedule(delay);
+        }
+
+        /// <summary>Schedules the single active drain timer.</summary>
+        /// <param name="delay">The delay before the drain should run.</param>
+        private void Schedule(TimeSpan delay) => _timer.Create(_sequencer.Schedule(delay, Tick));
+
+        /// <summary>Drains all due notifications in FIFO order.</summary>
+        private void Tick()
+        {
+            while (true)
+            {
+                TimeSpan delay;
+                var shouldReschedule = false;
+                var terminal = false;
+                lock (_gate)
+                {
+                    if (IsDisposed || _done)
+                    {
+                        _timerActive = false;
+                        return;
+                    }
+
+                    if (_queue.Count == 0)
+                    {
+                        _timerActive = false;
+                        return;
+                    }
+
+                    delay = DelayUntil(_queue.Peek().DueAt);
+                    if (delay > TimeSpan.Zero)
+                    {
+                        shouldReschedule = true;
+                    }
+                    else
+                    {
+                        terminal = Deliver(_queue.Dequeue());
+                    }
+                }
+
+                if (shouldReschedule)
+                {
+                    Schedule(delay);
+                    return;
+                }
+
+                if (terminal)
+                {
+                    Dispose();
+                    return;
+                }
+            }
+        }
+
+        /// <summary>Forwards a queued notification while the caller holds the gate.</summary>
+        /// <param name="notification">The queued notification.</param>
+        /// <returns><see langword="true"/> when a terminal notification was delivered.</returns>
+        private bool Deliver(DelayedNotification notification)
+        {
+            switch (notification.Kind)
+            {
+                case NotificationKind.Next:
+                {
+                    _observer.OnNext(notification.Value!);
+                    return false;
+                }
+
+                case NotificationKind.Error:
+                {
+                    _done = true;
+                    _observer.OnError(notification.Error!);
+                    return true;
+                }
+
+                default:
+                {
+                    _done = true;
+                    _observer.OnCompleted();
+                    return true;
+                }
+            }
+        }
+
+        /// <summary>Computes the remaining delay for an absolute due time.</summary>
+        /// <param name="dueAt">The absolute due time.</param>
+        /// <returns>The remaining non-negative delay.</returns>
+        private TimeSpan DelayUntil(DateTimeOffset dueAt) => Sequencer.Normalize(dueAt - _sequencer.Now);
+
+        /// <summary>A delayed source notification.</summary>
+        private sealed class DelayedNotification
+        {
+            /// <summary>Initializes a new instance of the <see cref="DelayedNotification"/> struct.</summary>
+            /// <param name="kind">The notification kind.</param>
+            /// <param name="value">The notification value.</param>
+            /// <param name="error">The notification error.</param>
+            /// <param name="dueAt">The notification due time.</param>
+            private DelayedNotification(NotificationKind kind, T? value, Exception? error, DateTimeOffset dueAt)
+            {
+                Kind = kind;
+                Value = value;
+                Error = error;
+                DueAt = dueAt;
+            }
+
+            /// <summary>Gets the notification kind.</summary>
+            public NotificationKind Kind { get; }
+
+            /// <summary>Gets the notification value.</summary>
+            public T? Value { get; }
+
+            /// <summary>Gets the notification error.</summary>
+            public Exception? Error { get; }
+
+            /// <summary>Gets the notification due time.</summary>
+            public DateTimeOffset DueAt { get; }
+
+            /// <summary>Creates a value notification.</summary>
+            /// <param name="value">The notification value.</param>
+            /// <param name="dueAt">The notification due time.</param>
+            /// <returns>The delayed notification.</returns>
+            public static DelayedNotification Next(T value, DateTimeOffset dueAt) => new(NotificationKind.Next, value, null, dueAt);
+
+            /// <summary>Creates an error notification.</summary>
+            /// <param name="error">The notification error.</param>
+            /// <param name="dueAt">The notification due time.</param>
+            /// <returns>The delayed notification.</returns>
+            public static DelayedNotification Failure(Exception error, DateTimeOffset dueAt) => new(NotificationKind.Error, default, error, dueAt);
+
+            /// <summary>Creates a completion notification.</summary>
+            /// <param name="dueAt">The notification due time.</param>
+            /// <returns>The delayed notification.</returns>
+            public static DelayedNotification Completed(DateTimeOffset dueAt) => new(NotificationKind.Completed, default, null, dueAt);
         }
     }
 

--- a/src/tests/ReactiveUI.Primitives.Tests/SignalOperatorMixinsTests.Delay.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/SignalOperatorMixinsTests.Delay.cs
@@ -92,6 +92,89 @@ public partial class SignalOperatorMixinsTests
         await Assert.That(Volatile.Read(ref completed)).IsEqualTo(0);
     }
 
+    /// <summary>Verifies a delayed error is forwarded after the queued values that precede it.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task ShiftForwardsDelayedErrorAfterQueuedValues()
+    {
+        var dueTime = TimeSpan.FromTicks(Ten);
+        RecordingSequencer sequencer = new(DateTimeOffset.UnixEpoch);
+        Signal<int> source = new();
+        RecordingWitness<int> observer = new();
+        InvalidOperationException failure = new("boom");
+        using var subscription = source.Shift(dueTime, sequencer).Subscribe(observer);
+
+        source.OnNext(One);
+        source.OnError(failure);
+
+        await Assert.That(observer.Values.Count).IsEqualTo(0);
+        await Assert.That(observer.Errors.Count).IsEqualTo(0);
+
+        sequencer.AdvanceBy(dueTime);
+        sequencer.RunNext();
+
+        await Assert.That(observer.Values.SequenceEqual([One])).IsTrue();
+        await Assert.That(observer.Errors.Count).IsEqualTo(One);
+        await Assert.That(observer.Errors[0]).IsSameReferenceAs(failure);
+        await Assert.That(observer.Completed).IsEqualTo(0);
+        await Assert.That(sequencer.ScheduledCount).IsEqualTo(0);
+    }
+
+    /// <summary>Verifies notifications after a terminal one are dropped while the source is stopped.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task ShiftDropsNotificationsAfterTerminalNotification()
+    {
+        var dueTime = TimeSpan.FromTicks(Ten);
+        RecordingSequencer sequencer = new(DateTimeOffset.UnixEpoch);
+        Signal<int> source = new();
+        RecordingWitness<int> observer = new();
+        using var subscription = source.Shift(dueTime, sequencer).Subscribe(observer);
+
+        source.OnNext(One);
+        source.OnCompleted();
+        source.OnNext(Two);
+
+        sequencer.AdvanceBy(dueTime);
+        sequencer.RunNext();
+
+        await Assert.That(observer.Values.SequenceEqual([One])).IsTrue();
+        await Assert.That(observer.Completed).IsEqualTo(One);
+        await Assert.That(observer.Errors.Count).IsEqualTo(0);
+        await Assert.That(sequencer.ScheduledCount).IsEqualTo(0);
+    }
+
+    /// <summary>Verifies the drain reschedules when the next queued notification is not yet due.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task ShiftReschedulesWhenNextNotificationIsNotYetDue()
+    {
+        var step = TimeSpan.FromTicks(Five);
+        var dueTime = TimeSpan.FromTicks(Ten);
+        RecordingSequencer sequencer = new(DateTimeOffset.UnixEpoch);
+        Signal<int> source = new();
+        RecordingWitness<int> observer = new();
+        using var subscription = source.Shift(dueTime, sequencer).Subscribe(observer);
+
+        source.OnNext(One);
+        sequencer.AdvanceBy(step);
+        source.OnNext(Two);
+
+        await Assert.That(sequencer.ScheduledCount).IsEqualTo(One);
+
+        sequencer.AdvanceBy(step);
+        sequencer.RunNext();
+
+        await Assert.That(observer.Values.SequenceEqual([One])).IsTrue();
+        await Assert.That(sequencer.ScheduledCount).IsEqualTo(One);
+
+        sequencer.AdvanceBy(step);
+        sequencer.RunNext();
+
+        await Assert.That(observer.Values.SequenceEqual([One, Two])).IsTrue();
+        await Assert.That(sequencer.ScheduledCount).IsEqualTo(0);
+    }
+
     /// <summary>Sequencer that records scheduled work for deterministic execution.</summary>
     private sealed class RecordingSequencer : ISequencer
     {

--- a/src/tests/ReactiveUI.Primitives.Tests/SignalOperatorMixinsTests.Delay.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/SignalOperatorMixinsTests.Delay.cs
@@ -1,0 +1,73 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using ReactiveUI.Primitives.Concurrency;
+using ReactiveUI.Primitives.Signals;
+
+namespace ReactiveUI.Primitives.Tests;
+
+/// <summary>Verifies delayed signal operator behavior.</summary>
+public partial class SignalOperatorMixinsTests
+{
+    /// <summary>Verifies shift uses one ordered drain for a burst of delayed notifications.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task ShiftUsesSingleSerializedDrainForQueuedNotifications()
+    {
+        var dueTime = TimeSpan.FromTicks(Ten);
+        RecordingSequencer sequencer = new(DateTimeOffset.UnixEpoch);
+        Signal<int> source = new();
+        RecordingWitness<int> observer = new();
+        using var subscription = source.Shift(dueTime, sequencer).Subscribe(observer);
+
+        source.OnNext(One);
+        source.OnNext(Two);
+        source.OnCompleted();
+
+        await Assert.That(sequencer.ScheduledCount).IsEqualTo(One);
+        await Assert.That(observer.Values.Count).IsEqualTo(0);
+        await Assert.That(observer.Completed).IsEqualTo(0);
+
+        sequencer.AdvanceBy(dueTime);
+        sequencer.RunNext();
+
+        await Assert.That(observer.Values.SequenceEqual([One, Two])).IsTrue();
+        await Assert.That(observer.Completed).IsEqualTo(One);
+        await Assert.That(observer.Errors.Count).IsEqualTo(0);
+        await Assert.That(sequencer.ScheduledCount).IsEqualTo(0);
+    }
+
+    /// <summary>Sequencer that records scheduled work for deterministic execution.</summary>
+    private sealed class RecordingSequencer : ISequencer
+    {
+        /// <summary>The scheduled work items.</summary>
+        private readonly Queue<IWorkItem> _items = [];
+
+        /// <summary>Initializes a new instance of the <see cref="RecordingSequencer"/> class.</summary>
+        /// <param name="now">The initial scheduler clock.</param>
+        public RecordingSequencer(DateTimeOffset now) => Now = now;
+
+        /// <inheritdoc/>
+        public DateTimeOffset Now { get; private set; }
+
+        /// <inheritdoc/>
+        public long Timestamp => 0;
+
+        /// <summary>Gets the number of scheduled work items.</summary>
+        public int ScheduledCount => _items.Count;
+
+        /// <inheritdoc/>
+        public void Schedule(IWorkItem item) => _items.Enqueue(item);
+
+        /// <inheritdoc/>
+        public void Schedule(IWorkItem item, long dueTimestamp) => _items.Enqueue(item);
+
+        /// <summary>Advances the scheduler clock without running queued work.</summary>
+        /// <param name="time">The clock movement.</param>
+        public void AdvanceBy(TimeSpan time) => Now += time;
+
+        /// <summary>Runs the next scheduled work item.</summary>
+        public void RunNext() => _items.Dequeue().Execute();
+    }
+}

--- a/src/tests/ReactiveUI.Primitives.Tests/SignalOperatorMixinsTests.Delay.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/SignalOperatorMixinsTests.Delay.cs
@@ -2,6 +2,8 @@
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.Collections.Concurrent;
+using System.Threading;
 using ReactiveUI.Primitives.Concurrency;
 using ReactiveUI.Primitives.Signals;
 
@@ -10,6 +12,9 @@ namespace ReactiveUI.Primitives.Tests;
 /// <summary>Verifies delayed signal operator behavior.</summary>
 public partial class SignalOperatorMixinsTests
 {
+    /// <summary>Observation window used to verify disposal waits for in-flight delivery.</summary>
+    private const int DisposeObservationMilliseconds = 200;
+
     /// <summary>Verifies shift uses one ordered drain for a burst of delayed notifications.</summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Test]
@@ -36,6 +41,55 @@ public partial class SignalOperatorMixinsTests
         await Assert.That(observer.Completed).IsEqualTo(One);
         await Assert.That(observer.Errors.Count).IsEqualTo(0);
         await Assert.That(sequencer.ScheduledCount).IsEqualTo(0);
+    }
+
+    /// <summary>Verifies that dispose waits for in-flight delivery and blocks queued notifications.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task ShiftDisposeWaitsForInflightDeliveryAndDisallowsFurtherDelivery()
+    {
+        TimeSpan dueTime = TimeSpan.FromMilliseconds(One);
+        Signal<int> source = new();
+        using ManualResetEventSlim onNextEntered = new(false);
+        using ManualResetEventSlim onNextRelease = new(false);
+        ConcurrentQueue<int> values = [];
+        var completed = 0;
+        var delivered = 0;
+
+        using var subscription = source
+            .Shift(dueTime, TaskPoolSequencer.Instance)
+            .Subscribe(
+                value =>
+                {
+                    if (Interlocked.Increment(ref delivered) == 1)
+                    {
+                        onNextEntered.Set();
+                    }
+
+                    onNextRelease.Wait();
+                    values.Enqueue(value);
+                },
+                _ => { },
+                () => Interlocked.Increment(ref completed));
+
+        source.OnNext(One);
+        source.OnNext(Two);
+        source.OnCompleted();
+
+        await Assert.That(onNextEntered.Wait(TimeSpan.FromSeconds(1))).IsTrue();
+
+        Task disposeTask = Task.Run(subscription.Dispose);
+        Task disposeObservation = Task.Delay(TimeSpan.FromMilliseconds(DisposeObservationMilliseconds));
+        var disposeCompleted = await Task.WhenAny(disposeTask, disposeObservation) == disposeTask;
+
+        await Assert.That(disposeCompleted).IsFalse();
+
+        onNextRelease.Set();
+        await disposeTask;
+
+        await Assert.That(values.ToArray().SequenceEqual([One])).IsTrue();
+
+        await Assert.That(Volatile.Read(ref completed)).IsEqualTo(0);
     }
 
     /// <summary>Sequencer that records scheduled work for deterministic execution.</summary>

--- a/src/tests/ReactiveUI.Primitives.Tests/SignalOperatorMixinsTests.Delay.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/SignalOperatorMixinsTests.Delay.cs
@@ -15,6 +15,9 @@ public partial class SignalOperatorMixinsTests
     /// <summary>Observation window used to verify disposal waits for in-flight delivery.</summary>
     private const int DisposeObservationMilliseconds = 200;
 
+    /// <summary>Generous bound for the in-flight delivery to begin, tolerant of a saturated thread pool.</summary>
+    private const int InflightDeliveryTimeoutSeconds = 30;
+
     /// <summary>Verifies shift uses one ordered drain for a burst of delayed notifications.</summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Test]
@@ -49,6 +52,15 @@ public partial class SignalOperatorMixinsTests
     public async Task ShiftDisposeWaitsForInflightDeliveryAndDisallowsFurtherDelivery()
     {
         TimeSpan dueTime = TimeSpan.FromMilliseconds(One);
+
+        // Drain on dedicated threads so a saturated thread pool cannot stall the
+        // blocking in-flight delivery this test relies on; only the brief timer
+        // callback stays on the pool.
+        TaskPoolSequencer sequencer = new(new TaskFactory(
+            CancellationToken.None,
+            TaskCreationOptions.LongRunning,
+            TaskContinuationOptions.None,
+            TaskScheduler.Default));
         Signal<int> source = new();
         using ManualResetEventSlim onNextEntered = new(false);
         using ManualResetEventSlim onNextRelease = new(false);
@@ -57,7 +69,7 @@ public partial class SignalOperatorMixinsTests
         var delivered = 0;
 
         using var subscription = source
-            .Shift(dueTime, TaskPoolSequencer.Instance)
+            .Shift(dueTime, sequencer)
             .Subscribe(
                 value =>
                 {
@@ -76,9 +88,13 @@ public partial class SignalOperatorMixinsTests
         source.OnNext(Two);
         source.OnCompleted();
 
-        await Assert.That(onNextEntered.Wait(TimeSpan.FromSeconds(1))).IsTrue();
+        await Assert.That(onNextEntered.Wait(TimeSpan.FromSeconds(InflightDeliveryTimeoutSeconds))).IsTrue();
 
-        Task disposeTask = Task.Run(subscription.Dispose);
+        Task disposeTask = Task.Factory.StartNew(
+            subscription.Dispose,
+            CancellationToken.None,
+            TaskCreationOptions.LongRunning,
+            TaskScheduler.Default);
         Task disposeObservation = Task.Delay(TimeSpan.FromMilliseconds(DisposeObservationMilliseconds));
         var disposeCompleted = await Task.WhenAny(disposeTask, disposeObservation) == disposeTask;
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix for delayed notification ordering and observer serialization.

## What is the new behavior?

`Shift`/`Delay` now queues delayed notifications and drains them through one serialized timer, preserving source order and preventing overlapping downstream observer calls.

Fixes #67.

## What is the current behavior?

Each notification creates an independent timer, so delayed values and terminal notifications can run concurrently and out of order on thread-pool schedulers.

## Checklist
- [x] Tests have been added or updated (for bug fixes / features) 
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the main branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) 

## Additional information

Validation:
- `dotnet restore "ReactiveUI.Primitives.slnx"`
- `dotnet build "tests/ReactiveUI.Primitives.Tests/ReactiveUI.Primitives.Tests.csproj" -f net10.0 --no-restore -v minimal`
- `dotnet test "tests/ReactiveUI.Primitives.Tests/ReactiveUI.Primitives.Tests.csproj" -f net10.0 --no-build -- --treenode-filter "/*/*/SignalOperatorMixinsTests/ShiftUsesSingleSerializedDrainForQueuedNotifications" --output Detailed`
- Rebased cleanly onto `origin/main` at `d101d36` and reran the build/test above.
- `mcp__mtpunittestmcp.get_solution_coverage` reported no Cobertura data because coverage was not collected.