### PR TITLE
fix(operators): reset Timeout per value to match Rx inactivity semantics

### DIFF
--- a/src/Primitives.Shared/Advanced/ExpireCoordinator{T}.cs
+++ b/src/Primitives.Shared/Advanced/ExpireCoordinator{T}.cs
@@ -44,6 +44,9 @@ public sealed class ExpireCoordinator<T> : IObserver<T>, IDisposable
     /// <summary>A value indicating whether the timeout or source has terminated.</summary>
     private int _done;
 
+    /// <summary>Monotonic version used to suppress timeouts superseded by a newer value.</summary>
+    private long _epoch;
+
     /// <summary>Initializes a new instance of the <see cref="ExpireCoordinator{T}"/> class.</summary>
     /// <param name="source">The source observable.</param>
     /// <param name="dueTime">The timeout period.</param>
@@ -128,6 +131,7 @@ public sealed class ExpireCoordinator<T> : IObserver<T>, IDisposable
     /// <inheritdoc/>
     public void OnNext(T value)
     {
+        long epoch;
         lock (_gate)
         {
             if (_done != 0)
@@ -135,15 +139,24 @@ public sealed class ExpireCoordinator<T> : IObserver<T>, IDisposable
                 return;
             }
 
+            epoch = ++_epoch;
             _observer.OnNext(value);
         }
