### PR TITLE
fix: harden R3 bridge generator emission

### DIFF
--- a/src/ReactiveUI.Primitives.R3Bridge.Generator/R3BridgeGenerator.cs
+++ b/src/ReactiveUI.Primitives.R3Bridge.Generator/R3BridgeGenerator.cs
@@ -279,7 +279,7 @@ internal static class R3AsyncBridge
 
         context.RegisterSourceOutput(context.CompilationProvider, static (output, compilation) =>
         {
-            if (compilation.GetTypeByMetadataName("R3.Observable`1") is null)
+            if (!HasR3ObservableShapes(compilation))
             {
                 return;
             }
@@ -289,7 +289,7 @@ internal static class R3AsyncBridge
 
         context.RegisterSourceOutput(context.CompilationProvider, static (output, compilation) =>
         {
-            if (compilation.GetTypeByMetadataName("R3.Observable`1") is null ||
+            if (!HasR3ObservableShapes(compilation) ||
                 compilation.GetTypeByMetadataName("ReactiveUI.Primitives.Async.IObservableAsync`1") is null)
             {
                 return;
@@ -298,4 +298,12 @@ internal static class R3AsyncBridge
             output.AddSource("R3AsyncBridge.g.cs", SourceText.From(AsyncBridgeSource, Encoding.UTF8));
         });
     }
+
+    /// <summary>Checks whether the consumer compilation exposes the R3 shapes used by generated adapters.</summary>
+    /// <param name="compilation">Consumer compilation inspected by the generator.</param>
+    /// <returns><see langword="true"/> when the required R3 observable, observer, and result shapes exist.</returns>
+    private static bool HasR3ObservableShapes(Compilation compilation) =>
+        compilation.GetTypeByMetadataName("R3.Observable`1") is not null &&
+        compilation.GetTypeByMetadataName("R3.Observer`1") is not null &&
+        compilation.GetTypeByMetadataName("R3.Result") is not null;
 }

--- a/src/tests/ReactiveUI.Primitives.Tests/R3BridgeGeneratorTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/R3BridgeGeneratorTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using ReactiveUI.Primitives.Async;
 using ReactiveUI.Primitives.R3Bridge.Generator;
 using ReactiveUI.Primitives.Signals;
 
@@ -16,6 +17,15 @@ public class R3BridgeGeneratorTests
 {
     /// <summary>Generated R3 bridge type marker.</summary>
     private const string R3BridgeName = "R3SignalBridge";
+
+    /// <summary>Generated R3 async bridge type marker.</summary>
+    private const string R3AsyncBridgeName = "R3AsyncBridge";
+
+    /// <summary>Generated marker attribute type name.</summary>
+    private const string GeneratedMarkerName = "PrimitivesR3BridgeGeneratedAttribute";
+
+    /// <summary>Compiler diagnostic raised when a source type conflicts with an imported type.</summary>
+    private const string ConflictingTypeDiagnosticId = "CS0436";
 
     /// <summary>Verifies the R3 bridge generator emits adapters when the R3 shapes are present.</summary>
     /// <returns>A task representing the asynchronous operation.</returns>
@@ -101,6 +111,57 @@ public class R3BridgeGeneratorTests
             static text => text.Contains(R3BridgeName, StringComparison.Ordinal))).IsTrue();
     }
 
