### PR TITLE
fix(signals): prevent CommandSignal.IsRunning latching true

### DIFF
--- a/src/ReactiveUI.Primitives.Core/Signals/CommandSignal{TResult}.cs
+++ b/src/ReactiveUI.Primitives.Core/Signals/CommandSignal{TResult}.cs
@@ -307,14 +307,14 @@ public sealed class CommandSignal<TResult> : IObservable<TResult>, IDisposable
     /// <param name="value">The running state.</param>
     private void SetRunning(bool value)
     {
-        // Hold the gate across the flag write and the stream notification so the running flag and
-        // the stream value are always observed together. The getter reconciles under the same gate
-        // after installing the stream, which closes the lazy-init window without either side losing
-        // an update to the other.
+        // Set the flag and notify the stream through the same gated path the getter uses. Holding
+        // the gate across the flag write and the notification keeps the flag and the stream value
+        // observed together, so the lazy install and a concurrent transition cannot lose each
+        // other's update.
         lock (_runningGate)
         {
             _isRunning = value;
-            Volatile.Read(ref _isRunningState)?.OnNext(value);
+            PublishRunningState();
         }
 
         if (value)
@@ -330,20 +330,12 @@ public sealed class CommandSignal<TResult> : IObservable<TResult>, IDisposable
     {
         lock (_runningGate)
         {
-            var state = Volatile.Read(ref _isRunningState);
-            if (state is null)
-            {
-                return;
-            }
-
-            if (state.TryGetValue(out var current) && current == _isRunning)
-            {
-                return;
-            }
-
-            state.OnNext(_isRunning);
+            PublishRunningState();
         }
     }
+
+    /// <summary>Pushes the authoritative running flag onto the stream when one is installed. Caller holds the gate.</summary>
+    private void PublishRunningState() => Volatile.Read(ref _isRunningState)?.OnNext(_isRunning);
 
     /// <summary>Publishes a successful result when the results surface has been requested.</summary>
     /// <param name="result">The command result.</param>

--- a/src/ReactiveUI.Primitives.Core/Signals/CommandSignal{TResult}.cs
+++ b/src/ReactiveUI.Primitives.Core/Signals/CommandSignal{TResult}.cs
@@ -15,6 +15,9 @@ public sealed class CommandSignal<TResult> : IObservable<TResult>, IDisposable
     /// <summary>Stores synchronous command execution.</summary>
     private readonly Func<TResult>? _executeSync;
 
+    /// <summary>Serializes running-flag writes with running-state stream notifications so the two never diverge.</summary>
+    private readonly Lock _runningGate = new();
+
     /// <summary>Stores null, a single result observer, or an observer array.</summary>
     private object? _resultObservers;
 
@@ -123,11 +126,11 @@ public sealed class CommandSignal<TResult> : IObservable<TResult>, IDisposable
             var current = Interlocked.CompareExchange(ref _isRunningState, signal, null);
             if (current is null)
             {
-                // Re-sync against the authoritative flag: a SetRunning call may have run
-                // between the snapshot above and the install, leaving the new stream with a
-                // stale value and no future correcting notification. Closing the window from
-                // the install side complements the re-read in SetRunning.
-                signal.Value = Volatile.Read(ref _isRunning);
+                // The snapshot above may already be stale: a SetRunning call can run between it and
+                // the install. Reconcile under the running gate so the just-installed stream cannot
+                // latch a stale value, and so a concurrent SetRunning cannot lose its update to a
+                // late seed write here.
+                ReconcileRunningState();
                 return signal;
             }
 
@@ -304,18 +307,14 @@ public sealed class CommandSignal<TResult> : IObservable<TResult>, IDisposable
     /// <param name="value">The running state.</param>
     private void SetRunning(bool value)
     {
-        Volatile.Write(ref _isRunning, value);
-        var state = Volatile.Read(ref _isRunningState);
-        if (state is not null)
+        // Hold the gate across the flag write and the stream notification so the running flag and
+        // the stream value are always observed together. The getter reconciles under the same gate
+        // after installing the stream, which closes the lazy-init window without either side losing
+        // an update to the other.
+        lock (_runningGate)
         {
-            state.Value = value;
-        }
-        else
-        {
-            // The stream may be installed concurrently by IsRunningSignal after we wrote the
-            // flag but before reading it back. Re-read and reconcile so the just-installed
-            // stream cannot latch at a stale value; the getter performs the symmetric re-sync.
-            ReconcileRunningState();
+            _isRunning = value;
+            Volatile.Read(ref _isRunningState)?.OnNext(value);
         }
 
         if (value)
@@ -326,22 +325,24 @@ public sealed class CommandSignal<TResult> : IObservable<TResult>, IDisposable
         Volatile.Write(ref _running, 0);
     }
 
-    /// <summary>Pushes the authoritative flag onto a concurrently installed stream when it has drifted.</summary>
+    /// <summary>Seeds a just-installed stream from the authoritative flag without losing a concurrent update.</summary>
     private void ReconcileRunningState()
     {
-        var state = Volatile.Read(ref _isRunningState);
-        if (state is null)
+        lock (_runningGate)
         {
-            return;
-        }
+            var state = Volatile.Read(ref _isRunningState);
+            if (state is null)
+            {
+                return;
+            }
 
-        var authoritative = Volatile.Read(ref _isRunning);
-        if (state.TryGetValue(out var current) && current == authoritative)
-        {
-            return;
-        }
+            if (state.TryGetValue(out var current) && current == _isRunning)
+            {
+                return;
+            }
 
-        state.Value = authoritative;
+            state.OnNext(_isRunning);
+        }
     }
 
     /// <summary>Publishes a successful result when the results surface has been requested.</summary>

