### PR TITLE
fix(signals): gate Signal.FromTask terminal notification against dispose

### DIFF
--- a/src/Primitives.Shared/Signals/Signal{FromTask}.cs
+++ b/src/Primitives.Shared/Signals/Signal{FromTask}.cs
@@ -39,7 +39,7 @@ public static partial class Signal
         Func<CancellationTokenSource, Task<RxVoid>> execution,
         ISequencer? scheduler,
         CancellationTokenSource? cancellationTokenSource) =>
-        CreateTaskSignal(execution, static _ => true, scheduler, cancellationTokenSource);
+        CreateTaskSignal(execution, scheduler, cancellationTokenSource);
 
     /// <summary>Froms the asynchronous.</summary>
     /// <typeparam name="TResult">The type of the return value.</typeparam>
@@ -72,24 +72,22 @@ public static partial class Signal
         Func<CancellationTokenSource, Task<TResult>> actionAsync,
         ISequencer? scheduler,
         CancellationTokenSource? cancellationTokenSource) =>
-        CreateTaskSignal(actionAsync, static _ => true, scheduler, cancellationTokenSource);
+        CreateTaskSignal(actionAsync, scheduler, cancellationTokenSource);
 
     /// <summary>Executes the CreateTaskSignal operation.</summary>
     /// <typeparam name="TResult">The TResult type.</typeparam>
     /// <param name="execution">The execution value.</param>
-    /// <param name="shouldEmit">The shouldEmit value.</param>
     /// <param name="scheduler">The scheduler value.</param>
     /// <param name="cancellationTokenSource">The cancellationTokenSource value.</param>
     /// <returns>The result.</returns>
     private static ITaskSignal<TResult> CreateTaskSignal<TResult>(
         Func<CancellationTokenSource, Task<TResult>> execution,
-        Func<TResult, bool> shouldEmit,
         ISequencer? scheduler,
         CancellationTokenSource? cancellationTokenSource) =>
         ReferenceEquals(scheduler, Sequencer.Immediate)
-            ? new ImmediateTaskSignal<TResult>(execution, shouldEmit, cancellationTokenSource)
+            ? new ImmediateTaskSignal<TResult>(execution, cancellationTokenSource)
             : TaskSignal.Create<TResult>(
-                ao => Lazy(() => Create<TResult>(observer => SubscribeTask(ao, execution, shouldEmit, observer))),
+                ao => Lazy(() => Create<TResult>(observer => SubscribeTask(ao, execution, observer))),
                 scheduler,
                 cancellationTokenSource);
 
@@ -97,19 +95,16 @@ public static partial class Signal
     /// <typeparam name="TResult">The TResult type.</typeparam>
     /// <param name="signal">The signal value.</param>
     /// <param name="execution">The execution value.</param>
-    /// <param name="shouldEmit">The shouldEmit value.</param>
     /// <param name="observer">The observer value.</param>
     /// <returns>The result.</returns>
     private static IDisposable SubscribeTask<TResult>(
         ITaskSignal<TResult> signal,
         Func<CancellationTokenSource, Task<TResult>> execution,
-        Func<TResult, bool> shouldEmit,
         IObserver<TResult> observer)
     {
         var source = signal.CancellationTokenSource!;
         var token = source.Token;
         token.ThrowIfCancellationRequested();
-        TaskStopGate gate = new();
         Task<TResult> task;
         try
         {
@@ -117,15 +112,17 @@ public static partial class Signal
         }
         catch (Exception error)
         {
-            return EmitError(gate, observer, error);
+            observer.OnError(error);
+            return EmptyDisposable.Instance;
         }
 
-        if (TryEmitSynchronously(task, shouldEmit, observer, gate, token, out var synchronous))
+        if (TryEmitSynchronously(task, observer, token))
         {
-            return synchronous;
+            return EmptyDisposable.Instance;
         }
 
-        _ = ObserveTask(task.WhenCancelled(token), shouldEmit, observer, gate, token);
+        TaskStopGate gate = new();
+        _ = ObserveTask(task.WhenCancelled(token), observer, gate, token);
 
         return CancelOnDispose(gate, source);
     }
@@ -148,87 +145,46 @@ public static partial class Signal
     /// <summary>Emits a synchronous terminal notification when the task has already finished.</summary>
     /// <typeparam name="TResult">The TResult type.</typeparam>
     /// <param name="task">The task to inspect.</param>
-    /// <param name="shouldEmit">The result filter.</param>
     /// <param name="observer">The observer value.</param>
-    /// <param name="gate">The terminal-notification gate shared with the disposer.</param>
     /// <param name="token">The token value.</param>
-    /// <param name="disposable">The disposable returned when a synchronous terminal was produced.</param>
     /// <returns><see langword="true"/> when a synchronous terminal notification was produced.</returns>
+    /// <remarks>
+    /// Runs before any disposer is handed out, so no dispose race is possible and the emission is ungated.
+    /// </remarks>
     [System.Diagnostics.CodeAnalysis.SuppressMessage(
         "Major Code Smell",
         "S4462:Calls to \"async\" methods should not be blocking",
         Justification = "Synchronous read of an already-completed (RanToCompletion) task for an allocation-free fast path; await is invalid in this synchronous factory.")]
     private static bool TryEmitSynchronously<TResult>(
         Task<TResult> task,
-        Func<TResult, bool> shouldEmit,
         IObserver<TResult> observer,
-        TaskStopGate gate,
-        CancellationToken token,
-        out IDisposable disposable)
+        CancellationToken token)
     {
         if (task.Status == TaskStatus.RanToCompletion)
         {
-            var result = task.Result;
-            disposable = shouldEmit(result)
-                ? EmitResult(gate, observer, result)
-                : EmitError(gate, observer, new OperationCanceledException());
+            observer.OnNext(task.Result);
+            observer.OnCompleted();
             return true;
         }
 
         if (task.IsCanceled || token.IsCancellationRequested)
         {
-            disposable = EmitError(gate, observer, new OperationCanceledException());
+            observer.OnError(new OperationCanceledException());
             return true;
         }
 
-        if (task.IsFaulted)
+        if (!task.IsFaulted)
         {
-            disposable = EmitError(gate, observer, task.Exception!.InnerException ?? task.Exception);
-            return true;
+            return false;
         }
 
-        disposable = EmptyDisposable.Instance;
-        return false;
+        observer.OnError(task.Exception!.InnerException ?? task.Exception);
+        return true;
     }
 
