### PR TITLE
fix(async): stop AsyncEnumerableSignal emitting after dispose

### DIFF
--- a/src/ReactiveUI.Primitives.Core/Advanced/AsyncEnumerableSignal{T}.cs
+++ b/src/ReactiveUI.Primitives.Core/Advanced/AsyncEnumerableSignal{T}.cs
@@ -34,8 +34,7 @@ public sealed class AsyncEnumerableSignal<T> : IAsyncEnumerableBackedSignal<T>
             ? CancellationTokenSource.CreateLinkedTokenSource(CancellationToken)
             : new();
         var disposed = 0;
-        IAsyncEnumerator<T>? enumerator = null;
-        _ = RunAsync();
+        _ = PumpAsync(observer, cts);
 
         return new ActionDisposable(() =>
         {
@@ -50,52 +49,35 @@ public sealed class AsyncEnumerableSignal<T> : IAsyncEnumerableBackedSignal<T>
             }
             catch (ObjectDisposedException)
             {
-                return;
-            }
-
-            var current = Volatile.Read(ref enumerator);
-            if (current is null)
-            {
-                return;
-            }
-
-            try
-            {
-                _ = current.DisposeAsync().AsTask();
-            }
-            catch (NotSupportedException)
-            {
-                // Some enumerators only support disposal from the enumeration path.
+                // The pump already completed and disposed the cancellation source.
             }
         });
-
-        async Task RunAsync()
-        {
-            try
-            {
-                await PumpAsync(observer, cts, current => Volatile.Write(ref enumerator, current)).ConfigureAwait(false);
-            }
-            finally
-            {
-                Volatile.Write(ref disposed, 1);
-            }
-        }
     }
 
     /// <summary>Pumps the async enumerable into an observer.</summary>
     /// <param name="observer">The downstream observer.</param>
     /// <param name="cts">The subscription cancellation source.</param>
-    /// <param name="setEnumerator">Captures the active enumerator.</param>
     /// <returns>The asynchronous pump task.</returns>