+    /// <summary>Verifies the generated marker stays private across project-reference-like compilations.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    [RequiresAssemblyFiles]
+    public async Task R3BridgeGeneratedMarkerDoesNotConflictAcrossProjectReferenceCompilations()
+    {
+        const string LibrarySource = """
+                                     public static class GeneratedLibrary
+                                     {
+                                         public static int Value => 42;
+                                     }
+                                     """;
+        const string ConsumerSource = """
+                                      public static class GeneratedConsumer
+                                      {
+                                          public static int Use() => GeneratedLibrary.Value;
+                                      }
+                                      """;
+        var libraryRun = RunGeneratorsCore("GeneratedLibrary", LibrarySource, []);
+        var libraryEmit = EmitToMetadataReference(libraryRun.Compilation);
+        await Assert.That(ContainsError(libraryRun.GeneratorDiagnostics.Concat(libraryEmit.Diagnostics))).IsFalse();
+        await Assert.That(libraryEmit.Reference).IsNotNull();
+        await Assert.That(GeneratedMarkerIsInternal(libraryRun.GeneratedSources)).IsTrue();
+        var consumerRun = RunGeneratorsCore("GeneratedConsumer", ConsumerSource, [libraryEmit.Reference!]);
+        var consumerDiagnostics = consumerRun.GeneratorDiagnostics
+            .Concat(consumerRun.Compilation.GetDiagnostics())
+            .ToArray();
+        await Assert.That(Array.Exists(consumerDiagnostics, IsConflictingMarkerTypeDiagnostic)).IsFalse();
+        await Assert.That(Array.Exists(consumerDiagnostics, IsErrorDiagnostic)).IsFalse();
+    }
+
+    /// <summary>Verifies the generator skips bridge sources when required R3 shapes are incomplete.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    [RequiresAssemblyFiles]
+    public async Task R3BridgeGeneratorDoesNotEmitAdaptersWhenR3ShapesAreIncomplete()
+    {
+        const string Source = """
+                              namespace R3
+                              {
+                                  public abstract class Observable<T>
+                                  {
+                                  }
+                              }
+                              """;
+        var (diagnostics, generatedSources) = RunGenerators(Source, includeAsyncReference: true);
+        await Assert.That(diagnostics.Length).IsEqualTo(0);
+        await Assert.That(GeneratedBridgeTypeExists(generatedSources, R3BridgeName)).IsFalse();
+        await Assert.That(GeneratedBridgeTypeExists(generatedSources, R3AsyncBridgeName)).IsFalse();
+    }
+
     /// <summary>Verifies the R3 bridge generator skips adapters when the R3 package is absent.</summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     [Test]
@@ -125,22 +186,42 @@ public class R3BridgeGeneratorTests
 
     /// <summary>Runs the R3 bridge source generator for the supplied source.</summary>
     /// <param name="source">Source code to compile.</param>
+    /// <param name="includeAsyncReference">Whether to include the async primitives assembly reference.</param>
     /// <returns>Compilation diagnostics and generated source text.</returns>
     [RequiresAssemblyFiles("Calls System.Reflection.Assembly.Location")]
-    private static (ImmutableArray<Diagnostic> Diagnostics, string[] GeneratedSources) RunGenerators(string source)
+    private static (ImmutableArray<Diagnostic> Diagnostics, string[] GeneratedSources) RunGenerators(
+        string source,
+        bool includeAsyncReference = false)
+    {
+        var run = RunGeneratorsCore("R3BridgeGeneratorSmoke", source, [], includeAsyncReference);
+        ImmutableArray<Diagnostic> diagnostics = [
+            ..run.GeneratorDiagnostics
+                .Concat(run.Compilation.GetDiagnostics()
+                    .Where(IsErrorDiagnostic))
+        ];
+        return (diagnostics, run.GeneratedSources);
+    }
+
+    /// <summary>Runs the R3 bridge source generator and keeps the updated compilation.</summary>
+    /// <param name="assemblyName">Compilation assembly name.</param>
+    /// <param name="source">Source code to compile.</param>
+    /// <param name="additionalReferences">Additional metadata references for project-reference scenarios.</param>
+    /// <param name="includeAsyncReference">Whether to include the async primitives assembly reference.</param>
+    /// <returns>The updated compilation, generator diagnostics, and generated source text.</returns>
+    [RequiresAssemblyFiles("Calls System.Reflection.Assembly.Location")]
+    private static (
+        Compilation Compilation,
+        ImmutableArray<Diagnostic> GeneratorDiagnostics,
+        string[] GeneratedSources) RunGeneratorsCore(
+        string assemblyName,
+        string source,
+        IEnumerable<MetadataReference> additionalReferences,
+        bool includeAsyncReference = false)
     {
         var parseOptions = CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview);