-    /// <summary>Emits a successful result and completion through the gate.</summary>
-    /// <typeparam name="TResult">The TResult type.</typeparam>
-    /// <param name="gate">The terminal-notification gate shared with the disposer.</param>
-    /// <param name="observer">The observer value.</param>
-    /// <param name="result">The task result.</param>
-    /// <returns>An empty disposable.</returns>
-    private static EmptyDisposable EmitResult<TResult>(TaskStopGate gate, IObserver<TResult> observer, TResult result)
-    {
-        if (!gate.TryStop())
-        {
-            return EmptyDisposable.Instance;
-        }
-
-        observer.OnNext(result);
-        observer.OnCompleted();
-        return EmptyDisposable.Instance;
-    }
-
-    /// <summary>Emits an error through the gate.</summary>
-    /// <typeparam name="TResult">The TResult type.</typeparam>
-    /// <param name="gate">The terminal-notification gate shared with the disposer.</param>
-    /// <param name="observer">The observer value.</param>
-    /// <param name="error">The error to emit.</param>
-    /// <returns>An empty disposable.</returns>
-    private static EmptyDisposable EmitError<TResult>(TaskStopGate gate, IObserver<TResult> observer, Exception error)
-    {
-        if (gate.TryStop())
-        {
-            observer.OnError(error);
-        }
-
-        return EmptyDisposable.Instance;
-    }
-
-    /// <summary>Executes the ObserveTask operation.</summary>
+    /// <summary>Observes a pending task and forwards the terminal notification while honoring disposal.</summary>
     /// <typeparam name="TResult">The TResult type.</typeparam>
     /// <param name="cancellableTask">The cancellableTask value.</param>
-    /// <param name="shouldEmit">The shouldEmit value.</param>
     /// <param name="observer">The observer value.</param>
     /// <param name="gate">The terminal-notification gate shared with the disposer.</param>
     /// <param name="token">The token value.</param>
@@ -240,7 +196,6 @@ public static partial class Signal
     /// </remarks>
     private static async Task ObserveTask<TResult>(
         Task<(TResult Value, bool IsCanceled)> cancellableTask,
-        Func<TResult, bool> shouldEmit,
         IObserver<TResult> observer,
         TaskStopGate gate,
         CancellationToken token)
@@ -248,13 +203,27 @@ public static partial class Signal
         try
         {
             var (result, isCanceled) = await cancellableTask.ConfigureAwait(false);
-            _ = !isCanceled && !token.IsCancellationRequested && shouldEmit(result)
-                ? EmitResult(gate, observer, result)
-                : EmitError(gate, observer, new OperationCanceledException());
+            if (!gate.TryStop())
+            {
+                return;
+            }
+
+            if (!isCanceled && !token.IsCancellationRequested)
+            {
+                observer.OnNext(result);
+                observer.OnCompleted();
+            }
+            else
+            {
+                observer.OnError(new OperationCanceledException());
+            }
         }
         catch (Exception error)
         {
-            _ = EmitError(gate, observer, error);
+            if (gate.TryStop())
+            {
+                observer.OnError(error);
+            }
         }
     }
 
@@ -279,24 +248,17 @@ public static partial class Signal
         /// <summary>Executes the task.</summary>
         private readonly Func<CancellationTokenSource, Task<TResult>> _execution;
 
-        /// <summary>Filters successful task results.</summary>
-        private readonly Func<TResult, bool> _shouldEmit;
-
         /// <summary>Non-zero after disposal.</summary>
         private int _disposed;
 
         /// <summary>Initializes a new instance of the <see cref="ImmediateTaskSignal{TResult}"/> class.</summary>
         /// <param name="execution">Task factory.</param>
-        /// <param name="shouldEmit">Result filter.</param>
         /// <param name="cancellationTokenSource">Optional cancellation source.</param>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0001:Simplify Names", Justification = "The argument validation uses ArgumentExceptionHelper")]
         public ImmediateTaskSignal(
             Func<CancellationTokenSource, Task<TResult>> execution,
-            Func<TResult, bool> shouldEmit,
             CancellationTokenSource? cancellationTokenSource)
         {
             _execution = execution ?? throw new ArgumentNullException(nameof(execution));
-            _shouldEmit = shouldEmit ?? throw new ArgumentNullException(nameof(shouldEmit));
             SourceCore = cancellationTokenSource ?? new CancellationTokenSource();
         }
 
@@ -335,7 +297,6 @@ public static partial class Signal
             var token = SourceCore.Token;
             token.ThrowIfCancellationRequested();
 
-            TaskStopGate gate = new();
             Task<TResult> task;
             try
             {
@@ -343,15 +304,17 @@ public static partial class Signal
             }
             catch (Exception error)
             {
-                return EmitError(gate, observer, error);
+                observer.OnError(error);
+                return EmptyDisposable.Instance;
             }
 
-            if (TryEmitSynchronously(task, _shouldEmit, observer, gate, token, out var synchronous))
+            if (TryEmitSynchronously(task, observer, token))
             {
-                return synchronous;
+                return EmptyDisposable.Instance;
             }
 
-            _ = ObserveTask(task.WhenCancelled(token), _shouldEmit, observer, gate, token);
+            TaskStopGate gate = new();
+            _ = ObserveTask(task.WhenCancelled(token), observer, gate, token);
 
             return CancelOnDispose(gate, SourceCore);
         }

--- a/src/Primitives.Shared/Signals/Signal{FromTask}.cs
+++ b/src/Primitives.Shared/Signals/Signal{FromTask}.cs
@@ -168,7 +168,10 @@ public static partial class Signal
     {
         if (task.Status == TaskStatus.RanToCompletion)
         {
-            disposable = EmitResult(gate, observer, task.Result, shouldEmit(task.Result));
+            var result = task.Result;
+            disposable = shouldEmit(result)
+                ? EmitResult(gate, observer, result)
+                : EmitError(gate, observer, new OperationCanceledException());
             return true;
         }
 
@@ -188,30 +191,21 @@ public static partial class Signal
         return false;
     }
 
