### PR TITLE
test(operators): make throttle supersession tests deterministic

### DIFF
--- a/src/tests/ReactiveUI.Primitives.Async.Tests/TimeBasedOperatorTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Async.Tests/TimeBasedOperatorTests.cs
@@ -671,14 +671,21 @@ public class TimeBasedOperatorTests
         DirectSource<int> source = new();
         List<int> items = [];
         TaskCompletionSource completed = new(TaskCreationOptions.RunContinuationsAsynchronously);
-        TaskCompletionSource lastEmitted = new(TaskCreationOptions.RunContinuationsAsynchronously);
         await using var sub = await source.Throttle(TimeSpan.FromMilliseconds(50), manualProvider).SubscribeAsync(
-            (x, ct) =>
+            async (x, ct) =>
             {
                 _ = ct;
                 items.Add(x);
-                _ = x == LastValue && lastEmitted.TrySetResult();
-                return default;
+
+                // Drive completion re-entrantly from the throttled emission itself. The emission
+                // runs on a pooled timer continuation; completing the source from the test thread
+                // would race that still-unwinding OnNext call and trip the witness's concurrent-call
+                // guard, silently dropping the completion. Completing from inside the handler keeps
+                // both notifications on the same thread, where re-entrant calls are permitted.
+                if (x == LastValue)
+                {
+                    await source.Complete(Result.Success);
+                }
             },
             null,
             _ =>
@@ -692,8 +699,6 @@ public class TimeBasedOperatorTests
 
         await Assert.That(manualProvider.TimerCount).IsEqualTo(LastValue);
         manualProvider.FireAll();
-        await lastEmitted.Task.WaitAsync(TimeSpan.FromSeconds(5));
-        await source.Complete(Result.Success);
         await completed.Task.WaitAsync(TimeSpan.FromSeconds(5));
         await Assert.That(items).Contains(LastValue);
     }

--- a/src/tests/ReactiveUI.Primitives.Extensions.Tests/Operators/ThrottleUntilTrueObservableTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Extensions.Tests/Operators/ThrottleUntilTrueObservableTests.cs
@@ -2,6 +2,7 @@
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.Collections.Concurrent;
 using System.Reactive.Subjects;
 
 namespace ReactiveUI.Primitives.Extensions.Tests.Operators;
@@ -64,13 +65,23 @@ public class ThrottleUntilTrueObservableTests
         const int Earlier = 1;
         const int Later = 2;
         Subject<int> subject = new();
-        TaskCompletionSource<int> emitted = new(TaskCreationOptions.RunContinuationsAsynchronously);
-        using var sub = subject.ThrottleUntilTrue(ThrottleWindow, static _ => false)
-            .Subscribe(v => emitted.TrySetResult(v));
+        ConcurrentQueue<int> emissions = new();
+        TaskCompletionSource laterArrived = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var sub = subject.ThrottleUntilTrue(ThrottleWindow, static _ => false).Subscribe(v =>
+        {
+            emissions.Enqueue(v);
+            _ = v == Later && laterArrived.TrySetResult();
+        });
         subject.OnNext(Earlier);
         subject.OnNext(Later);
-        var got = await emitted.Task.WaitAsync(TimeSpan.FromSeconds(5));
-        await Assert.That(got).IsEqualTo(Later);
+
+        // Later's timer is never superseded, so it always fires; wait on that deterministically
+        // rather than racing the wall-clock window. Under scheduling pressure Earlier's timer may
+        // still slip through first, so assert the invariant the operator guarantees: whatever the
+        // intermediate emissions, the final value observed is the latest one.
+        await laterArrived.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        var observed = emissions.ToArray();
+        await Assert.That(observed[^1]).IsEqualTo(Later);
     }
 
     /// <summary>Verifies that source errors are forwarded.</summary>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Test-only fix for two flaky throttle supersession tests. No product code changes.

## What is the new behavior?

Both tests now drive ordering with explicit synchronization instead of racing wall-clock timing:

- **`WhenThrottleReceivesRapidValues_ThenOnlyEmitsLatest`** (Async.Tests) now completes the `DirectSource` re-entrantly from inside the throttled emission handler. Because the emission and the completion then run on the same thread, the `WitnessAsync` concurrent-call guard is never tripped, so completion is always delivered. The redundant `lastEmitted` TCS is removed; the test now simply awaits `completed`.
- **`WhenThrottleUntilTrueFastReplacements_ThenLatestWins`** (Extensions.Tests) now records every emission and waits on the *later* value (whose throttle timer is never superseded), then asserts the final observed value is the latest one — instead of latching whichever emission happened to arrive first into a single-value TCS.

## What is the current behavior?

Both tests intermittently failed under CI load:

- `WhenThrottleReceivesRapidValues_ThenOnlyEmitsLatest` failed with a 5s `TimeoutException` at `await completed.Task.WaitAsync(...)`. Root cause: the throttled value-3 emission runs on a pooled timer continuation (the non-system `TimeProvider` path uses `PooledDelaySource` with `RunContinuationsAsynchronously = true`). The test then called `source.Complete(...)` from the test thread. When that raced the still-unwinding `OnNextAsync` call on the pool thread, `WitnessAsync.TryEnterOnSomethingCall` detected a cross-thread concurrent call and silently dropped the completion, so the `completed` TCS was never signalled. This is a test harness race, not a product bug — the product correctly rejects concurrent witness calls.
- `WhenThrottleUntilTrueFastReplacements_ThenLatestWins` failed with "Expected to be 2 but found 1". Root cause: `ThrottleUntilTrue` uses a real wall-clock scheduler with a 50 ms window and exposes no scheduler seam. The two synchronous `OnNext` calls are adjacent, but under thread starvation the earlier value's timer could fire before the later value replaced it, and the single-value `TrySetResult` latched the earlier value permanently.

Reproduced the first flake locally under heavy CPU load (~1 failure in 30 runs with a `TimeoutException`); both fixes then ran green 160/160 (primary) and 60/60 (secondary) under the same load.

Not closing an issue.

## What might this PR break?

None. Test-only change; no production code touched, no analyzer suppressions.

## Checklist
- [x] I have read the Contribute guide
- [x] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows Conventional Commits

## Additional information

Repetition-loop results on net11.0 Release under ~40 concurrent CPU burners (16 cores):

- `WhenThrottleReceivesRapidValues_ThenOnlyEmitsLatest`: pre-fix 1/30 failed (TimeoutException); post-fix 60/60 then 100/100 passed.
- `WhenThrottleUntilTrueFastReplacements_ThenLatestWins`: post-fix 60/60 passed.
- Full `ReactiveUI.Primitives.Async.Tests` and `ReactiveUI.Primitives.Extensions.Tests` projects pass on net11.0.