### PR TITLE
fix(signals): serialize priority semaphore drain

### DIFF
--- a/src/Primitives.Shared/Signals/PrioritySemaphoreSignal{T}.cs
+++ b/src/Primitives.Shared/Signals/PrioritySemaphoreSignal{T}.cs
@@ -31,6 +31,15 @@ public sealed class PrioritySemaphoreSignal<T> : ISignal<T>
     /// <summary>Prevents multiple concurrent drain loops from forwarding downstream at once.</summary>
     private bool _isDraining;
 
+    /// <summary>Queued terminal state waiting to be emitted by the drain owner.</summary>
+    private TerminalNotification _terminalNotification;
+
+    /// <summary>Queued values flushed on completion, ignoring semaphore capacity.</summary>
+    private PriorityQueue<T>? _terminalQueue;
+
+    /// <summary>Terminal error to forward when terminating with error.</summary>
+    private Exception? _terminalError;
+
     /// <summary>Initializes a new instance of the <see cref="PrioritySemaphoreSignal{T}"/> class.</summary>
     /// <param name="maxCount">The maximum number of values to forward before release is required.</param>
     public PrioritySemaphoreSignal(int maxCount)
@@ -45,6 +54,19 @@ public sealed class PrioritySemaphoreSignal<T> : ISignal<T>
     {
         _inner = sched is not null ? new ScheduledSignal<T>(sched) : new Signal<T>();
         _maximumCount = maxCount;
+    }
+
+    /// <summary>Terminal states consumed by the drain owner.</summary>
+    private enum TerminalNotification
+    {
+        /// <summary>No terminal notification has been queued.</summary>
+        None,
+
+        /// <summary>Completion notification.</summary>
+        Completed,
+
+        /// <summary>Error notification.</summary>
+        Error,
     }
 
     /// <inheritdoc />
@@ -95,18 +117,20 @@ public sealed class PrioritySemaphoreSignal<T> : ISignal<T>
     /// <inheritdoc />
     public void OnCompleted()
     {
-        var queue = CompleteQueue();
-        if (queue is null)
+        lock (_gate)
         {
-            return;
+            if (_nextItems is null)
+            {
+                return;
+            }
+
+            _terminalQueue = _nextItems;
+            _nextItems = null;
+            _terminalNotification = TerminalNotification.Completed;
+            _terminalError = null;
         }
 
-        while (queue.Count > 0)
-        {
-            _inner.OnNext(queue.Dequeue());
-        }
-
-        _inner.OnCompleted();
+        YieldUntilEmptyOrBlocked();
     }
 
     /// <inheritdoc />
@@ -116,10 +140,18 @@ public sealed class PrioritySemaphoreSignal<T> : ISignal<T>
 
         lock (_gate)
         {
+            if (_nextItems is null)
+            {
+                return;
+            }
+
             _nextItems = null;
+            _terminalQueue = null;
+            _terminalNotification = TerminalNotification.Error;
+            _terminalError = error;
         }
 
-        _inner.OnError(error);
+        YieldUntilEmptyOrBlocked();
     }
 
     /// <inheritdoc />
@@ -131,21 +163,12 @@ public sealed class PrioritySemaphoreSignal<T> : ISignal<T>
         lock (_gate)
         {
             _nextItems = null;
+            _terminalQueue = null;
+            _terminalNotification = TerminalNotification.None;
+            _terminalError = null;
         }
 
         _inner.Dispose();
-    }
-
-    /// <summary>Completes the priority queue and returns the remaining queued values.</summary>
-    /// <returns>The completed queue, or <see langword="null"/> when the signal was already terminal.</returns>
-    private PriorityQueue<T>? CompleteQueue()
-    {
-        lock (_gate)
-        {
-            var queue = _nextItems;
-            _nextItems = null;
-            return queue;
-        }
     }
 
     /// <summary>Queues a value when the signal is still accepting input.</summary>
@@ -169,49 +192,78 @@ public sealed class PrioritySemaphoreSignal<T> : ISignal<T>
     /// <summary>Dequeue and forwards values while capacity is available.</summary>
     private void YieldUntilEmptyOrBlocked()
     {
-        T next;
-        var ownsDrain = false;
-        lock (_gate)
+        if (!TryBeginDrain(out var item))
         {
-            if (_isDraining || !TryDequeue(out next))
-            {
-                return;
-            }
-
-            _isDraining = true;
-            ownsDrain = true;
+            return;
         }
 
         try
         {
-            while (true)
+            do
             {
-                _inner.OnNext(next);
-
-                lock (_gate)
-                {
-                    if (!TryDequeue(out next))
-                    {
-                        _isDraining = false;
-                        ownsDrain = false;
-                        return;
-                    }
-                }
+                Deliver(item);
             }
+            while (TryTakeNextDrainItem(out item));
         }
         finally
         {
-            if (ownsDrain)
-            {
-                lock (_gate)
-                {
-                    _isDraining = false;
-                }
-            }
+            EndDrain();
         }
     }
 
