### PR TITLE
fix(signals): connect AutoShare outside gate

### DIFF
--- a/src/Primitives.Shared/Advanced/AutoShareSignal{T}.cs
+++ b/src/Primitives.Shared/Advanced/AutoShareSignal{T}.cs
@@ -44,7 +44,6 @@ public sealed class AutoShareSignal<T> : IObservable<T>
         ArgumentExceptionHelper.ThrowIfNull(observer);
 
         var subscription = Source.Subscribe(observer);
-        IDisposable? connection;
         var shouldConnect = false;
 
         lock (_gate)
@@ -59,48 +58,7 @@ public sealed class AutoShareSignal<T> : IObservable<T>
 
         if (shouldConnect)
         {
-            try
-            {
-                connection = Source.Connect();
-            }
-            catch
-            {
-                lock (_gate)
-                {
-                    _isConnecting = false;
-                    if (_count > 0)
-                    {
-                        _count--;
-                    }
-                }
-
-                subscription.Dispose();
-                throw;
-            }
-
-            bool disposeConnection;
-            lock (_gate)
-            {
-                _isConnecting = false;
-                if (_count == 0)
-                {
-                    disposeConnection = true;
-                }
-                else if (_connection is null)
-                {
-                    _connection = connection;
-                    disposeConnection = false;
-                }
-                else
-                {
-                    disposeConnection = true;
-                }
-            }
-
-            if (disposeConnection)
-            {
-                connection.Dispose();
-            }
+            ConnectOutsideGate(subscription);
         }
 
         return new AutoShareSubscription<T>(this, subscription);
@@ -131,5 +89,60 @@ public sealed class AutoShareSignal<T> : IObservable<T>
         }
 
         connection?.Dispose();
+    }
+
+    /// <summary>Connects the source outside <see cref="_gate"/> and publishes or drops the connection.</summary>
+    /// <param name="subscription">The inner source subscription owned by the connecting observer.</param>
+    /// <remarks>
+    /// Connecting runs outside the lock so a synchronous source cannot drive user callbacks while the
+    /// gate is held. A re-entrant or concurrent <see cref="Release"/> can drop the subscriber count to
+    /// zero before the connection is published; in that case the freshly returned connection is orphaned
+    /// and is disposed here rather than stored.
+    /// </remarks>
+    private void ConnectOutsideGate(IDisposable subscription)
+    {
+        var connection = ConnectOrUnwind(subscription);
+
+        lock (_gate)
+        {
+            _isConnecting = false;
+
+            // _connection is null here: _isConnecting gated every other subscriber out of Connect, and
+            // Release only ever nulls _connection. Publish the connection while subscribers remain.
+            if (_count != 0)
+            {
+                _connection = connection;
+                return;
+            }
+        }
+
+        // A re-entrant or concurrent Release drained the count while connecting, so the connection is
+        // orphaned and disposed here.
+        connection.Dispose();
+    }
+
+    /// <summary>Connects the source, unwinding the connect intent if <see cref="ConnectableSignal{T}.Connect"/> throws.</summary>
+    /// <param name="subscription">The inner source subscription owned by the connecting observer.</param>
+    /// <returns>The active source connection.</returns>
+    private IDisposable ConnectOrUnwind(IDisposable subscription)
+    {
+        try
+        {
+            return Source.Connect();
+        }
+        catch
+        {
+            lock (_gate)
+            {
+                _isConnecting = false;
+                if (_count > 0)
+                {
+                    _count--;
+                }
+            }
+
+            subscription.Dispose();
+            throw;
+        }
     }
 }

--- a/src/Primitives.Shared/Advanced/AutoShareSignal{T}.cs
+++ b/src/Primitives.Shared/Advanced/AutoShareSignal{T}.cs
@@ -21,6 +21,9 @@ public sealed class AutoShareSignal<T> : IObservable<T>
     /// <summary>Active source connection.</summary>
     private IDisposable? _connection;
 