-    /// <summary>Emits a successful result (or cancellation) through the gate.</summary>
+    /// <summary>Emits a successful result and completion through the gate.</summary>
     /// <typeparam name="TResult">The TResult type.</typeparam>
     /// <param name="gate">The terminal-notification gate shared with the disposer.</param>
     /// <param name="observer">The observer value.</param>
     /// <param name="result">The task result.</param>
-    /// <param name="shouldEmit">Whether the result should be emitted.</param>
     /// <returns>An empty disposable.</returns>
-    private static EmptyDisposable EmitResult<TResult>(TaskStopGate gate, IObserver<TResult> observer, TResult result, bool shouldEmit)
+    private static EmptyDisposable EmitResult<TResult>(TaskStopGate gate, IObserver<TResult> observer, TResult result)
     {
         if (!gate.TryStop())
         {
             return EmptyDisposable.Instance;
         }
 
-        if (shouldEmit)
-        {
-            observer.OnNext(result);
-            observer.OnCompleted();
-        }
-        else
-        {
-            observer.OnError(new OperationCanceledException());
-        }
-
+        observer.OnNext(result);
+        observer.OnCompleted();
         return EmptyDisposable.Instance;
     }
 
@@ -254,8 +248,9 @@ public static partial class Signal
         try
         {
             var (result, isCanceled) = await cancellableTask.ConfigureAwait(false);
-            var shouldEmitResult = !isCanceled && !token.IsCancellationRequested && shouldEmit(result);
-            _ = EmitResult(gate, observer, result, shouldEmitResult);
+            _ = !isCanceled && !token.IsCancellationRequested && shouldEmit(result)
+                ? EmitResult(gate, observer, result)
+                : EmitError(gate, observer, new OperationCanceledException());
         }
         catch (Exception error)
         {

--- a/src/Primitives.Shared/Signals/Signal{FromTask}.cs
+++ b/src/Primitives.Shared/Signals/Signal{FromTask}.cs
@@ -11,12 +11,6 @@ namespace ReactiveUI.Primitives.Signals;
 /// <summary>Provides static factory and operator methods for signals.</summary>
 public static partial class Signal
 {
-    /// <summary>Stores state for the signal implementation.</summary>
-    private const int TaskCompleted = 1;
-
-    /// <summary>Stores state for the signal implementation.</summary>
-    private const int TaskFaulted = 2;
-
     /// <summary>Handles Asnyc Tasks with cancellation.</summary>
     /// <param name="execution">The function to execute.</param>
     /// <returns>
@@ -106,10 +100,6 @@ public static partial class Signal
     /// <param name="shouldEmit">The shouldEmit value.</param>
     /// <param name="observer">The observer value.</param>
     /// <returns>The result.</returns>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S4462:Calls to \"async\" methods should not be blocking",
-        Justification = "Synchronous read of an already-completed (RanToCompletion) task for an allocation-free fast path; await is invalid in this synchronous factory.")]
     private static IDisposable SubscribeTask<TResult>(
         ITaskSignal<TResult> signal,
         Func<CancellationTokenSource, Task<TResult>> execution,
@@ -119,7 +109,7 @@ public static partial class Signal
         var source = signal.CancellationTokenSource!;
         var token = source.Token;
         token.ThrowIfCancellationRequested();
-        var completionState = 0;
+        TaskStopGate gate = new();
         Task<TResult> task;
         try
         {
@@ -127,60 +117,118 @@ public static partial class Signal
         }
         catch (Exception error)
         {
-            Volatile.Write(ref completionState, TaskFaulted);
-            observer.OnError(error);
-            return EmptyDisposable.Instance;
+            return EmitError(gate, observer, error);
         }
 
-        if (task.Status == TaskStatus.RanToCompletion)
+        if (TryEmitSynchronously(task, shouldEmit, observer, gate, token, out var synchronous))
         {
-            var result = task.Result;
-            if (shouldEmit(result))
-            {
-                observer.OnNext(result);
-                Volatile.Write(ref completionState, TaskCompleted);
-                observer.OnCompleted();
-                return EmptyDisposable.Instance;
-            }
-
-            Volatile.Write(ref completionState, TaskFaulted);
-            observer.OnError(new OperationCanceledException());
-            return EmptyDisposable.Instance;
+            return synchronous;
         }
 
-        if (task.IsCanceled || token.IsCancellationRequested)
+        _ = ObserveTask(task.WhenCancelled(token), shouldEmit, observer, gate, token);
+
+        return CancelOnDispose(gate, source);
+    }
+
+    /// <summary>Builds a disposer that cancels the source if it wins the terminal transition.</summary>
+    /// <param name="gate">The terminal-notification gate shared with the continuation.</param>
+    /// <param name="source">The cancellation source to cancel on disposal.</param>
+    /// <returns>The disposer.</returns>
+    private static ActionDisposable CancelOnDispose(TaskStopGate gate, CancellationTokenSource source) =>
+        new(() =>
         {
-            Volatile.Write(ref completionState, TaskFaulted);
-            observer.OnError(new OperationCanceledException());
-            return EmptyDisposable.Instance;
-        }
-
-        if (task.IsFaulted)
-        {
-            Volatile.Write(ref completionState, TaskFaulted);
-            observer.OnError(task.Exception!.InnerException ?? task.Exception);
-            return EmptyDisposable.Instance;
-        }
-
-        var cancellableTask = task.WhenCancelled(token);
-
-        _ = ObserveTask(
-            cancellableTask,
-            shouldEmit,
-            observer,
-            () => Volatile.Write(ref completionState, TaskCompleted),
-            () => Volatile.Write(ref completionState, TaskFaulted),
-            token);
-
-        return new ActionDisposable(() =>
-        {
-            if (Volatile.Read(ref completionState) == TaskCompleted)
+            if (!gate.TryStop())
             {
                 return;
             }
 
             Cancel(source);
         });
+
+    /// <summary>Emits a synchronous terminal notification when the task has already finished.</summary>
+    /// <typeparam name="TResult">The TResult type.</typeparam>
+    /// <param name="task">The task to inspect.</param>
+    /// <param name="shouldEmit">The result filter.</param>
+    /// <param name="observer">The observer value.</param>
+    /// <param name="gate">The terminal-notification gate shared with the disposer.</param>
+    /// <param name="token">The token value.</param>
+    /// <param name="disposable">The disposable returned when a synchronous terminal was produced.</param>
+    /// <returns><see langword="true"/> when a synchronous terminal notification was produced.</returns>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Major Code Smell",
+        "S4462:Calls to \"async\" methods should not be blocking",
+        Justification = "Synchronous read of an already-completed (RanToCompletion) task for an allocation-free fast path; await is invalid in this synchronous factory.")]
+    private static bool TryEmitSynchronously<TResult>(
+        Task<TResult> task,
+        Func<TResult, bool> shouldEmit,
+        IObserver<TResult> observer,
+        TaskStopGate gate,
+        CancellationToken token,
+        out IDisposable disposable)
+    {
+        if (task.Status == TaskStatus.RanToCompletion)
+        {
+            disposable = EmitResult(gate, observer, task.Result, shouldEmit(task.Result));
+            return true;
+        }
+
+        if (task.IsCanceled || token.IsCancellationRequested)
+        {
+            disposable = EmitError(gate, observer, new OperationCanceledException());
+            return true;
+        }
+
+        if (task.IsFaulted)
+        {
+            disposable = EmitError(gate, observer, task.Exception!.InnerException ?? task.Exception);
+            return true;
+        }
+
+        disposable = EmptyDisposable.Instance;
+        return false;
+    }
+
+    /// <summary>Emits a successful result (or cancellation) through the gate.</summary>
+    /// <typeparam name="TResult">The TResult type.</typeparam>
+    /// <param name="gate">The terminal-notification gate shared with the disposer.</param>
+    /// <param name="observer">The observer value.</param>
+    /// <param name="result">The task result.</param>
+    /// <param name="shouldEmit">Whether the result should be emitted.</param>
+    /// <returns>An empty disposable.</returns>
+    private static EmptyDisposable EmitResult<TResult>(TaskStopGate gate, IObserver<TResult> observer, TResult result, bool shouldEmit)
+    {
+        if (!gate.TryStop())
+        {
+            return EmptyDisposable.Instance;
+        }
+
+        if (shouldEmit)
+        {
+            observer.OnNext(result);
+            observer.OnCompleted();
+        }
+        else
+        {
+            observer.OnError(new OperationCanceledException());
+        }
+
+        return EmptyDisposable.Instance;
+    }
+
+    /// <summary>Emits an error through the gate.</summary>
+    /// <typeparam name="TResult">The TResult type.</typeparam>
+    /// <param name="gate">The terminal-notification gate shared with the disposer.</param>
+    /// <param name="observer">The observer value.</param>
+    /// <param name="error">The error to emit.</param>
+    /// <returns>An empty disposable.</returns>
+    private static EmptyDisposable EmitError<TResult>(TaskStopGate gate, IObserver<TResult> observer, Exception error)
+    {
+        if (gate.TryStop())
+        {
+            observer.OnError(error);
+        }
+
+        return EmptyDisposable.Instance;
     }
 
     /// <summary>Executes the ObserveTask operation.</summary>
