### PR TITLE
fix(primitives): support value types in SubscribeSafe static aliases

### DIFF
--- a/src/Primitives.Shared/SignalOperatorParityMixins.RxNames.SubscribeSafe.cs
+++ b/src/Primitives.Shared/SignalOperatorParityMixins.RxNames.SubscribeSafe.cs
@@ -221,6 +221,104 @@ public static partial class LinqExtensions
         return SubscribeSafeCore(source, Witness.Create<T?>(static _ => { }, onError, onCompleted));
     }
 
+    /// <summary>Subscribes a non-nullable value observer with downstream exception protection from static-call syntax.</summary>
+    /// <param name="source">The source sequence.</param>
+    /// <param name="observer">The observer to subscribe.</param>
+    /// <param name="allowValueType">Reserved for value-type overload resolution.</param>
+    /// <typeparam name="T">The non-nullable value type.</typeparam>
+    /// <returns>A disposable that cancels the subscription.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="observer"/> is <see langword="null"/>.</exception>
+    [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
+    public static IDisposable SubscribeSafe<T>(
+        IObservable<T> source,
+        IObserver<T> observer,
+        params byte[] allowValueType)
+        where T : struct
+    {
+        _ = allowValueType;
+        return SubscribeSafeCore(source, observer);
+    }
+
+    /// <summary>Subscribes non-nullable value callbacks with downstream exception protection from static-call syntax.</summary>
+    /// <param name="source">The source sequence.</param>
+    /// <param name="onNext">The action to invoke for each value.</param>
+    /// <param name="onError">The action to invoke for an error.</param>
+    /// <param name="allowValueType">Reserved for value-type overload resolution.</param>
+    /// <typeparam name="T">The non-nullable value type.</typeparam>
+    /// <returns>A disposable that cancels the subscription.</returns>
+    /// <exception cref="ArgumentNullException">A required argument is <see langword="null"/>.</exception>
+    [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
+    public static IDisposable SubscribeSafe<T>(
+        IObservable<T> source,
+        Action<T> onNext,
+        Action<Exception> onError,
+        params byte[] allowValueType)
+        where T : struct
+    {
+        _ = allowValueType;
+        return SubscribeSafeCore(source, Witness.Create(onNext, onError));
+    }
+
+    /// <summary>Subscribes non-nullable value callbacks with downstream exception protection from static-call syntax.</summary>
+    /// <param name="source">The source sequence.</param>
+    /// <param name="onNext">The action to invoke for each value.</param>
+    /// <param name="onError">The action to invoke for an error.</param>
+    /// <param name="onCompleted">The action to invoke when the sequence completes.</param>
+    /// <param name="allowValueType">Reserved for value-type overload resolution.</param>
+    /// <typeparam name="T">The non-nullable value type.</typeparam>
+    /// <returns>A disposable that cancels the subscription.</returns>
+    /// <exception cref="ArgumentNullException">A required argument is <see langword="null"/>.</exception>
+    [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
+    public static IDisposable SubscribeSafe<T>(
+        IObservable<T> source,
+        Action<T> onNext,
+        Action<Exception> onError,
+        Action onCompleted,
+        params byte[] allowValueType)
+        where T : struct
+    {
+        _ = allowValueType;
+        return SubscribeSafeCore(source, Witness.Create(onNext, onError, onCompleted));
+    }
+
+    /// <summary>Subscribes non-nullable value terminal callbacks with downstream exception protection from static-call syntax.</summary>
+    /// <param name="source">The source sequence.</param>
+    /// <param name="onError">The action to invoke for an error.</param>
+    /// <param name="allowValueType">Reserved for value-type overload resolution.</param>
+    /// <typeparam name="T">The non-nullable value type.</typeparam>
+    /// <returns>A disposable that cancels the subscription.</returns>
+    /// <exception cref="ArgumentNullException">A required argument is <see langword="null"/>.</exception>
+    [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
+    public static IDisposable SubscribeSafe<T>(
+        IObservable<T> source,
+        Action<Exception> onError,
+        params byte[] allowValueType)
+        where T : struct
+    {
+        _ = allowValueType;
+        return SubscribeSafeCore(source, Witness.Create<T>(static _ => { }, onError));
+    }
+
+    /// <summary>Subscribes non-nullable value terminal callbacks with downstream exception protection from static-call syntax.</summary>
+    /// <param name="source">The source sequence.</param>
+    /// <param name="onError">The action to invoke for an error.</param>
+    /// <param name="onCompleted">The action to invoke when the sequence completes.</param>
+    /// <param name="allowValueType">Reserved for value-type overload resolution.</param>
+    /// <typeparam name="T">The non-nullable value type.</typeparam>
+    /// <returns>A disposable that cancels the subscription.</returns>
+    /// <exception cref="ArgumentNullException">A required argument is <see langword="null"/>.</exception>
+    [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
+    public static IDisposable SubscribeSafe<T>(
+        IObservable<T> source,
+        Action<Exception> onError,
+        Action onCompleted,
+        params byte[] allowValueType)
+        where T : struct
+    {
+        _ = allowValueType;
+        return SubscribeSafeCore(source, Witness.Create<T>(static _ => { }, onError, onCompleted));
+    }
+
     /// <summary>Subscribes an observer with downstream exception protection.</summary>
     /// <param name="source">The source sequence.</param>
     /// <param name="observer">The observer to subscribe.</param>

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-android/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-android/PublicAPI.Unshipped.txt
@@ -1,1 +1,6 @@
 #nullable enable
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-ios/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-ios/PublicAPI.Unshipped.txt
@@ -1,1 +1,6 @@
 #nullable enable
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,1 +1,6 @@
 #nullable enable
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-macos/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-macos/PublicAPI.Unshipped.txt
@@ -1,1 +1,6 @@
 #nullable enable
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-tvos/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-tvos/PublicAPI.Unshipped.txt
@@ -1,1 +1,6 @@
 #nullable enable
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,6 @@
 #nullable enable
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-android/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-android/PublicAPI.Unshipped.txt
@@ -1,1 +1,6 @@
 #nullable enable
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-ios/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-ios/PublicAPI.Unshipped.txt
@@ -1,1 +1,6 @@
 #nullable enable
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,1 +1,6 @@
 #nullable enable
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-macos/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-macos/PublicAPI.Unshipped.txt
@@ -1,1 +1,6 @@
 #nullable enable
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-tvos/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-tvos/PublicAPI.Unshipped.txt
@@ -1,1 +1,6 @@
 #nullable enable
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,6 @@
 #nullable enable
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net462/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net462/PublicAPI.Unshipped.txt
@@ -1,1 +1,6 @@
 #nullable enable
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,1 +1,6 @@
 #nullable enable
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net48/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net48/PublicAPI.Unshipped.txt
@@ -1,1 +1,6 @@
 #nullable enable
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net481/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net481/PublicAPI.Unshipped.txt
@@ -1,1 +1,6 @@
 #nullable enable
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,6 @@
 #nullable enable
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net9.0/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net9.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,6 @@
 #nullable enable
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives/PublicAPI/net10.0-android/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net10.0-android/PublicAPI.Unshipped.txt
@@ -1,1 +1,6 @@
 #nullable enable
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives/PublicAPI/net10.0-ios/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net10.0-ios/PublicAPI.Unshipped.txt
@@ -1,1 +1,6 @@
 #nullable enable
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives/PublicAPI/net10.0-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net10.0-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,1 +1,6 @@
 #nullable enable
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives/PublicAPI/net10.0-macos/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net10.0-macos/PublicAPI.Unshipped.txt
@@ -1,1 +1,6 @@
 #nullable enable
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives/PublicAPI/net10.0-tvos/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net10.0-tvos/PublicAPI.Unshipped.txt
@@ -1,1 +1,6 @@
 #nullable enable
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives/PublicAPI/net10.0/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net10.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,6 @@
 #nullable enable
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives/PublicAPI/net11.0-android/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net11.0-android/PublicAPI.Unshipped.txt
@@ -1,1 +1,6 @@
 #nullable enable
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives/PublicAPI/net11.0-ios/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net11.0-ios/PublicAPI.Unshipped.txt
@@ -1,1 +1,6 @@
 #nullable enable
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives/PublicAPI/net11.0-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net11.0-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,1 +1,6 @@
 #nullable enable
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives/PublicAPI/net11.0-macos/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net11.0-macos/PublicAPI.Unshipped.txt
@@ -1,1 +1,6 @@
 #nullable enable
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives/PublicAPI/net11.0-tvos/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net11.0-tvos/PublicAPI.Unshipped.txt
@@ -1,1 +1,6 @@
 #nullable enable
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives/PublicAPI/net11.0/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net11.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,6 @@
 #nullable enable
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives/PublicAPI/net462/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net462/PublicAPI.Unshipped.txt
@@ -1,1 +1,6 @@
 #nullable enable
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,1 +1,6 @@
 #nullable enable
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives/PublicAPI/net48/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net48/PublicAPI.Unshipped.txt
@@ -1,1 +1,6 @@
 #nullable enable
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives/PublicAPI/net481/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net481/PublicAPI.Unshipped.txt
@@ -1,1 +1,6 @@
 #nullable enable
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,6 @@
 #nullable enable
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives/PublicAPI/net9.0/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net9.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,6 @@
 #nullable enable
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/tests/ReactiveUI.Primitives.Reactive.Tests/LinqExtensionsTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Reactive.Tests/LinqExtensionsTests.cs
@@ -2,6 +2,7 @@
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.Reactive;
 using System.Reactive.Linq;
 using ReactiveUI.Primitives.Advanced;
 using ReactiveUI.Primitives.Reactive.Signals;
@@ -72,6 +73,50 @@ public class LinqExtensionsTests
 
         await Assert.That(values.SequenceEqual([SubscribeSafeValue])).IsTrue();
         await Assert.That(observed).IsNull();
+    }
+
+    /// <summary>Verifies static alias <c>SubscribeSafe</c> accepts every non-nullable value-type overload.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SubscribeSafeStaticAliasAcceptsNonNullableValueTypeOverloads()
+    {
+        var source = Observable.Return(Unit.Default);
+        List<Unit> values = [];
+        Exception? observed = null;
+        var completed = 0;
+
+        void OnError(Exception error) => observed = error;
+
+        using var callbackSubscription = ReactiveLinqExtensions.SubscribeSafe<Unit>(
+            source,
+            values.Add,
+            OnError,
+            (byte)0);
+        using var completionSubscription = ReactiveLinqExtensions.SubscribeSafe<Unit>(
+            source,
+            values.Add,
+            OnError,
+            () => completed++,
+            (byte)0);
+        using var observerSubscription = ReactiveLinqExtensions.SubscribeSafe<Unit>(
+            source,
+            Observer.Create<Unit>(values.Add, OnError),
+            (byte)0);
+
+        InvalidOperationException expected = new("expected");
+        using var errorSubscription = ReactiveLinqExtensions.SubscribeSafe<Unit>(
+            Observable.Throw<Unit>(expected),
+            OnError,
+            (byte)0);
+        using var terminalSubscription = ReactiveLinqExtensions.SubscribeSafe<Unit>(
+            source,
+            OnError,
+            () => completed++,
+            (byte)0);
+
+        await Assert.That(values.SequenceEqual([Unit.Default, Unit.Default, Unit.Default])).IsTrue();
+        await Assert.That(observed).IsSameReferenceAs(expected);
+        await Assert.That(completed).IsEqualTo(Two);
     }
 
     /// <summary>Verifies fluent <c>SubscribeSafe</c> accepts nullable value types with Rx imports present.</summary>

--- a/src/tests/ReactiveUI.Primitives.Tests/RxNamesTests.SubscribeSafe.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/RxNamesTests.SubscribeSafe.cs
@@ -2,7 +2,11 @@
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.Diagnostics.CodeAnalysis;
+using System.Reactive;
 using System.Reactive.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using ReactiveUI.Primitives.Advanced;
 using ReactiveUI.Primitives.Signals;
 using PrimitivesLinqExtensions = ReactiveUI.Primitives.LinqExtensions;
@@ -14,6 +18,70 @@ public partial class RxNamesTests
 {
     /// <summary>The string value used by nullable object subscription tests.</summary>
     private const string SubscribeSafeValue = "value";
+
+    /// <summary>A C# 12 consumer covering non-nullable and nullable value-type static calls.</summary>
+    private const string CSharp12ValueTypeConsumer = """
+        using System;
+        using System.Reactive;
+        using PrimitivesLinqExtensions = ReactiveUI.Primitives.LinqExtensions;
+
+        public static class Consumer
+        {
+            public static IDisposable SubscribeObserver(IObservable<Unit> source, IObserver<Unit> observer) =>
+                PrimitivesLinqExtensions.SubscribeSafe(source, observer);
+
+            public static IDisposable SubscribeCallbacks(
+                IObservable<Unit> source,
+                Action<Unit> onNext,
+                Action<Exception> onError) =>
+                PrimitivesLinqExtensions.SubscribeSafe(source, onNext, onError);
+
+            public static IDisposable SubscribeCallbacks(
+                IObservable<Unit> source,
+                Action<Unit> onNext,
+                Action<Exception> onError,
+                Action onCompleted) =>
+                PrimitivesLinqExtensions.SubscribeSafe(source, onNext, onError, onCompleted);
+
+            public static IDisposable SubscribeError(IObservable<Unit> source, Action<Exception> onError) =>
+                PrimitivesLinqExtensions.SubscribeSafe(source, onError);
+
+            public static IDisposable SubscribeTerminal(
+                IObservable<Unit> source,
+                Action<Exception> onError,
+                Action onCompleted) =>
+                PrimitivesLinqExtensions.SubscribeSafe(source, onError, onCompleted);
+
+            public static IDisposable SubscribeNullableObserver(
+                IObservable<int?> source,
+                IObserver<int?> observer) =>
+                PrimitivesLinqExtensions.SubscribeSafe(source, observer);
+
+            public static IDisposable SubscribeNullableCallbacks(
+                IObservable<int?> source,
+                Action<int?> onNext,
+                Action<Exception> onError) =>
+                PrimitivesLinqExtensions.SubscribeSafe(source, onNext, onError);
+
+            public static IDisposable SubscribeNullableCallbacks(
+                IObservable<int?> source,
+                Action<int?> onNext,
+                Action<Exception> onError,
+                Action onCompleted) =>
+                PrimitivesLinqExtensions.SubscribeSafe(source, onNext, onError, onCompleted);
+
+            public static IDisposable SubscribeNullableError(
+                IObservable<int?> source,
+                Action<Exception> onError) =>
+                PrimitivesLinqExtensions.SubscribeSafe(source, onError);
+
+            public static IDisposable SubscribeNullableTerminal(
+                IObservable<int?> source,
+                Action<Exception> onError,
+                Action onCompleted) =>
+                PrimitivesLinqExtensions.SubscribeSafe(source, onError, onCompleted);
+        }
+        """;
 
     /// <summary>Verifies fluent <c>SubscribeSafe</c> accepts nullable object values with Rx imports present.</summary>
     /// <returns>A task representing the asynchronous operation.</returns>
@@ -66,6 +134,81 @@ public partial class RxNamesTests
 
         await Assert.That(values.SequenceEqual([SubscribeSafeValue])).IsTrue();
         await Assert.That(observed).IsNull();
+    }
+
+    /// <summary>Verifies static alias <c>SubscribeSafe</c> accepts every non-nullable value-type overload.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SubscribeSafeStaticAliasAcceptsNonNullableValueTypeOverloads()
+    {
+        var source = Observable.Return(Unit.Default);
+        List<Unit> values = [];
+        Exception? observed = null;
+        var completed = 0;
+
+        void OnError(Exception error) => observed = error;
+
+        using var callbackSubscription = PrimitivesLinqExtensions.SubscribeSafe<Unit>(
+            source,
+            values.Add,
+            OnError,
+            (byte)0);
+        using var completionSubscription = PrimitivesLinqExtensions.SubscribeSafe<Unit>(
+            source,
+            values.Add,
+            OnError,
+            () => completed++,
+            (byte)0);
+        using var observerSubscription = PrimitivesLinqExtensions.SubscribeSafe<Unit>(
+            source,
+            Observer.Create<Unit>(values.Add, OnError),
+            (byte)0);
+
+        InvalidOperationException expected = new("expected");
+        using var errorSubscription = PrimitivesLinqExtensions.SubscribeSafe<Unit>(
+            Observable.Throw<Unit>(expected),
+            OnError,
+            (byte)0);
+        using var terminalSubscription = PrimitivesLinqExtensions.SubscribeSafe<Unit>(
+            source,
+            OnError,
+            () => completed++,
+            (byte)0);
+
+        await Assert.That(values.SequenceEqual([Unit.Default, Unit.Default, Unit.Default])).IsTrue();
+        await Assert.That(observed).IsSameReferenceAs(expected);
+        await Assert.That(completed).IsEqualTo(Two);
+    }
+
+    /// <summary>Verifies C# 12 consumers can statically call non-nullable and nullable value-type forms without ambiguity.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    [RequiresAssemblyFiles("Builds metadata references from loaded assembly locations.")]
+    public async Task SubscribeSafeStaticAliasCompilesForCSharp12ValueTypes()
+    {
+        var references = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!.ToString()!
+            .Split(Path.PathSeparator)
+            .Select(static path => MetadataReference.CreateFromFile(path))
+            .Cast<MetadataReference>()
+            .ToList();
+        references.Add(MetadataReference.CreateFromFile(typeof(Unit).Assembly.Location));
+        references.Add(MetadataReference.CreateFromFile(typeof(RxVoid).Assembly.Location));
+        references.Add(MetadataReference.CreateFromFile(typeof(PrimitivesLinqExtensions).Assembly.Location));
+
+        var syntaxTree = CSharpSyntaxTree.ParseText(
+            CSharp12ValueTypeConsumer,
+            CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp12));
+        var compilation = CSharpCompilation.Create(
+            "SubscribeSafeCSharp12Consumer",
+            [syntaxTree],
+            references,
+            new(OutputKind.DynamicallyLinkedLibrary));
+        var errors = compilation.GetDiagnostics()
+            .Where(static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)
+            .Select(static diagnostic => diagnostic.ToString())
+            .ToArray();
+
+        await Assert.That(errors).IsEmpty();
     }
 
     /// <summary>Verifies fluent <c>SubscribeSafe</c> accepts nullable value types with Rx imports present.</summary>


### PR DESCRIPTION
## What kind of change does this PR introduce?

A bug fix for the static `SubscribeSafe` aliases. Resolves #128.

## What is the new behavior?

- Non-nullable value-type sources such as `IObservable<System.Reactive.Unit>` can use all five static `SubscribeSafe` forms.
- The new struct-constrained adapters use a distinct `params byte[]` discriminator, avoiding CLR signature collisions and preserving nullable value-type selection for C# 12 consumers.
- Both ReactiveUI.Primitives package flavors publish the same additive API across every supported target framework.

## What is the current behavior?

Static calls with non-nullable value types can bind to the reference-constrained adapter and fail with `T must be a reference type`. Existing nullable-struct adapters do not accept `IObservable<Unit>`.

## Checklist
- [x] Tests have been added or updated (for bug fixes / features) 
- [x] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the main branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) 

## Additional information

Validation completed:

- Clean-worktree net10 builds for ReactiveUI.Primitives and ReactiveUI.Primitives.Reactive: 0 warnings, 0 errors.
- Focused TUnit regressions: 9/9 lean and 8/8 Reactive passed.
- Full net10 suites: 807/807 lean and 43/43 Reactive passed.
- Release builds passed for both package flavors on net462, net472, net48, net481, net8.0, net9.0, net10.0, and net11.0.
- Coverage inspection reported no missed coverage in the changed shared source.
- A full solution build attempt reached the ten-minute limit in Android `aapt2` packaging without diagnostics; the affected package builds and test suites above completed successfully.