+    /// <summary>Set while a connect operation is in progress.</summary>
+    private bool _isConnecting;
+
     /// <summary>Initializes a new instance of the <see cref="AutoShareSignal{T}"/> class.</summary>
     /// <param name="source">Connectable signal being reference-counted.</param>
     public AutoShareSignal(ConnectableSignal<T> source)
@@ -40,12 +43,64 @@ public sealed class AutoShareSignal<T> : IObservable<T>
     {
         ArgumentExceptionHelper.ThrowIfNull(observer);
 
-        IDisposable subscription;
+        var subscription = Source.Subscribe(observer);
+        IDisposable? connection;
+        var shouldConnect = false;
+
         lock (_gate)
         {
-            subscription = Source.Subscribe(observer);
             _count++;
-            _connection ??= Source.Connect();
+            if (_count == 1 && _connection is null && !_isConnecting)
+            {
+                _isConnecting = true;
+                shouldConnect = true;
+            }
+        }
+
+        if (shouldConnect)
+        {
+            try
+            {
+                connection = Source.Connect();
+            }
+            catch
+            {
+                lock (_gate)
+                {
+                    _isConnecting = false;
+                    if (_count > 0)
+                    {
+                        _count--;
+                    }
+                }
+
+                subscription.Dispose();
+                throw;
+            }
+
+            bool disposeConnection;
+            lock (_gate)
+            {
+                _isConnecting = false;
+                if (_count == 0)
+                {
+                    disposeConnection = true;
+                }
+                else if (_connection is null)
+                {
+                    _connection = connection;
+                    disposeConnection = false;
+                }
+                else
+                {
+                    disposeConnection = true;
+                }
+            }
+
+            if (disposeConnection)
+            {
+                connection.Dispose();
+            }
         }
 
         return new AutoShareSubscription<T>(this, subscription);
@@ -56,14 +111,25 @@ public sealed class AutoShareSignal<T> : IObservable<T>
     internal void Release(IDisposable subscription)
     {
         subscription.Dispose();
+
+        IDisposable? connection;
         lock (_gate)
         {
-            _count--;
             if (_count == 0)
             {
-                _connection?.Dispose();
-                _connection = null;
+                return;
             }
+
+            _count--;
+            if (_count != 0)
+            {
+                return;
+            }
+
+            connection = _connection;
+            _connection = null;
         }
+
+        connection?.Dispose();
     }
 }

--- a/src/tests/ReactiveUI.Primitives.Tests/ConnectableSignalTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/ConnectableSignalTests.cs
@@ -180,6 +180,160 @@ public sealed class ConnectableSignalTests
         await Assert.That(sourceDisposals).IsEqualTo(1);
     }
 
