### PR TITLE
fix(api)!: return concrete type from DisposeWith

### DIFF
--- a/src/Primitives.Shared/LinqExtensions.cs
+++ b/src/Primitives.Shared/LinqExtensions.cs
@@ -11,19 +11,10 @@ namespace ReactiveUI.Primitives;
 /// <summary>Miscellaneous Primitives extensions.</summary>
 public static partial class LinqExtensions
 {
-    /// <summary>Disposal-tracking operators for a disposable.</summary>
+    /// <summary>Disposal operators for a disposable.</summary>
     /// <param name="disposable">The disposable.</param>
     extension(IDisposable disposable)
     {
-        /// <summary>Disposes the IDisposable with the disposables instance.</summary>
-        /// <param name="disposables">The disposables.</param>
-        /// <returns>An IDisposable.</returns>
-        public IDisposable DisposeWith(MultipleDisposable disposables)
-        {
-            disposables?.Add(disposable);
-            return disposable;
-        }
-
         /// <summary>Disposes the with.</summary>
         /// <returns>A SingleDisposable.</returns>
         public SingleDisposable DisposeWith() =>
@@ -74,6 +65,24 @@ public static partial class LinqExtensions
             ArgumentOutOfRangeExceptionHelper.ThrowIfNegativeOrZero(skip);
 
             return new BufferCountSignal<TSource>(source, count, skip);
+        }
+    }
+
+    /// <summary>Disposal-tracking operators for a disposable.</summary>
+    /// <typeparam name="T">The disposable type.</typeparam>
+    /// <param name="disposable">The disposable.</param>
+    extension<T>(T disposable)
+        where T : IDisposable
+    {
+        /// <summary>Disposes the IDisposable with the disposables instance.</summary>
+        /// <param name="disposables">The disposables.</param>
+        /// <returns>The original disposable.</returns>
+        public T DisposeWith(MultipleDisposable disposables)
+        {
+            ArgumentExceptionHelper.ThrowIfNull(disposables);
+
+            disposables.Add(disposable);
+            return disposable;
         }
     }
 }

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-android/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-android/PublicAPI.txt
@@ -420,8 +420,11 @@ namespace ReactiveUI.Primitives.Reactive
         extension(System.IDisposable disposable)
         {
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith() { }
-            public System.IDisposable DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith(System.Action? action) { }
+        }
+        extension<T>(T disposable) where T : System.IDisposable
+        {
+            public T DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
         }
         extension(System.IObservable<object?> source)
         {

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-ios/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-ios/PublicAPI.txt
@@ -420,8 +420,11 @@ namespace ReactiveUI.Primitives.Reactive
         extension(System.IDisposable disposable)
         {
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith() { }
-            public System.IDisposable DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith(System.Action? action) { }
+        }
+        extension<T>(T disposable) where T : System.IDisposable
+        {
+            public T DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
         }
         extension(System.IObservable<object?> source)
         {

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-maccatalyst/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-maccatalyst/PublicAPI.txt
@@ -420,8 +420,11 @@ namespace ReactiveUI.Primitives.Reactive
         extension(System.IDisposable disposable)
         {
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith() { }
-            public System.IDisposable DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith(System.Action? action) { }
+        }
+        extension<T>(T disposable) where T : System.IDisposable
+        {
+            public T DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
         }
         extension(System.IObservable<object?> source)
         {

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-macos/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-macos/PublicAPI.txt
@@ -420,8 +420,11 @@ namespace ReactiveUI.Primitives.Reactive
         extension(System.IDisposable disposable)
         {
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith() { }
-            public System.IDisposable DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith(System.Action? action) { }
+        }
+        extension<T>(T disposable) where T : System.IDisposable
+        {
+            public T DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
         }
         extension(System.IObservable<object?> source)
         {

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-tvos/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-tvos/PublicAPI.txt
@@ -420,8 +420,11 @@ namespace ReactiveUI.Primitives.Reactive
         extension(System.IDisposable disposable)
         {
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith() { }
-            public System.IDisposable DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith(System.Action? action) { }
+        }
+        extension<T>(T disposable) where T : System.IDisposable
+        {
+            public T DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
         }
         extension(System.IObservable<object?> source)
         {

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0/PublicAPI.txt
@@ -419,8 +419,11 @@ namespace ReactiveUI.Primitives.Reactive
         extension(System.IDisposable disposable)
         {
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith() { }
-            public System.IDisposable DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith(System.Action? action) { }
+        }
+        extension<T>(T disposable) where T : System.IDisposable
+        {
+            public T DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
         }
         extension(System.IObservable<object?> source)
         {

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-android/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-android/PublicAPI.txt
@@ -420,8 +420,11 @@ namespace ReactiveUI.Primitives.Reactive
         extension(System.IDisposable disposable)
         {
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith() { }
-            public System.IDisposable DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith(System.Action? action) { }
+        }
+        extension<T>(T disposable) where T : System.IDisposable
+        {
+            public T DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
         }
         extension(System.IObservable<object?> source)
         {

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-ios/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-ios/PublicAPI.txt
@@ -420,8 +420,11 @@ namespace ReactiveUI.Primitives.Reactive
         extension(System.IDisposable disposable)
         {
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith() { }
-            public System.IDisposable DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith(System.Action? action) { }
+        }
+        extension<T>(T disposable) where T : System.IDisposable
+        {
+            public T DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
         }
         extension(System.IObservable<object?> source)
         {

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-maccatalyst/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-maccatalyst/PublicAPI.txt
@@ -420,8 +420,11 @@ namespace ReactiveUI.Primitives.Reactive
         extension(System.IDisposable disposable)
         {
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith() { }
-            public System.IDisposable DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith(System.Action? action) { }
+        }
+        extension<T>(T disposable) where T : System.IDisposable
+        {
+            public T DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
         }
         extension(System.IObservable<object?> source)
         {

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-macos/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-macos/PublicAPI.txt
@@ -420,8 +420,11 @@ namespace ReactiveUI.Primitives.Reactive
         extension(System.IDisposable disposable)
         {
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith() { }
-            public System.IDisposable DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith(System.Action? action) { }
+        }
+        extension<T>(T disposable) where T : System.IDisposable
+        {
+            public T DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
         }
         extension(System.IObservable<object?> source)
         {

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-tvos/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-tvos/PublicAPI.txt
@@ -420,8 +420,11 @@ namespace ReactiveUI.Primitives.Reactive
         extension(System.IDisposable disposable)
         {
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith() { }
-            public System.IDisposable DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith(System.Action? action) { }
+        }
+        extension<T>(T disposable) where T : System.IDisposable
+        {
+            public T DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
         }
         extension(System.IObservable<object?> source)
         {

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0/PublicAPI.txt
@@ -419,8 +419,11 @@ namespace ReactiveUI.Primitives.Reactive
         extension(System.IDisposable disposable)
         {
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith() { }
-            public System.IDisposable DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith(System.Action? action) { }
+        }
+        extension<T>(T disposable) where T : System.IDisposable
+        {
+            public T DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
         }
         extension(System.IObservable<object?> source)
         {

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net462/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net462/PublicAPI.txt
@@ -404,8 +404,11 @@ namespace ReactiveUI.Primitives.Reactive
         extension(System.IDisposable disposable)
         {
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith() { }
-            public System.IDisposable DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith(System.Action? action) { }
+        }
+        extension<T>(T disposable) where T : System.IDisposable
+        {
+            public T DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
         }
         extension(System.IObservable<object?> source)
         {

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net472/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net472/PublicAPI.txt
@@ -404,8 +404,11 @@ namespace ReactiveUI.Primitives.Reactive
         extension(System.IDisposable disposable)
         {
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith() { }
-            public System.IDisposable DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith(System.Action? action) { }
+        }
+        extension<T>(T disposable) where T : System.IDisposable
+        {
+            public T DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
         }
         extension(System.IObservable<object?> source)
         {

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net48/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net48/PublicAPI.txt
@@ -404,8 +404,11 @@ namespace ReactiveUI.Primitives.Reactive
         extension(System.IDisposable disposable)
         {
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith() { }
-            public System.IDisposable DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith(System.Action? action) { }
+        }
+        extension<T>(T disposable) where T : System.IDisposable
+        {
+            public T DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
         }
         extension(System.IObservable<object?> source)
         {

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net481/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net481/PublicAPI.txt
@@ -404,8 +404,11 @@ namespace ReactiveUI.Primitives.Reactive
         extension(System.IDisposable disposable)
         {
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith() { }
-            public System.IDisposable DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith(System.Action? action) { }
+        }
+        extension<T>(T disposable) where T : System.IDisposable
+        {
+            public T DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
         }
         extension(System.IObservable<object?> source)
         {

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net8.0/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net8.0/PublicAPI.txt
@@ -404,8 +404,11 @@ namespace ReactiveUI.Primitives.Reactive
         extension(System.IDisposable disposable)
         {
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith() { }
-            public System.IDisposable DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith(System.Action? action) { }
+        }
+        extension<T>(T disposable) where T : System.IDisposable
+        {
+            public T DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
         }
         extension(System.IObservable<object?> source)
         {

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net9.0/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net9.0/PublicAPI.txt
@@ -419,8 +419,11 @@ namespace ReactiveUI.Primitives.Reactive
         extension(System.IDisposable disposable)
         {
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith() { }
-            public System.IDisposable DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith(System.Action? action) { }
+        }
+        extension<T>(T disposable) where T : System.IDisposable
+        {
+            public T DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
         }
         extension(System.IObservable<object?> source)
         {

--- a/src/ReactiveUI.Primitives/PublicAPI/net10.0-android/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net10.0-android/PublicAPI.txt
@@ -78,8 +78,11 @@ namespace ReactiveUI.Primitives
         extension(System.IDisposable disposable)
         {
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith() { }
-            public System.IDisposable DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith(System.Action? action) { }
+        }
+        extension<T>(T disposable) where T : System.IDisposable
+        {
+            public T DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
         }
         extension(System.IObservable<object?> source)
         {

--- a/src/ReactiveUI.Primitives/PublicAPI/net10.0-ios/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net10.0-ios/PublicAPI.txt
@@ -78,8 +78,11 @@ namespace ReactiveUI.Primitives
         extension(System.IDisposable disposable)
         {
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith() { }
-            public System.IDisposable DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith(System.Action? action) { }
+        }
+        extension<T>(T disposable) where T : System.IDisposable
+        {
+            public T DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
         }
         extension(System.IObservable<object?> source)
         {

--- a/src/ReactiveUI.Primitives/PublicAPI/net10.0-maccatalyst/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net10.0-maccatalyst/PublicAPI.txt
@@ -78,8 +78,11 @@ namespace ReactiveUI.Primitives
         extension(System.IDisposable disposable)
         {
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith() { }
-            public System.IDisposable DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith(System.Action? action) { }
+        }
+        extension<T>(T disposable) where T : System.IDisposable
+        {
+            public T DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
         }
         extension(System.IObservable<object?> source)
         {

--- a/src/ReactiveUI.Primitives/PublicAPI/net10.0-macos/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net10.0-macos/PublicAPI.txt
@@ -78,8 +78,11 @@ namespace ReactiveUI.Primitives
         extension(System.IDisposable disposable)
         {
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith() { }
-            public System.IDisposable DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith(System.Action? action) { }
+        }
+        extension<T>(T disposable) where T : System.IDisposable
+        {
+            public T DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
         }
         extension(System.IObservable<object?> source)
         {

--- a/src/ReactiveUI.Primitives/PublicAPI/net10.0-tvos/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net10.0-tvos/PublicAPI.txt
@@ -78,8 +78,11 @@ namespace ReactiveUI.Primitives
         extension(System.IDisposable disposable)
         {
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith() { }
-            public System.IDisposable DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith(System.Action? action) { }
+        }
+        extension<T>(T disposable) where T : System.IDisposable
+        {
+            public T DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
         }
         extension(System.IObservable<object?> source)
         {

--- a/src/ReactiveUI.Primitives/PublicAPI/net10.0/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net10.0/PublicAPI.txt
@@ -77,8 +77,11 @@ namespace ReactiveUI.Primitives
         extension(System.IDisposable disposable)
         {
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith() { }
-            public System.IDisposable DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith(System.Action? action) { }
+        }
+        extension<T>(T disposable) where T : System.IDisposable
+        {
+            public T DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
         }
         extension(System.IObservable<object?> source)
         {

--- a/src/ReactiveUI.Primitives/PublicAPI/net11.0-android/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net11.0-android/PublicAPI.txt
@@ -78,8 +78,11 @@ namespace ReactiveUI.Primitives
         extension(System.IDisposable disposable)
         {
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith() { }
-            public System.IDisposable DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith(System.Action? action) { }
+        }
+        extension<T>(T disposable) where T : System.IDisposable
+        {
+            public T DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
         }
         extension(System.IObservable<object?> source)
         {

--- a/src/ReactiveUI.Primitives/PublicAPI/net11.0-ios/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net11.0-ios/PublicAPI.txt
@@ -78,8 +78,11 @@ namespace ReactiveUI.Primitives
         extension(System.IDisposable disposable)
         {
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith() { }
-            public System.IDisposable DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith(System.Action? action) { }
+        }
+        extension<T>(T disposable) where T : System.IDisposable
+        {
+            public T DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
         }
         extension(System.IObservable<object?> source)
         {

--- a/src/ReactiveUI.Primitives/PublicAPI/net11.0-maccatalyst/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net11.0-maccatalyst/PublicAPI.txt
@@ -78,8 +78,11 @@ namespace ReactiveUI.Primitives
         extension(System.IDisposable disposable)
         {
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith() { }
-            public System.IDisposable DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith(System.Action? action) { }
+        }
+        extension<T>(T disposable) where T : System.IDisposable
+        {
+            public T DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
         }
         extension(System.IObservable<object?> source)
         {

--- a/src/ReactiveUI.Primitives/PublicAPI/net11.0-macos/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net11.0-macos/PublicAPI.txt
@@ -78,8 +78,11 @@ namespace ReactiveUI.Primitives
         extension(System.IDisposable disposable)
         {
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith() { }
-            public System.IDisposable DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith(System.Action? action) { }
+        }
+        extension<T>(T disposable) where T : System.IDisposable
+        {
+            public T DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
         }
         extension(System.IObservable<object?> source)
         {

--- a/src/ReactiveUI.Primitives/PublicAPI/net11.0-tvos/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net11.0-tvos/PublicAPI.txt
@@ -78,8 +78,11 @@ namespace ReactiveUI.Primitives
         extension(System.IDisposable disposable)
         {
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith() { }
-            public System.IDisposable DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith(System.Action? action) { }
+        }
+        extension<T>(T disposable) where T : System.IDisposable
+        {
+            public T DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
         }
         extension(System.IObservable<object?> source)
         {

--- a/src/ReactiveUI.Primitives/PublicAPI/net11.0/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net11.0/PublicAPI.txt
@@ -77,8 +77,11 @@ namespace ReactiveUI.Primitives
         extension(System.IDisposable disposable)
         {
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith() { }
-            public System.IDisposable DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith(System.Action? action) { }
+        }
+        extension<T>(T disposable) where T : System.IDisposable
+        {
+            public T DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
         }
         extension(System.IObservable<object?> source)
         {

--- a/src/ReactiveUI.Primitives/PublicAPI/net462/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net462/PublicAPI.txt
@@ -62,8 +62,11 @@ namespace ReactiveUI.Primitives
         extension(System.IDisposable disposable)
         {
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith() { }
-            public System.IDisposable DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith(System.Action? action) { }
+        }
+        extension<T>(T disposable) where T : System.IDisposable
+        {
+            public T DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
         }
         extension(System.IObservable<object?> source)
         {

--- a/src/ReactiveUI.Primitives/PublicAPI/net472/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net472/PublicAPI.txt
@@ -62,8 +62,11 @@ namespace ReactiveUI.Primitives
         extension(System.IDisposable disposable)
         {
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith() { }
-            public System.IDisposable DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith(System.Action? action) { }
+        }
+        extension<T>(T disposable) where T : System.IDisposable
+        {
+            public T DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
         }
         extension(System.IObservable<object?> source)
         {

--- a/src/ReactiveUI.Primitives/PublicAPI/net48/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net48/PublicAPI.txt
@@ -62,8 +62,11 @@ namespace ReactiveUI.Primitives
         extension(System.IDisposable disposable)
         {
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith() { }
-            public System.IDisposable DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith(System.Action? action) { }
+        }
+        extension<T>(T disposable) where T : System.IDisposable
+        {
+            public T DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
         }
         extension(System.IObservable<object?> source)
         {

--- a/src/ReactiveUI.Primitives/PublicAPI/net481/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net481/PublicAPI.txt
@@ -62,8 +62,11 @@ namespace ReactiveUI.Primitives
         extension(System.IDisposable disposable)
         {
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith() { }
-            public System.IDisposable DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith(System.Action? action) { }
+        }
+        extension<T>(T disposable) where T : System.IDisposable
+        {
+            public T DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
         }
         extension(System.IObservable<object?> source)
         {

--- a/src/ReactiveUI.Primitives/PublicAPI/net8.0/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net8.0/PublicAPI.txt
@@ -62,8 +62,11 @@ namespace ReactiveUI.Primitives
         extension(System.IDisposable disposable)
         {
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith() { }
-            public System.IDisposable DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith(System.Action? action) { }
+        }
+        extension<T>(T disposable) where T : System.IDisposable
+        {
+            public T DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
         }
         extension(System.IObservable<object?> source)
         {

--- a/src/ReactiveUI.Primitives/PublicAPI/net9.0/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net9.0/PublicAPI.txt
@@ -77,8 +77,11 @@ namespace ReactiveUI.Primitives
         extension(System.IDisposable disposable)
         {
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith() { }
-            public System.IDisposable DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
             public ReactiveUI.Primitives.Disposables.SingleDisposable DisposeWith(System.Action? action) { }
+        }
+        extension<T>(T disposable) where T : System.IDisposable
+        {
+            public T DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
         }
         extension(System.IObservable<object?> source)
         {

--- a/src/tests/ReactiveUI.Primitives.Reactive.Tests/LinqExtensionsTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Reactive.Tests/LinqExtensionsTests.cs
@@ -5,6 +5,7 @@
 using System.Reactive;
 using System.Reactive.Linq;
 using ReactiveUI.Primitives.Advanced;
+using ReactiveUI.Primitives.Disposables;
 using ReactiveUI.Primitives.Reactive.Signals;
 using ReactiveLinqExtensions = ReactiveUI.Primitives.Reactive.LinqExtensions;
 
@@ -21,6 +22,37 @@ public class LinqExtensionsTests
 
     /// <summary>The string value used by nullable object subscription tests.</summary>
     private const string SubscribeSafeValue = "value";
+
+    /// <summary>Verifies DisposeWith preserves the concrete type and tracks the original disposable.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task DisposeWithReturnsConcreteDisposableAndTracksIt()
+    {
+        var disposalCount = 0;
+        ActionDisposable disposable = new(() => disposalCount++);
+        MultipleDisposable disposables = [];
+
+        var result = disposable.DisposeWith(disposables);
+
+        await Assert.That(result).IsSameReferenceAs(disposable);
+        await Assert.That(result.IsDisposed).IsFalse();
+        await Assert.That(disposables.Contains(disposable)).IsTrue();
+        disposables.Dispose();
+        await Assert.That(disposalCount).IsEqualTo(1);
+    }
+
+    /// <summary>Verifies DisposeWith rejects a null disposable collection.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task DisposeWithThrowsForNullMultipleDisposable()
+    {
+        using ActionDisposable disposable = new(static () => { });
+
+        var exception = Assert.Throws<ArgumentNullException>(() =>
+            disposable.DisposeWith((MultipleDisposable)null!));
+
+        await Assert.That(exception.ParamName).IsEqualTo("disposables");
+    }
 
     /// <summary>Verifies fluent <c>SubscribeSafe</c> accepts nullable object values with Rx imports present.</summary>
     /// <returns>A task representing the asynchronous operation.</returns>

--- a/src/tests/ReactiveUI.Primitives.Tests/LinqExtensionsTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/LinqExtensionsTests.cs
@@ -1,0 +1,42 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using ReactiveUI.Primitives.Disposables;
+
+namespace ReactiveUI.Primitives.Tests;
+
+/// <summary>Verifies miscellaneous Primitives extension contracts.</summary>
+public class LinqExtensionsTests
+{
+    /// <summary>Verifies DisposeWith preserves the concrete type and tracks the original disposable.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task DisposeWithReturnsConcreteDisposableAndTracksIt()
+    {
+        var disposalCount = 0;
+        ActionDisposable disposable = new(() => disposalCount++);
+        MultipleDisposable disposables = [];
+
+        var result = disposable.DisposeWith(disposables);
+
+        await Assert.That(result).IsSameReferenceAs(disposable);
+        await Assert.That(result.IsDisposed).IsFalse();
+        await Assert.That(disposables.Contains(disposable)).IsTrue();
+        disposables.Dispose();
+        await Assert.That(disposalCount).IsEqualTo(1);
+    }
+
+    /// <summary>Verifies DisposeWith rejects a null disposable collection.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task DisposeWithThrowsForNullMultipleDisposable()
+    {
+        using ActionDisposable disposable = new(static () => { });
+
+        var exception = Assert.Throws<ArgumentNullException>(() =>
+            disposable.DisposeWith((MultipleDisposable)null!));
+
+        await Assert.That(exception.ParamName).IsEqualTo("disposables");
+    }
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

A breaking API fix that makes the `MultipleDisposable` overload of `DisposeWith` preserve the receiver's concrete disposable type.

Closes #152 

## What is the new behavior?

`DisposeWith<T>(T disposable, MultipleDisposable disposables)` validates the disposable collection, adds the original item, and returns the same `T`. The parameterless and action overloads retain their existing `IDisposable` receiver metadata. Lean and Reactive API baselines are updated for every tracked target framework, with TUnit coverage for concrete-type preservation, identity, disposal tracking, and null validation.

## What is the current behavior?

The `MultipleDisposable` overload returns `IDisposable`, losing the receiver's concrete type, and silently accepts a null collection. Compiled consumers of that overload target the old non-generic metadata signature and must recompile for this change.

## Checklist
- [x] Tests have been added or updated (for bug fixes / features)
- [x] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the main branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information

Validation:
- Lean and Reactive `net10.0` builds passed with zero warnings and errors.
- Lean and Reactive `net462` builds passed with zero warnings and errors.
- Focused TUnit tests passed: lean 2/2; Reactive 12/12.
- Targeted Cobertura/Mtpunittest MCP review confirms the generic `DisposeWith` body is covered.
- `git diff --check` passed.

BREAKING CHANGE: `DisposeWith(IDisposable, MultipleDisposable)` is replaced by `DisposeWith<T>(T, MultipleDisposable)`. Already compiled consumers must recompile. The parameterless and action overloads preserve their existing metadata.