-        var references = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!.ToString()!
-            .Split(Path.PathSeparator)
-            .Where(path => !Path.GetFileName(path).StartsWith("System.Reactive", StringComparison.OrdinalIgnoreCase)
-                           && !Path.GetFileName(path).StartsWith("R3", StringComparison.OrdinalIgnoreCase))
-            .Select(path => MetadataReference.CreateFromFile(path))
-            .Cast<MetadataReference>()
-            .ToList();
-        references.Add(MetadataReference.CreateFromFile(typeof(Signal).Assembly.Location));
-        references.Add(MetadataReference.CreateFromFile(typeof(StateSignal<>).Assembly.Location));
+        var references = CreateReferences(additionalReferences, includeAsyncReference);
         var compilation = CSharpCompilation.Create(
-            "R3BridgeGeneratorSmoke",
+            assemblyName,
             [CSharpSyntaxTree.ParseText(source, parseOptions)],
             references,
             new(OutputKind.DynamicallyLinkedLibrary));
@@ -151,15 +232,83 @@ public class R3BridgeGeneratorTests
             compilation,
             out var updatedCompilation,
             out var generatorDiagnostics);
-        ImmutableArray<Diagnostic> diagnostics = [
-            ..generatorDiagnostics
-                .Concat(updatedCompilation.GetDiagnostics()
-                    .Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error))
-        ];
         var generatedSources = driver.GetRunResult().Results
             .SelectMany(result => result.GeneratedSources)
             .Select(sourceText => sourceText.SourceText.ToString())
             .ToArray();
-        return (diagnostics, generatedSources);
+        return (updatedCompilation, generatorDiagnostics, generatedSources);
     }
+
+    /// <summary>Creates the metadata references needed by in-memory generator smoke compilations.</summary>
+    /// <param name="additionalReferences">Additional metadata references for project-reference scenarios.</param>
+    /// <param name="includeAsyncReference">Whether to include the async primitives assembly reference.</param>
+    /// <returns>Metadata references for the smoke compilation.</returns>
+    [RequiresAssemblyFiles("Calls System.Reflection.Assembly.Location")]
+    private static List<MetadataReference> CreateReferences(
+        IEnumerable<MetadataReference> additionalReferences,
+        bool includeAsyncReference)
+    {
+        var references = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!.ToString()!
+            .Split(Path.PathSeparator)
+            .Where(path => !Path.GetFileName(path).StartsWith("System.Reactive", StringComparison.OrdinalIgnoreCase)
+                           && !Path.GetFileName(path).StartsWith("R3", StringComparison.OrdinalIgnoreCase))
+            .Select(path => MetadataReference.CreateFromFile(path))
+            .Cast<MetadataReference>()
+            .ToList();
+        references.Add(MetadataReference.CreateFromFile(typeof(Signal).Assembly.Location));
+        references.Add(MetadataReference.CreateFromFile(typeof(StateSignal<>).Assembly.Location));
+        if (includeAsyncReference)
+        {
+            references.Add(MetadataReference.CreateFromFile(typeof(IObservableAsync<>).Assembly.Location));
+        }
+
+        references.AddRange(additionalReferences);
+        return references;
+    }
+
+    /// <summary>Emits an in-memory compilation as a metadata reference.</summary>
+    /// <param name="compilation">Compilation to emit.</param>
+    /// <returns>The emit diagnostics and metadata reference when emission succeeds.</returns>
+    private static (ImmutableArray<Diagnostic> Diagnostics, PortableExecutableReference? Reference) EmitToMetadataReference(
+        Compilation compilation)
+    {
+        using MemoryStream stream = new();
+        var result = compilation.Emit(stream);
+        PortableExecutableReference? reference = result.Success
+            ? MetadataReference.CreateFromImage(stream.ToArray())
+            : null;
+        return (result.Diagnostics, reference);
+    }
+
+    /// <summary>Checks whether diagnostics contain any compiler errors.</summary>
+    /// <param name="diagnostics">Diagnostics to inspect.</param>
+    /// <returns><see langword="true"/> when an error diagnostic is present.</returns>
+    private static bool ContainsError(IEnumerable<Diagnostic> diagnostics) => diagnostics.Any(IsErrorDiagnostic);
+
+    /// <summary>Checks whether a diagnostic is an error.</summary>
+    /// <param name="diagnostic">Diagnostic to inspect.</param>
+    /// <returns><see langword="true"/> when the diagnostic is an error.</returns>
+    private static bool IsErrorDiagnostic(Diagnostic diagnostic) => diagnostic.Severity == DiagnosticSeverity.Error;
+
+    /// <summary>Checks whether a diagnostic is the marker-attribute type conflict.</summary>
+    /// <param name="diagnostic">Diagnostic to inspect.</param>
+    /// <returns><see langword="true"/> when the diagnostic is the expected conflict shape.</returns>
+    private static bool IsConflictingMarkerTypeDiagnostic(Diagnostic diagnostic) =>
+        diagnostic.Id == ConflictingTypeDiagnosticId &&
+        diagnostic.GetMessage().Contains(GeneratedMarkerName, StringComparison.Ordinal);
+
+    /// <summary>Checks whether generated source contains the named bridge type.</summary>
+    /// <param name="generatedSources">Generated source text to inspect.</param>
+    /// <param name="typeName">Bridge type name.</param>
+    /// <returns><see langword="true"/> when the bridge type is emitted.</returns>
+    private static bool GeneratedBridgeTypeExists(string[] generatedSources, string typeName) => Array.Exists(
+        generatedSources,
+        text => text.Contains($"internal static class {typeName}", StringComparison.Ordinal));
+
+    /// <summary>Checks whether the generated marker attribute type is internal.</summary>
+    /// <param name="generatedSources">Generated source text to inspect.</param>
+    /// <returns><see langword="true"/> when the marker source declares the attribute as internal.</returns>
+    private static bool GeneratedMarkerIsInternal(string[] generatedSources) => Array.Exists(
+        generatedSources,
+        static text => text.Contains($"internal sealed class {GeneratedMarkerName}", StringComparison.Ordinal));
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix and regression test coverage for the R3 bridge source generator.