-    /// <summary>Attempts to dequeue the next value when capacity is available.</summary>
+    /// <summary>Attempts to become the single drain owner.</summary>
+    /// <param name="item">The first drain item to deliver.</param>
+    /// <returns><see langword="true"/> when this caller owns the drain.</returns>
+    private bool TryBeginDrain(out DrainItem item)
+    {
+        item = DrainItem.Empty;
+        lock (_gate)
+        {
+            if (_isDraining || !TryTakeNextDrainItemCore(out item))
+            {
+                return false;
+            }
+
+            _isDraining = true;
+            return true;
+        }
+    }
+
+    /// <summary>Attempts to take the next drain item while holding the gate.</summary>
+    /// <param name="item">The next item to drain.</param>
+    /// <returns><see langword="true"/> when an item was captured.</returns>
+    private bool TryTakeNextDrainItem(out DrainItem item)
+    {
+        lock (_gate)
+        {
+            return TryTakeNextDrainItemCore(out item);
+        }
+    }
+
+    /// <summary>Attempts to take the next drain item.</summary>
+    /// <param name="item">The next item to drain.</param>
+    /// <returns><see langword="true"/> when an item was captured.</returns>
+    private bool TryTakeNextDrainItemCore(out DrainItem item)
+    {
+        if (TryDequeue(out var next))
+        {
+            item = DrainItem.Next(next);
+            return true;
+        }
+
+        return TryTakeTerminalNotification(out item);
+    }
+
+    /// <summary>Ends the single-owner drain.</summary>
+    private void EndDrain()
+    {
+        lock (_gate)
+        {
+            _isDraining = false;
+        }
+    }
+
+    /// <summary>Attempts to dequeue and capture the next value when capacity is available.</summary>
     /// <param name="next">The dequeued value.</param>
     /// <returns><see langword="true"/> when a value was dequeued; otherwise, <see langword="false"/>.</returns>
     private bool TryDequeue(out T next)
@@ -226,5 +278,107 @@ public sealed class PrioritySemaphoreSignal<T> : ISignal<T>
         next = queue.Dequeue();
         _ = Interlocked.Increment(ref _count);
         return true;
+    }
+
+    /// <summary>Attempts to read and consume a pending terminal notification.</summary>
+    /// <param name="item">The terminal drain item.</param>
+    /// <returns><see langword="true"/> when a terminal notification was found.</returns>
+    private bool TryTakeTerminalNotification(out DrainItem item)
+    {
+        var terminalNotification = _terminalNotification;
+        item = terminalNotification switch
+        {
+            TerminalNotification.Completed => DrainItem.Completed(_terminalQueue),
+            TerminalNotification.Error => DrainItem.Error(_terminalError!),
+            _ => DrainItem.Empty
+        };
+
+        if (terminalNotification == TerminalNotification.None)
+        {
+            return false;
+        }
+
+        _terminalNotification = TerminalNotification.None;
+        _terminalQueue = null;
+        _terminalError = null;
+        return true;
+    }
+
+    /// <summary>Delivers one captured drain item.</summary>
+    /// <param name="item">The item to deliver.</param>
+    private void Deliver(DrainItem item)
+    {
+        switch (item.Kind)
+        {
+            case TerminalNotification.Completed:
+            {
+                while (item.Queue is { Count: > 0 })
+                {
+                    _inner.OnNext(item.Queue.Dequeue());
+                }
+
+                _inner.OnCompleted();
+                break;
+            }
+
+            case TerminalNotification.Error:
+            {
+                _inner.OnError(item.Exception!);
+                break;
+            }
+
+            default:
+            {
+                _inner.OnNext(item.Value);
+                break;
+            }
+        }
+    }
+
+    /// <summary>A captured value or terminal notification to deliver outside the gate.</summary>
+    private sealed class DrainItem
+    {
+        /// <summary>An empty drain item used for failed capture paths.</summary>
+        public static readonly DrainItem Empty = new(TerminalNotification.None, default!, null, null);
+
+        /// <summary>Initializes a new instance of the <see cref="DrainItem"/> class.</summary>
+        /// <param name="kind">The captured item kind.</param>
+        /// <param name="value">The captured value.</param>
+        /// <param name="queue">The completion queue to flush.</param>
+        /// <param name="error">The captured error.</param>
+        private DrainItem(TerminalNotification kind, T value, PriorityQueue<T>? queue, Exception? error)
+        {
+            Kind = kind;
+            Value = value;
+            Queue = queue;
+            Exception = error;
+        }
+
+        /// <summary>Gets the captured item kind.</summary>
+        public TerminalNotification Kind { get; }
+
+        /// <summary>Gets the captured value.</summary>
+        public T Value { get; }
+
+        /// <summary>Gets the completion queue to flush.</summary>
+        public PriorityQueue<T>? Queue { get; }
+
+        /// <summary>Gets the captured error.</summary>
+        public Exception? Exception { get; }
+
+        /// <summary>Creates a value drain item.</summary>
+        /// <param name="value">The value to deliver.</param>
+        /// <returns>The captured drain item.</returns>
+        public static DrainItem Next(T value) => new(TerminalNotification.None, value, null, null);
+
+        /// <summary>Creates a completion drain item.</summary>
+        /// <param name="queue">The queued values to flush before completion.</param>
+        /// <returns>The captured drain item.</returns>
+        public static DrainItem Completed(PriorityQueue<T>? queue) => new(TerminalNotification.Completed, default!, queue, null);
+
+        /// <summary>Creates an error drain item.</summary>
+        /// <param name="exception">The error to deliver.</param>
+        /// <returns>The captured drain item.</returns>
+        public static DrainItem Error(Exception exception) => new(TerminalNotification.Error, default!, null, exception);
     }
 }

