### PR TITLE
fix(api): ship current PublicAPI baselines

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -22,9 +22,9 @@
   <ItemGroup>
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8"/>
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.8.0"/>
-    <PackageVersion Include="System.Reactive" Version="6.1.0"/>
+    <PackageVersion Include="System.Reactive" Version="7.0.0"/>
+    <PackageVersion Include="Microsoft.Reactive.Testing" Version="7.0.0"/>
     <PackageVersion Include="System.Reactive.Async" Version="6.0.0-alpha.18"/>
-    <PackageVersion Include="Microsoft.Reactive.Testing" Version="6.1.0"/>
     <PackageVersion Include="R3" Version="1.3.1"/>
     <PackageVersion Include="ReactiveUI.Extensions" Version="4.0.0"/>
   </ItemGroup>

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-android/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-android/PublicAPI.Shipped.txt
@@ -1243,6 +1243,11 @@ static ReactiveUI.Primitives.Reactive.LinqExtensions.Stabilize<T>(this System.IO
 static ReactiveUI.Primitives.Reactive.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, System.Collections.Generic.IEnumerable<T>! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, params T[]! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeOn<T>(this System.IObservable<T>! source, System.Reactive.Concurrency.IScheduler! scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-android/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-android/PublicAPI.Unshipped.txt
@@ -1,6 +1,1 @@
 #nullable enable
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-ios/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-ios/PublicAPI.Shipped.txt
@@ -1239,6 +1239,11 @@ static ReactiveUI.Primitives.Reactive.LinqExtensions.Stabilize<T>(this System.IO
 static ReactiveUI.Primitives.Reactive.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, System.Collections.Generic.IEnumerable<T>! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, params T[]! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeOn<T>(this System.IObservable<T>! source, System.Reactive.Concurrency.IScheduler! scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-ios/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-ios/PublicAPI.Unshipped.txt
@@ -1,6 +1,1 @@
 #nullable enable
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-maccatalyst/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-maccatalyst/PublicAPI.Shipped.txt
@@ -1239,6 +1239,11 @@ static ReactiveUI.Primitives.Reactive.LinqExtensions.Stabilize<T>(this System.IO
 static ReactiveUI.Primitives.Reactive.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, System.Collections.Generic.IEnumerable<T>! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, params T[]! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeOn<T>(this System.IObservable<T>! source, System.Reactive.Concurrency.IScheduler! scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,6 +1,1 @@
 #nullable enable
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-macos/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-macos/PublicAPI.Shipped.txt
@@ -1239,6 +1239,11 @@ static ReactiveUI.Primitives.Reactive.LinqExtensions.Stabilize<T>(this System.IO
 static ReactiveUI.Primitives.Reactive.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, System.Collections.Generic.IEnumerable<T>! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, params T[]! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeOn<T>(this System.IObservable<T>! source, System.Reactive.Concurrency.IScheduler! scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-macos/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-macos/PublicAPI.Unshipped.txt
@@ -1,6 +1,1 @@
 #nullable enable
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-tvos/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-tvos/PublicAPI.Shipped.txt
@@ -1239,6 +1239,11 @@ static ReactiveUI.Primitives.Reactive.LinqExtensions.Stabilize<T>(this System.IO
 static ReactiveUI.Primitives.Reactive.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, System.Collections.Generic.IEnumerable<T>! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, params T[]! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeOn<T>(this System.IObservable<T>! source, System.Reactive.Concurrency.IScheduler! scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-tvos/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-tvos/PublicAPI.Unshipped.txt
@@ -1,6 +1,1 @@
 #nullable enable
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0/PublicAPI.Shipped.txt
@@ -1230,6 +1230,11 @@ static ReactiveUI.Primitives.Reactive.LinqExtensions.Stabilize<T>(this System.IO
 static ReactiveUI.Primitives.Reactive.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, System.Collections.Generic.IEnumerable<T>! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, params T[]! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeOn<T>(this System.IObservable<T>! source, System.Reactive.Concurrency.IScheduler! scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0/PublicAPI.Unshipped.txt
@@ -1,6 +1,1 @@
 #nullable enable
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-android/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-android/PublicAPI.Shipped.txt
@@ -1243,6 +1243,11 @@ static ReactiveUI.Primitives.Reactive.LinqExtensions.Stabilize<T>(this System.IO
 static ReactiveUI.Primitives.Reactive.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, System.Collections.Generic.IEnumerable<T>! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, params T[]! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeOn<T>(this System.IObservable<T>! source, System.Reactive.Concurrency.IScheduler! scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-android/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-android/PublicAPI.Unshipped.txt
@@ -1,6 +1,1 @@
 #nullable enable
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-ios/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-ios/PublicAPI.Shipped.txt
@@ -1239,6 +1239,11 @@ static ReactiveUI.Primitives.Reactive.LinqExtensions.Stabilize<T>(this System.IO
 static ReactiveUI.Primitives.Reactive.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, System.Collections.Generic.IEnumerable<T>! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, params T[]! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeOn<T>(this System.IObservable<T>! source, System.Reactive.Concurrency.IScheduler! scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-ios/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-ios/PublicAPI.Unshipped.txt
@@ -1,6 +1,1 @@
 #nullable enable
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-maccatalyst/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-maccatalyst/PublicAPI.Shipped.txt
@@ -1239,6 +1239,11 @@ static ReactiveUI.Primitives.Reactive.LinqExtensions.Stabilize<T>(this System.IO
 static ReactiveUI.Primitives.Reactive.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, System.Collections.Generic.IEnumerable<T>! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, params T[]! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeOn<T>(this System.IObservable<T>! source, System.Reactive.Concurrency.IScheduler! scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,6 +1,1 @@
 #nullable enable
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-macos/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-macos/PublicAPI.Shipped.txt
@@ -1239,6 +1239,11 @@ static ReactiveUI.Primitives.Reactive.LinqExtensions.Stabilize<T>(this System.IO
 static ReactiveUI.Primitives.Reactive.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, System.Collections.Generic.IEnumerable<T>! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, params T[]! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeOn<T>(this System.IObservable<T>! source, System.Reactive.Concurrency.IScheduler! scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-macos/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-macos/PublicAPI.Unshipped.txt
@@ -1,6 +1,1 @@
 #nullable enable
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-tvos/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-tvos/PublicAPI.Shipped.txt
@@ -1239,6 +1239,11 @@ static ReactiveUI.Primitives.Reactive.LinqExtensions.Stabilize<T>(this System.IO
 static ReactiveUI.Primitives.Reactive.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, System.Collections.Generic.IEnumerable<T>! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, params T[]! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeOn<T>(this System.IObservable<T>! source, System.Reactive.Concurrency.IScheduler! scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-tvos/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-tvos/PublicAPI.Unshipped.txt
@@ -1,6 +1,1 @@
 #nullable enable
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0/PublicAPI.Shipped.txt
@@ -1230,6 +1230,11 @@ static ReactiveUI.Primitives.Reactive.LinqExtensions.Stabilize<T>(this System.IO
 static ReactiveUI.Primitives.Reactive.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, System.Collections.Generic.IEnumerable<T>! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, params T[]! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeOn<T>(this System.IObservable<T>! source, System.Reactive.Concurrency.IScheduler! scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0/PublicAPI.Unshipped.txt
@@ -1,6 +1,1 @@
 #nullable enable
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net462/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net462/PublicAPI.Shipped.txt
@@ -1229,6 +1229,11 @@ static ReactiveUI.Primitives.Reactive.LinqExtensions.Stabilize<T>(this System.IO
 static ReactiveUI.Primitives.Reactive.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, System.Collections.Generic.IEnumerable<T>! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, params T[]! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeOn<T>(this System.IObservable<T>! source, System.Reactive.Concurrency.IScheduler! scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net462/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net462/PublicAPI.Unshipped.txt
@@ -1,6 +1,1 @@
 #nullable enable
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -1229,6 +1229,11 @@ static ReactiveUI.Primitives.Reactive.LinqExtensions.Stabilize<T>(this System.IO
 static ReactiveUI.Primitives.Reactive.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, System.Collections.Generic.IEnumerable<T>! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, params T[]! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeOn<T>(this System.IObservable<T>! source, System.Reactive.Concurrency.IScheduler! scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,6 +1,1 @@
 #nullable enable
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net48/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net48/PublicAPI.Shipped.txt
@@ -1229,6 +1229,11 @@ static ReactiveUI.Primitives.Reactive.LinqExtensions.Stabilize<T>(this System.IO
 static ReactiveUI.Primitives.Reactive.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, System.Collections.Generic.IEnumerable<T>! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, params T[]! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeOn<T>(this System.IObservable<T>! source, System.Reactive.Concurrency.IScheduler! scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net48/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net48/PublicAPI.Unshipped.txt
@@ -1,6 +1,1 @@
 #nullable enable
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net481/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net481/PublicAPI.Shipped.txt
@@ -1229,6 +1229,11 @@ static ReactiveUI.Primitives.Reactive.LinqExtensions.Stabilize<T>(this System.IO
 static ReactiveUI.Primitives.Reactive.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, System.Collections.Generic.IEnumerable<T>! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, params T[]! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeOn<T>(this System.IObservable<T>! source, System.Reactive.Concurrency.IScheduler! scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net481/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net481/PublicAPI.Unshipped.txt
@@ -1,6 +1,1 @@
 #nullable enable
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -1229,6 +1229,11 @@ static ReactiveUI.Primitives.Reactive.LinqExtensions.Stabilize<T>(this System.IO
 static ReactiveUI.Primitives.Reactive.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, System.Collections.Generic.IEnumerable<T>! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, params T[]! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeOn<T>(this System.IObservable<T>! source, System.Reactive.Concurrency.IScheduler! scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -1,6 +1,1 @@
 #nullable enable
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net9.0/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net9.0/PublicAPI.Shipped.txt
@@ -1230,6 +1230,11 @@ static ReactiveUI.Primitives.Reactive.LinqExtensions.Stabilize<T>(this System.IO
 static ReactiveUI.Primitives.Reactive.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, System.Collections.Generic.IEnumerable<T>! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, params T[]! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeOn<T>(this System.IObservable<T>! source, System.Reactive.Concurrency.IScheduler! scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net9.0/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net9.0/PublicAPI.Unshipped.txt
@@ -1,6 +1,1 @@
 #nullable enable
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives/PublicAPI/net10.0-android/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net10.0-android/PublicAPI.Shipped.txt
@@ -1387,6 +1387,11 @@ static ReactiveUI.Primitives.LinqExtensions.Stabilize<T>(this System.IObservable
 static ReactiveUI.Primitives.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, System.Collections.Generic.IEnumerable<T>! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, params T[]! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeOn<T>(this System.IObservable<T>! source, ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives/PublicAPI/net10.0-android/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net10.0-android/PublicAPI.Unshipped.txt
@@ -1,6 +1,1 @@
 #nullable enable
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives/PublicAPI/net10.0-ios/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net10.0-ios/PublicAPI.Shipped.txt
@@ -1383,6 +1383,11 @@ static ReactiveUI.Primitives.LinqExtensions.Stabilize<T>(this System.IObservable
 static ReactiveUI.Primitives.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, System.Collections.Generic.IEnumerable<T>! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, params T[]! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeOn<T>(this System.IObservable<T>! source, ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives/PublicAPI/net10.0-ios/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net10.0-ios/PublicAPI.Unshipped.txt
@@ -1,6 +1,1 @@
 #nullable enable
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives/PublicAPI/net10.0-maccatalyst/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net10.0-maccatalyst/PublicAPI.Shipped.txt
@@ -1383,6 +1383,11 @@ static ReactiveUI.Primitives.LinqExtensions.Stabilize<T>(this System.IObservable
 static ReactiveUI.Primitives.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, System.Collections.Generic.IEnumerable<T>! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, params T[]! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeOn<T>(this System.IObservable<T>! source, ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives/PublicAPI/net10.0-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net10.0-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,6 +1,1 @@
 #nullable enable
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives/PublicAPI/net10.0-macos/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net10.0-macos/PublicAPI.Shipped.txt
@@ -1383,6 +1383,11 @@ static ReactiveUI.Primitives.LinqExtensions.Stabilize<T>(this System.IObservable
 static ReactiveUI.Primitives.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, System.Collections.Generic.IEnumerable<T>! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, params T[]! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeOn<T>(this System.IObservable<T>! source, ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives/PublicAPI/net10.0-macos/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net10.0-macos/PublicAPI.Unshipped.txt
@@ -1,6 +1,1 @@
 #nullable enable
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives/PublicAPI/net10.0-tvos/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net10.0-tvos/PublicAPI.Shipped.txt
@@ -1383,6 +1383,11 @@ static ReactiveUI.Primitives.LinqExtensions.Stabilize<T>(this System.IObservable
 static ReactiveUI.Primitives.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, System.Collections.Generic.IEnumerable<T>! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, params T[]! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeOn<T>(this System.IObservable<T>! source, ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives/PublicAPI/net10.0-tvos/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net10.0-tvos/PublicAPI.Unshipped.txt
@@ -1,6 +1,1 @@
 #nullable enable
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives/PublicAPI/net10.0/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net10.0/PublicAPI.Shipped.txt
@@ -1376,6 +1376,11 @@ static ReactiveUI.Primitives.LinqExtensions.Stabilize<T>(this System.IObservable
 static ReactiveUI.Primitives.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, System.Collections.Generic.IEnumerable<T>! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, params T[]! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeOn<T>(this System.IObservable<T>! source, ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives/PublicAPI/net10.0/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net10.0/PublicAPI.Unshipped.txt
@@ -1,6 +1,1 @@
 #nullable enable
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives/PublicAPI/net11.0-android/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net11.0-android/PublicAPI.Shipped.txt
@@ -1387,6 +1387,11 @@ static ReactiveUI.Primitives.LinqExtensions.Stabilize<T>(this System.IObservable
 static ReactiveUI.Primitives.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, System.Collections.Generic.IEnumerable<T>! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, params T[]! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeOn<T>(this System.IObservable<T>! source, ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives/PublicAPI/net11.0-android/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net11.0-android/PublicAPI.Unshipped.txt
@@ -1,6 +1,1 @@
 #nullable enable
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives/PublicAPI/net11.0-ios/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net11.0-ios/PublicAPI.Shipped.txt
@@ -1383,6 +1383,11 @@ static ReactiveUI.Primitives.LinqExtensions.Stabilize<T>(this System.IObservable
 static ReactiveUI.Primitives.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, System.Collections.Generic.IEnumerable<T>! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, params T[]! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeOn<T>(this System.IObservable<T>! source, ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives/PublicAPI/net11.0-ios/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net11.0-ios/PublicAPI.Unshipped.txt
@@ -1,6 +1,1 @@
 #nullable enable
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives/PublicAPI/net11.0-maccatalyst/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net11.0-maccatalyst/PublicAPI.Shipped.txt
@@ -1383,6 +1383,11 @@ static ReactiveUI.Primitives.LinqExtensions.Stabilize<T>(this System.IObservable
 static ReactiveUI.Primitives.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, System.Collections.Generic.IEnumerable<T>! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, params T[]! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeOn<T>(this System.IObservable<T>! source, ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives/PublicAPI/net11.0-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net11.0-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,6 +1,1 @@
 #nullable enable
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives/PublicAPI/net11.0-macos/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net11.0-macos/PublicAPI.Shipped.txt
@@ -1383,6 +1383,11 @@ static ReactiveUI.Primitives.LinqExtensions.Stabilize<T>(this System.IObservable
 static ReactiveUI.Primitives.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, System.Collections.Generic.IEnumerable<T>! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, params T[]! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeOn<T>(this System.IObservable<T>! source, ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives/PublicAPI/net11.0-macos/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net11.0-macos/PublicAPI.Unshipped.txt
@@ -1,6 +1,1 @@
 #nullable enable
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives/PublicAPI/net11.0-tvos/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net11.0-tvos/PublicAPI.Shipped.txt
@@ -1383,6 +1383,11 @@ static ReactiveUI.Primitives.LinqExtensions.Stabilize<T>(this System.IObservable
 static ReactiveUI.Primitives.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, System.Collections.Generic.IEnumerable<T>! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, params T[]! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeOn<T>(this System.IObservable<T>! source, ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives/PublicAPI/net11.0-tvos/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net11.0-tvos/PublicAPI.Unshipped.txt
@@ -1,6 +1,1 @@
 #nullable enable
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives/PublicAPI/net11.0/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net11.0/PublicAPI.Shipped.txt
@@ -1376,6 +1376,11 @@ static ReactiveUI.Primitives.LinqExtensions.Stabilize<T>(this System.IObservable
 static ReactiveUI.Primitives.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, System.Collections.Generic.IEnumerable<T>! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, params T[]! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeOn<T>(this System.IObservable<T>! source, ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives/PublicAPI/net11.0/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net11.0/PublicAPI.Unshipped.txt
@@ -1,6 +1,1 @@
 #nullable enable
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives/PublicAPI/net462/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net462/PublicAPI.Shipped.txt
@@ -1375,6 +1375,11 @@ static ReactiveUI.Primitives.LinqExtensions.Stabilize<T>(this System.IObservable
 static ReactiveUI.Primitives.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, System.Collections.Generic.IEnumerable<T>! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, params T[]! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeOn<T>(this System.IObservable<T>! source, ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives/PublicAPI/net462/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net462/PublicAPI.Unshipped.txt
@@ -1,6 +1,1 @@
 #nullable enable
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -1375,6 +1375,11 @@ static ReactiveUI.Primitives.LinqExtensions.Stabilize<T>(this System.IObservable
 static ReactiveUI.Primitives.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, System.Collections.Generic.IEnumerable<T>! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, params T[]! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeOn<T>(this System.IObservable<T>! source, ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,6 +1,1 @@
 #nullable enable
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives/PublicAPI/net48/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net48/PublicAPI.Shipped.txt
@@ -1375,6 +1375,11 @@ static ReactiveUI.Primitives.LinqExtensions.Stabilize<T>(this System.IObservable
 static ReactiveUI.Primitives.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, System.Collections.Generic.IEnumerable<T>! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, params T[]! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeOn<T>(this System.IObservable<T>! source, ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives/PublicAPI/net48/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net48/PublicAPI.Unshipped.txt
@@ -1,6 +1,1 @@
 #nullable enable
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives/PublicAPI/net481/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net481/PublicAPI.Shipped.txt
@@ -1375,6 +1375,11 @@ static ReactiveUI.Primitives.LinqExtensions.Stabilize<T>(this System.IObservable
 static ReactiveUI.Primitives.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, System.Collections.Generic.IEnumerable<T>! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, params T[]! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeOn<T>(this System.IObservable<T>! source, ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives/PublicAPI/net481/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net481/PublicAPI.Unshipped.txt
@@ -1,6 +1,1 @@
 #nullable enable
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -1375,6 +1375,11 @@ static ReactiveUI.Primitives.LinqExtensions.Stabilize<T>(this System.IObservable
 static ReactiveUI.Primitives.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, System.Collections.Generic.IEnumerable<T>! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, params T[]! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeOn<T>(this System.IObservable<T>! source, ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -1,6 +1,1 @@
 #nullable enable
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives/PublicAPI/net9.0/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net9.0/PublicAPI.Shipped.txt
@@ -1376,6 +1376,11 @@ static ReactiveUI.Primitives.LinqExtensions.Stabilize<T>(this System.IObservable
 static ReactiveUI.Primitives.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, System.Collections.Generic.IEnumerable<T>! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.StartWith<T>(this System.IObservable<T>! source, params T[]! values) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeOn<T>(this System.IObservable<T>! source, ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
+static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<System.Exception!>! onError, params bool[]! allowNullable) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T?>! source, System.Action<T!>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params bool[]! allowNullable) -> System.IDisposable!

--- a/src/ReactiveUI.Primitives/PublicAPI/net9.0/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net9.0/PublicAPI.Unshipped.txt
@@ -1,6 +1,1 @@
 #nullable enable
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted, params byte[]! allowValueType) -> System.IDisposable!
-static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(System.IObservable<T>! source, System.IObserver<T>! observer, params byte[]! allowValueType) -> System.IDisposable!

--- a/tools/generate-publicapi.ps1
+++ b/tools/generate-publicapi.ps1
@@ -18,10 +18,12 @@
 
     Tests, benchmarks, and source generators are skipped structurally.
 
-    Each (project, TFM) pair is independent — `dotnet format` builds an in-memory
-    MSBuildWorkspace and only writes its own PublicAPI/<tfm>/ files — so the pairs run
-    in parallel (PowerShell 7+ runspaces; falls back to sequential on 5.1). Override the
-    width with -Jobs <n> or $env:JOBS.
+    Projects run in parallel (PowerShell 7+ runspaces; sequential on 5.1), while the
+    TFMs within one project run serially. `dotnet format` can keep AdditionalFiles for
+    sibling TFMs memory-mapped, so concurrent TFMs from the same project are unsafe.
+    The formatter can also simplify source imports while applying analyzer fixes; the
+    script snapshots tracked source content and restores any such incidental edits.
+    Override the project concurrency width with -Jobs <n> or $env:JOBS.
 
     Run on Windows to generate the Windows-desktop and (with the relevant workloads)
     Apple/Android target frameworks. Use the bash sibling (generate-publicapi.sh) on
@@ -236,21 +238,72 @@ foreach ($proj in $restoreSet) {
 Write-Host ''
 
 Write-Host "Generating $($items.Count) (project, TFM) baseline(s) across $Jobs job(s)..."
-if ($PSVersionTable.PSVersion.Major -ge 7 -and $Jobs -gt 1) {
-    $funcDef = ${function:Invoke-PublicApiOne}.ToString()
-    $results = $items | ForEach-Object -ThrottleLimit $Jobs -Parallel {
-        ${function:Invoke-PublicApiOne} = $using:funcDef
-        Invoke-PublicApiOne -Item $_ -Diags $using:diags
+$projectGroups = @($items | Group-Object -Property Proj)
+
+# PublicApiAnalyzers fixes target AdditionalFiles, but dotnet-format can also apply
+# source simplification operations (for example, removing imports). Preserve the exact
+# pre-run source bytes, including any intentional dirty-worktree changes, and restore
+# only files that the formatter actually changed.
+$sourceSnapshot = [System.Collections.Generic.Dictionary[string, byte[]]]::new(
+    [System.StringComparer]::OrdinalIgnoreCase)
+$sourceFiles = Get-ChildItem -Path $srcDir -Recurse -Filter '*.cs' -File |
+    Where-Object { $_.FullName -notmatch '[\\/](bin|obj)[\\/]' }
+foreach ($sourceFile in $sourceFiles) {
+    $sourceSnapshot.Add($sourceFile.FullName, [IO.File]::ReadAllBytes($sourceFile.FullName))
+}
+
+function Restore-SourceSnapshot {
+    $restored = 0
+    foreach ($entry in $sourceSnapshot.GetEnumerator()) {
+        if (-not (Test-Path -LiteralPath $entry.Key)) { continue }
+
+        $current = [IO.File]::ReadAllBytes($entry.Key)
+        $original = $entry.Value
+        $equal = $current.Length -eq $original.Length
+        if ($equal) {
+            for ($index = 0; $index -lt $current.Length; $index++) {
+                if ($current[$index] -ne $original[$index]) {
+                    $equal = $false
+                    break
+                }
+            }
+        }
+
+        if (-not $equal) {
+            [IO.File]::WriteAllBytes($entry.Key, $original)
+            $restored++
+        }
+    }
+    return $restored
+}
+
+$restoredSourceFiles = 0
+try {
+    if ($PSVersionTable.PSVersion.Major -ge 7 -and $Jobs -gt 1) {
+        $funcDef = ${function:Invoke-PublicApiOne}.ToString()
+        $results = $projectGroups | ForEach-Object -ThrottleLimit $Jobs -Parallel {
+            ${function:Invoke-PublicApiOne} = $using:funcDef
+            foreach ($it in $_.Group) {
+                Invoke-PublicApiOne -Item $it -Diags $using:diags
+            }
+        }
+    }
+    else {
+        if ($Jobs -gt 1) { Write-Host '  (PowerShell 5.1: running sequentially — use pwsh 7+ for parallelism)' }
+        $results = foreach ($group in $projectGroups) {
+            foreach ($it in $group.Group) {
+                Invoke-PublicApiOne -Item $it -Diags $diags
+            }
+        }
     }
 }
-else {
-    if ($Jobs -gt 1) { Write-Host '  (PowerShell 5.1: running sequentially — use pwsh 7+ for parallelism)' }
-    $results = foreach ($it in $items) { Invoke-PublicApiOne -Item $it -Diags $diags }
+finally {
+    $restoredSourceFiles = Restore-SourceSnapshot
 }
 Write-Host ''
 
 $generated = @($results | Where-Object { $_.Ok }).Count
 $failed = @($results | Where-Object { -not $_.Ok }).Count
 
-Write-Host "Done. generated: $generated TFM baseline(s), failed: $failed, projects skipped: $skipped"
+Write-Host "Done. generated: $generated TFM baseline(s), failed: $failed, projects skipped: $skipped, source files restored: $restoredSourceFiles"
 if ($failed -ne 0) { exit 1 }

--- a/tools/generate-publicapi.sh
+++ b/tools/generate-publicapi.sh
@@ -16,9 +16,11 @@
 #
 # Tests, benchmarks, and source generators are skipped structurally.
 #
-# Each (project, TFM) pair is independent — `dotnet format` builds an in-memory
-# MSBuildWorkspace and only writes its own PublicAPI/<tfm>/ files — so the pairs run
-# in parallel through a bounded pool (override the width with JOBS=<n>).
+# Projects run in parallel through a bounded pool, while TFMs within one project run
+# serially. `dotnet format` can retain sibling-TFM AdditionalFiles as memory-mapped
+# inputs, so parallel TFMs from the same project are unsafe. The formatter can also
+# simplify source imports while applying analyzer fixes; exact pre-run source bytes are
+# restored on exit. Override project concurrency with JOBS=<n>.
 #
 # Usage:
 #   tools/generate-publicapi.sh [project-name-filter]
@@ -236,14 +238,58 @@ export -f merge_api_files
 
 RESULTS_DIR="$(mktemp -d)"
 export RESULTS_DIR
-trap 'rm -rf "$RESULTS_DIR"' EXIT
+
+REPO_DIR="$(cd "$SRC_DIR/.." && pwd)"
+SOURCE_BACKUP="$RESULTS_DIR/source-backup"
+ITEMS_FILE="$RESULTS_DIR/items"
+export SOURCE_BACKUP ITEMS_FILE REPO_DIR
+mkdir -p "$SOURCE_BACKUP"
+
+# Preserve exact source bytes, including intentional dirty-worktree changes. Analyzer
+# fixes should update only PublicAPI AdditionalFiles, but dotnet-format may also simplify
+# source imports as a side effect.
+while IFS= read -r -d '' source; do
+  rel="${source#"$REPO_DIR/"}"
+  mkdir -p "$SOURCE_BACKUP/$(dirname "$rel")"
+  cp "$source" "$SOURCE_BACKUP/$rel"
+done < <(find "$SRC_DIR" -type f -name '*.cs' ! -path '*/bin/*' ! -path '*/obj/*' -print0)
+
+restore_sources() {
+  local restored=0 backup rel target
+  while IFS= read -r -d '' backup; do
+    rel="${backup#$SOURCE_BACKUP/}"
+    target="$REPO_DIR/$rel"
+    if [ -f "$target" ] && ! cmp -s "$backup" "$target"; then
+      cp "$backup" "$target"
+      restored=$((restored + 1))
+    fi
+  done < <(find "$SOURCE_BACKUP" -type f -print0)
+  printf '%s' "$restored" >"$RESULTS_DIR/source-files-restored"
+}
+
+trap 'restore_sources; rm -rf "$RESULTS_DIR"' EXIT
+
+printf '%s\n' "${items[@]}" >"$ITEMS_FILE"
+
+generate_project() {
+  local project="$1" item item_project
+  while IFS= read -r item; do
+    IFS='|' read -r item_project _ <<<"$item"
+    if [ "$item_project" = "$project" ]; then
+      generate_one "$item"
+    fi
+  done <"$ITEMS_FILE"
+}
+export -f generate_project
 
 echo "Generating ${#items[@]} (project, TFM) baseline(s) across $JOBS job(s)..."
-printf '%s\n' "${items[@]}" | xargs -P "$JOBS" -I{} bash -c 'generate_one "$1"' _ {}
+printf '%s\0' "${restore_set[@]}" | xargs -0 -P "$JOBS" -I{} bash -c 'generate_project "$1"' _ "{}"
 echo
 
 generated="$(find "$RESULTS_DIR" -name '*.ok' | wc -l | tr -d '[:space:]')"
 failed="$(find "$RESULTS_DIR" -name '*.fail' | wc -l | tr -d '[:space:]')"
+restore_sources
+restored_sources="$(cat "$RESULTS_DIR/source-files-restored")"
 
-echo "Done. generated: $generated TFM baseline(s), failed: $failed, projects skipped: $skipped"
+echo "Done. generated: $generated TFM baseline(s), failed: $failed, projects skipped: $skipped, source files restored: $restored_sources"
 [ "$failed" -eq 0 ]


### PR DESCRIPTION
## What kind of change does this PR introduce?

A PublicAPI baseline fix with generator hardening and dependency maintenance.

## What is the new behavior?

- Every `PublicAPI.Unshipped.txt` contains only `#nullable enable`.
- Every `PublicAPI.Shipped.txt` contains the current API for its project and target framework.
- The five `SubscribeSafe` overloads are shipped for both `ReactiveUI.Primitives` variants across all applicable TFMs.
- PublicAPI generation runs projects in parallel while serializing TFMs within each project, preventing concurrent AdditionalFiles access.
- Both generators preserve and restore C# source bytes if `dotnet format` changes source files incidentally.
- `System.Reactive` and `Microsoft.Reactive.Testing` use version 7.0.0.

## What is the current behavior?

The affected `SubscribeSafe` APIs remain in Unshipped baselines, and parallel TFM generation for one project can contend over the same PublicAPI files or modify source imports as a formatter side effect. The Reactive dependencies remain on version 6.1.0.

## Checklist

- [ ] Tests have been added or updated (not required: baseline, generator, and dependency maintenance only)
- [ ] Docs have been added or updated (not required: no user-facing documentation change)
- [x] Changes target the main branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information

- Full PublicApiAnalyzers generator pass: 136 generated, 0 failed, 0 skipped.
- PublicAPI audit: 18 projects, 136 project/TFM pairs, and 272 baseline files.
- Direct MTP/TUnit validation:
  - `ReactiveUI.Primitives.Tests` net10.0: 822/822 passed.
  - `ReactiveUI.Primitives.Reactive.Tests` net10.0: 44/44 passed.
- PowerShell and Bash generator syntax checks passed.
- Committed diff passes `git diff --check`.

Fixes #128