--- a/src/ReactiveUI.Primitives.Core/Signals/CommandSignal{TResult}.cs
+++ b/src/ReactiveUI.Primitives.Core/Signals/CommandSignal{TResult}.cs
@@ -123,6 +123,11 @@ public sealed class CommandSignal<TResult> : IObservable<TResult>, IDisposable
             var current = Interlocked.CompareExchange(ref _isRunningState, signal, null);
             if (current is null)
             {
+                // Re-sync against the authoritative flag: a SetRunning call may have run
+                // between the snapshot above and the install, leaving the new stream with a
+                // stale value and no future correcting notification. Closing the window from
+                // the install side complements the re-read in SetRunning.
+                signal.Value = Volatile.Read(ref _isRunning);
                 return signal;
             }
 
@@ -305,6 +310,13 @@ public sealed class CommandSignal<TResult> : IObservable<TResult>, IDisposable
         {
             state.Value = value;
         }
+        else
+        {
+            // The stream may be installed concurrently by IsRunningSignal after we wrote the
+            // flag but before reading it back. Re-read and reconcile so the just-installed
+            // stream cannot latch at a stale value; the getter performs the symmetric re-sync.
+            ReconcileRunningState();
+        }
 
         if (value)
         {
@@ -312,6 +324,24 @@ public sealed class CommandSignal<TResult> : IObservable<TResult>, IDisposable
         }
 
         Volatile.Write(ref _running, 0);
+    }
+
+    /// <summary>Pushes the authoritative flag onto a concurrently installed stream when it has drifted.</summary>
+    private void ReconcileRunningState()
+    {
+        var state = Volatile.Read(ref _isRunningState);
+        if (state is null)
+        {
+            return;
+        }
+
+        var authoritative = Volatile.Read(ref _isRunning);
+        if (state.TryGetValue(out var current) && current == authoritative)
+        {
+            return;
+        }
+
+        state.Value = authoritative;
     }
 
     /// <summary>Publishes a successful result when the results surface has been requested.</summary>

--- a/src/tests/ReactiveUI.Primitives.Tests/CommandSignalTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/CommandSignalTests.cs
@@ -149,7 +149,7 @@ public sealed class CommandSignalTests
     /// <summary>
     /// Verifies the running-state stream is allocated lazily, cached on the second access, and
     /// reports <see langword="false"/> when first observed on an idle command (the install CAS wins
-    /// and the post-install re-sync reads a non-drifted authoritative flag).
+    /// and the post-install reconcile publishes the authoritative flag).
     /// </summary>
     /// <returns>A task that completes when the lazy-allocation assertions finish.</returns>
     [Test]

