### PR TITLE
fix(operators): gate ForkJoin OnError behind a terminal latch

### DIFF
--- a/src/Primitives.Shared/Advanced/ForkJoinWitness{TLeft,TRight,TResult}.cs
+++ b/src/Primitives.Shared/Advanced/ForkJoinWitness{TLeft,TRight,TResult}.cs
@@ -50,14 +50,17 @@ public sealed class ForkJoinWitness<TLeft, TRight, TResult>
     /// <summary>Gets or sets the latest right value.</summary>
     private TRight? LatestRight { get; set; }
 
+    /// <summary>Gets or sets a value indicating whether a terminal notification has been emitted.</summary>
+    private bool IsDone { get; set; }
+
     /// <summary>Subscribes to both sources.</summary>
     /// <param name="left">The left source.</param>
     /// <param name="right">The right source.</param>
     /// <returns>The subscriptions.</returns>
     public MultipleDisposable Run(IObservable<TLeft> left, IObservable<TRight> right) =>
         new(
-            left.Subscribe(OnLeftNext, Observer.OnError, OnLeftCompleted),
-            right.Subscribe(OnRightNext, Observer.OnError, OnRightCompleted));
+            left.Subscribe(OnLeftNext, OnError, OnLeftCompleted),
+            right.Subscribe(OnRightNext, OnError, OnRightCompleted));
 
     /// <summary>Records a left value.</summary>
     /// <param name="value">The left value.</param>
@@ -84,77 +87,63 @@ public sealed class ForkJoinWitness<TLeft, TRight, TResult>
     /// <summary>Marks the left source complete.</summary>
     private void OnLeftCompleted()
     {
-        if (!CompleteLeft(out var result, out var emit))
+        lock (_gate)
         {
-            return;
-        }
+            if (IsDone)
+            {
+                return;
+            }
 
-        Finish(result, emit);
+            IsLeftDone = true;
+            TryFinish();
+        }
     }
 
     /// <summary>Marks the right source complete.</summary>
     private void OnRightCompleted()
     {
-        if (!CompleteRight(out var result, out var emit))
+        lock (_gate)
+        {
+            if (IsDone)
+            {
+                return;
+            }
+
+            IsRightDone = true;
+            TryFinish();
+        }
+    }
+
+    /// <summary>Forwards the first source error and gates every later notification.</summary>
+    /// <param name="error">The error to forward.</param>
+    private void OnError(Exception error)
+    {
+        lock (_gate)
+        {
+            if (IsDone)
+            {
+                return;
+            }
+
+            IsDone = true;
+            Observer.OnError(error);
+        }
+    }
+
+    /// <summary>Emits the result and completes once both sources are done.</summary>
+    /// <remarks>Must be called while holding <see cref="_gate"/> so the terminal notification stays serialized.</remarks>
+    private void TryFinish()
+    {
+        if (!IsLeftDone || !IsRightDone)
         {
             return;
         }
 
-        Finish(result, emit);
-    }
+        IsDone = true;
 
