### PR TITLE
feat(advanced): add the SwitchMap fused sink

### DIFF
--- a/src/Primitives.Shared/Advanced/SwitchMapSignal{TSource,TResult}.cs
+++ b/src/Primitives.Shared/Advanced/SwitchMapSignal{TSource,TResult}.cs
@@ -1,0 +1,264 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+#if REACTIVE_SHIM
+namespace ReactiveUI.Primitives.Reactive.Advanced;
+#else
+namespace ReactiveUI.Primitives.Advanced;
+#endif
+
+/// <summary>Projects each source value to an inner observable and mirrors only the latest one.</summary>
+/// <typeparam name="TSource">The source element type.</typeparam>
+/// <typeparam name="TResult">The element type of the projected inner observables.</typeparam>
+/// <remarks>
+/// Fuses the projection into the switch: one object and one observer hop, where a projection followed by a
+/// separate switch costs two of each and an intermediate sequence of observables.
+/// </remarks>
+public sealed class SwitchMapSignal<TSource, TResult> : IObservable<TResult>
+{
+    /// <summary>The source whose values are projected to inner observables.</summary>
+    private readonly IObservable<TSource> _source;
+
+    /// <summary>Projects a source value to the inner observable to switch to.</summary>
+    private readonly Func<TSource, IObservable<TResult>> _selector;
+
+    /// <summary>Whether a null source value is skipped rather than projected.</summary>
+    private readonly bool _skipNullSources;
+
+    /// <summary>Initializes a new instance of the <see cref="SwitchMapSignal{TSource, TResult}"/> class.</summary>
+    /// <param name="source">The source whose values are projected to inner observables.</param>
+    /// <param name="selector">Projects a source value to the inner observable to switch to.</param>
+    public SwitchMapSignal(IObservable<TSource> source, Func<TSource, IObservable<TResult>> selector)
+        : this(source, selector, skipNullSources: false)
+    {
+    }
+
+    /// <summary>Initializes a new instance of the <see cref="SwitchMapSignal{TSource, TResult}"/> class.</summary>
+    /// <param name="source">The source whose values are projected to inner observables.</param>
+    /// <param name="selector">Projects a source value to the inner observable to switch to.</param>
+    /// <param name="skipNullSources">
+    /// Whether a null source value leaves the active inner subscription in place rather than switching. A caller
+    /// that projects null onto its own inner observable switches on it instead, which detaches the previous one.
+    /// </param>
+    internal SwitchMapSignal(
+        IObservable<TSource> source,
+        Func<TSource, IObservable<TResult>> selector,
+        bool skipNullSources)
+    {
+        ArgumentExceptionHelper.ThrowIfNull(source);
+        ArgumentExceptionHelper.ThrowIfNull(selector);
+
+        _source = source;
+        _selector = selector;
+        _skipNullSources = skipNullSources;
+    }
+
+    /// <inheritdoc/>
+    public IDisposable Subscribe(IObserver<TResult> observer)
+    {
+        ArgumentExceptionHelper.ThrowIfNull(observer);
+
+        Sink sink = new(_selector, observer, _skipNullSources);
+        sink.Run(_source);
+        return sink;
+    }
+
+    /// <summary>Subscribes to the source, switching the active inner subscription as values arrive.</summary>
+    /// <param name="selector">Projects a source value to the inner observable to switch to.</param>
+    /// <param name="downstream">The downstream observer that receives values from the latest inner observable.</param>
+    /// <param name="skipNullSources">Whether a null source value is skipped rather than projected.</param>
+    private sealed class Sink(
+        Func<TSource, IObservable<TResult>> selector,
+        IObserver<TResult> downstream,
+        bool skipNullSources) : IObserver<TSource>, IDisposable
+    {
+        /// <summary>Guards the switching state so outer and inner notifications stay consistent.</summary>
+        private readonly Lock _gate = new();
+
+        /// <summary>The outer (source) subscription.</summary>
+        private readonly OnceDisposable _outer = new();
+
+        /// <summary>The active inner subscription; assigning a new value disposes the previous one.</summary>
+        private readonly SwapDisposable _inner = new();
+
+        /// <summary>Generation id of the most recent inner observable; stale inner notifications are ignored.</summary>
+        private ulong _latest;
+
+        /// <summary>Whether an inner subscription is currently active.</summary>
+        private bool _hasInner;
+
+        /// <summary>Whether the outer source has completed.</summary>
+        private bool _outerCompleted;
+
+        /// <summary>Whether this sink has been disposed.</summary>
+        private bool _disposed;
+
+        /// <summary>Begins observing the source.</summary>
+        /// <param name="source">The source observable.</param>
+        public void Run(IObservable<TSource> source) => _outer.Disposable = source.Subscribe(this);
+
+        /// <inheritdoc/>
+        public void OnNext(TSource value)
+        {
+            if (skipNullSources && value is null)
+            {
+                return;
+            }
+
+            IObservable<TResult> inner;
+            try
+            {
+                inner = selector(value);
+            }
+            catch (Exception ex)
+            {
+                OnError(ex);
+                return;
+            }
+
+            ulong id;
+            lock (_gate)
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+
+                id = ++_latest;
+                _hasInner = true;
+            }
+
+            _inner.Disposable = inner.Subscribe(new InnerWitness(this, id));
+        }
+
+        /// <inheritdoc/>
+        public void OnError(Exception error)
+        {
+            lock (_gate)
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+            }
+
+            downstream.OnError(error);
+            Dispose();
+        }
+
+        /// <inheritdoc/>
+        public void OnCompleted()
+        {
+            bool complete;
+            lock (_gate)
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+
+                _outerCompleted = true;
+                complete = !_hasInner;
+            }
+
+            if (!complete)
+            {
+                return;
+            }
+
+            downstream.OnCompleted();
+            Dispose();
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            lock (_gate)
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+
+                _disposed = true;
+            }
+
+            _outer.Dispose();
+            _inner.Dispose();
+        }
+
+        /// <summary>Forwards an inner value to the downstream observer if it belongs to the active inner subscription.</summary>
+        /// <param name="id">The generation id of the inner subscription that produced the value.</param>
+        /// <param name="value">The value to forward.</param>
+        private void InnerOnNext(ulong id, TResult value)
+        {
+            lock (_gate)
+            {
+                if (_disposed || id != _latest)
+                {
+                    return;
+                }
+            }
+
+            downstream.OnNext(value);
+        }
+
+        /// <summary>Forwards an inner error to the downstream observer if it belongs to the active inner subscription.</summary>
+        /// <param name="id">The generation id of the inner subscription that errored.</param>
+        /// <param name="error">The error to forward.</param>
+        private void InnerOnError(ulong id, Exception error)
+        {
+            lock (_gate)
+            {
+                if (_disposed || id != _latest)
+                {
+                    return;
+                }
+            }
+
+            downstream.OnError(error);
+            Dispose();
+        }
+
+        /// <summary>Clears the active inner subscription; completes downstream only if the outer has also completed.</summary>
+        /// <param name="id">The generation id of the inner subscription that completed.</param>
+        private void InnerOnCompleted(ulong id)
+        {
+            bool complete;
+            lock (_gate)
+            {
+                if (_disposed || id != _latest)
+                {
+                    return;
+                }
+
+                _hasInner = false;
+                complete = _outerCompleted;
+            }
+
+            if (!complete)
+            {
+                return;
+            }
+
+            downstream.OnCompleted();
+            Dispose();
+        }
+
+        /// <summary>Observes a single inner observable and routes its notifications through the parent sink.</summary>
+        /// <param name="parent">The owning sink.</param>
+        /// <param name="id">The generation id of this inner subscription.</param>
+        private sealed class InnerWitness(Sink parent, ulong id) : IObserver<TResult>
+        {
+            /// <inheritdoc/>
+            public void OnNext(TResult value) => parent.InnerOnNext(id, value);
+
+            /// <inheritdoc/>
+            public void OnError(Exception error) => parent.InnerOnError(id, error);
+
+            /// <inheritdoc/>
+            public void OnCompleted() => parent.InnerOnCompleted(id);
+        }
+    }
+}

--- a/src/Primitives.Shared/SignalOperatorMixins.ChooseSwitchSelect.cs
+++ b/src/Primitives.Shared/SignalOperatorMixins.ChooseSwitchSelect.cs
@@ -9,8 +9,8 @@ namespace ReactiveUI.Primitives;
 #endif
 
 /// <summary>
-/// Fused projection operators: <c>Choose</c> (filter + map in one sink) and <c>SwitchSelect</c>
-/// (filter-null + map-to-inner + switch-to-latest in one sink).
+/// Fused projection operators: <c>Choose</c> (filter + map in one sink), <c>SwitchMap</c> (map-to-inner +
+/// switch-to-latest in one sink) and <c>SwitchSelect</c> (the same, skipping null source values).
 /// </summary>
 public static partial class LinqExtensions
 {
@@ -19,6 +19,26 @@ public static partial class LinqExtensions
     /// <typeparam name="TIn">The source element type.</typeparam>
     extension<TIn>(IObservable<TIn> source)
     {
+        /// <summary>
+        /// Projects each source value to an inner observable and mirrors only the latest one — a single fused
+        /// sink in place of <c>Select(selector).Switch()</c>.
+        /// </summary>
+        /// <typeparam name="TOut">The element type of the projected inner observables.</typeparam>
+        /// <param name="selector">Projects each source value to an inner observable.</param>
+        /// <returns>An observable that mirrors the latest projected inner observable.</returns>
+        /// <remarks>
+        /// Every source value switches, a null among them included. Skipping nulls, which leaves the active
+        /// inner subscription in place, is <see cref="SwitchSelect{TSource, TResult}"/> instead.
+        /// </remarks>
+        public IObservable<TOut> SwitchMap<TOut>(Func<TIn, IObservable<TOut>> selector)
+        {
+            ArgumentExceptionHelper.ThrowIfNull(source);
+
+            ArgumentExceptionHelper.ThrowIfNull(selector);
+
+            return new SwitchMapSignal<TIn, TOut>(source, selector);
+        }
+
         /// <summary>
         /// Maps each source value to a <c>(HasValue, Value)</c> pair and forwards only the values whose
         /// <c>HasValue</c> is <see langword="true"/> — a single fused sink in place of <c>Where(...).Select(...)</c>.
@@ -55,7 +75,7 @@ public static partial class LinqExtensions
 
             ArgumentExceptionHelper.ThrowIfNull(selector);
 
-            return new SwitchSelectSignal<TSource, TResult>(source, selector);
+            return new SwitchMapSignal<TSource, TResult>(source!, selector, skipNullSources: true);
         }
     }
 
@@ -108,220 +128,6 @@ public static partial class LinqExtensions
 
             /// <inheritdoc/>
             public void OnCompleted() => downstream.OnCompleted();