@@ -188,36 +236,30 @@ public static partial class Signal
     /// <param name="cancellableTask">The cancellableTask value.</param>
     /// <param name="shouldEmit">The shouldEmit value.</param>
     /// <param name="observer">The observer value.</param>
-    /// <param name="setCompleted">The setCompleted value.</param>
-    /// <param name="setFaulted">The setFaulted value.</param>
+    /// <param name="gate">The terminal-notification gate shared with the disposer.</param>
     /// <param name="token">The token value.</param>
     /// <returns>The result.</returns>
+    /// <remarks>
+    /// The terminal notification is gated on <see cref="TaskStopGate.TryStop"/>, the same atomic
+    /// transition the disposer wins when the subscription is torn down. Only the winner emits, so a
+    /// subscription disposed while the task continuation runs never observes a post-dispose notification.
+    /// </remarks>
     private static async Task ObserveTask<TResult>(
         Task<(TResult Value, bool IsCanceled)> cancellableTask,
         Func<TResult, bool> shouldEmit,
         IObserver<TResult> observer,
-        Action setCompleted,
-        Action setFaulted,
+        TaskStopGate gate,
         CancellationToken token)
     {
         try
         {
             var (result, isCanceled) = await cancellableTask.ConfigureAwait(false);
-            if (!isCanceled && !token.IsCancellationRequested && shouldEmit(result))
-            {
-                observer.OnNext(result);
-                setCompleted();
-                observer.OnCompleted();
-                return;
-            }
-
-            setFaulted();
-            observer.OnError(new OperationCanceledException());
+            var shouldEmitResult = !isCanceled && !token.IsCancellationRequested && shouldEmit(result);
+            _ = EmitResult(gate, observer, result, shouldEmitResult);
         }
         catch (Exception error)
         {
-            setFaulted();
-            observer.OnError(error);
+            _ = EmitError(gate, observer, error);
         }
     }
 
@@ -290,10 +332,6 @@ public static partial class Signal
         }
 
         /// <inheritdoc/>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage(