-    /// <summary>Completes the left side and computes the result when both sides are done.</summary>
-    /// <param name="result">The result to emit.</param>
-    /// <param name="emit">Whether a result should be emitted.</param>
-    /// <returns><see langword="true"/> when fork-join is ready to finish.</returns>
-    private bool CompleteLeft(out TResult result, out bool emit)
-    {
-        lock (_gate)
+        if (HasLeft && HasRight)
         {
-            IsLeftDone = true;
-            return TryFinish(out result, out emit);
-        }
-    }
-
-    /// <summary>Completes the right side and computes the result when both sides are done.</summary>
-    /// <param name="result">The result to emit.</param>
-    /// <param name="emit">Whether a result should be emitted.</param>
-    /// <returns><see langword="true"/> when fork-join is ready to finish.</returns>
-    private bool CompleteRight(out TResult result, out bool emit)
-    {
-        lock (_gate)
-        {
-            IsRightDone = true;
-            return TryFinish(out result, out emit);
-        }
-    }
-
-    /// <summary>Computes the result when both sources are complete.</summary>
-    /// <param name="result">The result to emit.</param>
-    /// <param name="emit">Whether a result should be emitted.</param>
-    /// <returns><see langword="true"/> when both sources are complete.</returns>
-    private bool TryFinish(out TResult result, out bool emit)
-    {
-        if (!IsLeftDone || !IsRightDone)
-        {
-            result = default!;
-            emit = false;
-            return false;
-        }
-
-        emit = HasLeft && HasRight;
-        result = emit ? Selector(LatestLeft!, LatestRight!) : default!;
-        return true;
-    }
-
-    /// <summary>Emits the result when present, then completes.</summary>
-    /// <param name="result">The result to emit.</param>
-    /// <param name="emit">Whether a result should be emitted.</param>
-    private void Finish(TResult result, bool emit)
-    {
-        if (emit)
-        {
-            Observer.OnNext(result);
+            Observer.OnNext(Selector(LatestLeft!, LatestRight!));
         }
 
         Observer.OnCompleted();

--- a/src/tests/ReactiveUI.Primitives.Tests/ForkJoinWitnessTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/ForkJoinWitnessTests.cs
@@ -1,0 +1,167 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using ReactiveUI.Primitives.Advanced;
+using ReactiveUI.Primitives.Disposables;
+
+namespace ReactiveUI.Primitives.Tests;
+
+/// <summary>Tests for <see cref="ForkJoinWitness{TLeft, TRight, TResult}"/>.</summary>
+public sealed class ForkJoinWitnessTests
+{
+    /// <summary>The integer constant one.</summary>
+    private const int One = 1;
+
+    /// <summary>The integer constant two.</summary>
+    private const int Two = 2;
+
+    /// <summary>Verifies both sources completing with values emits one result then completes.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task ForkJoinWitnessEmitsResultOnceWhenBothComplete()
+    {
+        RecordingWitness<int> observer = new();
+        CapturingObservable<int> left = new();
+        CapturingObservable<int> right = new();
+        using var subscription = new ForkJoinWitness<int, int, int>(observer, (a, b) => a + b).Run(left, right);
+
+        left.Observer!.OnNext(One);
+        right.Observer!.OnNext(Two);
+        left.Observer.OnCompleted();
+        right.Observer.OnCompleted();
+
+        await Assert.That(observer.Values).HasSingleItem();
+        await Assert.That(observer.Values[0]).IsEqualTo(One + Two);
+        await Assert.That(observer.Completed).IsEqualTo(One);
+        await Assert.That(observer.Errors).IsEmpty();
+    }
+
+    /// <summary>Verifies an error from one source is forwarded once and gates the other source.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task ForkJoinWitnessForwardsFirstErrorAndGatesAfterwards()
+    {
+        RecordingWitness<int> observer = new();
+        CapturingObservable<int> left = new();
+        CapturingObservable<int> right = new();
+        InvalidOperationException error = new("left");
+        using var subscription = new ForkJoinWitness<int, int, int>(observer, (a, b) => a + b).Run(left, right);
+
+        left.Observer!.OnError(error);
+
+        await Assert.That(observer.Errors).HasSingleItem();
+        await Assert.That(observer.Errors[0]).IsSameReferenceAs(error);
+
+        // Everything from either side is gated after the terminal error.
+        right.Observer!.OnNext(Two);
+        right.Observer.OnError(new InvalidOperationException("right"));
+        right.Observer.OnCompleted();
+        left.Observer.OnCompleted();
+
+        await Assert.That(observer.Values).IsEmpty();
+        await Assert.That(observer.Completed).IsEqualTo(0);
+        await Assert.That(observer.Errors).HasSingleItem();
+    }
+
+    /// <summary>Verifies two errors deliver <see cref="IObserver{T}.OnError"/> exactly once.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task ForkJoinWitnessForwardsOnlyTheFirstOfTwoErrors()
+    {
+        RecordingWitness<int> observer = new();
+        CapturingObservable<int> left = new();
+        CapturingObservable<int> right = new();
+        InvalidOperationException first = new("first");
+        InvalidOperationException second = new("second");
+        using var subscription = new ForkJoinWitness<int, int, int>(observer, (a, b) => a + b).Run(left, right);
+
+        left.Observer!.OnError(first);
+        right.Observer!.OnError(second);
+
+        await Assert.That(observer.Errors).HasSingleItem();
+        await Assert.That(observer.Errors[0]).IsSameReferenceAs(first);
+    }
+
+    /// <summary>Verifies an error after the result has been emitted produces no second terminal.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task ForkJoinWitnessIgnoresErrorAfterCompletion()
+    {
+        RecordingWitness<int> observer = new();
+        CapturingObservable<int> left = new();
+        CapturingObservable<int> right = new();
+        using var subscription = new ForkJoinWitness<int, int, int>(observer, (a, b) => a + b).Run(left, right);
+
+        left.Observer!.OnNext(One);
+        right.Observer!.OnNext(Two);
+        left.Observer.OnCompleted();
+        right.Observer.OnCompleted();
+
+        await Assert.That(observer.Completed).IsEqualTo(One);
+
+        // A late error from either side must not deliver a second terminal.
+        left.Observer.OnError(new InvalidOperationException("late"));
+        right.Observer.OnError(new InvalidOperationException("late"));
+
+        await Assert.That(observer.Errors).IsEmpty();
+        await Assert.That(observer.Completed).IsEqualTo(One);
+    }
+
+    /// <summary>Verifies completion with a side that produced no value completes without a result.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task ForkJoinWitnessCompletesWithoutResultWhenASideIsEmpty()
+    {
+        RecordingWitness<int> observer = new();
+        CapturingObservable<int> left = new();
+        CapturingObservable<int> right = new();
+        using var subscription = new ForkJoinWitness<int, int, int>(observer, (a, b) => a + b).Run(left, right);
+
+        left.Observer!.OnNext(One);
+        left.Observer.OnCompleted();
+
+        // Right completes empty: no result, single completion.
+        right.Observer!.OnCompleted();
+
+        await Assert.That(observer.Values).IsEmpty();
+        await Assert.That(observer.Completed).IsEqualTo(One);
+    }
+
+    /// <summary>Verifies a single source completing does not finish until both are done.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task ForkJoinWitnessDefersCompletionUntilBothComplete()
+    {
+        RecordingWitness<int> observer = new();
+        CapturingObservable<int> left = new();
+        CapturingObservable<int> right = new();
+        using var subscription = new ForkJoinWitness<int, int, int>(observer, (a, b) => a + b).Run(left, right);
+
+        left.Observer!.OnNext(One);
+        right.Observer!.OnNext(Two);
+        left.Observer.OnCompleted();
+
+        await Assert.That(observer.Completed).IsEqualTo(0);
+
+        right.Observer.OnCompleted();
+
+        await Assert.That(observer.Values).HasSingleItem();
+        await Assert.That(observer.Completed).IsEqualTo(One);
+    }
+
+    /// <summary>An observable that captures its observer for manual notification.</summary>
+    /// <typeparam name="T">The value type.</typeparam>
+    private sealed class CapturingObservable<T> : IObservable<T>
+    {
+        /// <summary>Gets the captured observer.</summary>
+        public IObserver<T>? Observer { get; private set; }
+
+        /// <inheritdoc/>
+        public IDisposable Subscribe(IObserver<T> observer)
+        {
+            Observer = observer;
+            return EmptyDisposable.Instance;
+        }
+    }
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix.

## What is the new behavior?
`ForkJoinWitness<TLeft, TRight, TResult>` now serializes its terminal notification:

- Both inner source errors route through a single gated `OnError` handler that takes `_gate`, flips an `IsDone` latch, and forwards `OnError` only when it wins the terminal transition.
- The result emission (`OnNext`) and `OnCompleted` are now produced under the same `_gate` and behind the same `IsDone` latch, mirroring the existing gating style of `OnLeftNext`/`OnRightNext`.

The result is that exactly one terminal notification is ever delivered, and it is never delivered concurrently with another notification.

## What is the current behavior?
Both inner subscriptions wired error straight to the raw `Observer.OnError` with no gate and no terminal latch, and `Finish` (result emission + completion) ran outside `_gate`:

```csharp
left.Subscribe(OnLeftNext, Observer.OnError, OnLeftCompleted);
right.Subscribe(OnRightNext, Observer.OnError, OnRightCompleted);
```

An error racing the other side's `OnNext`/`Finish`, or two near-simultaneous errors, could deliver `OnError` concurrently with another notification or deliver `OnError` twice — violating the observer grammar.

Closes #76

## What might this PR break?
None. Behavior is unchanged for well-behaved (serial) sources; only the racing/double-terminal cases are now correctly gated.

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [x] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information
New `ForkJoinWitnessTests` cover: single-error forwarding plus post-terminal gating, two errors delivering `OnError` exactly once (first wins), a late error after completion being dropped, empty-side completion, and deferred completion until both sources finish. Full `ReactiveUI.Primitives.Tests` suite (2012 tests across net8/9/10/11) and the Reactive shim suite pass; solution builds clean with 0 warnings.