+    /// <summary>Verifies AutoShare connects on the first subscriber and disconnects when the last one leaves.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task AutoShareConnectsOnFirstSubscriberAndDisconnectsOnLast()
+    {
+        Signal<int> source = new();
+        var sourceSubscriptions = 0;
+        var sourceDisposals = 0;
+        var cold = Signal.Create<int>(observer =>
+        {
+            sourceSubscriptions++;
+            var inner = source.Subscribe(observer);
+            return new ActionDisposable(() =>
+            {
+                sourceDisposals++;
+                inner.Dispose();
+            });
+        });
+
+        var shared = cold.Share().AutoShare();
+        List<int> first = [];
+        List<int> second = [];
+
+        var firstSubscription = shared.Subscribe(first.Add);
+        await Assert.That(sourceSubscriptions).IsEqualTo(1);
+
+        var secondSubscription = shared.Subscribe(second.Add);
+        source.OnNext(FirstSharedValue);
+
+        // The single upstream connection feeds every observer.
+        await Assert.That(sourceSubscriptions).IsEqualTo(1);
+
+        firstSubscription.Dispose();
+        await Assert.That(sourceDisposals).IsEqualTo(0);
+
+        secondSubscription.Dispose();
+
+        // The connection is disposed only once the final subscriber leaves.
+        await Assert.That(sourceDisposals).IsEqualTo(1);
+        await Assert.That(first.SequenceEqual(ExpectedFirstSharedValues)).IsTrue();
+        await Assert.That(second.SequenceEqual(ExpectedFirstSharedValues)).IsTrue();
+    }
+
+    /// <summary>Verifies AutoShare reconnects to the source after every subscriber leaves and a new one arrives.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task AutoShareReconnectsAfterAllSubscribersLeave()
+    {
+        const int ExpectedConnections = 2;
+        Signal<int> source = new();
+        var sourceSubscriptions = 0;
+        var sourceDisposals = 0;
+        var cold = Signal.Create<int>(observer =>
+        {
+            sourceSubscriptions++;
+            var inner = source.Subscribe(observer);
+            return new ActionDisposable(() =>
+            {
+                sourceDisposals++;
+                inner.Dispose();
+            });
+        });
+
+        var shared = cold.Share().AutoShare();
+
+        shared.Subscribe(static _ => { }).Dispose();
+        await Assert.That(sourceSubscriptions).IsEqualTo(1);
+        await Assert.That(sourceDisposals).IsEqualTo(1);
+
+        // A fresh subscriber after the count returned to zero forces a new connection.
+        using var second = shared.Subscribe(static _ => { });
+        await Assert.That(sourceSubscriptions).IsEqualTo(ExpectedConnections);
+        await Assert.That(sourceDisposals).IsEqualTo(1);
+    }
+
+    /// <summary>Verifies a throwing Connect propagates and unwinds the refcount so a later subscribe reconnects.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task AutoShareConnectFailureUnwindsRefcount()
+    {
+        const int ExpectedSubscribeAttempts = 2;
+        var subscribeAttempts = 0;
+        var shouldThrow = true;
+        InvalidOperationException expected = new("connect");
+        var cold = Signal.Create<int>(observer =>
+        {
+            subscribeAttempts++;
+            if (shouldThrow)
+            {
+                throw expected;
+            }
+
+            observer.OnNext(FirstSharedValue);
+            return Scope.Empty;
+        });
+
+        var shared = cold.Share().AutoShare();
+
+        // Connect runs outside the gate; a synchronous failure surfaces to the caller.
+        var thrown = Assert.Throws<InvalidOperationException>(() => shared.Subscribe(static _ => { }));
+        await Assert.That(thrown).IsSameReferenceAs(expected);
+        await Assert.That(subscribeAttempts).IsEqualTo(1);
+
+        // The failed attempt unwound the count, so the next subscriber reconnects rather than stalling.
+        shouldThrow = false;
+        List<int> values = [];
+        using var recovered = shared.Subscribe(values.Add);
+        await Assert.That(subscribeAttempts).IsEqualTo(ExpectedSubscribeAttempts);
+        await Assert.That(values.SequenceEqual(ExpectedFirstSharedValues)).IsTrue();
+    }
+
+    /// <summary>Verifies AutoShare maintains a single connection under concurrent subscribe and dispose churn.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task AutoShareKeepsSingleConnectionUnderConcurrentChurn()
+    {
+        const int Workers = 8;
+        const int IterationsPerWorker = 200;
+        var peakConnections = 0;
+        var liveConnections = 0;
+        var cold = Signal.Create<int>(observer =>
+        {
+            var live = Interlocked.Increment(ref liveConnections);
+            var peak = Volatile.Read(ref peakConnections);
+            while (live > peak && Interlocked.CompareExchange(ref peakConnections, live, peak) != peak)
+            {
+                peak = Volatile.Read(ref peakConnections);
+            }
+
+            observer.OnNext(FirstSharedValue);
+            return new ActionDisposable(() => Interlocked.Decrement(ref liveConnections));
+        });
+
+        var shared = cold.Share().AutoShare();
+
+        var workers = new Task[Workers];
+        for (var worker = 0; worker < Workers; worker++)
+        {
+            workers[worker] = Task.Run(() =>
+            {
+                for (var iteration = 0; iteration < IterationsPerWorker; iteration++)
+                {
+                    shared.Subscribe(static _ => { }).Dispose();
+                }
+            });
+        }
+
+        await Task.WhenAll(workers);
+
+        // Refcount churn must never run two upstream connections at once and must release the last one.
+        await Assert.That(peakConnections).IsEqualTo(1);
+        await Assert.That(liveConnections).IsEqualTo(0);
+    }
+
     /// <summary>Verifies direct connect handles reuse, terminate, and dispose idempotently.</summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Test]