--- a/src/Primitives.Shared/Signals/PrioritySemaphoreSignal{T}.cs
+++ b/src/Primitives.Shared/Signals/PrioritySemaphoreSignal{T}.cs
@@ -190,36 +190,46 @@ public sealed class PrioritySemaphoreSignal<T> : ISignal<T>
     }
 
     /// <summary>Dequeue and forwards values while capacity is available.</summary>
+    /// <remarks>
+    /// Only a single thread ever delivers downstream at a time. A caller that finds a drain
+    /// already in progress hands its work to the active owner and returns; the owner re-checks
+    /// for newly queued work under the gate before relinquishing ownership, so no wakeup is lost
+    /// and no two threads can deliver to the inner signal concurrently.
+    /// </remarks>
     private void YieldUntilEmptyOrBlocked()
     {
-        if (!TryBeginDrain(out var item))
+        if (!TryBeginDrain())
         {
             return;
         }
 
+        var owned = true;
         try
         {
-            do
+            while (TryTakeNextDrainItem(out var item))
             {
                 Deliver(item);
             }
-            while (TryTakeNextDrainItem(out item));
+
+            // TryTakeNextDrainItem cleared ownership when it returned false.
+            owned = false;
         }
         finally
         {
-            EndDrain();
+            if (owned)
+            {
+                EndDrain();
+            }
         }
     }
 
     /// <summary>Attempts to become the single drain owner.</summary>
-    /// <param name="item">The first drain item to deliver.</param>
     /// <returns><see langword="true"/> when this caller owns the drain.</returns>
-    private bool TryBeginDrain(out DrainItem item)
+    private bool TryBeginDrain()
     {
-        item = DrainItem.Empty;
         lock (_gate)
         {
-            if (_isDraining || !TryTakeNextDrainItemCore(out item))
+            if (_isDraining)
             {
                 return false;
             }
@@ -229,14 +239,31 @@ public sealed class PrioritySemaphoreSignal<T> : ISignal<T>
         }
     }
 
-    /// <summary>Attempts to take the next drain item while holding the gate.</summary>
+    /// <summary>Captures the next drain item, or relinquishes ownership when nothing is left to deliver.</summary>
     /// <param name="item">The next item to drain.</param>
-    /// <returns><see langword="true"/> when an item was captured.</returns>
+    /// <returns><see langword="true"/> when an item was captured and the caller retains ownership.</returns>
     private bool TryTakeNextDrainItem(out DrainItem item)
     {
         lock (_gate)
         {
-            return TryTakeNextDrainItemCore(out item);
+            if (TryTakeNextDrainItemCore(out item))
+            {
+                return true;
+            }
+
+            // No work remains; release ownership atomically with the empty check so a
+            // producer that queues work after this point will be able to begin a fresh drain.
+            _isDraining = false;
+            return false;
+        }
+    }
+
+    /// <summary>Releases drain ownership after an exceptional exit from the drain loop.</summary>
+    private void EndDrain()
+    {
+        lock (_gate)
+        {
+            _isDraining = false;
         }
     }
 
@@ -252,15 +279,6 @@ public sealed class PrioritySemaphoreSignal<T> : ISignal<T>
         }
 
         return TryTakeTerminalNotification(out item);
-    }
-
-    /// <summary>Ends the single-owner drain.</summary>
-    private void EndDrain()
-    {
-        lock (_gate)
-        {
-            _isDraining = false;
-        }
     }
 
     /// <summary>Attempts to dequeue and capture the next value when capacity is available.</summary>

--- a/src/Primitives.Shared/Signals/PrioritySemaphoreSignal{T}.cs
+++ b/src/Primitives.Shared/Signals/PrioritySemaphoreSignal{T}.cs
@@ -28,6 +28,9 @@ public sealed class PrioritySemaphoreSignal<T> : ISignal<T>
     /// <summary>The configured capacity.</summary>
     private int _maximumCount;
 
+    /// <summary>Prevents multiple concurrent drain loops from forwarding downstream at once.</summary>
+    private bool _isDraining;
+
     /// <summary>Initializes a new instance of the <see cref="PrioritySemaphoreSignal{T}"/> class.</summary>
     /// <param name="maxCount">The maximum number of values to forward before release is required.</param>
     public PrioritySemaphoreSignal(int maxCount)
@@ -75,7 +78,17 @@ public sealed class PrioritySemaphoreSignal<T> : ISignal<T>
     /// <summary>Releases one semaphore slot and drains queued values when capacity is available.</summary>
     public void Release()
     {
-        _ = Interlocked.Decrement(ref _count);
+        int previousCount;
+        do
+        {
+            previousCount = Volatile.Read(ref _count);
+            if (previousCount <= 0)
+            {
+                return;
+            }
+        }
+        while (Interlocked.CompareExchange(ref _count, previousCount - 1, previousCount) != previousCount);
+
         YieldUntilEmptyOrBlocked();
     }
 
@@ -156,9 +169,45 @@ public sealed class PrioritySemaphoreSignal<T> : ISignal<T>
     /// <summary>Dequeue and forwards values while capacity is available.</summary>
     private void YieldUntilEmptyOrBlocked()
     {
-        while (TryDequeue(out var next))
+        T next;
+        var ownsDrain = false;
+        lock (_gate)
         {
-            _inner.OnNext(next);
+            if (_isDraining || !TryDequeue(out next))
+            {
+                return;
+            }
+
+            _isDraining = true;
+            ownsDrain = true;
+        }
+
+        try
+        {
+            while (true)
+            {
+                _inner.OnNext(next);
+
+                lock (_gate)
+                {
+                    if (!TryDequeue(out next))
+                    {
+                        _isDraining = false;
+                        ownsDrain = false;
+                        return;
+                    }
+                }
+            }
+        }
+        finally
+        {
+            if (ownsDrain)
+            {
+                lock (_gate)
+                {
+                    _isDraining = false;
+                }
+            }
         }
     }
 