-            "Major Code Smell",
-            "S4462:Calls to \"async\" methods should not be blocking",
-            Justification = "Synchronous read of an already-completed (RanToCompletion) task for an allocation-free fast path; await is invalid in this synchronous factory.")]
         public IDisposable Subscribe(IObserver<TResult> observer)
         {
             ArgumentExceptionHelper.ThrowIfNull(observer);
@@ -302,6 +340,7 @@ public static partial class Signal
             var token = SourceCore.Token;
             token.ThrowIfCancellationRequested();
 
+            TaskStopGate gate = new();
             Task<TResult> task;
             try
             {
@@ -309,46 +348,17 @@ public static partial class Signal
             }
             catch (Exception error)
             {
-                observer.OnError(error);
-                return EmptyDisposable.Instance;
+                return EmitError(gate, observer, error);
             }
 
-            if (task.Status == TaskStatus.RanToCompletion)
+            if (TryEmitSynchronously(task, _shouldEmit, observer, gate, token, out var synchronous))
             {
-                var result = task.Result;
-                if (_shouldEmit(result))
-                {
-                    observer.OnNext(result);
-                    observer.OnCompleted();
-                    return EmptyDisposable.Instance;
-                }
-
-                observer.OnError(new OperationCanceledException());
-                return EmptyDisposable.Instance;
+                return synchronous;
             }
 
-            if (task.IsCanceled || token.IsCancellationRequested)
-            {
-                observer.OnError(new OperationCanceledException());
-                return EmptyDisposable.Instance;
-            }
+            _ = ObserveTask(task.WhenCancelled(token), _shouldEmit, observer, gate, token);
 
-            if (task.IsFaulted)
-            {
-                observer.OnError(task.Exception!.InnerException ?? task.Exception);
-                return EmptyDisposable.Instance;
-            }
-
-            ImmediateTaskSubscription subscription = new(SourceCore);
-            _ = ObserveTask(
-                task.WhenCancelled(token),
-                _shouldEmit,
-                observer,
-                subscription.MarkCompleted,
-                subscription.MarkFaulted,
-                token);
-
-            return subscription;
+            return CancelOnDispose(gate, SourceCore);
         }
 
         /// <inheritdoc/>
@@ -373,42 +383,21 @@ public static partial class Signal
 
             throw new ObjectDisposedException(nameof(ImmediateTaskSignal<>));
         }
+    }
 
-        /// <summary>Subscription for pending immediate tasks.</summary>
-        private sealed class ImmediateTaskSubscription : IDisposable
-        {
-            /// <summary>Completed state marker.</summary>
-            private const int Completed = 1;
+    /// <summary>Atomic gate that serializes the terminal notification against subscription disposal.</summary>
+    /// <remarks>
+    /// Mirrors the <c>TaskInstanceSubscription.TryStop()</c> pattern: both the task continuation and the
+    /// disposer race on a single <see cref="Interlocked.Exchange(ref int, int)"/>; only the winner proceeds,
+    /// so a notification can never reach a subscription that has already been disposed.
+    /// </remarks>
+    private sealed class TaskStopGate
+    {
+        /// <summary>Non-zero once the continuation has emitted or the subscription has been disposed.</summary>
+        private int _stopped;
 
-            /// <summary>Faulted state marker.</summary>
-            private const int Faulted = 2;
-
-            /// <summary>Cancellation source to cancel while pending.</summary>
-            private readonly CancellationTokenSource _source;
-
-            /// <summary>Completion state.</summary>
-            private int _state;
-
-            /// <summary>Initializes a new instance of the <see cref="ImmediateTaskSubscription"/> class.</summary>
-            /// <param name="source">Cancellation source.</param>
-            public ImmediateTaskSubscription(CancellationTokenSource source) => _source = source;
-
-            /// <summary>Marks the task completed.</summary>
-            public void MarkCompleted() => Volatile.Write(ref _state, Completed);
-
-            /// <summary>Marks the task faulted.</summary>
-            public void MarkFaulted() => Volatile.Write(ref _state, Faulted);
-
-            /// <inheritdoc/>
-            public void Dispose()
-            {
-                if (Volatile.Read(ref _state) == Completed)
-                {
-                    return;
-                }
-
-                Cancel(_source);
-            }
-        }
+        /// <summary>Attempts to win the terminal transition.</summary>
+        /// <returns><see langword="true"/> when this caller won the stop race.</returns>
+        public bool TryStop() => Interlocked.Exchange(ref _stopped, 1) == 0;
     }
 }

--- a/src/tests/ReactiveUI.Primitives.Tests/SignalFromTaskTest.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/SignalFromTaskTest.cs
@@ -146,6 +146,66 @@ public class SignalFromTaskTest
         await Assert.That(finalErrors).Contains(nameof(TaskCanceledException));
     }
 
+    /// <summary>Disposing the immediate subscription before the awaited task completes suppresses the terminal notification.</summary>
+    /// <returns>A <see cref = "Task"/> representing the asynchronous unit test.</returns>
+    [Test]
+    public async Task DisposeBeforeImmediateTaskCompletionSuppressesTerminalNotification()
+    {
+        ConcurrentQueue<int> values = new();
+        ConcurrentQueue<string> errors = new();
+        var completed = 0;
+        TaskCompletionSource<int> gate = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        var taskSignal = Signal.FromTask(_ => gate.Task, Sequencer.Immediate);
+        try
+        {
+            var subscription = taskSignal.Subscribe(values.Enqueue, error => errors.Enqueue(error.GetType().Name), () => Interlocked.Increment(ref completed));
+
+            // Dispose while the awaited task is still pending, then release the continuation.
+            subscription.Dispose();
+            gate.SetResult(SuccessValue);
+
+            // Give the continuation ample time to run; it must observe the dispose and stay silent.
+            await Task.Delay(InitialDelayMilliseconds).ConfigureAwait(false);
+            await Assert.That(values).IsEmpty();
+            await Assert.That(errors).IsEmpty();
+            await Assert.That(Volatile.Read(ref completed)).IsEqualTo(0);
+        }
+        finally
+        {
+            (taskSignal as IDisposable)?.Dispose();
+        }
+    }
+
+    /// <summary>Disposing the scheduled subscription before the awaited task completes suppresses the terminal notification.</summary>
+    /// <returns>A <see cref = "Task"/> representing the asynchronous unit test.</returns>
+    [Test]
+    public async Task DisposeBeforeScheduledTaskCompletionSuppressesTerminalNotification()
+    {
+        ConcurrentQueue<int> values = new();
+        ConcurrentQueue<string> errors = new();
+        var completed = 0;
+        TaskCompletionSource<int> gate = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        var taskSignal = Signal.FromTask(_ => gate.Task);
+        try
+        {
+            var subscription = taskSignal.Subscribe(values.Enqueue, error => errors.Enqueue(error.GetType().Name), () => Interlocked.Increment(ref completed));
+
+            // Dispose while the awaited task is still pending, then release the continuation.
+            subscription.Dispose();
+            gate.SetResult(SuccessValue);
+
+            // Give the continuation ample time to run; it must observe the dispose and stay silent.
+            await Task.Delay(InitialDelayMilliseconds).ConfigureAwait(false);
+            await Assert.That(values).IsEmpty();
+            await Assert.That(errors).IsEmpty();
+            await Assert.That(Volatile.Read(ref completed)).IsEqualTo(0);
+        }
+        finally
+        {
+            (taskSignal as IDisposable)?.Dispose();
+        }
+    }
+
     /// <summary>Signals from task handles user exceptions.</summary>
     /// <returns>A <see cref = "Task"/> representing the asynchronous unit test.</returns>
     [Test]