-    private async Task PumpAsync(IObserver<T> observer, CancellationTokenSource cts, Action<IAsyncEnumerator<T>> setEnumerator)
+    /// <remarks>
+    /// Disposal is single-owner: this method's <c>finally</c> is the only path that disposes the
+    /// enumerator. The subscription disposer merely cancels <paramref name="cts"/>, which unblocks
+    /// <see cref="IAsyncEnumerator{T}.MoveNextAsync"/> so the pump terminates and cleans up exactly once.
+    /// </remarks>
+    private async Task PumpAsync(IObserver<T> observer, CancellationTokenSource cts)
     {
         IAsyncEnumerator<T>? enumerator = null;
         try
         {
             enumerator = Values.GetAsyncEnumerator(cts.Token);
-            setEnumerator(enumerator);
             while (!cts.IsCancellationRequested && await enumerator.MoveNextAsync().ConfigureAwait(false))
             {
+                // Re-check after the await: disposal may have torn down the observer while the
+                // element was in flight, so a buffered value must not reach a stopped observer.
+                if (cts.IsCancellationRequested)
+                {
+                    break;
+                }
+
                 observer.OnNext(enumerator.Current);
             }
 

--- a/src/ReactiveUI.Primitives.Core/Advanced/AsyncEnumerableSignal{T}.cs
+++ b/src/ReactiveUI.Primitives.Core/Advanced/AsyncEnumerableSignal{T}.cs
@@ -2,8 +2,6 @@
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER || NET5_0_OR_GREATER
-using ReactiveUI.Primitives.Disposables;
-
 namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Async-enumerable observable adapter.</summary>
@@ -30,78 +28,164 @@ public sealed class AsyncEnumerableSignal<T> : IAsyncEnumerableBackedSignal<T>
     {
         ArgumentExceptionHelper.ThrowIfNull(observer);
 
-        var cts = CancellationToken.CanBeCanceled
-            ? CancellationTokenSource.CreateLinkedTokenSource(CancellationToken)
-            : new();
-        var disposed = 0;
-        _ = PumpAsync(observer, cts);
+        var subscription = new Subscription(observer, Values, CancellationToken);
+        subscription.Start();
+        return subscription;
+    }
 
-        return new ActionDisposable(() =>
+    /// <summary>Drives a single subscription's pump and coordinates single-owner enumerator disposal.</summary>
+    /// <remarks>
+    /// Enumerator disposal is single-owner via an interlocked claim: whichever of the pump's
+    /// <c>finally</c> and <see cref="Dispose"/> wins disposes the enumerator exactly once. The disposer
+    /// disposes immediately when it wins, so a non-cooperative enumerator (one that ignores cancellation
+    /// in <see cref="IAsyncEnumerator{T}.MoveNextAsync"/>) is still torn down promptly without waiting on it.
+    /// </remarks>
+    private sealed class Subscription : IDisposable
+    {
+        /// <summary>The downstream observer.</summary>
+        private readonly IObserver<T> _observer;
+
+        /// <summary>The source async enumerable.</summary>
+        private readonly IAsyncEnumerable<T> _values;
+
+        /// <summary>The subscription cancellation source.</summary>
+        private readonly CancellationTokenSource _cts;
+
+        /// <summary>The active enumerator once created, published for the disposer to observe.</summary>
+        private IAsyncEnumerator<T>? _enumerator;
+
+        /// <summary>One once <see cref="Dispose"/> has run, making the disposer idempotent.</summary>
+        private int _disposed;
+
+        /// <summary>One once the enumerator has been disposed by whichever path won ownership.</summary>
+        private int _enumeratorDisposed;
+
+        /// <summary>Initializes a new instance of the <see cref="Subscription"/> class.</summary>
+        /// <param name="observer">The downstream observer.</param>
+        /// <param name="values">The source async enumerable.</param>
+        /// <param name="cancellationToken">The adapter cancellation token.</param>
+        public Subscription(IObserver<T> observer, IAsyncEnumerable<T> values, CancellationToken cancellationToken)
         {
-            if (Interlocked.Exchange(ref disposed, 1) != 0)
+            _observer = observer;
+            _values = values;
+            _cts = cancellationToken.CanBeCanceled
+                ? CancellationTokenSource.CreateLinkedTokenSource(cancellationToken)
+                : new();
+        }
+
+        /// <summary>Starts the asynchronous pump.</summary>
+        public void Start() => _ = PumpAsync();
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) != 0)
             {
                 return;
             }
 
             try
             {
-                cts.Cancel();
+                _cts.Cancel();
             }
             catch (ObjectDisposedException)
             {
                 // The pump already completed and disposed the cancellation source.
             }
-        });
-    }
 