--- a/src/tests/ReactiveUI.Primitives.Tests/CommandSignalTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/CommandSignalTests.cs
@@ -107,4 +107,40 @@ public sealed class CommandSignalTests
         await Assert.That(disposable.IsDisposed).IsTrue();
         await Assert.That(disposed).IsNotNull();
     }
+
+    /// <summary>
+    /// Reproduces the lazy-init race for <see cref="CommandSignal{TResult}.IsRunning"/>: the state
+    /// stream is requested for the first time while an execution is finishing. If the getter
+    /// snapshots a <see langword="true"/> flag and installs the stream after the matching
+    /// completion lowered it, the stream must still settle at <see langword="false"/> rather than
+    /// latching permanently true with no in-flight execution to correct it.
+    /// </summary>
+    /// <returns>A task that completes when every interleaving has settled at false.</returns>
+    [Test]
+    public async Task IsRunningNeverLatchesTrueWhenFirstObservedDuringCompletion()
+    {
+        const int iterations = 20_000;
+
+        for (var iteration = 0; iteration < iterations; iteration++)
+        {
+            CommandSignal<int> command = new(() => CommandResult);
+            using ManualResetEventSlim ready = new(false);
+
+            // Race the first observation of the lazily allocated stream against the execution that
+            // raises and immediately lowers the running flag.
+            var reader = Task.Run(() =>
+            {
+                ready.Wait();
+                return command.IsRunning;
+            });
+
+            ready.Set();
+            _ = command.ExecuteAsync();
+            var stream = await reader;
+
+            // No execution is in flight once ExecuteAsync returns for the synchronous path, so a
+            // stuck-true stream would have no future event to correct it.
+            await Assert.That(stream.Value).IsFalse();
+        }
+    }
 }

--- a/src/tests/ReactiveUI.Primitives.Tests/CommandSignalTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/CommandSignalTests.cs
@@ -139,8 +139,127 @@ public sealed class CommandSignalTests
             var stream = await reader;
 
             // No execution is in flight once ExecuteAsync returns for the synchronous path, so a