--- a/src/tests/ReactiveUI.Primitives.Tests/SignalFromTaskTest.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/SignalFromTaskTest.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for full license information.
 
 using System.Collections.Concurrent;
+using ReactiveUI.Primitives.Advanced;
 using ReactiveUI.Primitives.Concurrency;
 using ReactiveUI.Primitives.Signals;
 
@@ -146,6 +147,157 @@ public class SignalFromTaskTest
         await Assert.That(finalErrors).Contains(nameof(TaskCanceledException));
     }
 
+    /// <summary>A synchronously completed task emits its result and completes through the immediate path.</summary>
+    /// <returns>A <see cref = "Task"/> representing the asynchronous unit test.</returns>
+    [Test]
+    public async Task ImmediateSynchronousSuccessEmitsResultAndCompletes()
+    {
+        ConcurrentQueue<int> values = new();
+        ConcurrentQueue<string> errors = new();
+        var completed = 0;
+        var taskSignal = Signal.FromTask(_ => Task.FromResult(SuccessValue), Sequencer.Immediate);
+        try
+        {
+            _ = taskSignal.Subscribe(values.Enqueue, error => errors.Enqueue(error.GetType().Name), () => Interlocked.Increment(ref completed));
+            await Assert.That(values.SequenceEqual([SuccessValue])).IsTrue();
+            await Assert.That(errors).IsEmpty();
+            await Assert.That(Volatile.Read(ref completed)).IsEqualTo(1);
+        }
+        finally
+        {
+            (taskSignal as IDisposable)?.Dispose();
+        }
+    }
+
+    /// <summary>A synchronously canceled task errors with a cancellation through the immediate path.</summary>
+    /// <returns>A <see cref = "Task"/> representing the asynchronous unit test.</returns>
+    [Test]
+    public async Task ImmediateSynchronousCanceledTaskErrors()
+    {
+        ConcurrentQueue<int> values = new();
+        ConcurrentQueue<string> errors = new();
+        var taskSignal = Signal.FromTask(_ => Task.FromCanceled<int>(new(true)), Sequencer.Immediate);
+        try
+        {
+            _ = taskSignal.Subscribe(values.Enqueue, error => errors.Enqueue(error.GetType().Name), () => { });
+            await Assert.That(values).IsEmpty();
+            await Assert.That(errors.SequenceEqual([nameof(OperationCanceledException)])).IsTrue();
+        }
+        finally
+        {
+            (taskSignal as IDisposable)?.Dispose();
+        }
+    }
+
+    /// <summary>A synchronously faulted task forwards the exception through the immediate path.</summary>
+    /// <returns>A <see cref = "Task"/> representing the asynchronous unit test.</returns>
+    [Test]
+    public async Task ImmediateSynchronousFaultedTaskForwardsError()
+    {
+        ConcurrentQueue<int> values = new();
+        ConcurrentQueue<string> errors = new();
+        var taskSignal = Signal.FromTask(_ => Task.FromException<int>(new InvalidOperationException(BreakExecutionMessage)), Sequencer.Immediate);
+        try
+        {
+            _ = taskSignal.Subscribe(values.Enqueue, error => errors.Enqueue(error.GetType().Name), () => { });
+            await Assert.That(values).IsEmpty();
+            await Assert.That(errors.SequenceEqual([nameof(InvalidOperationException)])).IsTrue();
+        }
+        finally
+        {
+            (taskSignal as IDisposable)?.Dispose();
+        }
+    }
+
+    /// <summary>A throwing task factory forwards the exception through the immediate path.</summary>
+    /// <returns>A <see cref = "Task"/> representing the asynchronous unit test.</returns>
+    [Test]
+    public async Task ImmediateFactoryThrowForwardsError()
+    {
+        ConcurrentQueue<int> values = new();
+        ConcurrentQueue<string> errors = new();
+        var taskSignal = Signal.FromTask<int>(_ => throw new InvalidOperationException(BreakExecutionMessage), Sequencer.Immediate);
+        try
+        {
+            _ = taskSignal.Subscribe(values.Enqueue, error => errors.Enqueue(error.GetType().Name), () => { });
+            await Assert.That(values).IsEmpty();
+            await Assert.That(errors.SequenceEqual([nameof(InvalidOperationException)])).IsTrue();
+        }
+        finally
+        {
+            (taskSignal as IDisposable)?.Dispose();
+        }
+    }
+
+    /// <summary>A throwing task factory forwards the exception through the scheduled path.</summary>
+    /// <returns>A <see cref = "Task"/> representing the asynchronous unit test.</returns>
+    [Test]
+    public async Task ScheduledFactoryThrowForwardsError()
+    {
+        ConcurrentQueue<int> values = new();
+        ConcurrentQueue<string> errors = new();
+        var taskSignal = Signal.FromTask<int>(_ => throw new InvalidOperationException(BreakExecutionMessage));
+        try
+        {
+            _ = taskSignal.Subscribe(values.Enqueue, error => errors.Enqueue(error.GetType().Name), () => { });
+            await TestPolling.SpinUntil(() => !errors.IsEmpty, TimeSpan.FromSeconds(2)).ConfigureAwait(false);
+            await Assert.That(values).IsEmpty();
+            await Assert.That(errors.SequenceEqual([nameof(InvalidOperationException)])).IsTrue();
+        }
+        finally
+        {
+            (taskSignal as IDisposable)?.Dispose();
+        }
+    }
+
+    /// <summary>A pending task that faults after subscription forwards the exception via the continuation through the immediate path.</summary>
+    /// <returns>A <see cref = "Task"/> representing the asynchronous unit test.</returns>
+    [Test]
+    public async Task ImmediatePendingTaskFaultForwardsErrorViaContinuation()
+    {
+        ConcurrentQueue<int> values = new();
+        ConcurrentQueue<string> errors = new();
+        TaskCompletionSource<int> gate = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        var taskSignal = Signal.FromTask(_ => gate.Task, Sequencer.Immediate);
+        try
+        {
+            _ = taskSignal.Subscribe(values.Enqueue, error => errors.Enqueue(error.GetType().Name), () => { });
+            gate.SetException(new InvalidOperationException(BreakExecutionMessage));
+            await TestPolling.SpinUntil(() => !errors.IsEmpty, TimeSpan.FromSeconds(2)).ConfigureAwait(false);
+            await Assert.That(values).IsEmpty();
+            await Assert.That(errors.SequenceEqual([nameof(InvalidOperationException)])).IsTrue();
+        }
+        finally
+        {
+            (taskSignal as IDisposable)?.Dispose();
+        }
+    }
+
+    /// <summary>A pending task that completes after subscription emits the result via the continuation through the immediate path.</summary>
+    /// <returns>A <see cref = "Task"/> representing the asynchronous unit test.</returns>
+    [Test]
+    public async Task ImmediatePendingTaskSuccessEmitsResultViaContinuation()
+    {
+        ConcurrentQueue<int> values = new();
+        ConcurrentQueue<string> errors = new();
+        var completed = 0;
+        TaskCompletionSource<int> gate = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        var taskSignal = Signal.FromTask(_ => gate.Task, Sequencer.Immediate);
+        try
+        {
+            _ = taskSignal.Subscribe(values.Enqueue, error => errors.Enqueue(error.GetType().Name), () => Interlocked.Increment(ref completed));
+            gate.SetResult(SuccessValue);
+            await TestPolling.SpinUntil(() => Volatile.Read(ref completed) == 1, TimeSpan.FromSeconds(2)).ConfigureAwait(false);
+            await Assert.That(values.SequenceEqual([SuccessValue])).IsTrue();
+            await Assert.That(errors).IsEmpty();
+            await Assert.That(Volatile.Read(ref completed)).IsEqualTo(1);
+        }
+        finally
+        {
+            (taskSignal as IDisposable)?.Dispose();
+        }
+    }
+
     /// <summary>Disposing the immediate subscription before the awaited task completes suppresses the terminal notification.</summary>
     /// <returns>A <see cref = "Task"/> representing the asynchronous unit test.</returns>
     [Test]