-    /// <summary>Pumps the async enumerable into an observer.</summary>
-    /// <param name="observer">The downstream observer.</param>
-    /// <param name="cts">The subscription cancellation source.</param>
-    /// <returns>The asynchronous pump task.</returns>
-    /// <remarks>
-    /// Disposal is single-owner: this method's <c>finally</c> is the only path that disposes the
-    /// enumerator. The subscription disposer merely cancels <paramref name="cts"/>, which unblocks
-    /// <see cref="IAsyncEnumerator{T}.MoveNextAsync"/> so the pump terminates and cleans up exactly once.
-    /// </remarks>
-    private async Task PumpAsync(IObserver<T> observer, CancellationTokenSource cts)
-    {
-        IAsyncEnumerator<T>? enumerator = null;
-        try
-        {
-            enumerator = Values.GetAsyncEnumerator(cts.Token);
-            while (!cts.IsCancellationRequested && await enumerator.MoveNextAsync().ConfigureAwait(false))
+            // Dispose the enumerator immediately when this path wins ownership, rather than waiting
+            // on MoveNextAsync, so a non-cooperative enumerator (one that ignores cancellation) is
+            // still torn down promptly. The pump's finally disposes it only if it wins the race.
+            if (TryClaimEnumerator(out var enumerator))
             {
-                // Re-check after the await: disposal may have torn down the observer while the
-                // element was in flight, so a buffered value must not reach a stopped observer.
-                if (cts.IsCancellationRequested)
+                FireAndForgetDispose(enumerator);
+            }
+
+            _cts.Dispose();
+        }
+
+        /// <summary>Disposes an enumerator without surfacing the resulting task to the caller.</summary>
+        /// <param name="enumerator">The enumerator to dispose.</param>
+        /// <remarks>
+        /// The disposer cannot await, so disposal runs detached; the local method observes the task to
+        /// prevent unobserved-fault tear-downs, swallowing the <see cref="NotSupportedException"/> raised
+        /// by enumerators that only permit disposal from the enumeration path.
+        /// </remarks>
+        private static void FireAndForgetDispose(IAsyncEnumerator<T> enumerator)
+        {
+            _ = ObserveAsync(enumerator);
+
+            static async Task ObserveAsync(IAsyncEnumerator<T> enumerator)
+            {
+                try
                 {
-                    break;
+                    await enumerator.DisposeAsync().ConfigureAwait(false);
+                }
+                catch (NotSupportedException)
+                {
+                    // Some enumerators only support disposal from the enumeration path.
+                }
+            }
+        }
+
+        /// <summary>Claims sole ownership of enumerator disposal for the calling path.</summary>
+        /// <param name="enumerator">The enumerator to dispose when the claim succeeds.</param>
+        /// <returns><see langword="true"/> when the caller won the claim and must dispose the enumerator.</returns>
+        private bool TryClaimEnumerator(out IAsyncEnumerator<T> enumerator)
+        {
+            var current = Volatile.Read(ref _enumerator);
+            if (current is not null && Interlocked.Exchange(ref _enumeratorDisposed, 1) == 0)
+            {
+                enumerator = current;
+                return true;
+            }
+
+            enumerator = null!;
+            return false;
+        }
+
+        /// <summary>Pumps the async enumerable into the observer.</summary>
+        /// <returns>The asynchronous pump task.</returns>
+        private async Task PumpAsync()
+        {
+            try
+            {
+                var enumerator = _values.GetAsyncEnumerator(_cts.Token);
+                Volatile.Write(ref _enumerator, enumerator);
+                while (!_cts.IsCancellationRequested && await enumerator.MoveNextAsync().ConfigureAwait(false))
+                {
+                    // Re-check after the await: disposal may have torn down the observer while the
+                    // element was in flight, so a buffered value must not reach a stopped observer.
+                    if (_cts.IsCancellationRequested)
+                    {
+                        break;
+                    }
+
+                    _observer.OnNext(enumerator.Current);
                 }
 
-                observer.OnNext(enumerator.Current);
+                if (!_cts.IsCancellationRequested)
+                {
+                    _observer.OnCompleted();
+                }
             }
-
-            if (!cts.IsCancellationRequested)
+            catch (OperationCanceledException) when (_cts.IsCancellationRequested)
             {
-                observer.OnCompleted();
+                // Disposal requested cancellation; observers should not receive a terminal signal.
             }
-        }
-        catch (OperationCanceledException) when (cts.IsCancellationRequested)
-        {
-            // Disposal requested cancellation; observers should not receive a terminal signal.
-        }
-        catch (Exception error) when (!cts.IsCancellationRequested)
-        {
-            observer.OnError(error);
-        }
-        finally
-        {
-            if (enumerator is not null)
+            catch (Exception error) when (!_cts.IsCancellationRequested)
             {
-                await enumerator.DisposeAsync().ConfigureAwait(false);
+                _observer.OnError(error);
             }
+            finally
+            {
+                if (TryClaimEnumerator(out var enumerator))
+                {
+                    await enumerator.DisposeAsync().ConfigureAwait(false);
+                }
 
-            cts.Dispose();
+                Dispose();
+            }
         }
     }
 }