@@ -167,18 +216,15 @@ public sealed class PrioritySemaphoreSignal<T> : ISignal<T>
     /// <returns><see langword="true"/> when a value was dequeued; otherwise, <see langword="false"/>.</returns>
     private bool TryDequeue(out T next)
     {
-        lock (_gate)
+        var queue = _nextItems;
+        if (queue is null || queue.Count == 0 || Volatile.Read(ref _count) >= Volatile.Read(ref _maximumCount))
         {
-            var queue = _nextItems;
-            if (queue is null || queue.Count == 0 || Volatile.Read(ref _count) >= Volatile.Read(ref _maximumCount))
-            {
-                next = default!;
-                return false;
-            }
-
-            next = queue.Dequeue();
-            _ = Interlocked.Increment(ref _count);
-            return true;
+            next = default!;
+            return false;
         }
+
+        next = queue.Dequeue();
+        _ = Interlocked.Increment(ref _count);
+        return true;
     }
 }

--- a/src/tests/ReactiveUI.Primitives.Tests/PrioritySemaphoreSignalTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/PrioritySemaphoreSignalTests.cs
@@ -332,6 +332,53 @@ public sealed class PrioritySemaphoreSignalTests
         await Assert.That(observer.OverlapDetected).IsFalse();
     }
 
+    /// <summary>A terminal notification arriving after the signal is already terminal is ignored.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task OnErrorAfterTerminalIsIgnored()
+    {
+        using var signal = new PrioritySemaphoreSignal<int>(InitialMaximumCount);
+        var observer = new RecordingObserver<int>();
+        using var subscription = signal.Subscribe(observer);
+        var first = new InvalidOperationException("first");
+
+        signal.OnError(first);
+        signal.OnError(new InvalidOperationException("second"));
+
+        await Assert.That(observer.Errors.Length).IsEqualTo(1);
+        await Assert.That(observer.Errors[0]).IsSameReferenceAs(first);
+    }
+
+    /// <summary>A throwing delivery still releases drain ownership so a later release can drain again.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task DrainReleasesOwnershipWhenDeliveryThrows()
+    {
+        using var signal = new PrioritySemaphoreSignal<int>(InitialMaximumCount);
+        var failure = new InvalidOperationException("boom");
+        var deliveries = 0;
+        using var subscription = signal.Subscribe(
+            _ =>
+            {
+                deliveries++;
+                throw failure;
+            },
+            _ => { },
+            () => { });
+
+        // Delivery throws out of the drain loop; the finally path must still release ownership.
+        var first = Assert.Throws<InvalidOperationException>(() => signal.OnNext(FirstValue));
+        await Assert.That(first).IsSameReferenceAs(failure);
+
+        // Capacity is now exhausted, so this value only enqueues.
+        signal.OnNext(SecondValue);
+
+        // Releasing frees capacity and must begin a fresh drain, proving ownership was released.
+        var second = Assert.Throws<InvalidOperationException>(signal.Release);
+        await Assert.That(second).IsSameReferenceAs(failure);
+        await Assert.That(deliveries).IsEqualTo(FirstDrainCount);
+    }
+
     /// <summary>Starts a background thread running the supplied action.</summary>
     /// <param name="action">The work to run.</param>
     /// <returns>The started thread.</returns>

--- a/src/tests/ReactiveUI.Primitives.Tests/PrioritySemaphoreSignalTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/PrioritySemaphoreSignalTests.cs
@@ -52,6 +52,9 @@ public sealed class PrioritySemaphoreSignalTests
     /// <summary>The spin delay used to amplify overlap detection.</summary>
     private const int ProbeSpinWaitIterations = 1000;
 
+    /// <summary>The wait duration for terminal serialization probes.</summary>
+    private const int TerminalProbeTimeoutSeconds = 1;
+
     /// <summary>Task-group offsets for the concurrent operations phase.</summary>
     private const int OnNextTaskOffsetMultiplier = 2;
 
@@ -268,6 +271,63 @@ public sealed class PrioritySemaphoreSignalTests
         subscription.Dispose();
     }
 
