### PR TITLE
fix(multicast): gate replayed values to prevent reorder and duplication

### DIFF
--- a/src/Primitives.Shared/Signals/ReplaySignal{T}.cs
+++ b/src/Primitives.Shared/Signals/ReplaySignal{T}.cs
@@ -188,10 +188,10 @@ public sealed class ReplaySignal<T> : ISignal<T>
             {
                 Trim();
             }
-        }
 
-        _broadcaster.Completed();
-        _broadcaster.Clear();
+            _broadcaster.Completed();
+            _broadcaster.Clear();
+        }
     }
 
     /// <summary>Called when [error].</summary>
@@ -215,14 +215,21 @@ public sealed class ReplaySignal<T> : ISignal<T>
             {
                 Trim();
             }
-        }
 
-        _broadcaster.Error(error);
-        _broadcaster.Clear();
+            _broadcaster.Error(error);
+            _broadcaster.Clear();
+        }
     }
 
     /// <summary>Called when [next].</summary>
     /// <param name="value">The value.</param>
+    /// <remarks>
+    /// The buffer append and the broadcast happen together under <see cref="_observerLock"/>, which is the
+    /// same gate <see cref="Subscribe"/> holds while it adds an observer and replays the buffer. A value is
+    /// therefore atomically either buffered-and-broadcast before a new observer is added (so that observer
+    /// receives it only via replay) or buffered-and-broadcast after the observer's replay completes (so it
+    /// receives it only live) - never both, and never out of order.
+    /// </remarks>
     public void OnNext(T value)
     {
         // Read the scheduler clock outside the lock; the window inputs are immutable.
@@ -244,9 +251,9 @@ public sealed class ReplaySignal<T> : ISignal<T>
                 _queue!.Enqueue(new(value, interval));
                 Trim();
             }
-        }
 
-        _broadcaster.Next(value);
+            _broadcaster.Next(value);
+        }
     }
 
     /// <summary>Subscribes the specified observer.</summary>

--- a/src/ReactiveUI.Primitives.Core/Signals/BehaviorSignalState{T}.cs
+++ b/src/ReactiveUI.Primitives.Core/Signals/BehaviorSignalState{T}.cs
@@ -86,6 +86,11 @@ internal record struct BehaviorSignalState<T>
     }
 
     /// <summary>Notifies all observers about the end of the sequence.</summary>
+    /// <remarks>
+    /// The broadcast runs under <see cref="_gate"/> so it serializes against <see cref="Subscribe"/>: a new
+    /// subscriber is either added before this completes (and is broadcast to here) or after (and replays the
+    /// terminal state itself), never seeing an out-of-order or duplicated notification.
+    /// </remarks>
     public void OnCompleted()
     {
         lock (_gate)
@@ -97,10 +102,9 @@ internal record struct BehaviorSignalState<T>
             }
 
             _isStopped = true;
+            _broadcaster.Completed();
+            _broadcaster.Clear();
         }
-
-        _broadcaster.Completed();
-        _broadcaster.Clear();
     }
 
     /// <summary>Notifies all observers about the exception.</summary>
@@ -119,14 +123,18 @@ internal record struct BehaviorSignalState<T>
 
             _isStopped = true;
             _lastError = error;
+            _broadcaster.Error(error);
+            _broadcaster.Clear();
         }
-
-        _broadcaster.Error(error);
-        _broadcaster.Clear();
     }
 
     /// <summary>Notifies all observers about the arrival of the specified value.</summary>
     /// <param name="value">The value to send to all observers.</param>
+    /// <remarks>
+    /// The latest-value update and the broadcast happen together under <see cref="_gate"/>, so they are atomic
+    /// with respect to <see cref="Subscribe"/>; a new subscriber never observes a live value before the initial
+    /// value it was promised, and never observes the same value twice.
+    /// </remarks>
     public void OnNext(T value)
     {
         lock (_gate)
@@ -137,9 +145,8 @@ internal record struct BehaviorSignalState<T>
             }
 
             _lastValue = value;
+            _broadcaster.Next(value);
         }
-
-        _broadcaster.Next(value);
     }
 
     /// <summary>Subscribes an observer, replaying the current value or terminal notification.</summary>
@@ -151,28 +158,23 @@ internal record struct BehaviorSignalState<T>
         ArgumentExceptionHelper.ThrowIfNull(observer);
 
         var ex = default(Exception);
