### PR TITLE
fix(primitives): support nullable SubscribeSafe static calls

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -112,6 +112,10 @@
     <Using Include="ReactiveUI.Primitives.Internal.ArgumentOutOfRangeExceptionHelper" Alias="ArgumentOutOfRangeExceptionHelper" />
   </ItemGroup>
 
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net9.0'))">
+    <Compile Include="$(MSBuildThisFileDirectory)Polyfills\OverloadResolutionPriorityAttribute.cs" Link="Polyfills\OverloadResolutionPriorityAttribute.cs" />
+  </ItemGroup>
+
   <ItemGroup Condition="!$(TargetFramework.StartsWith('net4')) and '$(IsTestProject)' != 'true'">
     <Using Include="System.ArgumentNullException" Alias="ArgumentExceptionHelper" />
     <Using Include="System.ArgumentOutOfRangeException" Alias="ArgumentOutOfRangeExceptionHelper" />

--- a/src/Polyfills/OverloadResolutionPriorityAttribute.cs
+++ b/src/Polyfills/OverloadResolutionPriorityAttribute.cs
@@ -1,0 +1,21 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+#if !NET9_0_OR_GREATER
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+
+namespace System.Runtime.CompilerServices;
+
+/// <summary>Specifies the relative priority of a member during overload resolution.</summary>
+/// <param name="priority">The overload resolution priority.</param>
+[ExcludeFromCodeCoverage]
+[DebuggerNonUserCode]
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Constructor | AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
+internal sealed class OverloadResolutionPriorityAttribute(int priority) : Attribute
+{
+    /// <summary>Gets the overload resolution priority.</summary>
+    public int Priority { get; } = priority;
+}
+#endif