@@ -204,6 +356,57 @@ public class SignalFromTaskTest
         {
             (taskSignal as IDisposable)?.Dispose();
         }
+    }
+
+    /// <summary>The non-generic RxVoid factory honors the scheduler overload and emits a completion.</summary>
+    /// <returns>A <see cref = "Task"/> representing the asynchronous unit test.</returns>
+    [Test]
+    public async Task RxVoidFactoryWithSchedulerEmitsCompletion()
+    {
+        var completed = 0;
+        var taskSignal = Signal.FromTask(_ => Task.FromResult(RxVoid.Default), Sequencer.Immediate);
+        try
+        {
+            _ = taskSignal.Subscribe(_ => { }, error => throw error, () => Interlocked.Increment(ref completed));
+            await Assert.That(Volatile.Read(ref completed)).IsEqualTo(1);
+        }
+        finally
+        {
+            (taskSignal as IDisposable)?.Dispose();
+        }
+    }
+
+    /// <summary>The immediate signal reports cancellation and disposal state and fires the cancellation callback once disposed.</summary>
+    /// <returns>A <see cref = "Task"/> representing the asynchronous unit test.</returns>
+    [Test]
+    public async Task ImmediateSignalReportsStateAndFiresCancellationCallbackOnDispose()
+    {
+        TaskCompletionSource<int> gate = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        var taskSignal = Signal.FromTask(_ => gate.Task, Sequencer.Immediate);
+        var canceledRaised = 0;
+        await Assert.That(taskSignal.IsCancellationRequested).IsFalse();
+        await Assert.That(taskSignal.IsDisposed).IsFalse();
+        taskSignal.GetOperationCanceled(Witness.Create<Exception>(_ => Interlocked.Increment(ref canceledRaised)));
+
+        ((IDisposable)taskSignal).Dispose();
+
+        await Assert.That(taskSignal.IsDisposed).IsTrue();
+        await Assert.That(taskSignal.IsCancellationRequested).IsTrue();
+        await TestPolling.SpinUntil(() => Volatile.Read(ref canceledRaised) == 1, TimeSpan.FromSeconds(2)).ConfigureAwait(false);
+        await Assert.That(Volatile.Read(ref canceledRaised)).IsEqualTo(1);
+
+        // A second dispose is a no-op (covers the already-disposed early return).
+        ((IDisposable)taskSignal).Dispose();
+        await Assert.That(taskSignal.IsDisposed).IsTrue();
+    }
+
+    /// <summary>Subscribing to a disposed immediate signal throws.</summary>
+    [Test]
+    public void ImmediateSignalSubscribeAfterDisposeThrows()
+    {
+        var taskSignal = Signal.FromTask(_ => Task.FromResult(SuccessValue), Sequencer.Immediate);
+        ((IDisposable)taskSignal).Dispose();
+        _ = Assert.Throws<ObjectDisposedException>(() => taskSignal.Subscribe(_ => { }));
     }
 
     /// <summary>Signals from task handles user exceptions.</summary>