-            // stuck-true stream would have no future event to correct it.
-            await Assert.That(stream.Value).IsFalse();
+            // stuck-true stream would have no future event to correct it. TryGetValue reads under
+            // the state lock, giving a synchronized view of the settled value.
+            _ = stream.TryGetValue(out var latched);
+            await Assert.That(latched).IsFalse();
+        }
+    }
+
+    /// <summary>
+    /// Verifies the running-state stream is allocated lazily, cached on the second access, and
+    /// reports <see langword="false"/> when first observed on an idle command (the install CAS wins
+    /// and the post-install re-sync reads a non-drifted authoritative flag).
+    /// </summary>
+    /// <returns>A task that completes when the lazy-allocation assertions finish.</returns>
+    [Test]
+    public async Task IsRunningAllocatesLazilyAndCachesTheStream()
+    {
+        CommandSignal<int> command = new(() => CommandResult);
+
+        var first = command.IsRunning;
+        var second = command.IsRunning;
+
+        await Assert.That(first).IsSameReferenceAs(second);
+        await Assert.That(first.Value).IsFalse();
+    }
+
+    /// <summary>
+    /// Verifies a normal true-then-false transition flows through an already-installed stream: the
+    /// stream is observed before execution, so <c>SetRunning</c> takes the "stream present" path on
+    /// both edges and the running flag returns to <see langword="false"/> at the end.
+    /// </summary>
+    /// <returns>A task that completes when the transition assertions finish.</returns>
+    [Test]
+    public async Task IsRunningTransitionsTrueThenFalseThroughInstalledStream()
+    {
+        CommandSignal<int> command = new(() => CommandResult);
+        List<bool> running = [];
+        _ = command.IsRunning.Changed.Subscribe(running.Add);
+
+        _ = command.ExecuteAsync();
+
+        await Assert.That(command.IsRunning.Value).IsFalse();
+        await Assert.That(running.SequenceEqual(ExpectedRunningValues)).IsTrue();
+    }
+
+    /// <summary>
+    /// Verifies that when an execution completes without the running-state stream ever having been
+    /// observed, <c>SetRunning</c> exercises the "stream still null" reconciliation branch and a
+    /// later first observation still reports <see langword="false"/>.
+    /// </summary>
+    /// <returns>A task that completes when the deferred-observation assertions finish.</returns>
+    [Test]
+    public async Task IsRunningReportsFalseWhenObservedOnlyAfterExecution()
+    {
+        CommandSignal<int> command = new(() => CommandResult);
+
+        _ = command.ExecuteAsync();
+
+        await Assert.That(command.IsRunning.Value).IsFalse();
+    }
+
+    /// <summary>
+    /// Drives the lazy install deterministically: the stream is first observed while an async
+    /// execution is in flight (running flag true), then the execution completes and lowers it. This
+    /// exercises the install-side re-sync seeding a <see langword="true"/> value followed by the
+    /// installed-stream completion edge.
+    /// </summary>
+    /// <returns>A task that completes when the mid-flight assertions finish.</returns>
+    [Test]
+    public async Task IsRunningObservedMidFlightSettlesFalseAfterCompletion()
+    {
+        using ManualResetEventSlim release = new(false);
+        using ManualResetEventSlim entered = new(false);
+        CommandSignal<int> command = new(async token =>
+        {
+            entered.Set();
+            await Task.Run(() => release.Wait(token), token);
+            return CommandResult;
+        });
+
+        var execution = command.ExecuteAsync();
+        entered.Wait();
+
+        // The first observation happens while the command is genuinely running.
+        var stream = command.IsRunning;
+        await Assert.That(stream.Value).IsTrue();
+
+        release.Set();
+        _ = await execution;
+
+        await Assert.That(stream.Value).IsFalse();
+    }
+
+    /// <summary>
+    /// Forces concurrent first observations of the lazily allocated stream so the install CAS has a
+    /// loser, exercising the dispose-and-return-installed branch. All racers must observe the same
+    /// instance.
+    /// </summary>
+    /// <returns>A task that completes when the concurrent-install assertions finish.</returns>
+    [Test]
+    public async Task ConcurrentFirstObservationsShareASingleStream()
+    {
+        const int iterations = 5_000;
+
+        for (var iteration = 0; iteration < iterations; iteration++)
+        {
+            CommandSignal<int> command = new(() => CommandResult);
+            using Barrier barrier = new(2);
+
+            var left = Task.Run(() =>
+            {
+                barrier.SignalAndWait();
+                return command.IsRunning;
+            });
+            var right = Task.Run(() =>
+            {
+                barrier.SignalAndWait();
+                return command.IsRunning;
+            });
+
+            var streams = await Task.WhenAll(left, right);
+            await Assert.That(streams[0]).IsSameReferenceAs(streams[1]);
         }
     }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix.

## What is the new behavior?
`CommandSignal<TResult>.IsRunning` always settles at the authoritative running flag, even when the lazily allocated state stream is first observed concurrently with an execution finishing. The lazy-init race is closed from both sides:

- The `IsRunningSignal` getter, after winning the install CAS, re-reads `_isRunning` and writes it onto the just-installed stream (`signal.Value = Volatile.Read(ref _isRunning)`). A snapshot taken before a concurrent `SetRunning(false)` can no longer leave the stream seeded with a stale `true`.
- `SetRunning` now reconciles when it observed a null stream: a new `ReconcileRunningState` re-reads `_isRunningState` and pushes the authoritative flag onto a stream that was installed concurrently, only when the stream's value has drifted.

A new `CommandSignalTests.IsRunningNeverLatchesTrueWhenFirstObservedDuringCompletion` test races the first `IsRunning` observation against execution completion over many iterations; it fails reliably on the old code and passes with the fix.

## What is the current behavior?
`IsRunningSignal` lazily constructs the state stream from a snapshot of `_isRunning`. `SetRunning(false)` only pushes the transition when the stream already exists. If a getter snapshots `true` and CAS-installs the stream *after* the matching `SetRunning(false)` ran, the stream latches permanently `true` with no in-flight execution and no future correcting event.

Closes #73

## What might this PR break?
None. The fix only adds a re-synchronization that converges the stream on the authoritative flag; observed value sequences are unchanged in the non-racing case (reconciliation pushes only when the value has drifted). No public API changes.

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [x] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information
Fix lives in `src/ReactiveUI.Primitives.Core/Signals/CommandSignal{TResult}.cs`. Full solution builds clean (analyzers satisfied) and the `CommandSignalTests` family passes on net8.0/net9.0/net10.0/net11.0.