+    /// <summary>Terminal completion notifications remain serialized with value delivery under concurrent drain.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task ConcurrentCompletionDoesNotOverlapObserverOnNext()
+    {
+        using var signal = new PrioritySemaphoreSignal<int>(0);
+        using var releaseOnNext = new ManualResetEventSlim();
+        var observer = new TerminalOverlapProbe(releaseOnNext);
+        using var subscription = signal.Subscribe(observer);
+
+        signal.OnNext(ThirdValue);
+        signal.OnNext(FirstValue);
+        signal.OnNext(SecondValue);
+
+        var drainTask = Task.Run(() => signal.MaximumCount = 1);
+        await observer.OnNextStarted.WaitAsync(TimeSpan.FromSeconds(TerminalProbeTimeoutSeconds));
+
+        var completionTask = Task.Run(signal.OnCompleted);
+
+        releaseOnNext.Set();
+        await drainTask;
+        await completionTask;
+
+        await Assert.That(observer.Completed).IsEqualTo(1);
+        await Assert.That(observer.Values.SequenceEqual([FirstValue, SecondValue, ThirdValue])).IsTrue();
+        await Assert.That(observer.OverlapDetected).IsFalse();
+    }
+
+    /// <summary>Terminal error notifications remain serialized with value delivery under concurrent drain.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task ConcurrentErrorDoesNotOverlapObserverOnNext()
+    {
+        using var signal = new PrioritySemaphoreSignal<int>(0);
+        using var releaseOnNext = new ManualResetEventSlim();
+        var observer = new TerminalOverlapProbe(releaseOnNext);
+        using var subscription = signal.Subscribe(observer);
+        var expected = new InvalidOperationException("expected");
+
+        signal.OnNext(ThirdValue);
+        signal.OnNext(FirstValue);
+        signal.OnNext(SecondValue);
+
+        var drainTask = Task.Run(() => signal.MaximumCount = 1);
+        await observer.OnNextStarted.WaitAsync(TimeSpan.FromSeconds(TerminalProbeTimeoutSeconds));
+
+        var errorTask = Task.Run(() => signal.OnError(expected));
+
+        releaseOnNext.Set();
+        await drainTask;
+        await errorTask;
+
+        await Assert.That(observer.Errors[0]).IsSameReferenceAs(expected);
+        await Assert.That(observer.Values.Length).IsEqualTo(1);
+        await Assert.That(observer.OverlapDetected).IsFalse();
+    }
+
     /// <summary>Test sequencer that queues scheduled work until drained explicitly.</summary>
     private sealed class QueuedSequencer : ISequencer
     {
@@ -385,6 +445,121 @@ public sealed class PrioritySemaphoreSignalTests
             lock (_gate)
             {
                 _values.Add(value);
+            }
+        }
+    }
+
+    /// <summary>Observer used to detect concurrent <see cref="IObserver{T}.OnCompleted"/> and <see cref="IObserver{T}.OnError"/> overlap.</summary>
+    private sealed class TerminalOverlapProbe : IObserver<int>
+    {
+        /// <summary>Gate to hold the first value until assertions can observe interleaving.</summary>
+        private readonly ManualResetEventSlim _releaseOnNext;
+
+        /// <summary>Guards internal state.</summary>
+        private readonly Lock _gate = new();
+
+        /// <summary>Captured errors.</summary>
+        private readonly List<Exception> _errors = [];
+
+        /// <summary>Captured values.</summary>
+        private readonly List<int> _values = [];
+
+        /// <summary>Signals that one <see cref="OnNext"/> value started delivering.</summary>
+        private readonly TaskCompletionSource _onNextStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        /// <summary>Whether the observer is currently inside <see cref="OnNext"/>.</summary>
+        private int _insideOnNext;
+
+        /// <summary>Whether a terminal notification was observed while a value was being delivered.</summary>
+        private int _overlapDetected;
+
+        /// <summary>Whether a value was emitted.</summary>
+        private int _onNextCount;
+
+        /// <summary>Completed notification count.</summary>
+        private int _completed;
+
+        /// <summary>Initializes a new instance of the <see cref="TerminalOverlapProbe"/> class.</summary>
+        /// <param name="releaseOnNext">Gate used by tests to hold <see cref="OnNext"/> in-flight.</param>
+        public TerminalOverlapProbe(ManualResetEventSlim releaseOnNext)
+        {
+            _releaseOnNext = releaseOnNext;
+        }
+
+        /// <summary>Gets whether overlapping terminal and value notifications were observed.</summary>
+        public bool OverlapDetected => Volatile.Read(ref _overlapDetected) != 0;
+
+        /// <summary>Gets whether <see cref="OnNext"/> has started delivering at least one value.</summary>
+        public Task OnNextStarted => _onNextStarted.Task;
+
+        /// <summary>Gets the number of delivered values.</summary>
+        public int[] Values
+        {
+            get
+            {
+                lock (_gate)
+                {
+                    return [.. _values];
+                }
+            }
+        }
+
+        /// <summary>Gets the number of completed notifications.</summary>
+        public int Completed => Volatile.Read(ref _completed);
+
+        /// <summary>Gets the errors delivered to this observer.</summary>
+        public Exception[] Errors
+        {
+            get
+            {
+                lock (_gate)
+                {
+                    return [.. _errors];
+                }
+            }
+        }
+
+        /// <inheritdoc />
+        public void OnNext(int value)
+        {
+            if (Interlocked.Exchange(ref _insideOnNext, 1) != 0)
+            {
+                _ = Interlocked.Exchange(ref _overlapDetected, 1);
+            }
+
+            lock (_gate)
+            {
+                _onNextCount++;
+                _values.Add(value);
+            }
+
+            _ = _onNextStarted.TrySetResult();
+            _releaseOnNext.Wait();
+            _ = Interlocked.Exchange(ref _insideOnNext, 0);
+        }
+
+        /// <inheritdoc />
+        public void OnCompleted()
+        {
+            if (Volatile.Read(ref _insideOnNext) != 0)
+            {
+                _ = Interlocked.Exchange(ref _overlapDetected, 1);
+            }
+
+            _ = Interlocked.Increment(ref _completed);
+        }
+
+        /// <inheritdoc />
+        public void OnError(Exception error)
+        {
+            if (Volatile.Read(ref _insideOnNext) != 0)
+            {
+                _ = Interlocked.Exchange(ref _overlapDetected, 1);
+            }
+
+            lock (_gate)
+            {
+                _errors.Add(error);
             }
         }
     }