-        var v = default(T);
-        BehaviorWitnessHandler<T>? subscription = null;
 
         lock (_gate)
         {
             ThrowIfDisposed();
             if (!_isStopped)
             {
+                // Add and deliver the initial value under the same gate that serializes live broadcast, so
+                // the new observer is either added before a concurrent OnNext (and sees the initial value
+                // first, then the live value) or after it (and the live value becomes its initial value).
+                // It can never observe a newer live value ahead of, or in addition to, its initial value.
                 _broadcaster.Add(observer);
-                v = _lastValue;
-                subscription = new(owner, observer);
+                var subscription = new BehaviorWitnessHandler<T>(owner, observer);
+                observer.OnNext(_lastValue!);
+                return subscription;
             }
-            else
-            {
-                ex = _lastError;
-            }
-        }
 
-        if (subscription is not null)
-        {
-            observer.OnNext(v!);
-            return subscription;
+            ex = _lastError;
         }
 
         if (ex is not null)

--- a/src/tests/ReactiveUI.Primitives.Tests/BehaviourSignalTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/BehaviourSignalTests.cs
@@ -230,4 +230,40 @@ public class BehaviourSignalTests
         _ = Assert.Throws<ObjectDisposedException>(() => _ = s.Value);
         await Assert.That(s.TryGetValue(out _)).IsFalse();
     }
+
+    /// <summary>
+    /// A new subscriber that races a live <see cref="BehaviorSignal{T}.OnNext"/> must never observe a newer
+    /// value before the initial value it was promised; the values it receives stay monotonically ordered.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task Subscribe_RacingOnNext_NeverDeliversNewerValueBeforeInitial()
+    {
+        const int subscribeAttempts = 50_000;
+
+        BehaviorSignal<int> signal = new(0);
+        using CancellationTokenSource stop = new();
+        var firstFailure = default(OrderingWitness<int>.OutOfOrderDelivery);
+
+        var producer = Task.Run(() =>
+        {
+            var value = 1;
+            while (!stop.IsCancellationRequested)
+            {
+                signal.OnNext(value++);
+            }
+        });
+
+        for (var attempt = 0; attempt < subscribeAttempts && firstFailure is null; attempt++)
+        {
+            OrderingWitness<int> witness = new();
+            signal.Subscribe(witness).Dispose();
+            firstFailure = witness.OutOfOrder;
+        }
+
+        await stop.CancelAsync();
+        await producer;
+
+        await Assert.That(firstFailure).IsNull();
+    }
 }

--- a/src/tests/ReactiveUI.Primitives.Tests/Common/OrderingWitness.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/Common/OrderingWitness.cs
@@ -1,0 +1,53 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace ReactiveUI.Primitives.Tests;
+
+/// <summary>
+/// An observer that watches a monotonically increasing stream and flags the first delivery that breaks the
+/// ordering contract: a value that is not strictly greater than the one before it. A repeat of the previous
+/// value (a duplicate) or a smaller value (a reorder) both trip the flag.
+/// </summary>
+/// <typeparam name="T">The observed value type.</typeparam>
+internal sealed class OrderingWitness<T> : IObserver<T>
+    where T : IComparable<T>
+{
+    /// <summary>The most recently observed value, or <see langword="default"/> before the first value.</summary>
+    private T? _previous;
+
+    /// <summary>Whether at least one value has been observed.</summary>
+    private bool _hasPrevious;
+
+    /// <summary>Gets the first delivery that broke ordering, or <see langword="null"/> when none did.</summary>
+    public OutOfOrderDelivery? OutOfOrder { get; private set; }
+
+    /// <summary>Records a completion callback.</summary>
+    public void OnCompleted()
+    {
+    }
+
+    /// <summary>Records an error callback.</summary>
+    /// <param name="error">The error to record.</param>
+    public void OnError(Exception error)
+    {
+    }
+
+    /// <summary>Records a value callback and flags the first out-of-order or duplicate delivery.</summary>
+    /// <param name="value">The value to record.</param>
+    public void OnNext(T value)
+    {
+        if (_hasPrevious && OutOfOrder is null && value.CompareTo(_previous!) <= 0)
+        {
+            OutOfOrder = new(_previous!.ToString(), value!.ToString());
+        }
+
+        _previous = value;
+        _hasPrevious = true;
+    }
+
+    /// <summary>The previous and offending values for the first delivery that broke ordering.</summary>
+    /// <param name="Previous">The value observed immediately before the offending one.</param>
+    /// <param name="Offending">The value that was not strictly greater than <paramref name="Previous"/>.</param>
+    internal sealed record OutOfOrderDelivery(string? Previous, string? Offending);
+}

--- a/src/tests/ReactiveUI.Primitives.Tests/ReplaySignalTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/ReplaySignalTests.cs
@@ -228,6 +228,54 @@ public class ReplaySignalTests
         await Assert.That(state.ParamName).IsEqualTo("selector");
     }
 