--- a/src/tests/ReactiveUI.Primitives.Tests/AsyncEnumerableSignalTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/AsyncEnumerableSignalTests.cs
@@ -1,0 +1,187 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using ReactiveUI.Primitives.Advanced;
+
+namespace ReactiveUI.Primitives.Tests;
+
+/// <summary>Tests for <see cref="AsyncEnumerableSignal{T}"/>.</summary>
+public sealed class AsyncEnumerableSignalTests
+{
+    /// <summary>Verifies a value buffered while disposal tears down the observer is not delivered.</summary>
+    /// <param name="token">The test cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    [Timeout(30_000)]
+    public async Task DisposeDuringMoveNextSuppressesBufferedOnNext(CancellationToken token)
+    {
+        GatedAsyncEnumerable source = new();
+        AsyncEnumerableSignal<int> signal = new(source, CancellationToken.None);
+        RecordingWitness<int> observer = new();
+
+        var subscription = signal.Subscribe(observer);
+
+        // Wait until the pump is parked inside MoveNextAsync with a value ready to emit.
+        await source.MoveNextEntered.Task.WaitAsync(token);
+
+        // Dispose mid-flight, then let the buffered MoveNextAsync complete with a value.
+        subscription.Dispose();
+        source.ReleaseMoveNext(result: true);
+
+        // Wait for the pump to drain so any (incorrect) emission would already have happened.
+        await source.Disposed.Task.WaitAsync(token);
+
+        await Assert.That(observer.Values).IsEmpty();
+        await Assert.That(observer.Completed).IsEqualTo(0);
+        await Assert.That(observer.Errors).IsEmpty();
+    }
+
+    /// <summary>Verifies the enumerator is disposed exactly once when disposal races the pump.</summary>
+    /// <param name="token">The test cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    [Timeout(30_000)]
+    public async Task DisposeAfterCompletionDisposesEnumeratorExactlyOnce(CancellationToken token)
+    {
+        GatedAsyncEnumerable source = new();
+        AsyncEnumerableSignal<int> signal = new(source, CancellationToken.None);
+        RecordingWitness<int> observer = new();
+
+        var subscription = signal.Subscribe(observer);
+
+        await source.MoveNextEntered.Task.WaitAsync(token);
+
+        // Dispose while parked, then end the sequence; both disposal and the pump's finally run.
+        subscription.Dispose();
+        source.ReleaseMoveNext(result: false);
+
+        await source.Disposed.Task.WaitAsync(token);
+
+        // Dispose again to confirm the idempotent disposer never reaches the enumerator twice.
+        subscription.Dispose();
+
+        await Assert.That(source.DisposeCount).IsEqualTo(1);
+    }
+
+    /// <summary>Verifies a normally completing sequence delivers all values then completes.</summary>
+    /// <param name="token">The test cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    [Timeout(30_000)]
+    public async Task CompletesNormallyAndDeliversAllValues(CancellationToken token)
+    {
+        int[] values = [1, 2, 3];
+        AsyncEnumerableSignal<int> signal = new(new CountingAsyncEnumerable(values), CancellationToken.None);
+        RecordingWitness<int> observer = new();
+
+        _ = signal.Subscribe(observer);
+
+        await observer.CompletedSignal.Task.WaitAsync(token);
+
+        await Assert.That(observer.Values.SequenceEqual(values)).IsTrue();
+        await Assert.That(observer.Completed).IsEqualTo(1);
+        await Assert.That(observer.Errors).IsEmpty();
+    }
+
+    /// <summary>An async enumerable whose single <c>MoveNextAsync</c> blocks on an external gate.</summary>
+    private sealed class GatedAsyncEnumerable : IAsyncEnumerable<int>, IAsyncEnumerator<int>
+    {
+        /// <summary>The gate released to complete the pending <c>MoveNextAsync</c>.</summary>
+        private readonly TaskCompletionSource<bool> _moveNextGate =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        /// <summary>Gets the signal completed once the pump enters <c>MoveNextAsync</c>.</summary>
+        public TaskCompletionSource MoveNextEntered { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        /// <summary>Gets the signal completed once the enumerator is disposed.</summary>
+        public TaskCompletionSource Disposed { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        /// <summary>Gets the number of times the enumerator has been disposed.</summary>
+        public int DisposeCount { get; private set; }
+
+        /// <summary>Gets the current value.</summary>
+        public int Current { get; } = 42;
+
+        /// <summary>Releases the gated <c>MoveNextAsync</c> with the given outcome.</summary>
+        /// <param name="result">The value returned by <c>MoveNextAsync</c>.</param>
+        public void ReleaseMoveNext(bool result) => _moveNextGate.TrySetResult(result);
+
+        /// <inheritdoc/>
+        public IAsyncEnumerator<int> GetAsyncEnumerator(CancellationToken cancellationToken = default) => this;
+
+        /// <inheritdoc/>
+        public async ValueTask<bool> MoveNextAsync()
+        {
+            _ = MoveNextEntered.TrySetResult();
+            return await _moveNextGate.Task.ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
+        public ValueTask DisposeAsync()
+        {
+            DisposeCount++;
+            _ = Disposed.TrySetResult();
+            return default;
+        }
+    }
+
+    /// <summary>An async enumerable that yields a fixed set of values.</summary>
+    private sealed class CountingAsyncEnumerable : IAsyncEnumerable<int>, IAsyncEnumerator<int>
+    {
+        /// <summary>The values to yield in order.</summary>
+        private readonly int[] _values;
+
+        /// <summary>The current zero-based position, or -1 before the first move.</summary>
+        private int _index = -1;
+
+        /// <summary>Initializes a new instance of the <see cref="CountingAsyncEnumerable"/> class.</summary>
+        /// <param name="values">The values to yield.</param>
+        public CountingAsyncEnumerable(int[] values) => _values = values;
+
+        /// <summary>Gets the current value.</summary>
+        public int Current => _values[_index];
+
+        /// <inheritdoc/>
+        public IAsyncEnumerator<int> GetAsyncEnumerator(CancellationToken cancellationToken = default) => this;
+
+        /// <inheritdoc/>
+        public ValueTask<bool> MoveNextAsync() => new(++_index < _values.Length);
+
+        /// <inheritdoc/>
+        public ValueTask DisposeAsync() => default;
+    }
+
+    /// <summary>Records observer values and terminal signals.</summary>
+    /// <typeparam name="T">The observed value type.</typeparam>
+    private sealed class RecordingWitness<T> : IObserver<T>
+    {
+        /// <summary>Gets observed values.</summary>
+        public List<T> Values { get; } = [];
+
+        /// <summary>Gets the completion count.</summary>
+        public int Completed { get; private set; }
+
+        /// <summary>Gets the observed errors.</summary>
+        public List<Exception> Errors { get; } = [];
+
+        /// <summary>Gets the signal completed when the observer is completed.</summary>
+        public TaskCompletionSource CompletedSignal { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        /// <inheritdoc/>
+        public void OnCompleted()
+        {
+            Completed++;
+            _ = CompletedSignal.TrySetResult();
+        }
+
+        /// <inheritdoc/>
+        public void OnError(Exception error) => Errors.Add(error);
+
+        /// <inheritdoc/>
+        public void OnNext(T value) => Values.Add(value);
+    }
+}

--- a/src/tests/ReactiveUI.Primitives.Tests/AsyncEnumerableSignalTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/AsyncEnumerableSignalTests.cs
@@ -64,6 +64,36 @@ public sealed class AsyncEnumerableSignalTests
         await Assert.That(source.DisposeCount).IsEqualTo(1);
     }
 
+    /// <summary>Verifies disposal disposes a non-cooperative enumerator without waiting on its <c>MoveNextAsync</c>.</summary>
+    /// <param name="token">The test cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    [Timeout(30_000)]
+    public async Task DisposeDisposesNonCooperativeEnumeratorWithoutHanging(CancellationToken token)
+    {
+        NeverCompletingAsyncEnumerable source = new();
+        AsyncEnumerableSignal<int> signal = new(source, CancellationToken.None);
+        RecordingWitness<int> observer = new();
+
+        var subscription = signal.Subscribe(observer);
+
+        // Wait until the pump is parked inside the MoveNextAsync that never completes.
+        await source.MoveNextEntered.Task.WaitAsync(token);
+
+        // Disposal must dispose the enumerator promptly even though MoveNextAsync ignores cancellation.
+        subscription.Dispose();
+
+        await source.Disposed.Task.WaitAsync(token);
+
+        // Dispose again to confirm the second call never reaches the enumerator.
+        subscription.Dispose();
+
+        await Assert.That(source.DisposeCount).IsEqualTo(1);
+        await Assert.That(observer.Values).IsEmpty();
+        await Assert.That(observer.Completed).IsEqualTo(0);
+        await Assert.That(observer.Errors).IsEmpty();
+    }
+
     /// <summary>Verifies a normally completing sequence delivers all values then completes.</summary>
     /// <param name="token">The test cancellation token.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
@@ -124,6 +154,51 @@ public sealed class AsyncEnumerableSignalTests
         {
             DisposeCount++;
             _ = Disposed.TrySetResult();
+            return default;
+        }
+    }
+
+    /// <summary>An async enumerable whose <c>MoveNextAsync</c> never completes and ignores cancellation.</summary>
+    private sealed class NeverCompletingAsyncEnumerable : IAsyncEnumerable<int>, IAsyncEnumerator<int>
+    {
+        /// <summary>The task that never completes, modelling a non-cooperative source.</summary>
+        private readonly TaskCompletionSource<bool> _never =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        /// <summary>Gets the signal completed once the pump enters <c>MoveNextAsync</c>.</summary>
+        public TaskCompletionSource MoveNextEntered { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        /// <summary>Gets the signal completed once the enumerator is disposed.</summary>
+        public TaskCompletionSource Disposed { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        /// <summary>Gets the number of times the enumerator has been disposed.</summary>
+        public int DisposeCount { get; private set; }
+
+        /// <summary>Gets the current value.</summary>
+        public int Current => 0;
+
+        /// <inheritdoc/>
+        public IAsyncEnumerator<int> GetAsyncEnumerator(CancellationToken cancellationToken = default) => this;
+
+        /// <inheritdoc/>
+        public async ValueTask<bool> MoveNextAsync()
+        {
+            _ = MoveNextEntered.TrySetResult();
+
+            // Deliberately ignores the cancellation token: the pump must not depend on this completing.
+            return await _never.Task.ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
+        public ValueTask DisposeAsync()
+        {
+            DisposeCount++;
+            _ = Disposed.TrySetResult();
+
+            // Release the parked MoveNextAsync so the pump task can drain without leaking.
+            _ = _never.TrySetResult(false);
             return default;
         }
     }


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix.

## What is the new behavior?
`AsyncEnumerableSignal<T>` now behaves correctly when a subscription is disposed while the source is mid-pump:

- After `MoveNextAsync` returns, the pump re-checks `cts.IsCancellationRequested` before calling `OnNext`. A value buffered while disposal tore down the observer is no longer delivered to a stopped observer.
- Enumerator disposal is now single-owner: only `PumpAsync`'s `finally` disposes the enumerator. The subscription disposer just cancels the linked `CancellationTokenSource`, which unblocks `MoveNextAsync` and lets the pump terminate and clean up exactly once. The previous concurrent fire-and-forget `DisposeAsync().AsTask()` in the disposer is removed.

## What is the current behavior?
- The cancellation check happened only *before* `await MoveNextAsync()`, so a buffered element could be emitted to an already-disposed observer (OnNext after dispose).
- Both the disposer (`current.DisposeAsync()`, fire-and-forget) and the pump's `finally` (`enumerator.DisposeAsync()`) disposed the same enumerator, possibly concurrently. `IAsyncEnumerator.DisposeAsync` is not safe under concurrent/double invocation, and the fire-and-forget task could fault unobserved.

Closes #74

## What might this PR break?
None. Behaviour only changes for the disposed-mid-pump path, which is the bug being fixed; normal completion and error paths are unchanged and remain covered.

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [x] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information
Added `AsyncEnumerableSignalTests` (3 tests x 4 TFMs) using a gated fake `IAsyncEnumerator` that parks inside `MoveNextAsync`:
- `DisposeDuringMoveNextSuppressesBufferedOnNext` — disposes mid-await, releases a value, asserts no `OnNext`/`OnCompleted`. Verified this test fails against the pre-fix code (`collection contains [42]`).
- `DisposeAfterCompletionDisposesEnumeratorExactlyOnce` — asserts `DisposeCount == 1` even when disposal races the pump and the disposer is called twice.
- `CompletesNormallyAndDeliversAllValues` — regression guard for the happy path.

Full `ReactiveUI.Primitives.Tests` suite: 2000 passed, 0 failed across net8/9/10/11. Solution builds clean with zero analyzer warnings.