--- a/src/tests/ReactiveUI.Primitives.Tests/PrioritySemaphoreSignalTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/PrioritySemaphoreSignalTests.cs
@@ -52,11 +52,11 @@ public sealed class PrioritySemaphoreSignalTests
     /// <summary>The spin delay used to amplify overlap detection.</summary>
     private const int ProbeSpinWaitIterations = 1000;
 
-    /// <summary>The wait duration for terminal serialization probes.</summary>
-    private const int TerminalProbeTimeoutSeconds = 1;
-
     /// <summary>Task-group offsets for the concurrent operations phase.</summary>
     private const int OnNextTaskOffsetMultiplier = 2;
+
+    /// <summary>The wait duration for terminal serialization probes.</summary>
+    private static readonly TimeSpan TerminalProbeTimeout = TimeSpan.FromSeconds(5);
 
     /// <summary>Constructor and observer validation follow the inner signal contract.</summary>
     /// <returns>A task representing the asynchronous operation.</returns>
@@ -278,21 +278,23 @@ public sealed class PrioritySemaphoreSignalTests
     {
         using var signal = new PrioritySemaphoreSignal<int>(0);
         using var releaseOnNext = new ManualResetEventSlim();
-        var observer = new TerminalOverlapProbe(releaseOnNext);
+        using var observer = new TerminalOverlapProbe(releaseOnNext);
         using var subscription = signal.Subscribe(observer);
 
         signal.OnNext(ThirdValue);
         signal.OnNext(FirstValue);
         signal.OnNext(SecondValue);
 
-        var drainTask = Task.Run(() => signal.MaximumCount = 1);
-        await observer.OnNextStarted.WaitAsync(TimeSpan.FromSeconds(TerminalProbeTimeoutSeconds));
+        // Drive the drain on a dedicated thread so the probe can block it without starving the
+        // thread pool; the started gate is observed synchronously to keep the race deterministic.
+        var drainThread = StartThread(() => signal.MaximumCount = 1);
+        await Assert.That(observer.WaitForOnNextStarted(TerminalProbeTimeout)).IsTrue();
 
-        var completionTask = Task.Run(signal.OnCompleted);
+        var completionThread = StartThread(signal.OnCompleted);
 
         releaseOnNext.Set();
-        await drainTask;
-        await completionTask;
+        drainThread.Join();
+        completionThread.Join();
 
         await Assert.That(observer.Completed).IsEqualTo(1);
         await Assert.That(observer.Values.SequenceEqual([FirstValue, SecondValue, ThirdValue])).IsTrue();
@@ -306,7 +308,7 @@ public sealed class PrioritySemaphoreSignalTests
     {
         using var signal = new PrioritySemaphoreSignal<int>(0);
         using var releaseOnNext = new ManualResetEventSlim();
-        var observer = new TerminalOverlapProbe(releaseOnNext);
+        using var observer = new TerminalOverlapProbe(releaseOnNext);
         using var subscription = signal.Subscribe(observer);
         var expected = new InvalidOperationException("expected");
 
@@ -314,18 +316,30 @@ public sealed class PrioritySemaphoreSignalTests
         signal.OnNext(FirstValue);
         signal.OnNext(SecondValue);
 
-        var drainTask = Task.Run(() => signal.MaximumCount = 1);
-        await observer.OnNextStarted.WaitAsync(TimeSpan.FromSeconds(TerminalProbeTimeoutSeconds));
+        // Drive the drain on a dedicated thread so the probe can block it without starving the
+        // thread pool; the started gate is observed synchronously to keep the race deterministic.
+        var drainThread = StartThread(() => signal.MaximumCount = 1);
+        await Assert.That(observer.WaitForOnNextStarted(TerminalProbeTimeout)).IsTrue();
 
-        var errorTask = Task.Run(() => signal.OnError(expected));
+        var errorThread = StartThread(() => signal.OnError(expected));
 
         releaseOnNext.Set();
-        await drainTask;
-        await errorTask;
+        drainThread.Join();
+        errorThread.Join();
 
         await Assert.That(observer.Errors[0]).IsSameReferenceAs(expected);
         await Assert.That(observer.Values.Length).IsEqualTo(1);
         await Assert.That(observer.OverlapDetected).IsFalse();
+    }
+
+    /// <summary>Starts a background thread running the supplied action.</summary>
+    /// <param name="action">The work to run.</param>
+    /// <returns>The started thread.</returns>
+    private static Thread StartThread(Action action)
+    {
+        var thread = new Thread(() => action()) { IsBackground = true };
+        thread.Start();
+        return thread;
     }
 
     /// <summary>Test sequencer that queues scheduled work until drained explicitly.</summary>
@@ -450,7 +464,7 @@ public sealed class PrioritySemaphoreSignalTests
     }
 
     /// <summary>Observer used to detect concurrent <see cref="IObserver{T}.OnCompleted"/> and <see cref="IObserver{T}.OnError"/> overlap.</summary>