-        }
-    }
-
-    /// <summary>A fused filter-null + map-to-inner + switch-to-latest observable.</summary>
-    /// <typeparam name="TSource">The (nullable) source element type.</typeparam>
-    /// <typeparam name="TResult">The element type of the projected inner observables.</typeparam>
-    /// <param name="source">The source observable whose non-null values are projected to inner observables.</param>
-    /// <param name="selector">Projects each non-null source value to an inner observable.</param>
-    private sealed class SwitchSelectSignal<TSource, TResult>(
-        IObservable<TSource?> source,
-        Func<TSource, IObservable<TResult>> selector) : IObservable<TResult>
-    {
-        /// <inheritdoc/>
-        public IDisposable Subscribe(IObserver<TResult> observer)
-        {
-            ArgumentExceptionHelper.ThrowIfNull(observer);
-
-            Sink sink = new(selector, observer);
-            sink.Run(source);
-            return sink;
-        }
-
-        /// <summary>Subscribes to the source, switching the active inner subscription on each non-null value.</summary>
-        /// <param name="selector">Projects each non-null source value to an inner observable.</param>
-        /// <param name="downstream">The downstream observer that receives values from the latest inner observable.</param>
-        private sealed class Sink(Func<TSource, IObservable<TResult>> selector, IObserver<TResult> downstream) : IObserver<TSource?>, IDisposable
-        {
-            /// <summary>Guards the switching state so outer and inner notifications stay consistent.</summary>
-            private readonly Lock _gate = new();
-
-            /// <summary>The outer (source) subscription.</summary>
-            private readonly OnceDisposable _outer = new();
-
-            /// <summary>The active inner subscription; assigning a new value disposes the previous one.</summary>
-            private readonly SwapDisposable _inner = new();
-
-            /// <summary>Generation id of the most recent inner observable; stale inner notifications are ignored.</summary>
-            private ulong _latest;
-
-            /// <summary>Whether an inner subscription is currently active.</summary>
-            private bool _hasInner;
-
-            /// <summary>Whether the outer source has completed.</summary>
-            private bool _outerCompleted;
-
-            /// <summary>Whether this sink has been disposed.</summary>
-            private bool _disposed;
-
-            /// <summary>Begins observing the source.</summary>
-            /// <param name="source">The source observable.</param>
-            public void Run(IObservable<TSource?> source) => _outer.Disposable = source.Subscribe(this);
-
-            /// <inheritdoc/>
-            public void OnNext(TSource? value)
-            {
-                if (value is null)
-                {
-                    return;
-                }
-
-                IObservable<TResult> inner;
-                try
-                {
-                    inner = selector(value);
-                }
-                catch (Exception ex)
-                {
-                    OnError(ex);
-                    return;
-                }
-
-                ulong id;
-                lock (_gate)
-                {
-                    if (_disposed)
-                    {
-                        return;
-                    }
-
-                    id = ++_latest;
-                    _hasInner = true;
-                }
-
-                _inner.Disposable = inner.Subscribe(new InnerWitness(this, id));
-            }
-
-            /// <inheritdoc/>
-            public void OnError(Exception error)
-            {
-                lock (_gate)
-                {
-                    if (_disposed)
-                    {
-                        return;
-                    }
-                }
-
-                downstream.OnError(error);
-                Dispose();
-            }
-
-            /// <inheritdoc/>
-            public void OnCompleted()
-            {
-                bool complete;
-                lock (_gate)
-                {
-                    if (_disposed)
-                    {
-                        return;
-                    }
-
-                    _outerCompleted = true;
-                    complete = !_hasInner;
-                }
-
-                if (!complete)
-                {
-                    return;
-                }
-
-                downstream.OnCompleted();
-                Dispose();
-            }
-
-            /// <inheritdoc/>
-            public void Dispose()
-            {
-                lock (_gate)
-                {
-                    if (_disposed)
-                    {
-                        return;
-                    }
-
-                    _disposed = true;
-                }
-
-                _outer.Dispose();
-                _inner.Dispose();
-            }
-
-            /// <summary>Forwards an inner value to the downstream observer if it belongs to the active inner subscription.</summary>
-            /// <param name="id">The generation id of the inner subscription that produced the value.</param>
-            /// <param name="value">The value to forward.</param>
-            private void InnerOnNext(ulong id, TResult value)
-            {
-                lock (_gate)
-                {
-                    if (_disposed || id != _latest)
-                    {
-                        return;
-                    }
-                }
-
-                downstream.OnNext(value);
-            }
-
-            /// <summary>Forwards an inner error to the downstream observer if it belongs to the active inner subscription.</summary>
-            /// <param name="id">The generation id of the inner subscription that errored.</param>
-            /// <param name="error">The error to forward.</param>
-            private void InnerOnError(ulong id, Exception error)
-            {
-                lock (_gate)
-                {
-                    if (_disposed || id != _latest)
-                    {
-                        return;
-                    }
-                }
-
-                downstream.OnError(error);
-                Dispose();
-            }
-
-            /// <summary>Clears the active inner subscription; completes downstream only if the outer has also completed.</summary>
-            /// <param name="id">The generation id of the inner subscription that completed.</param>
-            private void InnerOnCompleted(ulong id)
-            {
-                bool complete;
-                lock (_gate)
-                {
-                    if (_disposed || id != _latest)
-                    {
-                        return;
-                    }
-
-                    _hasInner = false;
-                    complete = _outerCompleted;
-                }
-
-                if (!complete)
-                {
-                    return;
-                }
-
-                downstream.OnCompleted();
-                Dispose();
-            }
-
-            /// <summary>Observes a single inner observable and routes its notifications through the parent sink.</summary>
-            /// <param name="parent">The owning sink.</param>
-            /// <param name="id">The generation id of this inner subscription.</param>
-            private sealed class InnerWitness(Sink parent, ulong id) : IObserver<TResult>
-            {
-                /// <inheritdoc/>
-                public void OnNext(TResult value) => parent.InnerOnNext(id, value);
-
-                /// <inheritdoc/>
-                public void OnError(Exception error) => parent.InnerOnError(id, error);
-
-                /// <inheritdoc/>
-                public void OnCompleted() => parent.InnerOnCompleted(id);
-            }
         }
     }
 }

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-android/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-android/PublicAPI.Shipped.txt
@@ -465,6 +465,9 @@ ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.OnError(System.E
 ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.OnNext(T value) -> void
 ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.SetSubscription(System.IDisposable! subscription) -> void
 ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.SubscribeSafeWitness(System.IObserver<T>! observer) -> void
+ReactiveUI.Primitives.Reactive.Advanced.SwitchMapSignal<TSource, TResult>
+ReactiveUI.Primitives.Reactive.Advanced.SwitchMapSignal<TSource, TResult>.Subscribe(System.IObserver<TResult>! observer) -> System.IDisposable!
+ReactiveUI.Primitives.Reactive.Advanced.SwitchMapSignal<TSource, TResult>.SwitchMapSignal(System.IObservable<TSource>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> void
 ReactiveUI.Primitives.Reactive.Advanced.SwitchSignal<T>
 ReactiveUI.Primitives.Reactive.Advanced.SwitchSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Reactive.Advanced.SwitchSignal<T>.SwitchSignal(System.IObservable<System.IObservable<T>!>! sources) -> void
@@ -822,6 +825,7 @@ ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.Threading.Task
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.Threading.Tasks.Task<T>!).ToTask(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<T>!
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TIn>(System.IObservable<TIn>!)
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).Choose<TOut>(System.Func<TIn, (bool HasValue, TOut Value)>! chooser) -> System.IObservable<TOut>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).SwitchMap<TOut>(System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!)
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).CombineLatest<TRight, TResult>(System.IObservable<TRight>! right, System.Func<TLeft, TRight, TResult>! selector) -> System.IObservable<TResult>!
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
@@ -1279,6 +1283,7 @@ static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(this Syste
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.IObserver<T>! observer) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.Switch<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SwitchMap<TIn, TOut>(this System.IObservable<TIn>! source, System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SwitchSelect<TSource, TResult>(this System.IObservable<TSource?>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SwitchTo<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SyncLatest<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>(this System.IObservable<T>! source, System.IObservable<T2>! source2, System.IObservable<T3>! source3, System.IObservable<T4>! source4, System.IObservable<T5>! source5, System.IObservable<T6>! source6, System.IObservable<T7>! source7, System.IObservable<T8>! source8, System.IObservable<T9>! source9, System.IObservable<T10>! source10, System.IObservable<T11>! source11, System.IObservable<T12>! source12, System.IObservable<T13>! source13, System.IObservable<T14>! source14, System.IObservable<T15>! source15, System.IObservable<T16>! source16, System.Func<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>! selector) -> System.IObservable<TResult>!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-ios/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-ios/PublicAPI.Shipped.txt
@@ -465,6 +465,9 @@ ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.OnError(System.E
 ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.OnNext(T value) -> void
 ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.SetSubscription(System.IDisposable! subscription) -> void
 ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.SubscribeSafeWitness(System.IObserver<T>! observer) -> void
+ReactiveUI.Primitives.Reactive.Advanced.SwitchMapSignal<TSource, TResult>
+ReactiveUI.Primitives.Reactive.Advanced.SwitchMapSignal<TSource, TResult>.Subscribe(System.IObserver<TResult>! observer) -> System.IDisposable!
+ReactiveUI.Primitives.Reactive.Advanced.SwitchMapSignal<TSource, TResult>.SwitchMapSignal(System.IObservable<TSource>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> void
 ReactiveUI.Primitives.Reactive.Advanced.SwitchSignal<T>
 ReactiveUI.Primitives.Reactive.Advanced.SwitchSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Reactive.Advanced.SwitchSignal<T>.SwitchSignal(System.IObservable<System.IObservable<T>!>! sources) -> void
@@ -820,6 +823,7 @@ ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.Threading.Task
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.Threading.Tasks.Task<T>!).ToTask(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<T>!
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TIn>(System.IObservable<TIn>!)
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).Choose<TOut>(System.Func<TIn, (bool HasValue, TOut Value)>! chooser) -> System.IObservable<TOut>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).SwitchMap<TOut>(System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!)
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).CombineLatest<TRight, TResult>(System.IObservable<TRight>! right, System.Func<TLeft, TRight, TResult>! selector) -> System.IObservable<TResult>!
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
@@ -1275,6 +1279,7 @@ static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(this Syste
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.IObserver<T>! observer) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.Switch<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SwitchMap<TIn, TOut>(this System.IObservable<TIn>! source, System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SwitchSelect<TSource, TResult>(this System.IObservable<TSource?>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SwitchTo<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SyncLatest<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>(this System.IObservable<T>! source, System.IObservable<T2>! source2, System.IObservable<T3>! source3, System.IObservable<T4>! source4, System.IObservable<T5>! source5, System.IObservable<T6>! source6, System.IObservable<T7>! source7, System.IObservable<T8>! source8, System.IObservable<T9>! source9, System.IObservable<T10>! source10, System.IObservable<T11>! source11, System.IObservable<T12>! source12, System.IObservable<T13>! source13, System.IObservable<T14>! source14, System.IObservable<T15>! source15, System.IObservable<T16>! source16, System.Func<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>! selector) -> System.IObservable<TResult>!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-maccatalyst/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-maccatalyst/PublicAPI.Shipped.txt
@@ -465,6 +465,9 @@ ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.OnError(System.E
 ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.OnNext(T value) -> void
 ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.SetSubscription(System.IDisposable! subscription) -> void
 ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.SubscribeSafeWitness(System.IObserver<T>! observer) -> void
+ReactiveUI.Primitives.Reactive.Advanced.SwitchMapSignal<TSource, TResult>
+ReactiveUI.Primitives.Reactive.Advanced.SwitchMapSignal<TSource, TResult>.Subscribe(System.IObserver<TResult>! observer) -> System.IDisposable!
+ReactiveUI.Primitives.Reactive.Advanced.SwitchMapSignal<TSource, TResult>.SwitchMapSignal(System.IObservable<TSource>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> void
 ReactiveUI.Primitives.Reactive.Advanced.SwitchSignal<T>
 ReactiveUI.Primitives.Reactive.Advanced.SwitchSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Reactive.Advanced.SwitchSignal<T>.SwitchSignal(System.IObservable<System.IObservable<T>!>! sources) -> void
@@ -820,6 +823,7 @@ ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.Threading.Task
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.Threading.Tasks.Task<T>!).ToTask(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<T>!
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TIn>(System.IObservable<TIn>!)
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).Choose<TOut>(System.Func<TIn, (bool HasValue, TOut Value)>! chooser) -> System.IObservable<TOut>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).SwitchMap<TOut>(System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!)
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).CombineLatest<TRight, TResult>(System.IObservable<TRight>! right, System.Func<TLeft, TRight, TResult>! selector) -> System.IObservable<TResult>!
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
@@ -1275,6 +1279,7 @@ static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(this Syste
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.IObserver<T>! observer) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.Switch<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SwitchMap<TIn, TOut>(this System.IObservable<TIn>! source, System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SwitchSelect<TSource, TResult>(this System.IObservable<TSource?>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SwitchTo<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SyncLatest<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>(this System.IObservable<T>! source, System.IObservable<T2>! source2, System.IObservable<T3>! source3, System.IObservable<T4>! source4, System.IObservable<T5>! source5, System.IObservable<T6>! source6, System.IObservable<T7>! source7, System.IObservable<T8>! source8, System.IObservable<T9>! source9, System.IObservable<T10>! source10, System.IObservable<T11>! source11, System.IObservable<T12>! source12, System.IObservable<T13>! source13, System.IObservable<T14>! source14, System.IObservable<T15>! source15, System.IObservable<T16>! source16, System.Func<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>! selector) -> System.IObservable<TResult>!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-macos/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-macos/PublicAPI.Shipped.txt
@@ -465,6 +465,9 @@ ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.OnError(System.E
 ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.OnNext(T value) -> void
 ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.SetSubscription(System.IDisposable! subscription) -> void
 ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.SubscribeSafeWitness(System.IObserver<T>! observer) -> void
+ReactiveUI.Primitives.Reactive.Advanced.SwitchMapSignal<TSource, TResult>
+ReactiveUI.Primitives.Reactive.Advanced.SwitchMapSignal<TSource, TResult>.Subscribe(System.IObserver<TResult>! observer) -> System.IDisposable!
+ReactiveUI.Primitives.Reactive.Advanced.SwitchMapSignal<TSource, TResult>.SwitchMapSignal(System.IObservable<TSource>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> void
 ReactiveUI.Primitives.Reactive.Advanced.SwitchSignal<T>
 ReactiveUI.Primitives.Reactive.Advanced.SwitchSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Reactive.Advanced.SwitchSignal<T>.SwitchSignal(System.IObservable<System.IObservable<T>!>! sources) -> void
@@ -820,6 +823,7 @@ ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.Threading.Task
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.Threading.Tasks.Task<T>!).ToTask(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<T>!
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TIn>(System.IObservable<TIn>!)
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).Choose<TOut>(System.Func<TIn, (bool HasValue, TOut Value)>! chooser) -> System.IObservable<TOut>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).SwitchMap<TOut>(System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!)
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).CombineLatest<TRight, TResult>(System.IObservable<TRight>! right, System.Func<TLeft, TRight, TResult>! selector) -> System.IObservable<TResult>!
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
@@ -1275,6 +1279,7 @@ static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(this Syste
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.IObserver<T>! observer) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.Switch<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SwitchMap<TIn, TOut>(this System.IObservable<TIn>! source, System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SwitchSelect<TSource, TResult>(this System.IObservable<TSource?>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SwitchTo<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SyncLatest<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>(this System.IObservable<T>! source, System.IObservable<T2>! source2, System.IObservable<T3>! source3, System.IObservable<T4>! source4, System.IObservable<T5>! source5, System.IObservable<T6>! source6, System.IObservable<T7>! source7, System.IObservable<T8>! source8, System.IObservable<T9>! source9, System.IObservable<T10>! source10, System.IObservable<T11>! source11, System.IObservable<T12>! source12, System.IObservable<T13>! source13, System.IObservable<T14>! source14, System.IObservable<T15>! source15, System.IObservable<T16>! source16, System.Func<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>! selector) -> System.IObservable<TResult>!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-tvos/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-tvos/PublicAPI.Shipped.txt
@@ -465,6 +465,9 @@ ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.OnError(System.E
 ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.OnNext(T value) -> void
 ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.SetSubscription(System.IDisposable! subscription) -> void
 ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.SubscribeSafeWitness(System.IObserver<T>! observer) -> void
+ReactiveUI.Primitives.Reactive.Advanced.SwitchMapSignal<TSource, TResult>
+ReactiveUI.Primitives.Reactive.Advanced.SwitchMapSignal<TSource, TResult>.Subscribe(System.IObserver<TResult>! observer) -> System.IDisposable!
+ReactiveUI.Primitives.Reactive.Advanced.SwitchMapSignal<TSource, TResult>.SwitchMapSignal(System.IObservable<TSource>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> void
 ReactiveUI.Primitives.Reactive.Advanced.SwitchSignal<T>
 ReactiveUI.Primitives.Reactive.Advanced.SwitchSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Reactive.Advanced.SwitchSignal<T>.SwitchSignal(System.IObservable<System.IObservable<T>!>! sources) -> void
@@ -820,6 +823,7 @@ ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.Threading.Task
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.Threading.Tasks.Task<T>!).ToTask(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<T>!
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TIn>(System.IObservable<TIn>!)
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).Choose<TOut>(System.Func<TIn, (bool HasValue, TOut Value)>! chooser) -> System.IObservable<TOut>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).SwitchMap<TOut>(System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!)
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).CombineLatest<TRight, TResult>(System.IObservable<TRight>! right, System.Func<TLeft, TRight, TResult>! selector) -> System.IObservable<TResult>!
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
@@ -1275,6 +1279,7 @@ static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(this Syste
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.IObserver<T>! observer) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.Switch<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SwitchMap<TIn, TOut>(this System.IObservable<TIn>! source, System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SwitchSelect<TSource, TResult>(this System.IObservable<TSource?>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SwitchTo<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SyncLatest<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>(this System.IObservable<T>! source, System.IObservable<T2>! source2, System.IObservable<T3>! source3, System.IObservable<T4>! source4, System.IObservable<T5>! source5, System.IObservable<T6>! source6, System.IObservable<T7>! source7, System.IObservable<T8>! source8, System.IObservable<T9>! source9, System.IObservable<T10>! source10, System.IObservable<T11>! source11, System.IObservable<T12>! source12, System.IObservable<T13>! source13, System.IObservable<T14>! source14, System.IObservable<T15>! source15, System.IObservable<T16>! source16, System.Func<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>! selector) -> System.IObservable<TResult>!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0/PublicAPI.Shipped.txt
@@ -465,6 +465,9 @@ ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.OnError(System.E
 ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.OnNext(T value) -> void
 ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.SetSubscription(System.IDisposable! subscription) -> void
 ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.SubscribeSafeWitness(System.IObserver<T>! observer) -> void
+ReactiveUI.Primitives.Reactive.Advanced.SwitchMapSignal<TSource, TResult>
+ReactiveUI.Primitives.Reactive.Advanced.SwitchMapSignal<TSource, TResult>.Subscribe(System.IObserver<TResult>! observer) -> System.IDisposable!
+ReactiveUI.Primitives.Reactive.Advanced.SwitchMapSignal<TSource, TResult>.SwitchMapSignal(System.IObservable<TSource>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> void
 ReactiveUI.Primitives.Reactive.Advanced.SwitchSignal<T>
 ReactiveUI.Primitives.Reactive.Advanced.SwitchSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Reactive.Advanced.SwitchSignal<T>.SwitchSignal(System.IObservable<System.IObservable<T>!>! sources) -> void
@@ -816,6 +819,7 @@ ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.Threading.Task
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.Threading.Tasks.Task<T>!).ToTask(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<T>!
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TIn>(System.IObservable<TIn>!)
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).Choose<TOut>(System.Func<TIn, (bool HasValue, TOut Value)>! chooser) -> System.IObservable<TOut>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).SwitchMap<TOut>(System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!)
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).CombineLatest<TRight, TResult>(System.IObservable<TRight>! right, System.Func<TLeft, TRight, TResult>! selector) -> System.IObservable<TResult>!
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
@@ -1266,6 +1270,7 @@ static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(this Syste
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.IObserver<T>! observer) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.Switch<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SwitchMap<TIn, TOut>(this System.IObservable<TIn>! source, System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SwitchSelect<TSource, TResult>(this System.IObservable<TSource?>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SwitchTo<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SyncLatest<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>(this System.IObservable<T>! source, System.IObservable<T2>! source2, System.IObservable<T3>! source3, System.IObservable<T4>! source4, System.IObservable<T5>! source5, System.IObservable<T6>! source6, System.IObservable<T7>! source7, System.IObservable<T8>! source8, System.IObservable<T9>! source9, System.IObservable<T10>! source10, System.IObservable<T11>! source11, System.IObservable<T12>! source12, System.IObservable<T13>! source13, System.IObservable<T14>! source14, System.IObservable<T15>! source15, System.IObservable<T16>! source16, System.Func<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>! selector) -> System.IObservable<TResult>!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-android/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-android/PublicAPI.Shipped.txt
@@ -465,6 +465,9 @@ ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.OnError(System.E
 ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.OnNext(T value) -> void
 ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.SetSubscription(System.IDisposable! subscription) -> void
 ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.SubscribeSafeWitness(System.IObserver<T>! observer) -> void
+ReactiveUI.Primitives.Reactive.Advanced.SwitchMapSignal<TSource, TResult>
+ReactiveUI.Primitives.Reactive.Advanced.SwitchMapSignal<TSource, TResult>.Subscribe(System.IObserver<TResult>! observer) -> System.IDisposable!
+ReactiveUI.Primitives.Reactive.Advanced.SwitchMapSignal<TSource, TResult>.SwitchMapSignal(System.IObservable<TSource>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> void
 ReactiveUI.Primitives.Reactive.Advanced.SwitchSignal<T>
 ReactiveUI.Primitives.Reactive.Advanced.SwitchSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Reactive.Advanced.SwitchSignal<T>.SwitchSignal(System.IObservable<System.IObservable<T>!>! sources) -> void
@@ -822,6 +825,7 @@ ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.Threading.Task
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.Threading.Tasks.Task<T>!).ToTask(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<T>!
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TIn>(System.IObservable<TIn>!)
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).Choose<TOut>(System.Func<TIn, (bool HasValue, TOut Value)>! chooser) -> System.IObservable<TOut>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).SwitchMap<TOut>(System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!)
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).CombineLatest<TRight, TResult>(System.IObservable<TRight>! right, System.Func<TLeft, TRight, TResult>! selector) -> System.IObservable<TResult>!
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
@@ -1279,6 +1283,7 @@ static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(this Syste
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.IObserver<T>! observer) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.Switch<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SwitchMap<TIn, TOut>(this System.IObservable<TIn>! source, System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SwitchSelect<TSource, TResult>(this System.IObservable<TSource?>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SwitchTo<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SyncLatest<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>(this System.IObservable<T>! source, System.IObservable<T2>! source2, System.IObservable<T3>! source3, System.IObservable<T4>! source4, System.IObservable<T5>! source5, System.IObservable<T6>! source6, System.IObservable<T7>! source7, System.IObservable<T8>! source8, System.IObservable<T9>! source9, System.IObservable<T10>! source10, System.IObservable<T11>! source11, System.IObservable<T12>! source12, System.IObservable<T13>! source13, System.IObservable<T14>! source14, System.IObservable<T15>! source15, System.IObservable<T16>! source16, System.Func<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>! selector) -> System.IObservable<TResult>!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-ios/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-ios/PublicAPI.Shipped.txt
@@ -465,6 +465,9 @@ ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.OnError(System.E
 ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.OnNext(T value) -> void
 ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.SetSubscription(System.IDisposable! subscription) -> void
 ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.SubscribeSafeWitness(System.IObserver<T>! observer) -> void
+ReactiveUI.Primitives.Reactive.Advanced.SwitchMapSignal<TSource, TResult>
+ReactiveUI.Primitives.Reactive.Advanced.SwitchMapSignal<TSource, TResult>.Subscribe(System.IObserver<TResult>! observer) -> System.IDisposable!
+ReactiveUI.Primitives.Reactive.Advanced.SwitchMapSignal<TSource, TResult>.SwitchMapSignal(System.IObservable<TSource>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> void
 ReactiveUI.Primitives.Reactive.Advanced.SwitchSignal<T>
 ReactiveUI.Primitives.Reactive.Advanced.SwitchSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Reactive.Advanced.SwitchSignal<T>.SwitchSignal(System.IObservable<System.IObservable<T>!>! sources) -> void
@@ -820,6 +823,7 @@ ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.Threading.Task
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.Threading.Tasks.Task<T>!).ToTask(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<T>!
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TIn>(System.IObservable<TIn>!)
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).Choose<TOut>(System.Func<TIn, (bool HasValue, TOut Value)>! chooser) -> System.IObservable<TOut>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).SwitchMap<TOut>(System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!)
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).CombineLatest<TRight, TResult>(System.IObservable<TRight>! right, System.Func<TLeft, TRight, TResult>! selector) -> System.IObservable<TResult>!
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
@@ -1275,6 +1279,7 @@ static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(this Syste
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.IObserver<T>! observer) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.Switch<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SwitchMap<TIn, TOut>(this System.IObservable<TIn>! source, System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SwitchSelect<TSource, TResult>(this System.IObservable<TSource?>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SwitchTo<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SyncLatest<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>(this System.IObservable<T>! source, System.IObservable<T2>! source2, System.IObservable<T3>! source3, System.IObservable<T4>! source4, System.IObservable<T5>! source5, System.IObservable<T6>! source6, System.IObservable<T7>! source7, System.IObservable<T8>! source8, System.IObservable<T9>! source9, System.IObservable<T10>! source10, System.IObservable<T11>! source11, System.IObservable<T12>! source12, System.IObservable<T13>! source13, System.IObservable<T14>! source14, System.IObservable<T15>! source15, System.IObservable<T16>! source16, System.Func<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>! selector) -> System.IObservable<TResult>!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-maccatalyst/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-maccatalyst/PublicAPI.Shipped.txt
@@ -465,6 +465,9 @@ ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.OnError(System.E
 ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.OnNext(T value) -> void
 ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.SetSubscription(System.IDisposable! subscription) -> void
 ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.SubscribeSafeWitness(System.IObserver<T>! observer) -> void
+ReactiveUI.Primitives.Reactive.Advanced.SwitchMapSignal<TSource, TResult>
+ReactiveUI.Primitives.Reactive.Advanced.SwitchMapSignal<TSource, TResult>.Subscribe(System.IObserver<TResult>! observer) -> System.IDisposable!
+ReactiveUI.Primitives.Reactive.Advanced.SwitchMapSignal<TSource, TResult>.SwitchMapSignal(System.IObservable<TSource>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> void
 ReactiveUI.Primitives.Reactive.Advanced.SwitchSignal<T>
 ReactiveUI.Primitives.Reactive.Advanced.SwitchSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Reactive.Advanced.SwitchSignal<T>.SwitchSignal(System.IObservable<System.IObservable<T>!>! sources) -> void
@@ -820,6 +823,7 @@ ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.Threading.Task
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.Threading.Tasks.Task<T>!).ToTask(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<T>!
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TIn>(System.IObservable<TIn>!)
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).Choose<TOut>(System.Func<TIn, (bool HasValue, TOut Value)>! chooser) -> System.IObservable<TOut>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).SwitchMap<TOut>(System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!)
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).CombineLatest<TRight, TResult>(System.IObservable<TRight>! right, System.Func<TLeft, TRight, TResult>! selector) -> System.IObservable<TResult>!
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
@@ -1275,6 +1279,7 @@ static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(this Syste
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.IObserver<T>! observer) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.Switch<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SwitchMap<TIn, TOut>(this System.IObservable<TIn>! source, System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SwitchSelect<TSource, TResult>(this System.IObservable<TSource?>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SwitchTo<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SyncLatest<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>(this System.IObservable<T>! source, System.IObservable<T2>! source2, System.IObservable<T3>! source3, System.IObservable<T4>! source4, System.IObservable<T5>! source5, System.IObservable<T6>! source6, System.IObservable<T7>! source7, System.IObservable<T8>! source8, System.IObservable<T9>! source9, System.IObservable<T10>! source10, System.IObservable<T11>! source11, System.IObservable<T12>! source12, System.IObservable<T13>! source13, System.IObservable<T14>! source14, System.IObservable<T15>! source15, System.IObservable<T16>! source16, System.Func<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>! selector) -> System.IObservable<TResult>!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-macos/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-macos/PublicAPI.Shipped.txt
@@ -465,6 +465,9 @@ ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.OnError(System.E
 ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.OnNext(T value) -> void
 ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.SetSubscription(System.IDisposable! subscription) -> void
 ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.SubscribeSafeWitness(System.IObserver<T>! observer) -> void
+ReactiveUI.Primitives.Reactive.Advanced.SwitchMapSignal<TSource, TResult>
+ReactiveUI.Primitives.Reactive.Advanced.SwitchMapSignal<TSource, TResult>.Subscribe(System.IObserver<TResult>! observer) -> System.IDisposable!
+ReactiveUI.Primitives.Reactive.Advanced.SwitchMapSignal<TSource, TResult>.SwitchMapSignal(System.IObservable<TSource>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> void
 ReactiveUI.Primitives.Reactive.Advanced.SwitchSignal<T>
 ReactiveUI.Primitives.Reactive.Advanced.SwitchSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Reactive.Advanced.SwitchSignal<T>.SwitchSignal(System.IObservable<System.IObservable<T>!>! sources) -> void
@@ -820,6 +823,7 @@ ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.Threading.Task
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.Threading.Tasks.Task<T>!).ToTask(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<T>!
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TIn>(System.IObservable<TIn>!)
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).Choose<TOut>(System.Func<TIn, (bool HasValue, TOut Value)>! chooser) -> System.IObservable<TOut>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).SwitchMap<TOut>(System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!)
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).CombineLatest<TRight, TResult>(System.IObservable<TRight>! right, System.Func<TLeft, TRight, TResult>! selector) -> System.IObservable<TResult>!
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
@@ -1275,6 +1279,7 @@ static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(this Syste
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.IObserver<T>! observer) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.Switch<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SwitchMap<TIn, TOut>(this System.IObservable<TIn>! source, System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SwitchSelect<TSource, TResult>(this System.IObservable<TSource?>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SwitchTo<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SyncLatest<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>(this System.IObservable<T>! source, System.IObservable<T2>! source2, System.IObservable<T3>! source3, System.IObservable<T4>! source4, System.IObservable<T5>! source5, System.IObservable<T6>! source6, System.IObservable<T7>! source7, System.IObservable<T8>! source8, System.IObservable<T9>! source9, System.IObservable<T10>! source10, System.IObservable<T11>! source11, System.IObservable<T12>! source12, System.IObservable<T13>! source13, System.IObservable<T14>! source14, System.IObservable<T15>! source15, System.IObservable<T16>! source16, System.Func<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>! selector) -> System.IObservable<TResult>!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-tvos/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-tvos/PublicAPI.Shipped.txt
@@ -465,6 +465,9 @@ ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.OnError(System.E
 ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.OnNext(T value) -> void
 ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.SetSubscription(System.IDisposable! subscription) -> void
 ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.SubscribeSafeWitness(System.IObserver<T>! observer) -> void
+ReactiveUI.Primitives.Reactive.Advanced.SwitchMapSignal<TSource, TResult>
+ReactiveUI.Primitives.Reactive.Advanced.SwitchMapSignal<TSource, TResult>.Subscribe(System.IObserver<TResult>! observer) -> System.IDisposable!
+ReactiveUI.Primitives.Reactive.Advanced.SwitchMapSignal<TSource, TResult>.SwitchMapSignal(System.IObservable<TSource>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> void
 ReactiveUI.Primitives.Reactive.Advanced.SwitchSignal<T>
 ReactiveUI.Primitives.Reactive.Advanced.SwitchSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Reactive.Advanced.SwitchSignal<T>.SwitchSignal(System.IObservable<System.IObservable<T>!>! sources) -> void
@@ -820,6 +823,7 @@ ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.Threading.Task
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.Threading.Tasks.Task<T>!).ToTask(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<T>!
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TIn>(System.IObservable<TIn>!)
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).Choose<TOut>(System.Func<TIn, (bool HasValue, TOut Value)>! chooser) -> System.IObservable<TOut>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).SwitchMap<TOut>(System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!)
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).CombineLatest<TRight, TResult>(System.IObservable<TRight>! right, System.Func<TLeft, TRight, TResult>! selector) -> System.IObservable<TResult>!
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
@@ -1275,6 +1279,7 @@ static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(this Syste
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.IObserver<T>! observer) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.Switch<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SwitchMap<TIn, TOut>(this System.IObservable<TIn>! source, System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SwitchSelect<TSource, TResult>(this System.IObservable<TSource?>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SwitchTo<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SyncLatest<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>(this System.IObservable<T>! source, System.IObservable<T2>! source2, System.IObservable<T3>! source3, System.IObservable<T4>! source4, System.IObservable<T5>! source5, System.IObservable<T6>! source6, System.IObservable<T7>! source7, System.IObservable<T8>! source8, System.IObservable<T9>! source9, System.IObservable<T10>! source10, System.IObservable<T11>! source11, System.IObservable<T12>! source12, System.IObservable<T13>! source13, System.IObservable<T14>! source14, System.IObservable<T15>! source15, System.IObservable<T16>! source16, System.Func<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>! selector) -> System.IObservable<TResult>!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0/PublicAPI.Shipped.txt
@@ -465,6 +465,9 @@ ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.OnError(System.E
 ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.OnNext(T value) -> void
 ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.SetSubscription(System.IDisposable! subscription) -> void
 ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.SubscribeSafeWitness(System.IObserver<T>! observer) -> void
+ReactiveUI.Primitives.Reactive.Advanced.SwitchMapSignal<TSource, TResult>
+ReactiveUI.Primitives.Reactive.Advanced.SwitchMapSignal<TSource, TResult>.Subscribe(System.IObserver<TResult>! observer) -> System.IDisposable!
+ReactiveUI.Primitives.Reactive.Advanced.SwitchMapSignal<TSource, TResult>.SwitchMapSignal(System.IObservable<TSource>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> void
 ReactiveUI.Primitives.Reactive.Advanced.SwitchSignal<T>
 ReactiveUI.Primitives.Reactive.Advanced.SwitchSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Reactive.Advanced.SwitchSignal<T>.SwitchSignal(System.IObservable<System.IObservable<T>!>! sources) -> void
@@ -816,6 +819,7 @@ ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.Threading.Task
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.Threading.Tasks.Task<T>!).ToTask(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<T>!
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TIn>(System.IObservable<TIn>!)
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).Choose<TOut>(System.Func<TIn, (bool HasValue, TOut Value)>! chooser) -> System.IObservable<TOut>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).SwitchMap<TOut>(System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!)
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).CombineLatest<TRight, TResult>(System.IObservable<TRight>! right, System.Func<TLeft, TRight, TResult>! selector) -> System.IObservable<TResult>!
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
@@ -1266,6 +1270,7 @@ static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(this Syste
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.IObserver<T>! observer) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.Switch<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SwitchMap<TIn, TOut>(this System.IObservable<TIn>! source, System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SwitchSelect<TSource, TResult>(this System.IObservable<TSource?>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SwitchTo<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SyncLatest<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>(this System.IObservable<T>! source, System.IObservable<T2>! source2, System.IObservable<T3>! source3, System.IObservable<T4>! source4, System.IObservable<T5>! source5, System.IObservable<T6>! source6, System.IObservable<T7>! source7, System.IObservable<T8>! source8, System.IObservable<T9>! source9, System.IObservable<T10>! source10, System.IObservable<T11>! source11, System.IObservable<T12>! source12, System.IObservable<T13>! source13, System.IObservable<T14>! source14, System.IObservable<T15>! source15, System.IObservable<T16>! source16, System.Func<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>! selector) -> System.IObservable<TResult>!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net462/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net462/PublicAPI.Shipped.txt
@@ -465,6 +465,9 @@ ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.OnError(System.E
 ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.OnNext(T value) -> void
 ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.SetSubscription(System.IDisposable! subscription) -> void
 ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.SubscribeSafeWitness(System.IObserver<T>! observer) -> void
+ReactiveUI.Primitives.Reactive.Advanced.SwitchMapSignal<TSource, TResult>
+ReactiveUI.Primitives.Reactive.Advanced.SwitchMapSignal<TSource, TResult>.Subscribe(System.IObserver<TResult>! observer) -> System.IDisposable!
+ReactiveUI.Primitives.Reactive.Advanced.SwitchMapSignal<TSource, TResult>.SwitchMapSignal(System.IObservable<TSource>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> void
 ReactiveUI.Primitives.Reactive.Advanced.SwitchSignal<T>
 ReactiveUI.Primitives.Reactive.Advanced.SwitchSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Reactive.Advanced.SwitchSignal<T>.SwitchSignal(System.IObservable<System.IObservable<T>!>! sources) -> void
@@ -815,6 +818,7 @@ ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.Threading.Task
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.Threading.Tasks.Task<T>!).ToTask(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<T>!
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TIn>(System.IObservable<TIn>!)
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).Choose<TOut>(System.Func<TIn, (bool HasValue, TOut Value)>! chooser) -> System.IObservable<TOut>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).SwitchMap<TOut>(System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!)
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).CombineLatest<TRight, TResult>(System.IObservable<TRight>! right, System.Func<TLeft, TRight, TResult>! selector) -> System.IObservable<TResult>!
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
@@ -1265,6 +1269,7 @@ static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(this Syste
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.IObserver<T>! observer) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.Switch<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SwitchMap<TIn, TOut>(this System.IObservable<TIn>! source, System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SwitchSelect<TSource, TResult>(this System.IObservable<TSource?>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SwitchTo<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SyncLatest<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>(this System.IObservable<T>! source, System.IObservable<T2>! source2, System.IObservable<T3>! source3, System.IObservable<T4>! source4, System.IObservable<T5>! source5, System.IObservable<T6>! source6, System.IObservable<T7>! source7, System.IObservable<T8>! source8, System.IObservable<T9>! source9, System.IObservable<T10>! source10, System.IObservable<T11>! source11, System.IObservable<T12>! source12, System.IObservable<T13>! source13, System.IObservable<T14>! source14, System.IObservable<T15>! source15, System.IObservable<T16>! source16, System.Func<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>! selector) -> System.IObservable<TResult>!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -465,6 +465,9 @@ ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.OnError(System.E
 ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.OnNext(T value) -> void
 ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.SetSubscription(System.IDisposable! subscription) -> void
 ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.SubscribeSafeWitness(System.IObserver<T>! observer) -> void
+ReactiveUI.Primitives.Reactive.Advanced.SwitchMapSignal<TSource, TResult>
+ReactiveUI.Primitives.Reactive.Advanced.SwitchMapSignal<TSource, TResult>.Subscribe(System.IObserver<TResult>! observer) -> System.IDisposable!
+ReactiveUI.Primitives.Reactive.Advanced.SwitchMapSignal<TSource, TResult>.SwitchMapSignal(System.IObservable<TSource>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> void
 ReactiveUI.Primitives.Reactive.Advanced.SwitchSignal<T>
 ReactiveUI.Primitives.Reactive.Advanced.SwitchSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Reactive.Advanced.SwitchSignal<T>.SwitchSignal(System.IObservable<System.IObservable<T>!>! sources) -> void
@@ -815,6 +818,7 @@ ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.Threading.Task
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.Threading.Tasks.Task<T>!).ToTask(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<T>!
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TIn>(System.IObservable<TIn>!)
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).Choose<TOut>(System.Func<TIn, (bool HasValue, TOut Value)>! chooser) -> System.IObservable<TOut>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).SwitchMap<TOut>(System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!)
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).CombineLatest<TRight, TResult>(System.IObservable<TRight>! right, System.Func<TLeft, TRight, TResult>! selector) -> System.IObservable<TResult>!
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
@@ -1265,6 +1269,7 @@ static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(this Syste
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.IObserver<T>! observer) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.Switch<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SwitchMap<TIn, TOut>(this System.IObservable<TIn>! source, System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SwitchSelect<TSource, TResult>(this System.IObservable<TSource?>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SwitchTo<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SyncLatest<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>(this System.IObservable<T>! source, System.IObservable<T2>! source2, System.IObservable<T3>! source3, System.IObservable<T4>! source4, System.IObservable<T5>! source5, System.IObservable<T6>! source6, System.IObservable<T7>! source7, System.IObservable<T8>! source8, System.IObservable<T9>! source9, System.IObservable<T10>! source10, System.IObservable<T11>! source11, System.IObservable<T12>! source12, System.IObservable<T13>! source13, System.IObservable<T14>! source14, System.IObservable<T15>! source15, System.IObservable<T16>! source16, System.Func<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>! selector) -> System.IObservable<TResult>!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net48/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net48/PublicAPI.Shipped.txt
@@ -465,6 +465,9 @@ ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.OnError(System.E
 ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.OnNext(T value) -> void
 ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.SetSubscription(System.IDisposable! subscription) -> void
 ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.SubscribeSafeWitness(System.IObserver<T>! observer) -> void
+ReactiveUI.Primitives.Reactive.Advanced.SwitchMapSignal<TSource, TResult>
+ReactiveUI.Primitives.Reactive.Advanced.SwitchMapSignal<TSource, TResult>.Subscribe(System.IObserver<TResult>! observer) -> System.IDisposable!
+ReactiveUI.Primitives.Reactive.Advanced.SwitchMapSignal<TSource, TResult>.SwitchMapSignal(System.IObservable<TSource>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> void
 ReactiveUI.Primitives.Reactive.Advanced.SwitchSignal<T>
 ReactiveUI.Primitives.Reactive.Advanced.SwitchSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Reactive.Advanced.SwitchSignal<T>.SwitchSignal(System.IObservable<System.IObservable<T>!>! sources) -> void
@@ -815,6 +818,7 @@ ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.Threading.Task
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.Threading.Tasks.Task<T>!).ToTask(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<T>!
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TIn>(System.IObservable<TIn>!)
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).Choose<TOut>(System.Func<TIn, (bool HasValue, TOut Value)>! chooser) -> System.IObservable<TOut>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).SwitchMap<TOut>(System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!)
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).CombineLatest<TRight, TResult>(System.IObservable<TRight>! right, System.Func<TLeft, TRight, TResult>! selector) -> System.IObservable<TResult>!
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
@@ -1265,6 +1269,7 @@ static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(this Syste
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.IObserver<T>! observer) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.Switch<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SwitchMap<TIn, TOut>(this System.IObservable<TIn>! source, System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SwitchSelect<TSource, TResult>(this System.IObservable<TSource?>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SwitchTo<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SyncLatest<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>(this System.IObservable<T>! source, System.IObservable<T2>! source2, System.IObservable<T3>! source3, System.IObservable<T4>! source4, System.IObservable<T5>! source5, System.IObservable<T6>! source6, System.IObservable<T7>! source7, System.IObservable<T8>! source8, System.IObservable<T9>! source9, System.IObservable<T10>! source10, System.IObservable<T11>! source11, System.IObservable<T12>! source12, System.IObservable<T13>! source13, System.IObservable<T14>! source14, System.IObservable<T15>! source15, System.IObservable<T16>! source16, System.Func<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>! selector) -> System.IObservable<TResult>!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net481/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net481/PublicAPI.Shipped.txt
@@ -465,6 +465,9 @@ ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.OnError(System.E
 ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.OnNext(T value) -> void
 ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.SetSubscription(System.IDisposable! subscription) -> void
 ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.SubscribeSafeWitness(System.IObserver<T>! observer) -> void
+ReactiveUI.Primitives.Reactive.Advanced.SwitchMapSignal<TSource, TResult>
+ReactiveUI.Primitives.Reactive.Advanced.SwitchMapSignal<TSource, TResult>.Subscribe(System.IObserver<TResult>! observer) -> System.IDisposable!
+ReactiveUI.Primitives.Reactive.Advanced.SwitchMapSignal<TSource, TResult>.SwitchMapSignal(System.IObservable<TSource>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> void
 ReactiveUI.Primitives.Reactive.Advanced.SwitchSignal<T>
 ReactiveUI.Primitives.Reactive.Advanced.SwitchSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Reactive.Advanced.SwitchSignal<T>.SwitchSignal(System.IObservable<System.IObservable<T>!>! sources) -> void
@@ -815,6 +818,7 @@ ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.Threading.Task
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.Threading.Tasks.Task<T>!).ToTask(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<T>!
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TIn>(System.IObservable<TIn>!)
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).Choose<TOut>(System.Func<TIn, (bool HasValue, TOut Value)>! chooser) -> System.IObservable<TOut>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).SwitchMap<TOut>(System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!)
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).CombineLatest<TRight, TResult>(System.IObservable<TRight>! right, System.Func<TLeft, TRight, TResult>! selector) -> System.IObservable<TResult>!
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
@@ -1265,6 +1269,7 @@ static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(this Syste
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.IObserver<T>! observer) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.Switch<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SwitchMap<TIn, TOut>(this System.IObservable<TIn>! source, System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SwitchSelect<TSource, TResult>(this System.IObservable<TSource?>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SwitchTo<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SyncLatest<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>(this System.IObservable<T>! source, System.IObservable<T2>! source2, System.IObservable<T3>! source3, System.IObservable<T4>! source4, System.IObservable<T5>! source5, System.IObservable<T6>! source6, System.IObservable<T7>! source7, System.IObservable<T8>! source8, System.IObservable<T9>! source9, System.IObservable<T10>! source10, System.IObservable<T11>! source11, System.IObservable<T12>! source12, System.IObservable<T13>! source13, System.IObservable<T14>! source14, System.IObservable<T15>! source15, System.IObservable<T16>! source16, System.Func<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>! selector) -> System.IObservable<TResult>!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -465,6 +465,9 @@ ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.OnError(System.E
 ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.OnNext(T value) -> void
 ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.SetSubscription(System.IDisposable! subscription) -> void
 ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.SubscribeSafeWitness(System.IObserver<T>! observer) -> void
+ReactiveUI.Primitives.Reactive.Advanced.SwitchMapSignal<TSource, TResult>
+ReactiveUI.Primitives.Reactive.Advanced.SwitchMapSignal<TSource, TResult>.Subscribe(System.IObserver<TResult>! observer) -> System.IDisposable!
+ReactiveUI.Primitives.Reactive.Advanced.SwitchMapSignal<TSource, TResult>.SwitchMapSignal(System.IObservable<TSource>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> void
 ReactiveUI.Primitives.Reactive.Advanced.SwitchSignal<T>
 ReactiveUI.Primitives.Reactive.Advanced.SwitchSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Reactive.Advanced.SwitchSignal<T>.SwitchSignal(System.IObservable<System.IObservable<T>!>! sources) -> void
@@ -815,6 +818,7 @@ ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.Threading.Task
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.Threading.Tasks.Task<T>!).ToTask(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<T>!
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TIn>(System.IObservable<TIn>!)
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).Choose<TOut>(System.Func<TIn, (bool HasValue, TOut Value)>! chooser) -> System.IObservable<TOut>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).SwitchMap<TOut>(System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!)
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).CombineLatest<TRight, TResult>(System.IObservable<TRight>! right, System.Func<TLeft, TRight, TResult>! selector) -> System.IObservable<TResult>!
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
@@ -1265,6 +1269,7 @@ static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(this Syste
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.IObserver<T>! observer) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.Switch<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SwitchMap<TIn, TOut>(this System.IObservable<TIn>! source, System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SwitchSelect<TSource, TResult>(this System.IObservable<TSource?>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SwitchTo<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SyncLatest<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>(this System.IObservable<T>! source, System.IObservable<T2>! source2, System.IObservable<T3>! source3, System.IObservable<T4>! source4, System.IObservable<T5>! source5, System.IObservable<T6>! source6, System.IObservable<T7>! source7, System.IObservable<T8>! source8, System.IObservable<T9>! source9, System.IObservable<T10>! source10, System.IObservable<T11>! source11, System.IObservable<T12>! source12, System.IObservable<T13>! source13, System.IObservable<T14>! source14, System.IObservable<T15>! source15, System.IObservable<T16>! source16, System.Func<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>! selector) -> System.IObservable<TResult>!

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net9.0/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net9.0/PublicAPI.Shipped.txt
@@ -465,6 +465,9 @@ ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.OnError(System.E
 ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.OnNext(T value) -> void
 ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.SetSubscription(System.IDisposable! subscription) -> void
 ReactiveUI.Primitives.Reactive.Advanced.SubscribeSafeWitness<T>.SubscribeSafeWitness(System.IObserver<T>! observer) -> void
+ReactiveUI.Primitives.Reactive.Advanced.SwitchMapSignal<TSource, TResult>
+ReactiveUI.Primitives.Reactive.Advanced.SwitchMapSignal<TSource, TResult>.Subscribe(System.IObserver<TResult>! observer) -> System.IDisposable!
+ReactiveUI.Primitives.Reactive.Advanced.SwitchMapSignal<TSource, TResult>.SwitchMapSignal(System.IObservable<TSource>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> void
 ReactiveUI.Primitives.Reactive.Advanced.SwitchSignal<T>
 ReactiveUI.Primitives.Reactive.Advanced.SwitchSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Reactive.Advanced.SwitchSignal<T>.SwitchSignal(System.IObservable<System.IObservable<T>!>! sources) -> void
@@ -816,6 +819,7 @@ ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.Threading.Task
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<T>(System.Threading.Tasks.Task<T>!).ToTask(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<T>!
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TIn>(System.IObservable<TIn>!)
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).Choose<TOut>(System.Func<TIn, (bool HasValue, TOut Value)>! chooser) -> System.IObservable<TOut>!
+ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).SwitchMap<TOut>(System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!)
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).CombineLatest<TRight, TResult>(System.IObservable<TRight>! right, System.Func<TLeft, TRight, TResult>! selector) -> System.IObservable<TResult>!
 ReactiveUI.Primitives.Reactive.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
@@ -1266,6 +1270,7 @@ static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(this Syste
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.IObserver<T>! observer) -> System.IDisposable!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.Switch<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.Reactive.LinqExtensions.SwitchMap<TIn, TOut>(this System.IObservable<TIn>! source, System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SwitchSelect<TSource, TResult>(this System.IObservable<TSource?>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SwitchTo<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
 static ReactiveUI.Primitives.Reactive.LinqExtensions.SyncLatest<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>(this System.IObservable<T>! source, System.IObservable<T2>! source2, System.IObservable<T3>! source3, System.IObservable<T4>! source4, System.IObservable<T5>! source5, System.IObservable<T6>! source6, System.IObservable<T7>! source7, System.IObservable<T8>! source8, System.IObservable<T9>! source9, System.IObservable<T10>! source10, System.IObservable<T11>! source11, System.IObservable<T12>! source12, System.IObservable<T13>! source13, System.IObservable<T14>! source14, System.IObservable<T15>! source15, System.IObservable<T16>! source16, System.Func<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>! selector) -> System.IObservable<TResult>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net10.0-android/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net10.0-android/PublicAPI.Shipped.txt
@@ -322,6 +322,9 @@ ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.OnError(System.Exception!
 ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.OnNext(T value) -> void
 ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.SetSubscription(System.IDisposable! subscription) -> void
 ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.SubscribeSafeWitness(System.IObserver<T>! observer) -> void
+ReactiveUI.Primitives.Advanced.SwitchMapSignal<TSource, TResult>
+ReactiveUI.Primitives.Advanced.SwitchMapSignal<TSource, TResult>.Subscribe(System.IObserver<TResult>! observer) -> System.IDisposable!
+ReactiveUI.Primitives.Advanced.SwitchMapSignal<TSource, TResult>.SwitchMapSignal(System.IObservable<TSource>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> void
 ReactiveUI.Primitives.Advanced.SwitchSignal<T>
 ReactiveUI.Primitives.Advanced.SwitchSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Advanced.SwitchSignal<T>.SwitchSignal(System.IObservable<System.IObservable<T>!>! sources) -> void
@@ -933,6 +936,7 @@ ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Threading.Tasks.Task<T>
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Threading.Tasks.Task<T>!).ToTask(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<TIn>(System.IObservable<TIn>!)
 ReactiveUI.Primitives.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).Choose<TOut>(System.Func<TIn, (bool HasValue, TOut Value)>! chooser) -> System.IObservable<TOut>!
+ReactiveUI.Primitives.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).SwitchMap<TOut>(System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!)
 ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).CombineLatest<TRight, TResult>(System.IObservable<TRight>! right, System.Func<TLeft, TRight, TResult>! selector) -> System.IObservable<TResult>!
 ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
@@ -1423,6 +1427,7 @@ static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(this System.IObserv
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.IObserver<T>! observer) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.Switch<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.SwitchMap<TIn, TOut>(this System.IObservable<TIn>! source, System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 static ReactiveUI.Primitives.LinqExtensions.SwitchSelect<TSource, TResult>(this System.IObservable<TSource?>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.LinqExtensions.SwitchTo<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.SyncLatest<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>(this System.IObservable<T>! source, System.IObservable<T2>! source2, System.IObservable<T3>! source3, System.IObservable<T4>! source4, System.IObservable<T5>! source5, System.IObservable<T6>! source6, System.IObservable<T7>! source7, System.IObservable<T8>! source8, System.IObservable<T9>! source9, System.IObservable<T10>! source10, System.IObservable<T11>! source11, System.IObservable<T12>! source12, System.IObservable<T13>! source13, System.IObservable<T14>! source14, System.IObservable<T15>! source15, System.IObservable<T16>! source16, System.Func<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>! selector) -> System.IObservable<TResult>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net10.0-ios/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net10.0-ios/PublicAPI.Shipped.txt
@@ -322,6 +322,9 @@ ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.OnError(System.Exception!
 ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.OnNext(T value) -> void
 ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.SetSubscription(System.IDisposable! subscription) -> void
 ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.SubscribeSafeWitness(System.IObserver<T>! observer) -> void
+ReactiveUI.Primitives.Advanced.SwitchMapSignal<TSource, TResult>
+ReactiveUI.Primitives.Advanced.SwitchMapSignal<TSource, TResult>.Subscribe(System.IObserver<TResult>! observer) -> System.IDisposable!
+ReactiveUI.Primitives.Advanced.SwitchMapSignal<TSource, TResult>.SwitchMapSignal(System.IObservable<TSource>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> void
 ReactiveUI.Primitives.Advanced.SwitchSignal<T>
 ReactiveUI.Primitives.Advanced.SwitchSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Advanced.SwitchSignal<T>.SwitchSignal(System.IObservable<System.IObservable<T>!>! sources) -> void
@@ -931,6 +934,7 @@ ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Threading.Tasks.Task<T>
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Threading.Tasks.Task<T>!).ToTask(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<TIn>(System.IObservable<TIn>!)
 ReactiveUI.Primitives.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).Choose<TOut>(System.Func<TIn, (bool HasValue, TOut Value)>! chooser) -> System.IObservable<TOut>!
+ReactiveUI.Primitives.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).SwitchMap<TOut>(System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!)
 ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).CombineLatest<TRight, TResult>(System.IObservable<TRight>! right, System.Func<TLeft, TRight, TResult>! selector) -> System.IObservable<TResult>!
 ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
@@ -1419,6 +1423,7 @@ static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(this System.IObserv
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.IObserver<T>! observer) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.Switch<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.SwitchMap<TIn, TOut>(this System.IObservable<TIn>! source, System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 static ReactiveUI.Primitives.LinqExtensions.SwitchSelect<TSource, TResult>(this System.IObservable<TSource?>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.LinqExtensions.SwitchTo<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.SyncLatest<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>(this System.IObservable<T>! source, System.IObservable<T2>! source2, System.IObservable<T3>! source3, System.IObservable<T4>! source4, System.IObservable<T5>! source5, System.IObservable<T6>! source6, System.IObservable<T7>! source7, System.IObservable<T8>! source8, System.IObservable<T9>! source9, System.IObservable<T10>! source10, System.IObservable<T11>! source11, System.IObservable<T12>! source12, System.IObservable<T13>! source13, System.IObservable<T14>! source14, System.IObservable<T15>! source15, System.IObservable<T16>! source16, System.Func<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>! selector) -> System.IObservable<TResult>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net10.0-maccatalyst/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net10.0-maccatalyst/PublicAPI.Shipped.txt
@@ -322,6 +322,9 @@ ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.OnError(System.Exception!
 ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.OnNext(T value) -> void
 ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.SetSubscription(System.IDisposable! subscription) -> void
 ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.SubscribeSafeWitness(System.IObserver<T>! observer) -> void
+ReactiveUI.Primitives.Advanced.SwitchMapSignal<TSource, TResult>
+ReactiveUI.Primitives.Advanced.SwitchMapSignal<TSource, TResult>.Subscribe(System.IObserver<TResult>! observer) -> System.IDisposable!
+ReactiveUI.Primitives.Advanced.SwitchMapSignal<TSource, TResult>.SwitchMapSignal(System.IObservable<TSource>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> void
 ReactiveUI.Primitives.Advanced.SwitchSignal<T>
 ReactiveUI.Primitives.Advanced.SwitchSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Advanced.SwitchSignal<T>.SwitchSignal(System.IObservable<System.IObservable<T>!>! sources) -> void
@@ -931,6 +934,7 @@ ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Threading.Tasks.Task<T>
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Threading.Tasks.Task<T>!).ToTask(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<TIn>(System.IObservable<TIn>!)
 ReactiveUI.Primitives.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).Choose<TOut>(System.Func<TIn, (bool HasValue, TOut Value)>! chooser) -> System.IObservable<TOut>!
+ReactiveUI.Primitives.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).SwitchMap<TOut>(System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!)
 ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).CombineLatest<TRight, TResult>(System.IObservable<TRight>! right, System.Func<TLeft, TRight, TResult>! selector) -> System.IObservable<TResult>!
 ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
@@ -1419,6 +1423,7 @@ static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(this System.IObserv
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.IObserver<T>! observer) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.Switch<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.SwitchMap<TIn, TOut>(this System.IObservable<TIn>! source, System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 static ReactiveUI.Primitives.LinqExtensions.SwitchSelect<TSource, TResult>(this System.IObservable<TSource?>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.LinqExtensions.SwitchTo<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.SyncLatest<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>(this System.IObservable<T>! source, System.IObservable<T2>! source2, System.IObservable<T3>! source3, System.IObservable<T4>! source4, System.IObservable<T5>! source5, System.IObservable<T6>! source6, System.IObservable<T7>! source7, System.IObservable<T8>! source8, System.IObservable<T9>! source9, System.IObservable<T10>! source10, System.IObservable<T11>! source11, System.IObservable<T12>! source12, System.IObservable<T13>! source13, System.IObservable<T14>! source14, System.IObservable<T15>! source15, System.IObservable<T16>! source16, System.Func<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>! selector) -> System.IObservable<TResult>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net10.0-macos/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net10.0-macos/PublicAPI.Shipped.txt
@@ -322,6 +322,9 @@ ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.OnError(System.Exception!
 ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.OnNext(T value) -> void
 ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.SetSubscription(System.IDisposable! subscription) -> void
 ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.SubscribeSafeWitness(System.IObserver<T>! observer) -> void
+ReactiveUI.Primitives.Advanced.SwitchMapSignal<TSource, TResult>
+ReactiveUI.Primitives.Advanced.SwitchMapSignal<TSource, TResult>.Subscribe(System.IObserver<TResult>! observer) -> System.IDisposable!
+ReactiveUI.Primitives.Advanced.SwitchMapSignal<TSource, TResult>.SwitchMapSignal(System.IObservable<TSource>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> void
 ReactiveUI.Primitives.Advanced.SwitchSignal<T>
 ReactiveUI.Primitives.Advanced.SwitchSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Advanced.SwitchSignal<T>.SwitchSignal(System.IObservable<System.IObservable<T>!>! sources) -> void
@@ -931,6 +934,7 @@ ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Threading.Tasks.Task<T>
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Threading.Tasks.Task<T>!).ToTask(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<TIn>(System.IObservable<TIn>!)
 ReactiveUI.Primitives.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).Choose<TOut>(System.Func<TIn, (bool HasValue, TOut Value)>! chooser) -> System.IObservable<TOut>!
+ReactiveUI.Primitives.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).SwitchMap<TOut>(System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!)
 ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).CombineLatest<TRight, TResult>(System.IObservable<TRight>! right, System.Func<TLeft, TRight, TResult>! selector) -> System.IObservable<TResult>!
 ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
@@ -1419,6 +1423,7 @@ static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(this System.IObserv
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.IObserver<T>! observer) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.Switch<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.SwitchMap<TIn, TOut>(this System.IObservable<TIn>! source, System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 static ReactiveUI.Primitives.LinqExtensions.SwitchSelect<TSource, TResult>(this System.IObservable<TSource?>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.LinqExtensions.SwitchTo<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.SyncLatest<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>(this System.IObservable<T>! source, System.IObservable<T2>! source2, System.IObservable<T3>! source3, System.IObservable<T4>! source4, System.IObservable<T5>! source5, System.IObservable<T6>! source6, System.IObservable<T7>! source7, System.IObservable<T8>! source8, System.IObservable<T9>! source9, System.IObservable<T10>! source10, System.IObservable<T11>! source11, System.IObservable<T12>! source12, System.IObservable<T13>! source13, System.IObservable<T14>! source14, System.IObservable<T15>! source15, System.IObservable<T16>! source16, System.Func<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>! selector) -> System.IObservable<TResult>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net10.0-tvos/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net10.0-tvos/PublicAPI.Shipped.txt
@@ -322,6 +322,9 @@ ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.OnError(System.Exception!
 ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.OnNext(T value) -> void
 ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.SetSubscription(System.IDisposable! subscription) -> void
 ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.SubscribeSafeWitness(System.IObserver<T>! observer) -> void
+ReactiveUI.Primitives.Advanced.SwitchMapSignal<TSource, TResult>
+ReactiveUI.Primitives.Advanced.SwitchMapSignal<TSource, TResult>.Subscribe(System.IObserver<TResult>! observer) -> System.IDisposable!
+ReactiveUI.Primitives.Advanced.SwitchMapSignal<TSource, TResult>.SwitchMapSignal(System.IObservable<TSource>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> void
 ReactiveUI.Primitives.Advanced.SwitchSignal<T>
 ReactiveUI.Primitives.Advanced.SwitchSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Advanced.SwitchSignal<T>.SwitchSignal(System.IObservable<System.IObservable<T>!>! sources) -> void
@@ -931,6 +934,7 @@ ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Threading.Tasks.Task<T>
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Threading.Tasks.Task<T>!).ToTask(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<TIn>(System.IObservable<TIn>!)
 ReactiveUI.Primitives.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).Choose<TOut>(System.Func<TIn, (bool HasValue, TOut Value)>! chooser) -> System.IObservable<TOut>!
+ReactiveUI.Primitives.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).SwitchMap<TOut>(System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!)
 ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).CombineLatest<TRight, TResult>(System.IObservable<TRight>! right, System.Func<TLeft, TRight, TResult>! selector) -> System.IObservable<TResult>!
 ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
@@ -1419,6 +1423,7 @@ static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(this System.IObserv
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.IObserver<T>! observer) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.Switch<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.SwitchMap<TIn, TOut>(this System.IObservable<TIn>! source, System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 static ReactiveUI.Primitives.LinqExtensions.SwitchSelect<TSource, TResult>(this System.IObservable<TSource?>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.LinqExtensions.SwitchTo<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.SyncLatest<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>(this System.IObservable<T>! source, System.IObservable<T2>! source2, System.IObservable<T3>! source3, System.IObservable<T4>! source4, System.IObservable<T5>! source5, System.IObservable<T6>! source6, System.IObservable<T7>! source7, System.IObservable<T8>! source8, System.IObservable<T9>! source9, System.IObservable<T10>! source10, System.IObservable<T11>! source11, System.IObservable<T12>! source12, System.IObservable<T13>! source13, System.IObservable<T14>! source14, System.IObservable<T15>! source15, System.IObservable<T16>! source16, System.Func<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>! selector) -> System.IObservable<TResult>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net10.0/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net10.0/PublicAPI.Shipped.txt
@@ -322,6 +322,9 @@ ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.OnError(System.Exception!
 ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.OnNext(T value) -> void
 ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.SetSubscription(System.IDisposable! subscription) -> void
 ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.SubscribeSafeWitness(System.IObserver<T>! observer) -> void
+ReactiveUI.Primitives.Advanced.SwitchMapSignal<TSource, TResult>
+ReactiveUI.Primitives.Advanced.SwitchMapSignal<TSource, TResult>.Subscribe(System.IObserver<TResult>! observer) -> System.IDisposable!
+ReactiveUI.Primitives.Advanced.SwitchMapSignal<TSource, TResult>.SwitchMapSignal(System.IObservable<TSource>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> void
 ReactiveUI.Primitives.Advanced.SwitchSignal<T>
 ReactiveUI.Primitives.Advanced.SwitchSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Advanced.SwitchSignal<T>.SwitchSignal(System.IObservable<System.IObservable<T>!>! sources) -> void
@@ -926,6 +929,7 @@ ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Threading.Tasks.Task<T>
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Threading.Tasks.Task<T>!).ToTask(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<TIn>(System.IObservable<TIn>!)
 ReactiveUI.Primitives.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).Choose<TOut>(System.Func<TIn, (bool HasValue, TOut Value)>! chooser) -> System.IObservable<TOut>!
+ReactiveUI.Primitives.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).SwitchMap<TOut>(System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!)
 ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).CombineLatest<TRight, TResult>(System.IObservable<TRight>! right, System.Func<TLeft, TRight, TResult>! selector) -> System.IObservable<TResult>!
 ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
@@ -1412,6 +1416,7 @@ static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(this System.IObserv
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.IObserver<T>! observer) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.Switch<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.SwitchMap<TIn, TOut>(this System.IObservable<TIn>! source, System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 static ReactiveUI.Primitives.LinqExtensions.SwitchSelect<TSource, TResult>(this System.IObservable<TSource?>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.LinqExtensions.SwitchTo<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.SyncLatest<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>(this System.IObservable<T>! source, System.IObservable<T2>! source2, System.IObservable<T3>! source3, System.IObservable<T4>! source4, System.IObservable<T5>! source5, System.IObservable<T6>! source6, System.IObservable<T7>! source7, System.IObservable<T8>! source8, System.IObservable<T9>! source9, System.IObservable<T10>! source10, System.IObservable<T11>! source11, System.IObservable<T12>! source12, System.IObservable<T13>! source13, System.IObservable<T14>! source14, System.IObservable<T15>! source15, System.IObservable<T16>! source16, System.Func<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>! selector) -> System.IObservable<TResult>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net11.0-android/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net11.0-android/PublicAPI.Shipped.txt
@@ -322,6 +322,9 @@ ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.OnError(System.Exception!
 ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.OnNext(T value) -> void
 ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.SetSubscription(System.IDisposable! subscription) -> void
 ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.SubscribeSafeWitness(System.IObserver<T>! observer) -> void
+ReactiveUI.Primitives.Advanced.SwitchMapSignal<TSource, TResult>
+ReactiveUI.Primitives.Advanced.SwitchMapSignal<TSource, TResult>.Subscribe(System.IObserver<TResult>! observer) -> System.IDisposable!
+ReactiveUI.Primitives.Advanced.SwitchMapSignal<TSource, TResult>.SwitchMapSignal(System.IObservable<TSource>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> void
 ReactiveUI.Primitives.Advanced.SwitchSignal<T>
 ReactiveUI.Primitives.Advanced.SwitchSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Advanced.SwitchSignal<T>.SwitchSignal(System.IObservable<System.IObservable<T>!>! sources) -> void
@@ -933,6 +936,7 @@ ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Threading.Tasks.Task<T>
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Threading.Tasks.Task<T>!).ToTask(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<TIn>(System.IObservable<TIn>!)
 ReactiveUI.Primitives.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).Choose<TOut>(System.Func<TIn, (bool HasValue, TOut Value)>! chooser) -> System.IObservable<TOut>!
+ReactiveUI.Primitives.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).SwitchMap<TOut>(System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!)
 ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).CombineLatest<TRight, TResult>(System.IObservable<TRight>! right, System.Func<TLeft, TRight, TResult>! selector) -> System.IObservable<TResult>!
 ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
@@ -1423,6 +1427,7 @@ static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(this System.IObserv
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.IObserver<T>! observer) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.Switch<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.SwitchMap<TIn, TOut>(this System.IObservable<TIn>! source, System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 static ReactiveUI.Primitives.LinqExtensions.SwitchSelect<TSource, TResult>(this System.IObservable<TSource?>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.LinqExtensions.SwitchTo<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.SyncLatest<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>(this System.IObservable<T>! source, System.IObservable<T2>! source2, System.IObservable<T3>! source3, System.IObservable<T4>! source4, System.IObservable<T5>! source5, System.IObservable<T6>! source6, System.IObservable<T7>! source7, System.IObservable<T8>! source8, System.IObservable<T9>! source9, System.IObservable<T10>! source10, System.IObservable<T11>! source11, System.IObservable<T12>! source12, System.IObservable<T13>! source13, System.IObservable<T14>! source14, System.IObservable<T15>! source15, System.IObservable<T16>! source16, System.Func<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>! selector) -> System.IObservable<TResult>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net11.0-ios/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net11.0-ios/PublicAPI.Shipped.txt
@@ -322,6 +322,9 @@ ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.OnError(System.Exception!
 ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.OnNext(T value) -> void
 ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.SetSubscription(System.IDisposable! subscription) -> void
 ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.SubscribeSafeWitness(System.IObserver<T>! observer) -> void
+ReactiveUI.Primitives.Advanced.SwitchMapSignal<TSource, TResult>
+ReactiveUI.Primitives.Advanced.SwitchMapSignal<TSource, TResult>.Subscribe(System.IObserver<TResult>! observer) -> System.IDisposable!
+ReactiveUI.Primitives.Advanced.SwitchMapSignal<TSource, TResult>.SwitchMapSignal(System.IObservable<TSource>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> void
 ReactiveUI.Primitives.Advanced.SwitchSignal<T>
 ReactiveUI.Primitives.Advanced.SwitchSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Advanced.SwitchSignal<T>.SwitchSignal(System.IObservable<System.IObservable<T>!>! sources) -> void
@@ -931,6 +934,7 @@ ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Threading.Tasks.Task<T>
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Threading.Tasks.Task<T>!).ToTask(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<TIn>(System.IObservable<TIn>!)
 ReactiveUI.Primitives.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).Choose<TOut>(System.Func<TIn, (bool HasValue, TOut Value)>! chooser) -> System.IObservable<TOut>!
+ReactiveUI.Primitives.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).SwitchMap<TOut>(System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!)
 ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).CombineLatest<TRight, TResult>(System.IObservable<TRight>! right, System.Func<TLeft, TRight, TResult>! selector) -> System.IObservable<TResult>!
 ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
@@ -1419,6 +1423,7 @@ static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(this System.IObserv
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.IObserver<T>! observer) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.Switch<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.SwitchMap<TIn, TOut>(this System.IObservable<TIn>! source, System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 static ReactiveUI.Primitives.LinqExtensions.SwitchSelect<TSource, TResult>(this System.IObservable<TSource?>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.LinqExtensions.SwitchTo<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.SyncLatest<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>(this System.IObservable<T>! source, System.IObservable<T2>! source2, System.IObservable<T3>! source3, System.IObservable<T4>! source4, System.IObservable<T5>! source5, System.IObservable<T6>! source6, System.IObservable<T7>! source7, System.IObservable<T8>! source8, System.IObservable<T9>! source9, System.IObservable<T10>! source10, System.IObservable<T11>! source11, System.IObservable<T12>! source12, System.IObservable<T13>! source13, System.IObservable<T14>! source14, System.IObservable<T15>! source15, System.IObservable<T16>! source16, System.Func<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>! selector) -> System.IObservable<TResult>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net11.0-maccatalyst/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net11.0-maccatalyst/PublicAPI.Shipped.txt
@@ -322,6 +322,9 @@ ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.OnError(System.Exception!
 ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.OnNext(T value) -> void
 ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.SetSubscription(System.IDisposable! subscription) -> void
 ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.SubscribeSafeWitness(System.IObserver<T>! observer) -> void
+ReactiveUI.Primitives.Advanced.SwitchMapSignal<TSource, TResult>
+ReactiveUI.Primitives.Advanced.SwitchMapSignal<TSource, TResult>.Subscribe(System.IObserver<TResult>! observer) -> System.IDisposable!
+ReactiveUI.Primitives.Advanced.SwitchMapSignal<TSource, TResult>.SwitchMapSignal(System.IObservable<TSource>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> void
 ReactiveUI.Primitives.Advanced.SwitchSignal<T>
 ReactiveUI.Primitives.Advanced.SwitchSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Advanced.SwitchSignal<T>.SwitchSignal(System.IObservable<System.IObservable<T>!>! sources) -> void
@@ -931,6 +934,7 @@ ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Threading.Tasks.Task<T>
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Threading.Tasks.Task<T>!).ToTask(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<TIn>(System.IObservable<TIn>!)
 ReactiveUI.Primitives.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).Choose<TOut>(System.Func<TIn, (bool HasValue, TOut Value)>! chooser) -> System.IObservable<TOut>!
+ReactiveUI.Primitives.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).SwitchMap<TOut>(System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!)
 ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).CombineLatest<TRight, TResult>(System.IObservable<TRight>! right, System.Func<TLeft, TRight, TResult>! selector) -> System.IObservable<TResult>!
 ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
@@ -1419,6 +1423,7 @@ static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(this System.IObserv
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.IObserver<T>! observer) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.Switch<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.SwitchMap<TIn, TOut>(this System.IObservable<TIn>! source, System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 static ReactiveUI.Primitives.LinqExtensions.SwitchSelect<TSource, TResult>(this System.IObservable<TSource?>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.LinqExtensions.SwitchTo<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.SyncLatest<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>(this System.IObservable<T>! source, System.IObservable<T2>! source2, System.IObservable<T3>! source3, System.IObservable<T4>! source4, System.IObservable<T5>! source5, System.IObservable<T6>! source6, System.IObservable<T7>! source7, System.IObservable<T8>! source8, System.IObservable<T9>! source9, System.IObservable<T10>! source10, System.IObservable<T11>! source11, System.IObservable<T12>! source12, System.IObservable<T13>! source13, System.IObservable<T14>! source14, System.IObservable<T15>! source15, System.IObservable<T16>! source16, System.Func<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>! selector) -> System.IObservable<TResult>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net11.0-macos/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net11.0-macos/PublicAPI.Shipped.txt
@@ -322,6 +322,9 @@ ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.OnError(System.Exception!
 ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.OnNext(T value) -> void
 ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.SetSubscription(System.IDisposable! subscription) -> void
 ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.SubscribeSafeWitness(System.IObserver<T>! observer) -> void
+ReactiveUI.Primitives.Advanced.SwitchMapSignal<TSource, TResult>
+ReactiveUI.Primitives.Advanced.SwitchMapSignal<TSource, TResult>.Subscribe(System.IObserver<TResult>! observer) -> System.IDisposable!
+ReactiveUI.Primitives.Advanced.SwitchMapSignal<TSource, TResult>.SwitchMapSignal(System.IObservable<TSource>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> void
 ReactiveUI.Primitives.Advanced.SwitchSignal<T>
 ReactiveUI.Primitives.Advanced.SwitchSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Advanced.SwitchSignal<T>.SwitchSignal(System.IObservable<System.IObservable<T>!>! sources) -> void
@@ -931,6 +934,7 @@ ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Threading.Tasks.Task<T>
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Threading.Tasks.Task<T>!).ToTask(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<TIn>(System.IObservable<TIn>!)
 ReactiveUI.Primitives.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).Choose<TOut>(System.Func<TIn, (bool HasValue, TOut Value)>! chooser) -> System.IObservable<TOut>!
+ReactiveUI.Primitives.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).SwitchMap<TOut>(System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!)
 ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).CombineLatest<TRight, TResult>(System.IObservable<TRight>! right, System.Func<TLeft, TRight, TResult>! selector) -> System.IObservable<TResult>!
 ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
@@ -1419,6 +1423,7 @@ static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(this System.IObserv
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.IObserver<T>! observer) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.Switch<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.SwitchMap<TIn, TOut>(this System.IObservable<TIn>! source, System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 static ReactiveUI.Primitives.LinqExtensions.SwitchSelect<TSource, TResult>(this System.IObservable<TSource?>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.LinqExtensions.SwitchTo<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.SyncLatest<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>(this System.IObservable<T>! source, System.IObservable<T2>! source2, System.IObservable<T3>! source3, System.IObservable<T4>! source4, System.IObservable<T5>! source5, System.IObservable<T6>! source6, System.IObservable<T7>! source7, System.IObservable<T8>! source8, System.IObservable<T9>! source9, System.IObservable<T10>! source10, System.IObservable<T11>! source11, System.IObservable<T12>! source12, System.IObservable<T13>! source13, System.IObservable<T14>! source14, System.IObservable<T15>! source15, System.IObservable<T16>! source16, System.Func<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>! selector) -> System.IObservable<TResult>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net11.0-tvos/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net11.0-tvos/PublicAPI.Shipped.txt
@@ -322,6 +322,9 @@ ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.OnError(System.Exception!
 ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.OnNext(T value) -> void
 ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.SetSubscription(System.IDisposable! subscription) -> void
 ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.SubscribeSafeWitness(System.IObserver<T>! observer) -> void
+ReactiveUI.Primitives.Advanced.SwitchMapSignal<TSource, TResult>
+ReactiveUI.Primitives.Advanced.SwitchMapSignal<TSource, TResult>.Subscribe(System.IObserver<TResult>! observer) -> System.IDisposable!
+ReactiveUI.Primitives.Advanced.SwitchMapSignal<TSource, TResult>.SwitchMapSignal(System.IObservable<TSource>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> void
 ReactiveUI.Primitives.Advanced.SwitchSignal<T>
 ReactiveUI.Primitives.Advanced.SwitchSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Advanced.SwitchSignal<T>.SwitchSignal(System.IObservable<System.IObservable<T>!>! sources) -> void
@@ -931,6 +934,7 @@ ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Threading.Tasks.Task<T>
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Threading.Tasks.Task<T>!).ToTask(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<TIn>(System.IObservable<TIn>!)
 ReactiveUI.Primitives.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).Choose<TOut>(System.Func<TIn, (bool HasValue, TOut Value)>! chooser) -> System.IObservable<TOut>!
+ReactiveUI.Primitives.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).SwitchMap<TOut>(System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!)
 ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).CombineLatest<TRight, TResult>(System.IObservable<TRight>! right, System.Func<TLeft, TRight, TResult>! selector) -> System.IObservable<TResult>!
 ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
@@ -1419,6 +1423,7 @@ static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(this System.IObserv
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.IObserver<T>! observer) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.Switch<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.SwitchMap<TIn, TOut>(this System.IObservable<TIn>! source, System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 static ReactiveUI.Primitives.LinqExtensions.SwitchSelect<TSource, TResult>(this System.IObservable<TSource?>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.LinqExtensions.SwitchTo<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.SyncLatest<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>(this System.IObservable<T>! source, System.IObservable<T2>! source2, System.IObservable<T3>! source3, System.IObservable<T4>! source4, System.IObservable<T5>! source5, System.IObservable<T6>! source6, System.IObservable<T7>! source7, System.IObservable<T8>! source8, System.IObservable<T9>! source9, System.IObservable<T10>! source10, System.IObservable<T11>! source11, System.IObservable<T12>! source12, System.IObservable<T13>! source13, System.IObservable<T14>! source14, System.IObservable<T15>! source15, System.IObservable<T16>! source16, System.Func<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>! selector) -> System.IObservable<TResult>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net11.0/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net11.0/PublicAPI.Shipped.txt
@@ -322,6 +322,9 @@ ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.OnError(System.Exception!
 ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.OnNext(T value) -> void
 ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.SetSubscription(System.IDisposable! subscription) -> void
 ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.SubscribeSafeWitness(System.IObserver<T>! observer) -> void
+ReactiveUI.Primitives.Advanced.SwitchMapSignal<TSource, TResult>
+ReactiveUI.Primitives.Advanced.SwitchMapSignal<TSource, TResult>.Subscribe(System.IObserver<TResult>! observer) -> System.IDisposable!
+ReactiveUI.Primitives.Advanced.SwitchMapSignal<TSource, TResult>.SwitchMapSignal(System.IObservable<TSource>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> void
 ReactiveUI.Primitives.Advanced.SwitchSignal<T>
 ReactiveUI.Primitives.Advanced.SwitchSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Advanced.SwitchSignal<T>.SwitchSignal(System.IObservable<System.IObservable<T>!>! sources) -> void
@@ -926,6 +929,7 @@ ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Threading.Tasks.Task<T>
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Threading.Tasks.Task<T>!).ToTask(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<TIn>(System.IObservable<TIn>!)
 ReactiveUI.Primitives.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).Choose<TOut>(System.Func<TIn, (bool HasValue, TOut Value)>! chooser) -> System.IObservable<TOut>!
+ReactiveUI.Primitives.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).SwitchMap<TOut>(System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!)
 ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).CombineLatest<TRight, TResult>(System.IObservable<TRight>! right, System.Func<TLeft, TRight, TResult>! selector) -> System.IObservable<TResult>!
 ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
@@ -1412,6 +1416,7 @@ static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(this System.IObserv
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.IObserver<T>! observer) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.Switch<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.SwitchMap<TIn, TOut>(this System.IObservable<TIn>! source, System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 static ReactiveUI.Primitives.LinqExtensions.SwitchSelect<TSource, TResult>(this System.IObservable<TSource?>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.LinqExtensions.SwitchTo<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.SyncLatest<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>(this System.IObservable<T>! source, System.IObservable<T2>! source2, System.IObservable<T3>! source3, System.IObservable<T4>! source4, System.IObservable<T5>! source5, System.IObservable<T6>! source6, System.IObservable<T7>! source7, System.IObservable<T8>! source8, System.IObservable<T9>! source9, System.IObservable<T10>! source10, System.IObservable<T11>! source11, System.IObservable<T12>! source12, System.IObservable<T13>! source13, System.IObservable<T14>! source14, System.IObservable<T15>! source15, System.IObservable<T16>! source16, System.Func<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>! selector) -> System.IObservable<TResult>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net462/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net462/PublicAPI.Shipped.txt
@@ -322,6 +322,9 @@ ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.OnError(System.Exception!
 ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.OnNext(T value) -> void
 ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.SetSubscription(System.IDisposable! subscription) -> void
 ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.SubscribeSafeWitness(System.IObserver<T>! observer) -> void
+ReactiveUI.Primitives.Advanced.SwitchMapSignal<TSource, TResult>
+ReactiveUI.Primitives.Advanced.SwitchMapSignal<TSource, TResult>.Subscribe(System.IObserver<TResult>! observer) -> System.IDisposable!
+ReactiveUI.Primitives.Advanced.SwitchMapSignal<TSource, TResult>.SwitchMapSignal(System.IObservable<TSource>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> void
 ReactiveUI.Primitives.Advanced.SwitchSignal<T>
 ReactiveUI.Primitives.Advanced.SwitchSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Advanced.SwitchSignal<T>.SwitchSignal(System.IObservable<System.IObservable<T>!>! sources) -> void
@@ -925,6 +928,7 @@ ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Threading.Tasks.Task<T>
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Threading.Tasks.Task<T>!).ToTask(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<TIn>(System.IObservable<TIn>!)
 ReactiveUI.Primitives.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).Choose<TOut>(System.Func<TIn, (bool HasValue, TOut Value)>! chooser) -> System.IObservable<TOut>!
+ReactiveUI.Primitives.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).SwitchMap<TOut>(System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!)
 ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).CombineLatest<TRight, TResult>(System.IObservable<TRight>! right, System.Func<TLeft, TRight, TResult>! selector) -> System.IObservable<TResult>!
 ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
@@ -1411,6 +1415,7 @@ static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(this System.IObserv
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.IObserver<T>! observer) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.Switch<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.SwitchMap<TIn, TOut>(this System.IObservable<TIn>! source, System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 static ReactiveUI.Primitives.LinqExtensions.SwitchSelect<TSource, TResult>(this System.IObservable<TSource?>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.LinqExtensions.SwitchTo<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.SyncLatest<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>(this System.IObservable<T>! source, System.IObservable<T2>! source2, System.IObservable<T3>! source3, System.IObservable<T4>! source4, System.IObservable<T5>! source5, System.IObservable<T6>! source6, System.IObservable<T7>! source7, System.IObservable<T8>! source8, System.IObservable<T9>! source9, System.IObservable<T10>! source10, System.IObservable<T11>! source11, System.IObservable<T12>! source12, System.IObservable<T13>! source13, System.IObservable<T14>! source14, System.IObservable<T15>! source15, System.IObservable<T16>! source16, System.Func<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>! selector) -> System.IObservable<TResult>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -322,6 +322,9 @@ ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.OnError(System.Exception!
 ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.OnNext(T value) -> void
 ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.SetSubscription(System.IDisposable! subscription) -> void
 ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.SubscribeSafeWitness(System.IObserver<T>! observer) -> void
+ReactiveUI.Primitives.Advanced.SwitchMapSignal<TSource, TResult>
+ReactiveUI.Primitives.Advanced.SwitchMapSignal<TSource, TResult>.Subscribe(System.IObserver<TResult>! observer) -> System.IDisposable!
+ReactiveUI.Primitives.Advanced.SwitchMapSignal<TSource, TResult>.SwitchMapSignal(System.IObservable<TSource>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> void
 ReactiveUI.Primitives.Advanced.SwitchSignal<T>
 ReactiveUI.Primitives.Advanced.SwitchSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Advanced.SwitchSignal<T>.SwitchSignal(System.IObservable<System.IObservable<T>!>! sources) -> void
@@ -925,6 +928,7 @@ ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Threading.Tasks.Task<T>
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Threading.Tasks.Task<T>!).ToTask(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<TIn>(System.IObservable<TIn>!)
 ReactiveUI.Primitives.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).Choose<TOut>(System.Func<TIn, (bool HasValue, TOut Value)>! chooser) -> System.IObservable<TOut>!
+ReactiveUI.Primitives.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).SwitchMap<TOut>(System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!)
 ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).CombineLatest<TRight, TResult>(System.IObservable<TRight>! right, System.Func<TLeft, TRight, TResult>! selector) -> System.IObservable<TResult>!
 ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
@@ -1411,6 +1415,7 @@ static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(this System.IObserv
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.IObserver<T>! observer) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.Switch<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.SwitchMap<TIn, TOut>(this System.IObservable<TIn>! source, System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 static ReactiveUI.Primitives.LinqExtensions.SwitchSelect<TSource, TResult>(this System.IObservable<TSource?>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.LinqExtensions.SwitchTo<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.SyncLatest<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>(this System.IObservable<T>! source, System.IObservable<T2>! source2, System.IObservable<T3>! source3, System.IObservable<T4>! source4, System.IObservable<T5>! source5, System.IObservable<T6>! source6, System.IObservable<T7>! source7, System.IObservable<T8>! source8, System.IObservable<T9>! source9, System.IObservable<T10>! source10, System.IObservable<T11>! source11, System.IObservable<T12>! source12, System.IObservable<T13>! source13, System.IObservable<T14>! source14, System.IObservable<T15>! source15, System.IObservable<T16>! source16, System.Func<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>! selector) -> System.IObservable<TResult>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net48/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net48/PublicAPI.Shipped.txt
@@ -322,6 +322,9 @@ ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.OnError(System.Exception!
 ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.OnNext(T value) -> void
 ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.SetSubscription(System.IDisposable! subscription) -> void
 ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.SubscribeSafeWitness(System.IObserver<T>! observer) -> void
+ReactiveUI.Primitives.Advanced.SwitchMapSignal<TSource, TResult>
+ReactiveUI.Primitives.Advanced.SwitchMapSignal<TSource, TResult>.Subscribe(System.IObserver<TResult>! observer) -> System.IDisposable!
+ReactiveUI.Primitives.Advanced.SwitchMapSignal<TSource, TResult>.SwitchMapSignal(System.IObservable<TSource>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> void
 ReactiveUI.Primitives.Advanced.SwitchSignal<T>
 ReactiveUI.Primitives.Advanced.SwitchSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Advanced.SwitchSignal<T>.SwitchSignal(System.IObservable<System.IObservable<T>!>! sources) -> void
@@ -925,6 +928,7 @@ ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Threading.Tasks.Task<T>
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Threading.Tasks.Task<T>!).ToTask(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<TIn>(System.IObservable<TIn>!)
 ReactiveUI.Primitives.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).Choose<TOut>(System.Func<TIn, (bool HasValue, TOut Value)>! chooser) -> System.IObservable<TOut>!
+ReactiveUI.Primitives.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).SwitchMap<TOut>(System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!)
 ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).CombineLatest<TRight, TResult>(System.IObservable<TRight>! right, System.Func<TLeft, TRight, TResult>! selector) -> System.IObservable<TResult>!
 ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
@@ -1411,6 +1415,7 @@ static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(this System.IObserv
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.IObserver<T>! observer) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.Switch<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.SwitchMap<TIn, TOut>(this System.IObservable<TIn>! source, System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 static ReactiveUI.Primitives.LinqExtensions.SwitchSelect<TSource, TResult>(this System.IObservable<TSource?>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.LinqExtensions.SwitchTo<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.SyncLatest<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>(this System.IObservable<T>! source, System.IObservable<T2>! source2, System.IObservable<T3>! source3, System.IObservable<T4>! source4, System.IObservable<T5>! source5, System.IObservable<T6>! source6, System.IObservable<T7>! source7, System.IObservable<T8>! source8, System.IObservable<T9>! source9, System.IObservable<T10>! source10, System.IObservable<T11>! source11, System.IObservable<T12>! source12, System.IObservable<T13>! source13, System.IObservable<T14>! source14, System.IObservable<T15>! source15, System.IObservable<T16>! source16, System.Func<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>! selector) -> System.IObservable<TResult>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net481/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net481/PublicAPI.Shipped.txt
@@ -322,6 +322,9 @@ ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.OnError(System.Exception!
 ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.OnNext(T value) -> void
 ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.SetSubscription(System.IDisposable! subscription) -> void
 ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.SubscribeSafeWitness(System.IObserver<T>! observer) -> void
+ReactiveUI.Primitives.Advanced.SwitchMapSignal<TSource, TResult>
+ReactiveUI.Primitives.Advanced.SwitchMapSignal<TSource, TResult>.Subscribe(System.IObserver<TResult>! observer) -> System.IDisposable!
+ReactiveUI.Primitives.Advanced.SwitchMapSignal<TSource, TResult>.SwitchMapSignal(System.IObservable<TSource>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> void
 ReactiveUI.Primitives.Advanced.SwitchSignal<T>
 ReactiveUI.Primitives.Advanced.SwitchSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Advanced.SwitchSignal<T>.SwitchSignal(System.IObservable<System.IObservable<T>!>! sources) -> void
@@ -925,6 +928,7 @@ ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Threading.Tasks.Task<T>
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Threading.Tasks.Task<T>!).ToTask(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<TIn>(System.IObservable<TIn>!)
 ReactiveUI.Primitives.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).Choose<TOut>(System.Func<TIn, (bool HasValue, TOut Value)>! chooser) -> System.IObservable<TOut>!
+ReactiveUI.Primitives.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).SwitchMap<TOut>(System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!)
 ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).CombineLatest<TRight, TResult>(System.IObservable<TRight>! right, System.Func<TLeft, TRight, TResult>! selector) -> System.IObservable<TResult>!
 ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
@@ -1411,6 +1415,7 @@ static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(this System.IObserv
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.IObserver<T>! observer) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.Switch<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.SwitchMap<TIn, TOut>(this System.IObservable<TIn>! source, System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 static ReactiveUI.Primitives.LinqExtensions.SwitchSelect<TSource, TResult>(this System.IObservable<TSource?>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.LinqExtensions.SwitchTo<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.SyncLatest<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>(this System.IObservable<T>! source, System.IObservable<T2>! source2, System.IObservable<T3>! source3, System.IObservable<T4>! source4, System.IObservable<T5>! source5, System.IObservable<T6>! source6, System.IObservable<T7>! source7, System.IObservable<T8>! source8, System.IObservable<T9>! source9, System.IObservable<T10>! source10, System.IObservable<T11>! source11, System.IObservable<T12>! source12, System.IObservable<T13>! source13, System.IObservable<T14>! source14, System.IObservable<T15>! source15, System.IObservable<T16>! source16, System.Func<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>! selector) -> System.IObservable<TResult>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -322,6 +322,9 @@ ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.OnError(System.Exception!
 ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.OnNext(T value) -> void
 ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.SetSubscription(System.IDisposable! subscription) -> void
 ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.SubscribeSafeWitness(System.IObserver<T>! observer) -> void
+ReactiveUI.Primitives.Advanced.SwitchMapSignal<TSource, TResult>
+ReactiveUI.Primitives.Advanced.SwitchMapSignal<TSource, TResult>.Subscribe(System.IObserver<TResult>! observer) -> System.IDisposable!
+ReactiveUI.Primitives.Advanced.SwitchMapSignal<TSource, TResult>.SwitchMapSignal(System.IObservable<TSource>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> void
 ReactiveUI.Primitives.Advanced.SwitchSignal<T>
 ReactiveUI.Primitives.Advanced.SwitchSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Advanced.SwitchSignal<T>.SwitchSignal(System.IObservable<System.IObservable<T>!>! sources) -> void
@@ -925,6 +928,7 @@ ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Threading.Tasks.Task<T>
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Threading.Tasks.Task<T>!).ToTask(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<TIn>(System.IObservable<TIn>!)
 ReactiveUI.Primitives.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).Choose<TOut>(System.Func<TIn, (bool HasValue, TOut Value)>! chooser) -> System.IObservable<TOut>!
+ReactiveUI.Primitives.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).SwitchMap<TOut>(System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!)
 ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).CombineLatest<TRight, TResult>(System.IObservable<TRight>! right, System.Func<TLeft, TRight, TResult>! selector) -> System.IObservable<TResult>!
 ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
@@ -1411,6 +1415,7 @@ static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(this System.IObserv
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.IObserver<T>! observer) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.Switch<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.SwitchMap<TIn, TOut>(this System.IObservable<TIn>! source, System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 static ReactiveUI.Primitives.LinqExtensions.SwitchSelect<TSource, TResult>(this System.IObservable<TSource?>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.LinqExtensions.SwitchTo<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.SyncLatest<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>(this System.IObservable<T>! source, System.IObservable<T2>! source2, System.IObservable<T3>! source3, System.IObservable<T4>! source4, System.IObservable<T5>! source5, System.IObservable<T6>! source6, System.IObservable<T7>! source7, System.IObservable<T8>! source8, System.IObservable<T9>! source9, System.IObservable<T10>! source10, System.IObservable<T11>! source11, System.IObservable<T12>! source12, System.IObservable<T13>! source13, System.IObservable<T14>! source14, System.IObservable<T15>! source15, System.IObservable<T16>! source16, System.Func<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>! selector) -> System.IObservable<TResult>!

--- a/src/ReactiveUI.Primitives/PublicAPI/net9.0/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net9.0/PublicAPI.Shipped.txt
@@ -322,6 +322,9 @@ ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.OnError(System.Exception!
 ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.OnNext(T value) -> void
 ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.SetSubscription(System.IDisposable! subscription) -> void
 ReactiveUI.Primitives.Advanced.SubscribeSafeWitness<T>.SubscribeSafeWitness(System.IObserver<T>! observer) -> void
+ReactiveUI.Primitives.Advanced.SwitchMapSignal<TSource, TResult>
+ReactiveUI.Primitives.Advanced.SwitchMapSignal<TSource, TResult>.Subscribe(System.IObserver<TResult>! observer) -> System.IDisposable!
+ReactiveUI.Primitives.Advanced.SwitchMapSignal<TSource, TResult>.SwitchMapSignal(System.IObservable<TSource>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> void
 ReactiveUI.Primitives.Advanced.SwitchSignal<T>
 ReactiveUI.Primitives.Advanced.SwitchSignal<T>.Subscribe(System.IObserver<T>! observer) -> System.IDisposable!
 ReactiveUI.Primitives.Advanced.SwitchSignal<T>.SwitchSignal(System.IObservable<System.IObservable<T>!>! sources) -> void
@@ -926,6 +929,7 @@ ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Threading.Tasks.Task<T>
 ReactiveUI.Primitives.LinqExtensions.extension<T>(System.Threading.Tasks.Task<T>!).ToTask(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<T>!
 ReactiveUI.Primitives.LinqExtensions.extension<TIn>(System.IObservable<TIn>!)
 ReactiveUI.Primitives.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).Choose<TOut>(System.Func<TIn, (bool HasValue, TOut Value)>! chooser) -> System.IObservable<TOut>!
+ReactiveUI.Primitives.LinqExtensions.extension<TIn>(System.IObservable<TIn>!).SwitchMap<TOut>(System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!)
 ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).CombineLatest<TRight, TResult>(System.IObservable<TRight>! right, System.Func<TLeft, TRight, TResult>! selector) -> System.IObservable<TResult>!
 ReactiveUI.Primitives.LinqExtensions.extension<TLeft>(System.IObservable<TLeft>!).Delay(System.DateTimeOffset dueTime) -> System.IObservable<TLeft>!
@@ -1412,6 +1416,7 @@ static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(this System.IObserv
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.Action<T>! onNext, System.Action<System.Exception!>! onError, System.Action! onCompleted) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.SubscribeSafe<T>(this System.IObservable<T>! source, System.IObserver<T>! observer) -> System.IDisposable!
 static ReactiveUI.Primitives.LinqExtensions.Switch<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
+static ReactiveUI.Primitives.LinqExtensions.SwitchMap<TIn, TOut>(this System.IObservable<TIn>! source, System.Func<TIn, System.IObservable<TOut>!>! selector) -> System.IObservable<TOut>!
 static ReactiveUI.Primitives.LinqExtensions.SwitchSelect<TSource, TResult>(this System.IObservable<TSource?>! source, System.Func<TSource, System.IObservable<TResult>!>! selector) -> System.IObservable<TResult>!
 static ReactiveUI.Primitives.LinqExtensions.SwitchTo<T>(this System.IObservable<System.IObservable<T>!>! sources) -> System.IObservable<T>!
 static ReactiveUI.Primitives.LinqExtensions.SyncLatest<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>(this System.IObservable<T>! source, System.IObservable<T2>! source2, System.IObservable<T3>! source3, System.IObservable<T4>! source4, System.IObservable<T5>! source5, System.IObservable<T6>! source6, System.IObservable<T7>! source7, System.IObservable<T8>! source8, System.IObservable<T9>! source9, System.IObservable<T10>! source10, System.IObservable<T11>! source11, System.IObservable<T12>! source12, System.IObservable<T13>! source13, System.IObservable<T14>! source14, System.IObservable<T15>! source15, System.IObservable<T16>! source16, System.Func<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>! selector) -> System.IObservable<TResult>!

--- a/src/tests/ReactiveUI.Primitives.Tests/SwitchMapTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/SwitchMapTests.cs
@@ -1,0 +1,203 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using ReactiveUI.Primitives.Advanced;
+using ReactiveUI.Primitives.Signals;
+
+namespace ReactiveUI.Primitives.Tests;
+
+/// <summary>Tests for the fused <see cref = "LinqExtensions.SwitchMap{TIn, TOut}"/> projection operator.</summary>
+public class SwitchMapTests
+{
+    /// <summary>The value ten.</summary>
+    private const int Ten = 10;
+
+    /// <summary>The value eleven, produced by a superseded inner and therefore ignored.</summary>
+    private const int Eleven = 11;
+
+    /// <summary>The value twenty.</summary>
+    private const int Twenty = 20;
+
+    /// <summary>The value thirty.</summary>
+    private const int Thirty = 30;
+
+    /// <summary>The expected single-occurrence count.</summary>
+    private const int Once = 1;
+
+    /// <summary>The first outer selector key.</summary>
+    private const string KeyA = "a";
+
+    /// <summary>The second outer selector key.</summary>
+    private const string KeyB = "b";
+
+    /// <summary>Shared error message.</summary>
+    private const string Boom = "boom";
+
+    /// <summary>Expected forwarded values after switching inner sources.</summary>
+    private static readonly int[] _tenThenTwenty = [Ten, Twenty];
+
+    /// <summary>Expected forwarded values when a null switches onto its own inner.</summary>
+    private static readonly int[] _tenThenThirty = [Ten, Thirty];
+
+    /// <summary>Expected single forwarded value.</summary>
+    private static readonly int[] _tenOnly = [Ten];
+
+    /// <summary>Verifies that the latest inner is mirrored and a superseded inner is ignored.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SwitchMapMirrorsLatestInnerAndIgnoresStaleInner()
+    {
+        Signal<string> outer = new();
+        Signal<int> inner1 = new();
+        Signal<int> inner2 = new();
+        List<int> values = [];
+        _ = outer.SwitchMap(key => key == KeyA ? inner1 : inner2).Subscribe(values.Add);
+        outer.OnNext(KeyA);
+        inner1.OnNext(Ten);
+        outer.OnNext(KeyB);
+        inner1.OnNext(Eleven);
+        inner2.OnNext(Twenty);
+        await Assert.That(values.SequenceEqual(_tenThenTwenty)).IsTrue();
+    }
+
+    /// <summary>
+    /// Verifies that a null source value switches onto whatever the selector returns for it, which detaches the
+    /// previous inner rather than leaving it attached.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SwitchMapSwitchesOnNullSourceValue()
+    {
+        Signal<string?> outer = new();
+        Signal<int> inner = new();
+        Signal<int> fallback = new();
+        List<int> values = [];
+        _ = outer.SwitchMap(key => key is null ? fallback : inner).Subscribe(values.Add);
+        outer.OnNext(KeyA);
+        inner.OnNext(Ten);
+        outer.OnNext(null);
+        inner.OnNext(Eleven);
+        fallback.OnNext(Thirty);
+        await Assert.That(values.SequenceEqual(_tenThenThirty)).IsTrue();
+    }
+
+    /// <summary>Verifies that completion waits for both the outer and the active inner.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SwitchMapCompletesAfterOuterAndInner()
+    {
+        Signal<string> outer = new();
+        Signal<int> inner = new();
+        var completed = 0;
+        _ = outer.SwitchMap(_ => inner).Subscribe(
+            static _ => { },
+            static ex => throw ex,
+            () => completed++);
+        outer.OnNext(KeyA);
+        outer.OnCompleted();
+        await Assert.That(completed).IsEqualTo(0);
+        inner.OnCompleted();
+        await Assert.That(completed).IsEqualTo(Once);
+    }
+
+    /// <summary>Verifies that an outer that completes without ever producing a value completes downstream.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SwitchMapCompletesWhenOuterCompletesWithoutInner()
+    {
+        Signal<string> outer = new();
+        var completed = 0;
+        _ = outer.SwitchMap(static _ => new Signal<int>()).Subscribe(
+            static _ => { },
+            static ex => throw ex,
+            () => completed++);
+        outer.OnCompleted();
+        await Assert.That(completed).IsEqualTo(Once);
+    }
+
+    /// <summary>Verifies that a selector exception terminates the sequence with that error.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SwitchMapForwardsSelectorError()
+    {
+        Signal<string> outer = new();
+        Exception? error = null;
+        _ = outer.SwitchMap<string, int>(static _ => throw new InvalidOperationException(Boom)).Subscribe(
+            static _ => { },
+            ex => error = ex,
+            static () => { });
+        outer.OnNext(KeyA);
+        await Assert.That(error is InvalidOperationException).IsTrue();
+    }
+
+    /// <summary>Verifies that an outer error terminates the sequence.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SwitchMapForwardsOuterError()
+    {
+        Signal<string> outer = new();
+        Exception? error = null;
+        _ = outer.SwitchMap(static _ => new Signal<int>()).Subscribe(
+            static _ => { },
+            ex => error = ex,
+            static () => { });
+        outer.OnError(new InvalidOperationException(Boom));
+        await Assert.That(error is InvalidOperationException).IsTrue();
+    }
+
+    /// <summary>Verifies that an error from the active inner terminates the sequence.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SwitchMapForwardsInnerError()
+    {
+        Signal<string> outer = new();
+        Signal<int> inner = new();
+        Exception? error = null;
+        _ = outer.SwitchMap(_ => inner).Subscribe(
+            static _ => { },
+            ex => error = ex,
+            static () => { });
+        outer.OnNext(KeyA);
+        inner.OnError(new InvalidOperationException(Boom));
+        await Assert.That(error is InvalidOperationException).IsTrue();
+    }
+
+    /// <summary>Verifies that disposing the subscription stops forwarding inner values.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SwitchMapStopsForwardingAfterDispose()
+    {
+        Signal<string> outer = new();
+        Signal<int> inner = new();
+        List<int> values = [];
+        var subscription = outer.SwitchMap(_ => inner).Subscribe(values.Add);
+        outer.OnNext(KeyA);
+        inner.OnNext(Ten);
+        subscription.Dispose();
+        inner.OnNext(Eleven);
+        await Assert.That(values.SequenceEqual(_tenOnly)).IsTrue();
+    }
+
+    /// <summary>Verifies that the sink rejects a null source.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SwitchMapSignalRejectsNullSource() =>
+        await Assert.That(static () => new SwitchMapSignal<string, int>(null!, static _ => new Signal<int>()))
+            .Throws<ArgumentNullException>();
+
+    /// <summary>Verifies that the sink rejects a null selector.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SwitchMapSignalRejectsNullSelector() =>
+        await Assert.That(static () => new SwitchMapSignal<string, int>(new Signal<string>(), null!))
+            .Throws<ArgumentNullException>();
+
+    /// <summary>Verifies that the sink rejects a null observer.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SwitchMapSignalRejectsNullObserver() =>
+        await Assert.That(static () =>
+                new SwitchMapSignal<string, int>(new Signal<string>(), static _ => new Signal<int>()).Subscribe(null!))
+            .Throws<ArgumentNullException>();
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature, plus a refactor of an existing operator onto the new sink.

## What is the new behavior?

**`SwitchMap` projects each value to an inner observable and mirrors the latest one, in a single fused sink.**

- **`SwitchMapSignal<TSource, TResult>` is public in `Advanced`.** One object and one observer hop, where a projection followed by a separate switch costs two of each plus an intermediate sequence of observables.
- **Every source value switches, null included.** A caller that projects null onto its own inner observable switches onto it, which detaches the previous inner and drops its subscription.
- **`SwitchSelect` is reimplemented on the same sink.** It keeps its existing behavior of skipping nulls, which leaves the active inner subscription in place. The two now differ only in that flag; the switching bookkeeping - generation ids, the gate, the outer/inner completion interlock - exists once instead of twice.
- **Both flavours get it.** The sink is shared source, so it lands in `ReactiveUI.Primitives.Advanced` and `ReactiveUI.Primitives.Reactive.Advanced`.

## What is the current behavior?

**Reaching the latest inner observable from a projection means composing two sinks.**

- `Select(selector).Switch()` allocates the projection sink, its observer, the switch sink and its observer, and threads an `IObservable<IObservable<T>>` between them.
- `SwitchSelect` is the only fused form and it always skips nulls, so it cannot express a projection that switches on null.

## What might this PR break?

**None.**

- `SwitchMap` is new API.
- `SwitchSelect` keeps its signature and its skip-null semantics; only its implementation moved.

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [x] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information

**Most of the diff is the public API baselines; two files were authored.**

- `src/Primitives.Shared/Advanced/SwitchMapSignal{TSource,TResult}.cs` - the sink.
- `src/Primitives.Shared/SignalOperatorMixins.ChooseSwitchSelect.cs` - the `SwitchMap` operator, and `SwitchSelect` reduced to a call into the sink.
- `src/tests/ReactiveUI.Primitives.Tests/SwitchMapTests.cs` - covers switching on null, stale-inner suppression, the completion interlock, selector/outer/inner errors, and disposal.
- The remaining 36 files are one added block each in `PublicAPI.Shipped.txt`, inserted at its sorted position.

The existing `SwitchSelect` tests are unchanged and still pass, which is what pins the refactor.