--- a/src/Primitives.Shared/SignalOperatorParityMixins.RxNames.cs
+++ b/src/Primitives.Shared/SignalOperatorParityMixins.RxNames.cs
@@ -15,6 +15,207 @@ namespace ReactiveUI.Primitives;
 /// </summary>
 public static partial class LinqExtensions
 {
+    /// <summary>Subscribes a nullable reference observer with downstream exception protection from static-call syntax.</summary>
+    /// <param name="source">The source sequence.</param>
+    /// <param name="observer">The observer to subscribe.</param>
+    /// <param name="allowNullable">Reserved for nullable overload resolution.</param>
+    /// <typeparam name="T">The non-nullable reference value type.</typeparam>
+    /// <returns>A disposable that cancels the subscription.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="observer"/> is <see langword="null"/>.</exception>
+    [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
+    public static IDisposable SubscribeSafe<T>(IObservable<T?> source, IObserver<T> observer, params bool[] allowNullable)
+        where T : class
+    {
+        _ = allowNullable;
+        return SubscribeSafeCore(source, (IObserver<T?>)observer);
+    }
+
+    /// <summary>Subscribes a nullable value observer with downstream exception protection from static-call syntax.</summary>
+    /// <param name="source">The source sequence.</param>
+    /// <param name="observer">The observer to subscribe.</param>
+    /// <param name="allowNullable">Reserved for nullable overload resolution.</param>
+    /// <typeparam name="T">The non-nullable value type.</typeparam>
+    /// <returns>A disposable that cancels the subscription.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="observer"/> is <see langword="null"/>.</exception>
+    [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
+    public static IDisposable SubscribeSafe<T>(IObservable<T?> source, IObserver<T?> observer, params bool[] allowNullable)
+        where T : struct
+    {
+        _ = allowNullable;
+        return SubscribeSafeCore(source, observer);
+    }
+
+    /// <summary>Subscribes nullable reference callbacks with downstream exception protection from static-call syntax.</summary>
+    /// <param name="source">The source sequence.</param>
+    /// <param name="onNext">The action to invoke for each value.</param>
+    /// <param name="onError">The action to invoke for an error.</param>
+    /// <param name="allowNullable">Reserved for nullable overload resolution.</param>
+    /// <typeparam name="T">The non-nullable reference value type.</typeparam>
+    /// <returns>A disposable that cancels the subscription.</returns>
+    /// <exception cref="ArgumentNullException">A required argument is <see langword="null"/>.</exception>
+    [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
+    public static IDisposable SubscribeSafe<T>(
+        IObservable<T?> source,
+        Action<T> onNext,
+        Action<Exception> onError,
+        params bool[] allowNullable)
+        where T : class
+    {
+        _ = allowNullable;
+        return SubscribeSafeCore(source, Witness.Create<T?>(value => onNext(value!), onError));
+    }
+
+    /// <summary>Subscribes nullable value callbacks with downstream exception protection from static-call syntax.</summary>
+    /// <param name="source">The source sequence.</param>
+    /// <param name="onNext">The action to invoke for each value.</param>
+    /// <param name="onError">The action to invoke for an error.</param>
+    /// <param name="allowNullable">Reserved for nullable overload resolution.</param>
+    /// <typeparam name="T">The non-nullable value type.</typeparam>
+    /// <returns>A disposable that cancels the subscription.</returns>
+    /// <exception cref="ArgumentNullException">A required argument is <see langword="null"/>.</exception>
+    [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
+    public static IDisposable SubscribeSafe<T>(
+        IObservable<T?> source,
+        Action<T?> onNext,
+        Action<Exception> onError,
+        params bool[] allowNullable)
+        where T : struct
+    {
+        _ = allowNullable;
+        return SubscribeSafeCore(source, Witness.Create(onNext, onError));
+    }
+
+    /// <summary>Subscribes nullable reference callbacks with downstream exception protection from static-call syntax.</summary>
+    /// <param name="source">The source sequence.</param>
+    /// <param name="onNext">The action to invoke for each value.</param>
+    /// <param name="onError">The action to invoke for an error.</param>
+    /// <param name="onCompleted">The action to invoke when the sequence completes.</param>
+    /// <param name="allowNullable">Reserved for nullable overload resolution.</param>
+    /// <typeparam name="T">The non-nullable reference value type.</typeparam>
+    /// <returns>A disposable that cancels the subscription.</returns>
+    /// <exception cref="ArgumentNullException">A required argument is <see langword="null"/>.</exception>
+    [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
+    public static IDisposable SubscribeSafe<T>(
+        IObservable<T?> source,
+        Action<T> onNext,
+        Action<Exception> onError,
+        Action onCompleted,
+        params bool[] allowNullable)
+        where T : class
+    {
+        _ = allowNullable;
+        return SubscribeSafeCore(source, Witness.Create<T?>(value => onNext(value!), onError, onCompleted));
+    }
+
+    /// <summary>Subscribes nullable value callbacks with downstream exception protection from static-call syntax.</summary>
+    /// <param name="source">The source sequence.</param>
+    /// <param name="onNext">The action to invoke for each value.</param>
+    /// <param name="onError">The action to invoke for an error.</param>
+    /// <param name="onCompleted">The action to invoke when the sequence completes.</param>
+    /// <param name="allowNullable">Reserved for nullable overload resolution.</param>
+    /// <typeparam name="T">The non-nullable value type.</typeparam>
+    /// <returns>A disposable that cancels the subscription.</returns>
+    /// <exception cref="ArgumentNullException">A required argument is <see langword="null"/>.</exception>
+    [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
+    public static IDisposable SubscribeSafe<T>(
+        IObservable<T?> source,
+        Action<T?> onNext,
+        Action<Exception> onError,
+        Action onCompleted,
+        params bool[] allowNullable)
+        where T : struct
+    {
+        _ = allowNullable;
+        return SubscribeSafeCore(source, Witness.Create(onNext, onError, onCompleted));
+    }
+
+    /// <summary>Subscribes nullable reference terminal callbacks with downstream exception protection from static-call syntax.</summary>
+    /// <param name="source">The source sequence.</param>
+    /// <param name="onError">The action to invoke for an error.</param>
+    /// <param name="allowNullable">Reserved for nullable overload resolution.</param>
+    /// <typeparam name="T">The non-nullable reference value type.</typeparam>
+    /// <returns>A disposable that cancels the subscription.</returns>
+    /// <exception cref="ArgumentNullException">A required argument is <see langword="null"/>.</exception>
+    [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
+    public static IDisposable SubscribeSafe<T>(IObservable<T?> source, Action<Exception> onError, params bool[] allowNullable)
+        where T : class
+    {
+        _ = allowNullable;
+        return SubscribeSafeCore(source, Witness.Create<T?>(static _ => { }, onError));
+    }
+
+    /// <summary>Subscribes nullable value terminal callbacks with downstream exception protection from static-call syntax.</summary>
+    /// <param name="source">The source sequence.</param>
+    /// <param name="onError">The action to invoke for an error.</param>
+    /// <param name="allowNullable">Reserved for nullable overload resolution.</param>
+    /// <typeparam name="T">The non-nullable value type.</typeparam>
+    /// <returns>A disposable that cancels the subscription.</returns>
+    /// <exception cref="ArgumentNullException">A required argument is <see langword="null"/>.</exception>
+    [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
+    public static IDisposable SubscribeSafe<T>(IObservable<T?> source, Action<Exception> onError, params bool[] allowNullable)
+        where T : struct
+    {
+        _ = allowNullable;
+        return SubscribeSafeCore(source, Witness.Create<T?>(static _ => { }, onError));
+    }
+
+    /// <summary>Subscribes nullable reference terminal callbacks with downstream exception protection from static-call syntax.</summary>
+    /// <param name="source">The source sequence.</param>
+    /// <param name="onError">The action to invoke for an error.</param>
+    /// <param name="onCompleted">The action to invoke when the sequence completes.</param>
+    /// <param name="allowNullable">Reserved for nullable overload resolution.</param>
+    /// <typeparam name="T">The non-nullable reference value type.</typeparam>
+    /// <returns>A disposable that cancels the subscription.</returns>
+    /// <exception cref="ArgumentNullException">A required argument is <see langword="null"/>.</exception>
+    [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
+    public static IDisposable SubscribeSafe<T>(
+        IObservable<T?> source,
+        Action<Exception> onError,
+        Action onCompleted,
+        params bool[] allowNullable)
+        where T : class
+    {
+        _ = allowNullable;
+        return SubscribeSafeCore(source, Witness.Create<T?>(static _ => { }, onError, onCompleted));
+    }
+
+    /// <summary>Subscribes nullable value terminal callbacks with downstream exception protection from static-call syntax.</summary>
+    /// <param name="source">The source sequence.</param>
+    /// <param name="onError">The action to invoke for an error.</param>
+    /// <param name="onCompleted">The action to invoke when the sequence completes.</param>
+    /// <param name="allowNullable">Reserved for nullable overload resolution.</param>
+    /// <typeparam name="T">The non-nullable value type.</typeparam>
+    /// <returns>A disposable that cancels the subscription.</returns>
+    /// <exception cref="ArgumentNullException">A required argument is <see langword="null"/>.</exception>
+    [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
+    public static IDisposable SubscribeSafe<T>(
+        IObservable<T?> source,
+        Action<Exception> onError,
+        Action onCompleted,
+        params bool[] allowNullable)
+        where T : struct
+    {
+        _ = allowNullable;
+        return SubscribeSafeCore(source, Witness.Create<T?>(static _ => { }, onError, onCompleted));
+    }
+
+    /// <summary>Subscribes an observer with downstream exception protection.</summary>
+    /// <param name="source">The source sequence.</param>
+    /// <param name="observer">The observer to subscribe.</param>
+    /// <typeparam name="T">The value type.</typeparam>
+    /// <returns>A disposable that cancels the subscription.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="observer"/> is <see langword="null"/>.</exception>
+    private static SubscribeSafeWitness<T> SubscribeSafeCore<T>(IObservable<T> source, IObserver<T> observer)
+    {
+        ArgumentExceptionHelper.ThrowIfNull(source);
+
+        ArgumentExceptionHelper.ThrowIfNull(observer);
+
+        SubscribeSafeWitness<T> safe = new(observer);
+        safe.SetSubscription(source.Subscribe(safe));
+        return safe;
+    }
+
     /// <summary>System.Reactive-named combining operators for enumerable observable sources.</summary>
     /// <param name="sources">The observable sources.</param>
     /// <typeparam name="T">The value type.</typeparam>
@@ -118,16 +319,7 @@ public static partial class LinqExtensions
         /// <param name="observer">The observer to subscribe.</param>
         /// <returns>A disposable that cancels the subscription.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="observer"/> is <see langword="null"/>.</exception>
-        public IDisposable SubscribeSafe(IObserver<T> observer)
-        {
-            ArgumentExceptionHelper.ThrowIfNull(source);
-
-            ArgumentExceptionHelper.ThrowIfNull(observer);
-
-            SubscribeSafeWitness<T> safe = new(observer);
-            safe.SetSubscription(source.Subscribe(safe));
-            return safe;
-        }
+        public IDisposable SubscribeSafe(IObserver<T> observer) => SubscribeSafeCore(source, observer);
 
         /// <summary>Subscribes callbacks with downstream exception protection.</summary>
         /// <param name="onNext">The action to invoke for each value.</param>
@@ -135,7 +327,7 @@ public static partial class LinqExtensions
         /// <returns>A disposable that cancels the subscription.</returns>
         /// <exception cref="ArgumentNullException">A required argument is <see langword="null"/>.</exception>
         public IDisposable SubscribeSafe(Action<T> onNext, Action<Exception> onError) =>
-            source.SubscribeSafe(Witness.Create(onNext, onError));
+            SubscribeSafeCore(source, Witness.Create(onNext, onError));
 
         /// <summary>Subscribes callbacks with downstream exception protection.</summary>
         /// <param name="onNext">The action to invoke for each value.</param>
@@ -144,14 +336,14 @@ public static partial class LinqExtensions
         /// <returns>A disposable that cancels the subscription.</returns>
         /// <exception cref="ArgumentNullException">A required argument is <see langword="null"/>.</exception>
         public IDisposable SubscribeSafe(Action<T> onNext, Action<Exception> onError, Action onCompleted) =>
-            source.SubscribeSafe(Witness.Create(onNext, onError, onCompleted));
+            SubscribeSafeCore(source, Witness.Create(onNext, onError, onCompleted));
 
         /// <summary>Subscribes terminal callbacks with downstream exception protection.</summary>
         /// <param name="onError">The action to invoke for an error.</param>
         /// <returns>A disposable that cancels the subscription.</returns>
         /// <exception cref="ArgumentNullException">A required argument is <see langword="null"/>.</exception>
         public IDisposable SubscribeSafe(Action<Exception> onError) =>
-            source.SubscribeSafe(Witness.Create<T>(static _ => { }, onError));
+            SubscribeSafeCore(source, Witness.Create<T>(static _ => { }, onError));
 
         /// <summary>Subscribes terminal callbacks with downstream exception protection.</summary>
         /// <param name="onError">The action to invoke for an error.</param>
@@ -159,7 +351,7 @@ public static partial class LinqExtensions
         /// <returns>A disposable that cancels the subscription.</returns>
         /// <exception cref="ArgumentNullException">A required argument is <see langword="null"/>.</exception>
         public IDisposable SubscribeSafe(Action<Exception> onError, Action onCompleted) =>
-            source.SubscribeSafe(Witness.Create<T>(static _ => { }, onError, onCompleted));
+            SubscribeSafeCore(source, Witness.Create<T>(static _ => { }, onError, onCompleted));
 
         /// <summary>Invokes an action for each value while preserving the sequence. System.Reactive name for <c>Tap</c>.</summary>
         /// <param name="onNext">The action to invoke for each value.</param>

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-android/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-android/PublicAPI.Unshipped.txt
@@ -18,6 +18,14 @@ static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this S
 static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T!>! observer, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T?>! observer, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-ios/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-ios/PublicAPI.Unshipped.txt
@@ -18,6 +18,14 @@ static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this S
 static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T!>! observer, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T?>! observer, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-maccatalyst/PublicAPI.Unshipped.txt
@@ -18,6 +18,14 @@ static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this S
 static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T!>! observer, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T?>! observer, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-macos/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-macos/PublicAPI.Unshipped.txt
@@ -18,6 +18,14 @@ static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this S
 static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T!>! observer, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T?>! observer, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-tvos/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-tvos/PublicAPI.Unshipped.txt
@@ -18,6 +18,14 @@ static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this S
 static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T!>! observer, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T?>! observer, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0/PublicAPI.Unshipped.txt
@@ -18,6 +18,14 @@ static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this S
 static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T!>! observer, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T?>! observer, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-android/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-android/PublicAPI.Unshipped.txt
@@ -18,6 +18,14 @@ static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this S
 static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T!>! observer, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T?>! observer, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-ios/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-ios/PublicAPI.Unshipped.txt
@@ -18,6 +18,14 @@ static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this S
 static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T!>! observer, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T?>! observer, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-maccatalyst/PublicAPI.Unshipped.txt
@@ -18,6 +18,14 @@ static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this S
 static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T!>! observer, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T?>! observer, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-macos/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-macos/PublicAPI.Unshipped.txt
@@ -18,6 +18,14 @@ static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this S
 static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T!>! observer, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T?>! observer, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-tvos/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-tvos/PublicAPI.Unshipped.txt
@@ -18,6 +18,14 @@ static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this S
 static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T!>! observer, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T?>! observer, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0/PublicAPI.Unshipped.txt
@@ -18,6 +18,14 @@ static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this S
 static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T!>! observer, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T?>! observer, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net462/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net462/PublicAPI.Unshipped.txt
@@ -18,6 +18,14 @@ static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this S
 static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T!>! observer, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T?>! observer, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -18,6 +18,14 @@ static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this S
 static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T!>! observer, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T?>! observer, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net48/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net48/PublicAPI.Unshipped.txt
@@ -18,6 +18,14 @@ static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this S
 static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T!>! observer, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T?>! observer, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net481/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net481/PublicAPI.Unshipped.txt
@@ -18,6 +18,14 @@ static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this S
 static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T!>! observer, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T?>! observer, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -18,6 +18,14 @@ static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this S
 static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T!>! observer, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T?>! observer, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net9.0/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net9.0/PublicAPI.Unshipped.txt
@@ -18,6 +18,14 @@ static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this S
 static ReactiveUI.Primitives.Reactive.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T!>! observer, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T?>! observer, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler? scheduler) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.Reactive.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net10.0-android/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net10.0-android/PublicAPI.Unshipped.txt
@@ -18,6 +18,14 @@ static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IOb
 static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T!>! observer, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T?>! observer, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net10.0-ios/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net10.0-ios/PublicAPI.Unshipped.txt
@@ -18,6 +18,14 @@ static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IOb
 static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T!>! observer, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T?>! observer, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net10.0-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net10.0-maccatalyst/PublicAPI.Unshipped.txt
@@ -18,6 +18,14 @@ static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IOb
 static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T!>! observer, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T?>! observer, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net10.0-macos/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net10.0-macos/PublicAPI.Unshipped.txt
@@ -18,6 +18,14 @@ static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IOb
 static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T!>! observer, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T?>! observer, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net10.0-tvos/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net10.0-tvos/PublicAPI.Unshipped.txt
@@ -18,6 +18,14 @@ static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IOb
 static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T!>! observer, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T?>! observer, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net10.0/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net10.0/PublicAPI.Unshipped.txt
@@ -18,6 +18,14 @@ static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IOb
 static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T!>! observer, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T?>! observer, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net11.0-android/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net11.0-android/PublicAPI.Unshipped.txt
@@ -18,6 +18,14 @@ static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IOb
 static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T!>! observer, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T?>! observer, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net11.0-ios/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net11.0-ios/PublicAPI.Unshipped.txt
@@ -18,6 +18,14 @@ static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IOb
 static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T!>! observer, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T?>! observer, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net11.0-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net11.0-maccatalyst/PublicAPI.Unshipped.txt
@@ -18,6 +18,14 @@ static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IOb
 static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T!>! observer, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T?>! observer, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net11.0-macos/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net11.0-macos/PublicAPI.Unshipped.txt
@@ -18,6 +18,14 @@ static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IOb
 static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T!>! observer, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T?>! observer, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net11.0-tvos/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net11.0-tvos/PublicAPI.Unshipped.txt
@@ -18,6 +18,14 @@ static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IOb
 static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T!>! observer, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T?>! observer, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net11.0/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net11.0/PublicAPI.Unshipped.txt
@@ -18,6 +18,14 @@ static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IOb
 static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T!>! observer, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T?>! observer, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net462/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net462/PublicAPI.Unshipped.txt
@@ -18,6 +18,14 @@ static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IOb
 static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T!>! observer, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T?>! observer, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -18,6 +18,14 @@ static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IOb
 static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T!>! observer, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T?>! observer, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net48/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net48/PublicAPI.Unshipped.txt
@@ -18,6 +18,14 @@ static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IOb
 static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T!>! observer, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T?>! observer, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net481/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net481/PublicAPI.Unshipped.txt
@@ -18,6 +18,14 @@ static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IOb
 static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T!>! observer, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T?>! observer, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -18,6 +18,14 @@ static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IOb
 static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T!>! observer, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T?>! observer, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net9.0/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net9.0/PublicAPI.Unshipped.txt
@@ -18,6 +18,14 @@ static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IOb
 static ReactiveUI.Primitives.LinqExtensions.DelaySubscription<T>(this System.IObservable<T>! source, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.OfType<TResult>(this System.IObservable<object?>! source) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.LinqExtensions.OnErrorResumeNext<T>(this System.IObservable<T>! source, System.IObservable<T>! second) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T?>! onNext, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T!>! observer, params bool[]! allowNullable) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.IObserver<T?>! observer, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.LinqExtensions.Timeout<TLeft>(this System.IObservable<TLeft>! left, System.DateTimeOffset dueTime, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) -> System.IObservable<TLeft>!
 static ReactiveUI.Primitives.Signals.Signal.Case<TKey, T>(System.Func<TKey>! selector, System.Collections.Generic.IDictionary<TKey, System.IObservable<T>!>! sources) -> System.IObservable<T>!

--- a/src/tests/ReactiveUI.Primitives.Reactive.Tests/LinqExtensionsTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Reactive.Tests/LinqExtensionsTests.cs
@@ -1,0 +1,109 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Reactive.Linq;
+using ReactiveUI.Primitives.Reactive.Signals;
+using ReactiveLinqExtensions = ReactiveUI.Primitives.Reactive.LinqExtensions;
+
+namespace ReactiveUI.Primitives.Reactive.Tests;
+
+/// <summary>Tests for the System.Reactive-flavored LINQ compatibility extensions.</summary>
+public class LinqExtensionsTests
+{
+    /// <summary>The first non-null test value.</summary>
+    private const int One = 1;
+
+    /// <summary>The second non-null test value.</summary>
+    private const int Two = 2;
+
+    /// <summary>The string value used by nullable object subscription tests.</summary>
+    private const string SubscribeSafeValue = "value";
+
+    /// <summary>Verifies fluent <c>SubscribeSafe</c> accepts nullable object values with Rx imports present.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SubscribeSafeFluentAcceptsNullableObjectHandlerWithRxImports()
+    {
+        IObservable<object?> source = Observable.Concat(
+            Observable.Return<object?>(null),
+            Observable.Return<object?>(SubscribeSafeValue));
+        List<object?> values = [];
+        Exception? observed = null;
+
+        void OnNext(object? value) => values.Add(value);
+
+        using var subscription = source.SubscribeSafe(OnNext, error => observed = error);
+
+        await Assert.That(values.SequenceEqual((object?[])[null, SubscribeSafeValue])).IsTrue();
+        await Assert.That(observed).IsNull();
+    }
+
+    /// <summary>Verifies static alias <c>SubscribeSafe</c> accepts nullable object values with Rx imports present.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SubscribeSafeStaticAliasAcceptsNullableObjectHandlerWithRxImports()
+    {
+        IObservable<object?> source = Signal.FromEnumerable<object?>([null, SubscribeSafeValue]);
+        List<object?> values = [];
+        Exception? observed = null;
+
+        void OnNext(object? value) => values.Add(value);
+
+        using var subscription = ReactiveLinqExtensions.SubscribeSafe(source, OnNext, error => observed = error);
+
+        await Assert.That(values.SequenceEqual((object?[])[null, SubscribeSafeValue])).IsTrue();
+        await Assert.That(observed).IsNull();
+    }
+
+    /// <summary>Verifies static alias <c>SubscribeSafe</c> preserves non-nullable reference handlers.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SubscribeSafeStaticAliasAcceptsNonNullableObjectHandlerWithRxImports()
+    {
+        IObservable<string> source = Signal.FromEnumerable([SubscribeSafeValue]);
+        List<string> values = [];
+        Exception? observed = null;
+
+        void OnNext(string value) => values.Add(value);
+
+        using var subscription = ReactiveLinqExtensions.SubscribeSafe(source, OnNext, error => observed = error);
+
+        await Assert.That(values.SequenceEqual([SubscribeSafeValue])).IsTrue();
+        await Assert.That(observed).IsNull();
+    }
+
+    /// <summary>Verifies fluent <c>SubscribeSafe</c> accepts nullable value types with Rx imports present.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SubscribeSafeFluentAcceptsNullableValueTypeHandlerWithRxImports()
+    {
+        IObservable<int?> source = Signal.FromEnumerable<int?>([null, One, null, Two]);
+        List<int?> values = [];
+        Exception? observed = null;
+
+        void OnNext(int? value) => values.Add(value);
+
+        using var subscription = source.SubscribeSafe(OnNext, error => observed = error);
+
+        await Assert.That(values.SequenceEqual((int?[])[null, One, null, Two])).IsTrue();
+        await Assert.That(observed).IsNull();
+    }
+
+    /// <summary>Verifies static alias <c>SubscribeSafe</c> accepts nullable value types with Rx imports present.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SubscribeSafeStaticAliasAcceptsNullableValueTypeHandlerWithRxImports()
+    {
+        IObservable<int?> source = Signal.FromEnumerable<int?>([null, One, null, Two]);
+        List<int?> values = [];
+        Exception? observed = null;
+
+        void OnNext(int? value) => values.Add(value);
+
+        using var subscription = ReactiveLinqExtensions.SubscribeSafe(source, OnNext, error => observed = error);
+
+        await Assert.That(values.SequenceEqual((int?[])[null, One, null, Two])).IsTrue();
+        await Assert.That(observed).IsNull();
+    }
+}

--- a/src/tests/ReactiveUI.Primitives.Reactive.Tests/LinqExtensionsTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Reactive.Tests/LinqExtensionsTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for full license information.
 
 using System.Reactive.Linq;
+using ReactiveUI.Primitives.Advanced;
 using ReactiveUI.Primitives.Reactive.Signals;
 using ReactiveLinqExtensions = ReactiveUI.Primitives.Reactive.LinqExtensions;
 
@@ -105,5 +106,115 @@ public class LinqExtensionsTests
 
         await Assert.That(values.SequenceEqual((int?[])[null, One, null, Two])).IsTrue();
         await Assert.That(observed).IsNull();
+    }
+
+    /// <summary>Verifies static alias <c>SubscribeSafe</c> accepts nullable observer overloads with Rx imports present.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SubscribeSafeStaticAliasAcceptsNullableObserverOverloadsWithRxImports()
+    {
+        IObservable<object?> referenceSource = Signal.FromEnumerable<object?>([null, SubscribeSafeValue]);
+        List<object?> referenceValues = [];
+        var referenceObserver = Witness.Create<object>(
+            referenceValues.Add,
+            static _ => { });
+
+        using var referenceSubscription = ReactiveLinqExtensions.SubscribeSafe(referenceSource, referenceObserver);
+
+        IObservable<int?> valueSource = Signal.FromEnumerable<int?>([null, One, null, Two]);
+        List<int?> valueValues = [];
+        var valueObserver = Witness.Create<int?>(
+            valueValues.Add,
+            static _ => { });
+
+        using var valueSubscription = ReactiveLinqExtensions.SubscribeSafe(valueSource, valueObserver);
+
+        await Assert.That(referenceValues.SequenceEqual((object?[])[null, SubscribeSafeValue])).IsTrue();
+        await Assert.That(valueValues.SequenceEqual((int?[])[null, One, null, Two])).IsTrue();
+    }
+
+    /// <summary>Verifies static alias <c>SubscribeSafe</c> accepts nullable completion callback overloads with Rx imports present.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SubscribeSafeStaticAliasAcceptsNullableCompletionCallbackOverloadsWithRxImports()
+    {
+        IObservable<object?> referenceSource = Signal.FromEnumerable<object?>([null, SubscribeSafeValue]);
+        List<object?> referenceValues = [];
+        Exception? referenceObserved = null;
+        var referenceCompleted = 0;
+
+        void OnReferenceNext(object? value) => referenceValues.Add(value);
+
+        using var referenceSubscription = ReactiveLinqExtensions.SubscribeSafe(
+            referenceSource,
+            OnReferenceNext,
+            error => referenceObserved = error,
+            () => referenceCompleted++);
+
+        IObservable<int?> valueSource = Signal.FromEnumerable<int?>([null, One, null, Two]);
+        List<int?> valueValues = [];
+        Exception? valueObserved = null;
+        var valueCompleted = 0;
+
+        void OnValueNext(int? value) => valueValues.Add(value);
+
+        using var valueSubscription = ReactiveLinqExtensions.SubscribeSafe(
+            valueSource,
+            OnValueNext,
+            error => valueObserved = error,
+            () => valueCompleted++);
+
+        await Assert.That(referenceValues.SequenceEqual((object?[])[null, SubscribeSafeValue])).IsTrue();
+        await Assert.That(referenceObserved).IsNull();
+        await Assert.That(referenceCompleted).IsEqualTo(1);
+        await Assert.That(valueValues.SequenceEqual((int?[])[null, One, null, Two])).IsTrue();
+        await Assert.That(valueObserved).IsNull();
+        await Assert.That(valueCompleted).IsEqualTo(1);
+    }
+
+    /// <summary>Verifies static alias <c>SubscribeSafe</c> accepts nullable error-only overloads with Rx imports present.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SubscribeSafeStaticAliasAcceptsNullableErrorOnlyOverloadsWithRxImports()
+    {
+        InvalidOperationException referenceError = new("reference");
+        InvalidOperationException valueError = new("value");
+        Exception? observedReferenceError = null;
+        Exception? observedValueError = null;
+
+        using var referenceSubscription = ReactiveLinqExtensions.SubscribeSafe(
+            Signal.Fail<object?>(referenceError),
+            error => observedReferenceError = error);
+        using var valueSubscription = ReactiveLinqExtensions.SubscribeSafe(
+            Signal.Fail<int?>(valueError),
+            error => observedValueError = error);
+
+        await Assert.That(observedReferenceError).IsSameReferenceAs(referenceError);
+        await Assert.That(observedValueError).IsSameReferenceAs(valueError);
+    }
+
+    /// <summary>Verifies static alias <c>SubscribeSafe</c> accepts nullable terminal completion overloads with Rx imports present.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SubscribeSafeStaticAliasAcceptsNullableTerminalCompletionOverloadsWithRxImports()
+    {
+        Exception? referenceObserved = null;
+        Exception? valueObserved = null;
+        var referenceCompleted = 0;
+        var valueCompleted = 0;
+
+        using var referenceSubscription = ReactiveLinqExtensions.SubscribeSafe(
+            Signal.FromEnumerable<object?>([null, SubscribeSafeValue]),
+            error => referenceObserved = error,
+            () => referenceCompleted++);
+        using var valueSubscription = ReactiveLinqExtensions.SubscribeSafe(
+            Signal.FromEnumerable<int?>([null, One, null, Two]),
+            error => valueObserved = error,
+            () => valueCompleted++);
+
+        await Assert.That(referenceObserved).IsNull();
+        await Assert.That(referenceCompleted).IsEqualTo(1);
+        await Assert.That(valueObserved).IsNull();
+        await Assert.That(valueCompleted).IsEqualTo(1);
     }
 }

--- a/src/tests/ReactiveUI.Primitives.Tests/RxNamesTests.SubscribeSafe.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/RxNamesTests.SubscribeSafe.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for full license information.
 
 using System.Reactive.Linq;
+using ReactiveUI.Primitives.Advanced;
 using ReactiveUI.Primitives.Signals;
 using PrimitivesLinqExtensions = ReactiveUI.Primitives.LinqExtensions;
 
@@ -99,5 +100,115 @@ public partial class RxNamesTests
 
         await Assert.That(values.SequenceEqual((int?[])[null, One, null, Two])).IsTrue();
         await Assert.That(observed).IsNull();
+    }
+
+    /// <summary>Verifies static alias <c>SubscribeSafe</c> accepts nullable observer overloads with Rx imports present.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SubscribeSafeStaticAliasAcceptsNullableObserverOverloadsWithRxImports()
+    {
+        IObservable<object?> referenceSource = Signal.FromEnumerable<object?>([null, SubscribeSafeValue]);
+        List<object?> referenceValues = [];
+        var referenceObserver = Witness.Create<object>(
+            referenceValues.Add,
+            static _ => { });
+
+        using var referenceSubscription = PrimitivesLinqExtensions.SubscribeSafe(referenceSource, referenceObserver);
+
+        IObservable<int?> valueSource = Signal.FromEnumerable<int?>([null, One, null, Two]);
+        List<int?> valueValues = [];
+        var valueObserver = Witness.Create<int?>(
+            valueValues.Add,
+            static _ => { });
+
+        using var valueSubscription = PrimitivesLinqExtensions.SubscribeSafe(valueSource, valueObserver);
+
+        await Assert.That(referenceValues.SequenceEqual((object?[])[null, SubscribeSafeValue])).IsTrue();
+        await Assert.That(valueValues.SequenceEqual((int?[])[null, One, null, Two])).IsTrue();
+    }
+
+    /// <summary>Verifies static alias <c>SubscribeSafe</c> accepts nullable completion callback overloads with Rx imports present.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SubscribeSafeStaticAliasAcceptsNullableCompletionCallbackOverloadsWithRxImports()
+    {
+        IObservable<object?> referenceSource = Signal.FromEnumerable<object?>([null, SubscribeSafeValue]);
+        List<object?> referenceValues = [];
+        Exception? referenceObserved = null;
+        var referenceCompleted = 0;
+
+        void OnReferenceNext(object? value) => referenceValues.Add(value);
+
+        using var referenceSubscription = PrimitivesLinqExtensions.SubscribeSafe(
+            referenceSource,
+            OnReferenceNext,
+            error => referenceObserved = error,
+            () => referenceCompleted++);
+
+        IObservable<int?> valueSource = Signal.FromEnumerable<int?>([null, One, null, Two]);
+        List<int?> valueValues = [];
+        Exception? valueObserved = null;
+        var valueCompleted = 0;
+
+        void OnValueNext(int? value) => valueValues.Add(value);
+
+        using var valueSubscription = PrimitivesLinqExtensions.SubscribeSafe(
+            valueSource,
+            OnValueNext,
+            error => valueObserved = error,
+            () => valueCompleted++);
+
+        await Assert.That(referenceValues.SequenceEqual((object?[])[null, SubscribeSafeValue])).IsTrue();
+        await Assert.That(referenceObserved).IsNull();
+        await Assert.That(referenceCompleted).IsEqualTo(1);
+        await Assert.That(valueValues.SequenceEqual((int?[])[null, One, null, Two])).IsTrue();
+        await Assert.That(valueObserved).IsNull();
+        await Assert.That(valueCompleted).IsEqualTo(1);
+    }
+
+    /// <summary>Verifies static alias <c>SubscribeSafe</c> accepts nullable error-only overloads with Rx imports present.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SubscribeSafeStaticAliasAcceptsNullableErrorOnlyOverloadsWithRxImports()
+    {
+        InvalidOperationException referenceError = new("reference");
+        InvalidOperationException valueError = new("value");
+        Exception? observedReferenceError = null;
+        Exception? observedValueError = null;
+
+        using var referenceSubscription = PrimitivesLinqExtensions.SubscribeSafe(
+            Signal.Fail<object?>(referenceError),
+            error => observedReferenceError = error);
+        using var valueSubscription = PrimitivesLinqExtensions.SubscribeSafe(
+            Signal.Fail<int?>(valueError),
+            error => observedValueError = error);
+
+        await Assert.That(observedReferenceError).IsSameReferenceAs(referenceError);
+        await Assert.That(observedValueError).IsSameReferenceAs(valueError);
+    }
+
+    /// <summary>Verifies static alias <c>SubscribeSafe</c> accepts nullable terminal completion overloads with Rx imports present.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SubscribeSafeStaticAliasAcceptsNullableTerminalCompletionOverloadsWithRxImports()
+    {
+        Exception? referenceObserved = null;
+        Exception? valueObserved = null;
+        var referenceCompleted = 0;
+        var valueCompleted = 0;
+
+        using var referenceSubscription = PrimitivesLinqExtensions.SubscribeSafe(
+            Signal.FromEnumerable<object?>([null, SubscribeSafeValue]),
+            error => referenceObserved = error,
+            () => referenceCompleted++);
+        using var valueSubscription = PrimitivesLinqExtensions.SubscribeSafe(
+            Signal.FromEnumerable<int?>([null, One, null, Two]),
+            error => valueObserved = error,
+            () => valueCompleted++);
+
+        await Assert.That(referenceObserved).IsNull();
+        await Assert.That(referenceCompleted).IsEqualTo(1);
+        await Assert.That(valueObserved).IsNull();
+        await Assert.That(valueCompleted).IsEqualTo(1);
     }
 }

--- a/src/tests/ReactiveUI.Primitives.Tests/RxNamesTests.SubscribeSafe.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/RxNamesTests.SubscribeSafe.cs
@@ -1,0 +1,103 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Reactive.Linq;
+using ReactiveUI.Primitives.Signals;
+using PrimitivesLinqExtensions = ReactiveUI.Primitives.LinqExtensions;
+
+namespace ReactiveUI.Primitives.Tests;
+
+/// <summary>SubscribeSafe-specific Rx-name compatibility tests.</summary>
+public partial class RxNamesTests
+{
+    /// <summary>The string value used by nullable object subscription tests.</summary>
+    private const string SubscribeSafeValue = "value";
+
+    /// <summary>Verifies fluent <c>SubscribeSafe</c> accepts nullable object values with Rx imports present.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SubscribeSafeFluentAcceptsNullableObjectHandlerWithRxImports()
+    {
+        IObservable<object?> source = Observable.Concat(
+            Observable.Return<object?>(null),
+            Observable.Return<object?>(SubscribeSafeValue));
+        List<object?> values = [];
+        Exception? observed = null;
+
+        void OnNext(object? value) => values.Add(value);
+
+        using var subscription = source.SubscribeSafe(OnNext, error => observed = error);
+
+        await Assert.That(values.SequenceEqual((object?[])[null, SubscribeSafeValue])).IsTrue();
+        await Assert.That(observed).IsNull();
+    }
+
+    /// <summary>Verifies static alias <c>SubscribeSafe</c> accepts nullable object values with Rx imports present.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SubscribeSafeStaticAliasAcceptsNullableObjectHandlerWithRxImports()
+    {
+        IObservable<object?> source = Signal.FromEnumerable<object?>([null, SubscribeSafeValue]);
+        List<object?> values = [];
+        Exception? observed = null;
+
+        void OnNext(object? value) => values.Add(value);
+
+        using var subscription = PrimitivesLinqExtensions.SubscribeSafe(source, OnNext, error => observed = error);
+
+        await Assert.That(values.SequenceEqual((object?[])[null, SubscribeSafeValue])).IsTrue();
+        await Assert.That(observed).IsNull();
+    }
+
+    /// <summary>Verifies static alias <c>SubscribeSafe</c> preserves non-nullable reference handlers.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SubscribeSafeStaticAliasAcceptsNonNullableObjectHandlerWithRxImports()
+    {
+        IObservable<string> source = Signal.FromEnumerable([SubscribeSafeValue]);
+        List<string> values = [];
+        Exception? observed = null;
+
+        void OnNext(string value) => values.Add(value);
+
+        using var subscription = PrimitivesLinqExtensions.SubscribeSafe(source, OnNext, error => observed = error);
+
+        await Assert.That(values.SequenceEqual([SubscribeSafeValue])).IsTrue();
+        await Assert.That(observed).IsNull();
+    }
+
+    /// <summary>Verifies fluent <c>SubscribeSafe</c> accepts nullable value types with Rx imports present.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SubscribeSafeFluentAcceptsNullableValueTypeHandlerWithRxImports()
+    {
+        IObservable<int?> source = Signal.FromEnumerable<int?>([null, One, null, Two]);
+        List<int?> values = [];
+        Exception? observed = null;
+
+        void OnNext(int? value) => values.Add(value);
+
+        using var subscription = source.SubscribeSafe(OnNext, error => observed = error);
+
+        await Assert.That(values.SequenceEqual((int?[])[null, One, null, Two])).IsTrue();
+        await Assert.That(observed).IsNull();
+    }
+
+    /// <summary>Verifies static alias <c>SubscribeSafe</c> accepts nullable value types with Rx imports present.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SubscribeSafeStaticAliasAcceptsNullableValueTypeHandlerWithRxImports()
+    {
+        IObservable<int?> source = Signal.FromEnumerable<int?>([null, One, null, Two]);
+        List<int?> values = [];
+        Exception? observed = null;
+
+        void OnNext(int? value) => values.Add(value);
+
+        using var subscription = PrimitivesLinqExtensions.SubscribeSafe(source, OnNext, error => observed = error);
+
+        await Assert.That(values.SequenceEqual((int?[])[null, One, null, Two])).IsTrue();
+        await Assert.That(observed).IsNull();
+    }
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix for `SubscribeSafe` overload resolution when consumers call `LinqExtensions.SubscribeSafe(...)` statically with nullable observable element types.

## What is the new behavior?

`SubscribeSafe` can be used from both `ReactiveUI.Primitives` and `ReactiveUI.Primitives.Reactive` in fluent extension style and static alias style for nullable and non-nullable sources, including `IObservable<object?>`, `IObservable<string?>`, and `IObservable<int?>`.

The fix adds nullable-source static-call overloads, keeps the existing `Action<T>` extension signatures for non-nullable consumers, and tracks the new public API entries in `PublicAPI.Unshipped.txt` across target frameworks.

Closes #103 

## What is the current behavior?

Static alias calls such as `PrimitivesLinqExtensions.SubscribeSafe(source, OnNext, SubscriptionErrors.Throw)` can bind to the extension-block generated static member and fail with `CS8714` when `source` is `IObservable<object?>` or another nullable `T`.

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [x] Tests have been added or updated (for bug fixes / features) 
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the main branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) 

## Additional information

Validation run:

- `dotnet test "tests/ReactiveUI.Primitives.Tests/ReactiveUI.Primitives.Tests.csproj" -- --treenode-filter "/*/*/RxNamesTests/*SubscribeSafe*" --output Detailed`
- `dotnet test "tests/ReactiveUI.Primitives.Reactive.Tests/ReactiveUI.Primitives.Reactive.Tests.csproj" -- --treenode-filter "/*/*/LinqExtensionsTests/*SubscribeSafe*" --output Detailed`
- Broader affected suites and targeted package builds were also run before commit: `RxNamesTests`, `ReactiveUI.Primitives.Reactive.Tests`, `net462`, `net10.0-android`, and `net10.0-ios` package builds for both package variants.