+    /// <summary>
+    /// A new subscriber that races a live <see cref="ReplaySignal{T}.OnNext"/> must receive each value exactly
+    /// once: the replayed buffer must not duplicate or reorder a value that is also delivered live.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task Subscribe_RacingOnNext_DeliversEachValueOnce()
+    {
+        await RaceSubscribeAgainstProducer(() => new(1));
+        await RaceSubscribeAgainstProducer(() => new(Three));
+    }
+
+    /// <summary>
+    /// Continuously emits increasing values from one thread while another thread repeatedly subscribes and
+    /// disposes, asserting that no subscriber ever receives a value out of order or twice.
+    /// </summary>
+    /// <param name = "factory">Factory used to create the replay signal under test.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    private static async Task RaceSubscribeAgainstProducer(Func<ReplaySignal<int>> factory)
+    {
+        const int subscribeAttempts = 50_000;
+
+        using var signal = factory();
+        using CancellationTokenSource stop = new();
+        var firstFailure = default(OrderingWitness<int>.OutOfOrderDelivery);
+
+        var producer = Task.Run(() =>
+        {
+            var value = 1;
+            while (!stop.IsCancellationRequested)
+            {
+                signal.OnNext(value++);
+            }
+        });
+
+        for (var attempt = 0; attempt < subscribeAttempts && firstFailure is null; attempt++)
+        {
+            OrderingWitness<int> witness = new();
+            signal.Subscribe(witness).Dispose();
+            firstFailure = witness.OutOfOrder;
+        }
+
+        await stop.CancelAsync();
+        await producer;
+
+        await Assert.That(firstFailure).IsNull();
+    }
+
     /// <summary>Creates a replay signal and disposes it immediately.</summary>
     /// <param name = "factory">Factory used to create the signal.</param>
     private static void CreateAndDispose(Func<ReplaySignal<int>> factory)


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix.

## What is the new behavior?
Replayed/initial values can no longer interleave with live broadcast, so a new subscriber sees each value exactly once and in order:

- **`BehaviorSignal<T>`** delivers the initial value to a new subscriber under the same gate that serializes live broadcast, and broadcasts `OnNext`/`OnError`/`OnCompleted` under that gate. Adding the observer and delivering its initial value is now atomic with respect to a concurrent `OnNext`: the subscriber is either added before the live value (and sees `initial` then `live`) or after it (and the live value simply becomes its initial value). It can never observe a newer live value ahead of its promised initial value. This matches `BehaviorSubject<T>`, which calls `OnNext(value)` inside its gate in `Subscribe`.
- **`ReplaySignal<T>`** broadcasts live `OnNext` (and terminal notifications) under `_observerLock` — the same lock `Subscribe` already holds while it adds an observer and replays the buffer. A value is therefore atomically either buffered-and-broadcast before a new observer is added (so the observer receives it only via replay) or after the observer's replay completes (so it receives it only live), never both.

Regression tests (`Subscribe_RacingOnNext_*`) run a continuous producer against repeated concurrent subscribe/dispose and assert, via a new `OrderingWitness` helper, that every subscriber's stream is strictly increasing — catching both the reorder and the duplicate.

## What is the current behavior?
Replay and live delivery could interleave for a subscriber that races a live `OnNext`:

- `BehaviorSignal<T>.Subscribe` captured the latest value under the gate but called `observer.OnNext(value)` *after* releasing it, while live `OnNext` broadcast after releasing the gate too. A new subscriber could therefore see a newer live value and then the stale initial value (out of order).
- `ReplaySignal<T>.Subscribe` replayed the buffer under `_observerLock`, but live `OnNext` called `_broadcaster.Next(value)` *outside* the lock, so a value straddling the subscribe could be delivered twice (once via replay, once live).

Reproduced deterministically by the new tests on the pre-fix code: Behavior reported `Previous = 7028, Offending = 7021` (reorder); Replay reported `Previous = 27861, Offending = 27861` (duplicate).

Closes #75.

## What might this PR break?
None expected. Live broadcast now runs under the existing gate/observer lock rather than just after releasing it; this serializes notifications (the intended fix) but does mean user `OnNext`/`OnError`/`OnCompleted` callbacks execute while the gate is held, matching how `BehaviorSubject` already behaves. Re-entrant calls into the same signal from within a callback would deadlock on the non-reentrant lock, consistent with the existing `ReplaySignal` replay path, which already invoked user callbacks under the lock.

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [x] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information
Full solution suite: 9880 passed, 0 failed across all TFMs. Build is clean with 0 warnings (analyzers satisfied, no pragmas).