+
+        ArmTimer(epoch);
     }
 
     /// <summary>Starts observing the source and timeout timer.</summary>
     /// <returns>The coordinator that owns the subscription cleanup.</returns>
     public ExpireCoordinator<T> Run()
     {
-        _timer = _sequencer.Schedule(this, _dueTime, static (_, coordinator) => coordinator.EmitTimeout());
+        long epoch;
+        lock (_gate)
+        {
+            epoch = ++_epoch;
+        }
+
+        ArmTimer(epoch);
         _subscription = _source.Subscribe(this);
         if (Volatile.Read(ref _done) == 0)
         {
@@ -154,16 +167,25 @@ public sealed class ExpireCoordinator<T> : IObserver<T>, IDisposable
         return this;
     }
 
-    /// <summary>Emits the timeout error.</summary>
+    /// <summary>Schedules a fresh inactivity timer for the given epoch and discards the in-flight one.</summary>
+    /// <param name="epoch">The version this timer must still match to fire.</param>
+    private void ArmTimer(long epoch)
+    {
+        var timer = _sequencer.Schedule((Coordinator: this, Epoch: epoch), _dueTime, static (_, state) => state.Coordinator.EmitTimeout(state.Epoch));
+        Interlocked.Exchange(ref _timer, timer)?.Dispose();
+    }
+
+    /// <summary>Emits the timeout error when the firing timer is still current.</summary>
+    /// <param name="epoch">The version captured when the firing timer was armed.</param>
     /// <returns>An empty disposable.</returns>
-    private EmptyDisposable EmitTimeout()
+    private EmptyDisposable EmitTimeout(long epoch)
     {
         var shouldDispose = false;
         try
         {
             lock (_gate)
             {
-                if (_done != 0)
+                if (_done != 0 || epoch != _epoch)
                 {
                     return EmptyDisposable.Instance;
                 }

--- a/src/Primitives.Shared/Advanced/ExpireCoordinator{T}.cs
+++ b/src/Primitives.Shared/Advanced/ExpireCoordinator{T}.cs
@@ -169,10 +169,25 @@ public sealed class ExpireCoordinator<T> : IObserver<T>, IDisposable
 
     /// <summary>Schedules a fresh inactivity timer for the given epoch and discards the in-flight one.</summary>
     /// <param name="epoch">The version this timer must still match to fire.</param>
+    /// <remarks>Scheduled outside the gate to avoid reentrant <see cref="Lock"/> acquisition on a synchronous
+    /// sequencer; the publish is re-checked under the gate so a timer never survives a terminal notification.</remarks>
     private void ArmTimer(long epoch)
     {
         var timer = _sequencer.Schedule((Coordinator: this, Epoch: epoch), _dueTime, static (_, state) => state.Coordinator.EmitTimeout(state.Epoch));
-        Interlocked.Exchange(ref _timer, timer)?.Dispose();
+
+        IDisposable? previous;
+        lock (_gate)
+        {
+            if (_done != 0)
+            {
+                timer.Dispose();
+                return;
+            }
+
+            previous = Interlocked.Exchange(ref _timer, timer);
+        }
+
+        previous?.Dispose();
     }
 
     /// <summary>Emits the timeout error when the firing timer is still current.</summary>

--- a/src/tests/ReactiveUI.Primitives.Tests/ExpireCoordinatorTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/ExpireCoordinatorTests.cs
@@ -14,10 +14,67 @@ public sealed class ExpireCoordinatorTests
     /// <summary>The integer constant one.</summary>
     private const int One = 1;
 
+    /// <summary>The number of values emitted by the re-arming test.</summary>
+    private const int ValueCount = 5;
+
+    /// <summary>The timeout window in ticks used by the re-arming tests.</summary>
+    private const int DueTicks = 10;
+
+    /// <summary>A gap shorter than <see cref="DueTicks"/> that must not expire the timeout.</summary>
+    private const int ActiveGapTicks = 9;
+
+    /// <summary>A gap shorter than <see cref="DueTicks"/> after which a value still arrives in time.</summary>
+    private const int ShortGapTicks = 5;
+
+    /// <summary>The values forwarded by the active-source re-arming test.</summary>
+    private static readonly int[] ExpectedActiveValues = [0, 1, 2, 3, 4];
+
     /// <summary>Timeout used while waiting for background work in this test.</summary>
     private static readonly TimeSpan WaitTimeout = TimeSpan.FromSeconds(5);
 
-    /// <summary>Verifies timeout delivery is serialized behind an in-flight source value.</summary>
+    /// <summary>Verifies the timeout re-arms on each value so an active source never expires.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task TimeoutResetsOnEachValueSoActiveSourceNeverExpires()
+    {
+        VirtualClock clock = new(DateTimeOffset.UnixEpoch);
+        Signal<int> source = new();
+        List<int> values = [];
+        List<string> errors = [];
+        using var subscription = source.Expire(TimeSpan.FromTicks(DueTicks), clock)
+            .Subscribe(values.Add, ex => errors.Add(ex.GetType().Name));
+
+        for (var i = 0; i < ValueCount; i++)
+        {
+            clock.AdvanceBy(TimeSpan.FromTicks(ActiveGapTicks));
+            source.OnNext(i);
+        }
+
+        await Assert.That(errors.Count).IsEqualTo(0);
+        await Assert.That(values.SequenceEqual(ExpectedActiveValues)).IsTrue();
+    }
+
+    /// <summary>Verifies silence longer than the timeout still expires after re-arming.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task TimeoutExpiresWhenSilenceExceedsDueTimeAfterAValue()
+    {
+        VirtualClock clock = new(DateTimeOffset.UnixEpoch);
+        Signal<int> source = new();
+        List<int> values = [];
+        List<string> errors = [];
+        using var subscription = source.Expire(TimeSpan.FromTicks(DueTicks), clock)
+            .Subscribe(values.Add, ex => errors.Add(ex.GetType().Name));
+
+        clock.AdvanceBy(TimeSpan.FromTicks(ShortGapTicks));
+        source.OnNext(One);
+        clock.AdvanceBy(TimeSpan.FromTicks(DueTicks));
+
+        await Assert.That(values.SequenceEqual([One])).IsTrue();
+        await Assert.That(errors.SequenceEqual([nameof(TimeoutException)])).IsTrue();
+    }
+
+    /// <summary>Verifies an in-flight value wins the race and suppresses the superseded timeout.</summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Test]
     public async Task TimeoutDoesNotEnterObserverWhileOnNextIsInFlight()
@@ -39,7 +96,7 @@ public sealed class ExpireCoordinatorTests
         await onNextTask.WaitAsync(WaitTimeout).ConfigureAwait(false);
         await timeoutTask.WaitAsync(WaitTimeout).ConfigureAwait(false);
 
-        await Assert.That(observer.Errors).IsEqualTo(One);
+        await Assert.That(observer.Errors).IsEqualTo(0);
         await Assert.That(observer.Values).IsEqualTo(One);
     }
 

--- a/src/tests/ReactiveUI.Primitives.Tests/ExpireCoordinatorTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/ExpireCoordinatorTests.cs
@@ -74,6 +74,50 @@ public sealed class ExpireCoordinatorTests
         await Assert.That(errors.SequenceEqual([nameof(TimeoutException)])).IsTrue();
     }
 
+    /// <summary>Verifies no timer fires once the source has terminated.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task NoTimeoutFiresAfterCompletion()
+    {
+        VirtualClock clock = new(DateTimeOffset.UnixEpoch);
+        Signal<int> source = new();
+        List<int> values = [];
+        List<string> errors = [];
+        var completed = false;
+        using var subscription = source.Expire(TimeSpan.FromTicks(DueTicks), clock)
+            .Subscribe(values.Add, ex => errors.Add(ex.GetType().Name), () => completed = true);
+
+        clock.AdvanceBy(TimeSpan.FromTicks(ShortGapTicks));
+        source.OnNext(One);
+        source.OnCompleted();
+        clock.AdvanceBy(TimeSpan.FromTicks(DueTicks * ValueCount));
+
+        await Assert.That(completed).IsTrue();
+        await Assert.That(values.SequenceEqual([One])).IsTrue();
+        await Assert.That(errors.Count).IsEqualTo(0);
+    }
+
+    /// <summary>Verifies no timer fires once the source has errored.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task NoTimeoutFiresAfterError()
+    {
+        VirtualClock clock = new(DateTimeOffset.UnixEpoch);
+        Signal<int> source = new();
+        List<int> values = [];
+        List<string> errors = [];
+        using var subscription = source.Expire(TimeSpan.FromTicks(DueTicks), clock)
+            .Subscribe(values.Add, ex => errors.Add(ex.GetType().Name));
+
+        clock.AdvanceBy(TimeSpan.FromTicks(ShortGapTicks));
+        source.OnNext(One);
+        source.OnError(new InvalidOperationException());
+        clock.AdvanceBy(TimeSpan.FromTicks(DueTicks * ValueCount));
+
+        await Assert.That(values.SequenceEqual([One])).IsTrue();
+        await Assert.That(errors.SequenceEqual([nameof(InvalidOperationException)])).IsTrue();
+    }
+
     /// <summary>Verifies an in-flight value wins the race and suppresses the superseded timeout.</summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Test]


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the new behavior?

`Timeout`/`Expire` now behaves as a true **inactivity** timeout, matching System.Reactive. Each `OnNext` invalidates the in-flight timer and arms a fresh one for `dueTime`, so a `TimeoutException` is raised only when no notification arrives within `dueTime` of the previous one. An active source whose total runtime exceeds `dueTime` is no longer wrongly failed.

Implementation detail: a monotonic `_epoch` counter is bumped under the existing gate on every value (and at subscription). A timer fire only emits when its captured epoch is still current, so a value that wins the race cancels the pending timeout and a superseded timer fire is suppressed. This preserves the existing OnNext/timeout serialization while adding the per-value reset.

## What is the current behavior?

`ExpireCoordinator<T>.Run` scheduled a single timer for `dueTime` at subscription and `OnNext` never rescheduled it. This made `Timeout` a fixed deadline from subscription rather than an inactivity timeout, so a healthy, actively-emitting source was incorrectly terminated with `TimeoutException` once its total elapsed time crossed `dueTime`.

Closes #77

## What might this PR break?

Behavioural change (the intended fix): a source that emits values more frequently than `dueTime` no longer times out, whereas before it could. Code that (incorrectly) relied on `Timeout` acting as a total-duration deadline will see different behaviour; the new behaviour matches Rx semantics. No public API changes.

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [x] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information

Verified with `dotnet build` (clean, 0 warnings/errors) and the full `ReactiveUI.Primitives.Tests` suite (1996 passing across net8.0/9.0/10.0/11.0) plus `ReactiveUI.Primitives.Reactive.Tests`. New tests in `ExpireCoordinatorTests`: per-value reset never expires an active source, inactivity beyond `dueTime` still expires, and an in-flight value wins the race against a superseded timeout.
