### PR TITLE
fix(advanced): keep switch and merge generation bookkeeping correct

### DIFF
--- a/src/Primitives.Shared/Advanced/MergeCoordinator{T}.cs
+++ b/src/Primitives.Shared/Advanced/MergeCoordinator{T}.cs
@@ -79,7 +79,22 @@ public sealed class MergeCoordinator<T> : IDisposable
             Active++;
         }
 
-        Subscriptions.Add(source.Subscribe(OnInnerNext, OnAnyError, OnInnerCompleted));
+        // A source is free to signal completion more than once. Latch per inner so a repeat cannot decrement
+        // the active count a second time - that would drop the count on behalf of a sibling that is still
+        // running and complete the merge early, losing everything the sibling had left to produce.
+        var completed = 0;
+        Subscriptions.Add(source.Subscribe(
+            OnInnerNext,
+            OnAnyError,
+            () =>
+            {
+                if (Interlocked.Exchange(ref completed, 1) != 0)
+                {
+                    return;
+                }
+
+                OnInnerCompleted();
+            }));
     }
 
     /// <summary>Forwards the first terminal error.</summary>

--- a/src/Primitives.Shared/Advanced/SwitchWitness{T}.cs
+++ b/src/Primitives.Shared/Advanced/SwitchWitness{T}.cs
@@ -74,10 +74,36 @@ public sealed class SwitchWitness<T> : IDisposable
             IsInnerActive = true;
         }
 
-        InnerSlot.Create(source.Subscribe(
+        var subscription = source.Subscribe(
             value => OnNext(current, value),
             error => OnError(current, error),
-            () => OnCompleted(current)));
+            () => OnCompleted(current));
+
+        // Subscribing can push a value downstream synchronously, and a downstream handler is free to feed the
+        // outer source again. That re-enters OnSource, installs a newer generation, and only then returns here.
+        // Installing unconditionally at that point would replace the newer subscription with this stale one and
+        // dispose it, leaving a subscription whose notifications are all filtered out by version - the sequence
+        // would then never produce another value nor complete. Only the generation that is still current may
+        // occupy the slot; a superseded one disposes itself, outside the gate.
+        var superseded = false;
+        lock (_gate)
+        {
+            if (IsDone || current != _version)
+            {
+                superseded = true;
+            }
+            else
+            {
+                InnerSlot.Create(subscription);
+            }
+        }
+
+        if (!superseded)
+        {
+            return;
+        }
+
+        subscription.Dispose();
     }
 
     /// <summary>Marks the outer source complete.</summary>