## What is the new behavior?

- R3 bridge sources are emitted only when the consumer compilation has the complete R3 shape used by the generated code: `R3.Observable<T>`, `R3.Observer<T>`, and `R3.Result`.
- The R3 generated marker behavior is covered by a project-reference-style regression test to prevent `PrimitivesR3BridgeGeneratedAttribute` from becoming a public cross-assembly conflict again.
- Incomplete R3-shaped compilations no longer get sync or async bridge source emitted.

## What is the current behavior?

- Refit issue reactiveui/refit#2176 reports `CS0436` when a public generated `PrimitivesR3BridgeGeneratedAttribute` appears in both a referenced assembly and the consuming project.
- The async R3 bridge emission guard only checked for `R3.Observable<T>` and async primitives, even though the generated code also referenced `R3.Observer<T>` and `R3.Result`.

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [x] Tests have been added or updated (for bug fixes / features) 
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the main branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) 

## Additional information

Addresses reactiveui/refit#2176.

Validation:

- `dotnet test tests/ReactiveUI.Primitives.Tests/ReactiveUI.Primitives.Tests.csproj -- --treenode-filter "/*/*/R3BridgeGeneratorTests/*"` passed 16 tests across `net8.0`, `net9.0`, `net10.0`, and `net11.0`.
- `dotnet test tests/ReactiveUI.Primitives.Async.Tests/ReactiveUI.Primitives.Async.Tests.csproj -- --treenode-filter "/*/*/AsyncBridgeGeneratorContractTests/*"` passed 8 tests across `net8.0`, `net9.0`, `net10.0`, and `net11.0`.
- TUnit MCP coverage summary reported `ReactiveUI.Primitives.R3Bridge.Generator` at `63/63` covered lines in existing Cobertura data.