-    private sealed class TerminalOverlapProbe : IObserver<int>
+    private sealed class TerminalOverlapProbe : IObserver<int>, IDisposable
     {
         /// <summary>Gate to hold the first value until assertions can observe interleaving.</summary>
         private readonly ManualResetEventSlim _releaseOnNext;
@@ -465,7 +479,7 @@ public sealed class PrioritySemaphoreSignalTests
         private readonly List<int> _values = [];
 
         /// <summary>Signals that one <see cref="OnNext"/> value started delivering.</summary>
-        private readonly TaskCompletionSource _onNextStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly ManualResetEventSlim _onNextStarted = new();
 
         /// <summary>Whether the observer is currently inside <see cref="OnNext"/>.</summary>
         private int _insideOnNext;
@@ -488,9 +502,6 @@ public sealed class PrioritySemaphoreSignalTests
 
         /// <summary>Gets whether overlapping terminal and value notifications were observed.</summary>
         public bool OverlapDetected => Volatile.Read(ref _overlapDetected) != 0;
-
-        /// <summary>Gets whether <see cref="OnNext"/> has started delivering at least one value.</summary>
-        public Task OnNextStarted => _onNextStarted.Task;
 
         /// <summary>Gets the number of delivered values.</summary>
         public int[] Values
@@ -519,6 +530,14 @@ public sealed class PrioritySemaphoreSignalTests
             }
         }
 
+        /// <summary>Blocks until <see cref="OnNext"/> has started delivering at least one value.</summary>
+        /// <param name="timeout">The maximum time to wait.</param>
+        /// <returns><see langword="true"/> when delivery started within the timeout.</returns>
+        public bool WaitForOnNextStarted(TimeSpan timeout) => _onNextStarted.Wait(timeout);
+
+        /// <inheritdoc />
+        public void Dispose() => _onNextStarted.Dispose();
+
         /// <inheritdoc />
         public void OnNext(int value)
         {
@@ -533,7 +552,7 @@ public sealed class PrioritySemaphoreSignalTests
                 _values.Add(value);
             }
 
-            _ = _onNextStarted.TrySetResult();
+            _onNextStarted.Set();
             _releaseOnNext.Wait();
             _ = Interlocked.Exchange(ref _insideOnNext, 0);
         }

--- a/src/tests/ReactiveUI.Primitives.Tests/PrioritySemaphoreSignalTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/PrioritySemaphoreSignalTests.cs
@@ -28,6 +28,33 @@ public sealed class PrioritySemaphoreSignalTests
     /// <summary>The number of values expected after the first drain.</summary>
     private const int FirstDrainCount = 2;
 
+    /// <summary>The number of worker tasks used to stress concurrent signaling.</summary>
+    private const int StressWorkers = 4;
+
+    /// <summary>The number of operations each stress worker performs.</summary>
+    private const int StressIterations = 4;
+
+    /// <summary>The number of seeded values for the concurrent drain scenario.</summary>
+    private const int SeededValueCount = 12;
+
+    /// <summary>The initial semaphore capacity used in the concurrent drain scenario.</summary>
+    private const int InitialDrainCapacity = 3;
+
+    /// <summary>The amount added during alternating capacity updates.</summary>
+    private const int CapacityJitter = 2;
+
+    /// <summary>The number of polling loops while waiting for signal drain.</summary>
+    private const int PollIterations = 500;
+
+    /// <summary>The wait duration for each drain polling loop.</summary>
+    private const int PollDelayMilliseconds = 1;
+
+    /// <summary>The spin delay used to amplify overlap detection.</summary>
+    private const int ProbeSpinWaitIterations = 1000;
+
+    /// <summary>Task-group offsets for the concurrent operations phase.</summary>
+    private const int OnNextTaskOffsetMultiplier = 2;
+
     /// <summary>Constructor and observer validation follow the inner signal contract.</summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Test]
@@ -94,6 +121,33 @@ public sealed class PrioritySemaphoreSignalTests
         await Assert.That(observer.Errors.Length).IsEqualTo(0);
     }
 
+    /// <summary>Releasing more times than capacity usage does not allow negative count or extra capacity.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task ReleaseDoesNotAllowNegativeCount()
+    {
+        using var signal = new PrioritySemaphoreSignal<int>(1);
+        var observer = new RecordingObserver<int>();
+        using var subscription = signal.Subscribe(observer);
+
+        signal.OnNext(FirstValue);
+
+        signal.Release();
+        signal.Release();
+        signal.Release();
+
+        signal.OnNext(SecondValue);
+        signal.OnNext(ThirdValue);
+
+        await Assert.That(observer.Values.SequenceEqual([FirstValue, SecondValue])).IsTrue();
+
+        signal.Release();
+
+        await Assert.That(observer.Values.SequenceEqual([FirstValue, SecondValue, ThirdValue])).IsTrue();
+
+        subscription.Dispose();
+    }
+
     /// <summary>Error stops the queue and forwards the exact exception.</summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Test]
@@ -142,6 +196,76 @@ public sealed class PrioritySemaphoreSignalTests
         await Assert.That(signal.IsDisposed).IsTrue();
         await Assert.That(signal.HasObservers).IsFalse();
         await Assert.That(observer.Values.SequenceEqual([FourthValue])).IsTrue();