--- a/src/tests/ReactiveUI.Primitives.Tests/GenerationSafetyTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/GenerationSafetyTests.cs
@@ -1,0 +1,182 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using ReactiveUI.Primitives.Advanced;
+using ReactiveUI.Primitives.Signals;
+
+namespace ReactiveUI.Primitives.Tests;
+
+/// <summary>
+/// Tests that the switch and merge coordinators keep their generation bookkeeping correct when a source
+/// behaves awkwardly: re-entering the outer sequence from a downstream handler, or signalling completion
+/// more than once. Both shapes previously lost notifications or terminated early.
+/// </summary>
+public sealed class GenerationSafetyTests
+{
+    /// <summary>The value the first inner emits synchronously while it is being subscribed.</summary>
+    private const int FirstValue = 1;
+
+    /// <summary>The value the second inner emits after the re-entrant switch has settled.</summary>
+    private const int SecondValue = 2;
+
+    /// <summary>
+    /// Subscribing an inner can push a value downstream synchronously, and a downstream handler may feed the
+    /// outer sequence again. The newer generation must survive that re-entrancy: installing the older
+    /// subscription afterwards would dispose the newer one and strand the sequence, because every surviving
+    /// notification is then filtered out by version.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SwitchWitnessKeepsTheNewestGenerationWhenTheOuterIsReenteredWhileSubscribing()
+    {
+        Signal<IObservable<int>> outer = new();
+        TrackedObservable<int> second = new();
+        SynchronousObservable<int> first = new(FirstValue);
+        ReenteringObserver<int> downstream = new(outer, second);
+
+        using var subscription = new SwitchWitness<int>(downstream).Run(outer);
+
+        // Pushing `first` subscribes it, which emits synchronously, which re-enters the outer with `second`.
+        outer.OnNext(first);
+
+        // `second` is the current generation, so it must still be live and still be heard.
+        second.Observer?.OnNext(SecondValue);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(second.DisposeCount).IsEqualTo(0);
+            await Assert.That(downstream.Values).Contains(SecondValue);
+        }
+    }
+
+    /// <summary>
+    /// A source may signal completion more than once. A repeat must not decrement the merge's active count a
+    /// second time, because that count belongs to a sibling that is still running - the merge would otherwise
+    /// complete early and drop whatever the sibling had left.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task MergeCoordinatorIgnoresARepeatedInnerCompletionWhileASiblingIsStillRunning()
+    {
+        CapturingObservable<int> left = new();
+        CapturingObservable<int> right = new();
+        RecordingObserver<int> downstream = new();
+
+        using var subscription = new MergeCoordinator<int>(downstream).Run([left, right]);
+
+        left.Observer!.OnCompleted();
+        left.Observer!.OnCompleted();
+
+        // `right` has not finished, so the merge must still be open.
+        await Assert.That(downstream.Completed).IsEqualTo(0);
+
+        right.Observer!.OnCompleted();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(downstream.Completed).IsEqualTo(1);
+            await Assert.That(right.Observer).IsNotNull();
+        }
+    }
+
+    /// <summary>An observable that emits one value while it is being subscribed, and counts its disposals.</summary>
+    /// <typeparam name="T">The value type.</typeparam>
+    /// <param name="value">The value emitted during subscription.</param>
+    private sealed class SynchronousObservable<T>(T value) : IObservable<T>
+    {
+        /// <summary>Gets the number of times the subscription was disposed.</summary>
+        public int DisposeCount { get; private set; }
+
+        /// <inheritdoc/>
+        public IDisposable Subscribe(IObserver<T> observer)
+        {
+            observer.OnNext(value);
+            return new Tracker(() => DisposeCount++);
+        }
+    }
+
+    /// <summary>An observable that captures its observer and counts its disposals.</summary>
+    /// <typeparam name="T">The value type.</typeparam>
+    private sealed class TrackedObservable<T> : IObservable<T>
+    {
+        /// <summary>Gets the captured observer.</summary>
+        public IObserver<T>? Observer { get; private set; }
+
+        /// <summary>Gets the number of times the subscription was disposed.</summary>
+        public int DisposeCount { get; private set; }
+
+        /// <inheritdoc/>
+        public IDisposable Subscribe(IObserver<T> observer)
+        {
+            Observer = observer;
+            return new Tracker(() => DisposeCount++);
+        }
+    }
+
+    /// <summary>An observable that captures its observer for manual notification.</summary>
+    /// <typeparam name="T">The value type.</typeparam>
+    private sealed class CapturingObservable<T> : IObservable<T>
+    {
+        /// <summary>Gets the captured observer.</summary>
+        public IObserver<T>? Observer { get; private set; }
+
+        /// <inheritdoc/>
+        public IDisposable Subscribe(IObserver<T> observer)
+        {
+            Observer = observer;
+            return new Tracker(static () => { });
+        }
+    }
+
+    /// <summary>Records values and terminal signals.</summary>
+    /// <typeparam name="T">The observed value type.</typeparam>
+    private class RecordingObserver<T> : IObserver<T>
+    {
+        /// <summary>Gets the observed values.</summary>
+        public List<T> Values { get; } = [];
+
+        /// <summary>Gets the completion count.</summary>
+        public int Completed { get; private set; }
+
+        /// <inheritdoc/>
+        public void OnCompleted() => Completed++;
+
+        /// <inheritdoc/>
+        public void OnError(Exception error) => throw error;
+
+        /// <inheritdoc/>
+        public virtual void OnNext(T value) => Values.Add(value);
+    }
+
+    /// <summary>Feeds a replacement inner into the outer sequence the first time it observes a value.</summary>
+    /// <typeparam name="T">The observed value type.</typeparam>
+    /// <param name="outer">The outer sequence to re-enter.</param>
+    /// <param name="replacement">The inner pushed on the first observed value.</param>
+    private sealed class ReenteringObserver<T>(Signal<IObservable<T>> outer, IObservable<T> replacement) : RecordingObserver<T>
+    {
+        /// <summary>Whether the re-entrant push has already happened.</summary>
+        private bool _pushed;
+
+        /// <inheritdoc/>
+        public override void OnNext(T value)
+        {
+            base.OnNext(value);
+            if (_pushed)
+            {
+                return;
+            }
+
+            _pushed = true;
+            outer.OnNext(replacement);
+        }
+    }
+
+    /// <summary>Runs an action when disposed.</summary>
+    /// <param name="onDispose">The action to run on disposal.</param>
+    private sealed class Tracker(Action onDispose) : IDisposable
+    {
+        /// <inheritdoc/>
+        public void Dispose() => onDispose();
+    }
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix. Two correctness defects in the `Advanced` switch and merge coordinators, both of which can silently stall or truncate a sequence.