--- a/src/tests/ReactiveUI.Primitives.Tests/SignalFromTaskTest.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/SignalFromTaskTest.cs
@@ -250,6 +250,80 @@ public class SignalFromTaskTest
         }
     }
 
+    /// <summary>A synchronously completed task emits its result through the scheduled synchronous fast path.</summary>
+    /// <returns>A <see cref = "Task"/> representing the asynchronous unit test.</returns>
+    [Test]
+    public async Task ScheduledSynchronousSuccessEmitsResultAndCompletes()
+    {
+        ConcurrentQueue<int> values = new();
+        ConcurrentQueue<string> errors = new();
+        var completed = 0;
+        var taskSignal = Signal.FromTask(_ => Task.FromResult(SuccessValue), Sequencer.CurrentThread);
+        try
+        {
+            _ = taskSignal.Subscribe(values.Enqueue, error => errors.Enqueue(error.GetType().Name), () => Interlocked.Increment(ref completed));
+            await TestPolling.SpinUntil(() => Volatile.Read(ref completed) == 1, TimeSpan.FromSeconds(2)).ConfigureAwait(false);
+            await Assert.That(values.SequenceEqual([SuccessValue])).IsTrue();
+            await Assert.That(errors).IsEmpty();
+        }
+        finally
+        {
+            (taskSignal as IDisposable)?.Dispose();
+        }
+    }
+
+    /// <summary>A synchronously canceled task errors through the scheduled synchronous fast path.</summary>
+    /// <returns>A <see cref = "Task"/> representing the asynchronous unit test.</returns>
+    [Test]
+    public async Task ScheduledSynchronousCanceledTaskErrors()
+    {
+        ConcurrentQueue<int> values = new();
+        ConcurrentQueue<string> errors = new();
+        var taskSignal = Signal.FromTask(_ => Task.FromCanceled<int>(new(true)), Sequencer.CurrentThread);
+        try
+        {
+            _ = taskSignal.Subscribe(values.Enqueue, error => errors.Enqueue(error.GetType().Name), () => { });
+            await TestPolling.SpinUntil(() => !errors.IsEmpty, TimeSpan.FromSeconds(2)).ConfigureAwait(false);
+            await Assert.That(values).IsEmpty();
+            await Assert.That(errors.SequenceEqual([nameof(OperationCanceledException)])).IsTrue();
+        }
+        finally
+        {
+            (taskSignal as IDisposable)?.Dispose();
+        }
+    }
+
+    /// <summary>Disposing a subscription whose cancellation source was already disposed swallows the resulting error.</summary>
+    /// <returns>A <see cref = "Task"/> representing the asynchronous unit test.</returns>
+    [Test]
+    public async Task DisposeAfterCancellationSourceDisposedSwallowsObjectDisposedException()
+    {
+        ConcurrentQueue<int> values = new();
+        ConcurrentQueue<string> errors = new();
+        TaskCompletionSource<int> gate = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        var cts = new CancellationTokenSource();
+        var taskSignal = Signal.FromTask(_ => gate.Task, Sequencer.Immediate, cts);
+        try
+        {
+            var subscription = taskSignal.Subscribe(values.Enqueue, error => errors.Enqueue(error.GetType().Name), () => { });
+
+            // Dispose the cancellation source out from under the subscription, then dispose the
+            // subscription. The disposer wins the gate and calls Cancel on the disposed source,
+            // which must swallow the ObjectDisposedException.
+            cts.Dispose();
+            subscription.Dispose();
+
+            gate.SetResult(SuccessValue);
+            await Task.Delay(InitialDelayMilliseconds).ConfigureAwait(false);
+            await Assert.That(values).IsEmpty();
+            await Assert.That(errors).IsEmpty();
+        }
+        finally
+        {
+            (taskSignal as IDisposable)?.Dispose();
+        }
+    }
+
     /// <summary>A pending task that faults after subscription forwards the exception via the continuation through the immediate path.</summary>
     /// <returns>A <see cref = "Task"/> representing the asynchronous unit test.</returns>
     [Test]


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the new behavior?

`Signal.FromTask` now gates its terminal notification on an atomic stop transition shared between the awaited task's continuation (`ObserveTask`) and the subscription disposer. A new private `TaskStopGate` exposes `TryStop()` (an `Interlocked.Exchange` CAS) that both sides race on; only the winner emits.

- If the subscription is disposed first, the disposer wins the gate and cancels the source; the continuation loses and stays silent — no `OnNext`/`OnCompleted`/`OnError` reaches the disposed subscription.
- If the task completes first, the continuation wins and emits the terminal notification; the disposer loses and does nothing.

This mirrors the existing `TaskInstanceSubscription.TryStop()` pattern already used elsewhere in the repo. The fix applies to both the scheduled subscription path (`SubscribeTask`) and the `Sequencer.Immediate` path (`ImmediateTaskSignal.Subscribe`); the synchronous fast-paths and the disposer route through the same gate.

## What is the current behavior?

The terminal notification was gated only by a non-atomic `token.IsCancellationRequested` check, and the disposer merely cancelled the token. A subscription disposed while the awaited task completed could still receive `OnNext`/`OnCompleted`/`OnError` after teardown — a post-dispose grammar violation. (The added immediate-path test reproduces this: pre-fix it delivered a stray `OnError(OperationCanceledException)` after dispose.)

Closes #72

## What might this PR break?

None. Behaviour change is limited to suppressing post-dispose notifications; the public API is unchanged. All existing `Signal.FromTask`/task-signal tests continue to pass.

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [x] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information

Two deterministic tests added in `SignalFromTaskTest` (`DisposeBeforeImmediateTaskCompletionSuppressesTerminalNotification` and `DisposeBeforeScheduledTaskCompletionSuppressesTerminalNotification`): subscribe to a `TaskCompletionSource`-backed task, dispose the subscription while the task is still pending, then complete the task and assert no value, error, or completion is observed. Full `ReactiveUI.Primitives.Tests` (499) and `ReactiveUI.Primitives.Async.Tests` (1232) pass; full solution builds clean with analyzers satisfied (no pragmas).