--- a/src/tests/ReactiveUI.Primitives.Tests/ConnectableSignalTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/ConnectableSignalTests.cs
@@ -2,6 +2,7 @@
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using ReactiveUI.Primitives.Advanced;
 using ReactiveUI.Primitives.Disposables;
 using ReactiveUI.Primitives.Signals;
 
@@ -147,6 +148,36 @@ public sealed class ConnectableSignalTests
         await Assert.That(first.SequenceEqual(ExpectedSecondSharedValues[1..])).IsTrue();
         await Assert.That(second.SequenceEqual(ExpectedSecondSharedValues[1..])).IsTrue();
         _ = Assert.Throws<ArgumentNullException>(() => cold.Publish().AutoConnect(1, null!));
+    }
+
+    /// <summary>Verifies AutoShare disposes the source connection when release happens during Connect().</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task AutoShareDisposesConnectionWhenRefcountDropsDuringConnect()
+    {
+        var sourceSubscriptions = 0;
+        var sourceDisposals = 0;
+        IObservable<int> cold = Signal.Create<int>(observer =>
+        {
+            sourceSubscriptions++;
+            observer.OnNext(FirstSharedValue);
+            return new ActionDisposable(() => sourceDisposals++);
+        });
+
+        AutoShareSignal<int> shared = new(cold.Share());
+
+        var reentrantReleaseInvoked = false;
+        void OnNext(int _)
+        {
+            reentrantReleaseInvoked = true;
+            using AutoShareSubscription<int> reentrantRelease = new(shared, Scope.Empty);
+            reentrantRelease.Dispose();
+        }
+        using var subscription = shared.Subscribe((Action<int>)OnNext);
+
+        await Assert.That(reentrantReleaseInvoked).IsTrue();
+        await Assert.That(sourceSubscriptions).IsEqualTo(1);
+        await Assert.That(sourceDisposals).IsEqualTo(1);
     }
 
     /// <summary>Verifies direct connect handles reuse, terminate, and dispose idempotently.</summary>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix for AutoShare refcount connection lifecycle.

## What is the new behavior?

`AutoShareSignal<T>` now performs source subscription and `Connect()` outside the AutoShare refcount gate, tracks in-flight connects, and disposes captured connections outside the lock when the refcount drops to zero.

Fixes #70.

## What is the current behavior?

`AutoShare` subscribes and connects while holding its gate. Synchronous sources can run observer callbacks under that lock and a refcount drop during `Connect()` can leave the returned connection undisposed.

## Checklist
- [x] Tests have been added or updated (for bug fixes / features) 
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the main branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) 

## Additional information

Validation:
- `dotnet build "tests/ReactiveUI.Primitives.Tests/ReactiveUI.Primitives.Tests.csproj" -f net10.0 --no-restore -v minimal`
- `dotnet test "tests/ReactiveUI.Primitives.Tests/ReactiveUI.Primitives.Tests.csproj" -f net10.0 --no-build -- --treenode-filter "/*/*/ConnectableSignalTests/*" --output Detailed`
- Worker validation also passed `dotnet build tests/ReactiveUI.Primitives.Tests/ReactiveUI.Primitives.Tests.csproj` and a net10.0 project test run with 450 passed.
- Rebased onto `origin/main` at `d101d36`, resolved the adjacent ConnectableSignalTests conflict, and reran the net10 build/test above.
- `mcp__mtpunittestmcp.get_solution_coverage` reported no Cobertura data because coverage was not collected.