## What is the new behavior?

**Switch and merge keep their generation bookkeeping correct when a source behaves awkwardly.**

- **`SwitchWitness<T>` keeps the newest generation when the outer is re-entered during subscription.** Only the generation that is still current may occupy the inner slot; a superseded subscription disposes itself.
- **`MergeCoordinator<T>` ignores a repeated completion from the same inner.** Each inner's completion is latched, so it can decrement the active count at most once.
- Regression tests for both, in `GenerationSafetyTests`.

## What is the current behavior?

**Both coordinators can be driven into a state where the sequence never completes, or completes while data is still coming.**

- `SwitchWitness<T>.OnSource` subscribed the inner and then called `InnerSlot.Create(...)` unconditionally. Subscribing can deliver a value synchronously, and a downstream handler is free to feed the outer sequence again. That re-entrant call installs generation N+1 and returns; the original call then installs generation N, disposing N+1. Because `_version` is now N+1, every notification from the surviving subscription is filtered out by the version check -- the sequence produces nothing further and never completes. A consumer awaiting completion waits forever.
- `MergeCoordinator<T>.OnInnerCompleted` decremented `Active` on every inner completion. A source that signals completion more than once therefore decremented on behalf of a sibling that was still running, driving `Active` to zero early: the merge completed and dropped everything the sibling had left to produce.

Neither requires a misbehaving consumer to hit -- the switch case only needs a feedback loop through a downstream handler, which is ordinary in property-observation pipelines.

## What might this PR break?

- **A consumer relying on the early completion from a doubled inner completion** would now wait for its siblings, which is the documented merge contract.
- No public API change: both types keep their existing surface, and the fixes are internal to `OnSource` / the inner completion path.

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [x] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information

**These were found from downstream, not by inspection.** ReactiveUI's `WhenAnyObservable` has its own hand-written switch and merge sinks that duplicate what `Advanced` provides. Replacing them with `SwitchSignal<T>` and `SwitchSignal<T>` over `MergeSignal<T>` compiled cleanly but failed three of ReactiveUI's concurrency tests -- the two re-entrancy cases and the doubled-completion case above. The stalling shape matches a CI hang that took a six-hour job timeout to surface there, so the failure mode is not theoretical.

Both new tests were confirmed to fail against the unmodified coordinators and pass with the fix, so they are genuine regression guards rather than tests written to match current behaviour.

Verification: `ReactiveUI.Primitives` builds clean for net9.0, and `ReactiveUI.Primitives.Tests` is 838/838 on net9.0 (836/838 with the fixes reverted -- exactly the two new tests).