+    }
+
+    /// <summary>Concurrent release and production drain work without concurrent downstream <see langword="OnNext"/> calls.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task ConcurrentOperationsDoNotNotifyObserverConcurrently()
+    {
+        using var signal = new PrioritySemaphoreSignal<int>(InitialDrainCapacity);
+        var observer = new ConcurrencyProbe();
+        using var subscription = signal.Subscribe(observer);
+        for (var i = 0; i < SeededValueCount; i++)
+        {
+            signal.OnNext(i);
+        }
+
+        var go = new ManualResetEventSlim();
+        var tasks = new Task[StressWorkers * 3];
+        var next = 0;
+        for (var t = 0; t < StressWorkers; t++)
+        {
+            tasks[t] = Task.Run(() =>
+            {
+                go.Wait();
+                for (var i = 0; i < StressIterations; i++)
+                {
+                    signal.Release();
+                    signal.OnNext(Interlocked.Increment(ref next));
+                }
+            });
+        }
+
+        for (var t = 0; t < StressWorkers; t++)
+        {
+            tasks[StressWorkers + t] = Task.Run(() =>
+            {
+                go.Wait();
+                for (var i = 0; i < StressIterations; i++)
+                {
+                    signal.MaximumCount = InitialDrainCapacity + (i % CapacityJitter);
+                }
+            });
+        }
+
+        for (var t = 0; t < StressWorkers; t++)
+        {
+            tasks[(StressWorkers * OnNextTaskOffsetMultiplier) + t] = Task.Run(() =>
+            {
+                go.Wait();
+                for (var i = 0; i < StressIterations; i++)
+                {
+                    signal.OnNext(InitialDrainCapacity + Interlocked.Increment(ref next));
+                }
+            });
+        }
+
+        go.Set();
+        await Task.WhenAll(tasks);
+
+        signal.MaximumCount = int.MaxValue;
+
+        const int ExpectedValues = SeededValueCount + (StressWorkers * StressIterations * 2);
+        for (var i = 0; i < PollIterations && observer.OnNextCount < ExpectedValues; i++)
+        {
+            await Task.Delay(PollDelayMilliseconds);
+        }
+
+        await Assert.That(observer.OverlapDetected).IsFalse();
+        await Assert.That(observer.OnNextCount).IsEqualTo(ExpectedValues);
+
+        subscription.Dispose();
     }
 
     /// <summary>Test sequencer that queues scheduled work until drained explicitly.</summary>
@@ -262,6 +386,50 @@ public sealed class PrioritySemaphoreSignalTests
             {
                 _values.Add(value);
             }
+        }
+    }
+
+    /// <summary>Observer used to detect overlapping <see cref="IObserver{T}.OnNext"/> notifications.</summary>
+    private sealed class ConcurrencyProbe : IObserver<int>
+    {
+        /// <summary>Non-zero while a notification is in-flight.</summary>
+        private int _inside;
+
+        /// <summary>Whether two notifications overlapped.</summary>
+        private int _overlapDetected;
+
+        /// <summary>Count of delivered notifications.</summary>
+        private int _onNextCount;
+
+        /// <summary>Gets whether overlapping notifications were observed.</summary>
+        public bool OverlapDetected => Volatile.Read(ref _overlapDetected) != 0;
+
+        /// <summary>Gets the number of delivered notifications.</summary>
+        public int OnNextCount => Volatile.Read(ref _onNextCount);
+
+        /// <summary>Records a single notification value, pausing briefly to amplify overlap races.</summary>
+        /// <param name="value">The observed value.</param>
+        public void OnNext(int value)
+        {
+            if (Interlocked.Exchange(ref _inside, 1) != 0)
+            {
+                _ = Interlocked.Exchange(ref _overlapDetected, 1);
+            }
+
+            _ = Interlocked.Increment(ref _onNextCount);
+            Thread.SpinWait(ProbeSpinWaitIterations);
+            _ = Interlocked.Exchange(ref _inside, 0);
+        }
+
+        /// <summary>Implements the generic observer interface for value-only checks.</summary>
+        public void OnCompleted()
+        {
+        }
+
+        /// <summary>Implements the generic observer interface for value-only checks.</summary>
+        /// <param name="error">The observed error.</param>
+        public void OnError(Exception error)
+        {
         }
     }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix for priority semaphore draining and release accounting.

## What is the new behavior?

`PrioritySemaphoreSignal<T>` now has a single active drain owner so downstream `OnNext` calls cannot overlap, and `Release()` no longer allows the active count to drop below zero.

Fixes #71.

## What is the current behavior?

Concurrent `OnNext`, `Release`, and `MaximumCount` changes can drain to the inner signal concurrently, and unbalanced releases can make the count negative and over-open capacity.

## Checklist
- [x] Tests have been added or updated (for bug fixes / features) 
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the main branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) 

## Additional information

Validation:
- `dotnet build "tests/ReactiveUI.Primitives.Tests/ReactiveUI.Primitives.Tests.csproj" -f net10.0 --no-restore -v minimal`
- `dotnet test "tests/ReactiveUI.Primitives.Tests/ReactiveUI.Primitives.Tests.csproj" -f net10.0 --no-build -- --treenode-filter "/*/*/PrioritySemaphoreSignalTests/*" --output Detailed`
- Worker validation also passed all `PrioritySemaphoreSignalTests` across target TFMs and built `tests/ReactiveUI.Primitives.Tests/ReactiveUI.Primitives.Tests.csproj`.
- Rebased cleanly onto `origin/main` at `d101d36` and reran the net10 build/test above.
- `mcp__mtpunittestmcp.get_solution_coverage` reported no Cobertura data because coverage was not collected.