### PR TITLE
feat(reactive): add ContainerDisposable for CompositeDisposable interop

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,12 @@ These two types are the only places the lean surface departs from the System.Rea
 variants close the gap: they recompile the same source with `ISequencer` mapped to `IScheduler` and `RxVoid` mapped to
 `System.Reactive.Unit`, so code that already speaks System.Reactive sees the types it expects.
 
+Disposal groups are a third seam, and one the shared types cannot close on their own: `MultipleDisposable` ships in the
+dependency-free `ReactiveUI.Disposables` package, so it cannot name `CompositeDisposable`. `ReactiveUI.Primitives.Reactive`
+adds `ContainerDisposable` for that - a `MultipleDisposable` that converts implicitly to a `CompositeDisposable` it owns
+and disposes. Hand one to `DisposeWith`, to a library that takes a `CompositeDisposable`, or to your own helper, and it
+just works; anything registered through the composite is disposed with the container.
+
 ## Table of contents
 
 1. [Install](#install)

--- a/src/ReactiveUI.Primitives.Reactive/Disposables/ContainerDisposable.cs
+++ b/src/ReactiveUI.Primitives.Reactive/Disposables/ContainerDisposable.cs
@@ -1,0 +1,112 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Reactive.Disposables;
+
+namespace ReactiveUI.Primitives.Reactive.Disposables;
+
+/// <summary>
+/// A <see cref="MultipleDisposable"/> that a System.Reactive consumer can use as a
+/// <see cref="CompositeDisposable"/>, so an activation-scoped container flows into APIs written against
+/// System.Reactive - <c>DisposeWith</c> above all - without the caller converting it by hand.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The conversion is identity-stable: every conversion of the same container yields the same
+/// <see cref="CompositeDisposable"/>, and the container owns that composite, so anything registered through it
+/// is disposed when the container is. Registering after the container is disposed disposes the registration
+/// immediately, matching <see cref="MultipleDisposable.Add"/>.
+/// </para>
+/// <para>
+/// Registrations made through the composite are not visible to the container's own
+/// <see cref="ICollection{T}"/> members: the composite occupies a single slot, so <c>Count</c> counts it once
+/// and <c>Contains</c>/<c>Remove</c> do not see through it.
+/// </para>
+/// </remarks>
+[System.Diagnostics.DebuggerDisplay("Count = {Count}, IsDisposed = {IsDisposed}")]
+public sealed class ContainerDisposable : MultipleDisposable
+{
+    /// <summary>Serializes creation of the composite.</summary>
+    private readonly Lock _gate = new();
+
+    /// <summary>The composite handed to System.Reactive consumers, created on first conversion.</summary>
+    private CompositeDisposable? _composite;
+
+    /// <summary>Initializes a new instance of the <see cref="ContainerDisposable"/> class.</summary>
+    public ContainerDisposable()
+    {
+    }
+
+    /// <summary>Initializes a new instance of the <see cref="ContainerDisposable"/> class.</summary>
+    /// <param name="first">The first disposable.</param>
+    /// <param name="second">The second disposable.</param>
+    public ContainerDisposable(IDisposable first, IDisposable second)
+        : base(first, second)
+    {
+    }
+
+    /// <summary>Initializes a new instance of the <see cref="ContainerDisposable"/> class.</summary>
+    /// <param name="first">The first disposable.</param>
+    /// <param name="second">The second disposable.</param>
+    /// <param name="third">The third disposable.</param>
+    public ContainerDisposable(IDisposable first, IDisposable second, IDisposable third)
+        : base(first, second, third)
+    {
+    }
+
+    /// <summary>Initializes a new instance of the <see cref="ContainerDisposable"/> class from a group of disposables.</summary>
+    /// <param name="disposables">Disposables that will be disposed together.</param>
+    /// <exception cref="ArgumentExceptionHelper"><paramref name="disposables"/> is <see langword="null"/>.</exception>
+    public ContainerDisposable(params IDisposable[] disposables)
+        : base(disposables)
+    {
+    }
+
+    /// <summary>Hands the container to a System.Reactive consumer as the composite it owns.</summary>
+    /// <param name="container">The container to convert.</param>
+    /// <exception cref="ArgumentExceptionHelper"><paramref name="container"/> is <see langword="null"/>.</exception>
+    public static implicit operator CompositeDisposable(ContainerDisposable container)
+    {
+        ArgumentExceptionHelper.ThrowIfNull(container);
+
+        return container.ToCompositeDisposable();
+    }
+
+    /// <summary>Gets the <see cref="CompositeDisposable"/> this container owns, creating it on first call.</summary>
+    /// <returns>The composite whose contents are disposed along with this container.</returns>
+    public CompositeDisposable ToCompositeDisposable()
+    {
+        lock (_gate)
+        {
+            // A disposed composite is still the right answer once the container itself is disposed - it is the
+            // sink that disposes late arrivals. After Clear() or Remove() the container lives on, so a composite
+            // it disposed has to be replaced rather than handed out again.
+            var existing = _composite;
+            if (existing is not null && (!existing.IsDisposed || IsDisposed))
+            {
+                return existing;
+            }
+
+            var created = new CompositeDisposable();
+            _composite = created;
+
+            // Registering the composite with the container is what ties the two lifetimes together. On an
+            // already-disposed container this disposes the composite instead, which is what a caller adding to
+            // a disposed container should get.
+            Add(created);
+            return created;
+        }
+    }
+
+    /// <inheritdoc/>
+    protected override void Dispose(bool disposing)
+    {
+        base.Dispose(disposing);
+
+        // The composite occupies a slot in the container, so the base disposed it just now - or Clear()/Remove()
+        // did on the way out. Disposing it here is idempotent and states the ownership outright. Nothing in this
+        // hierarchy has a finalizer and the class is sealed, so this only ever runs on the deterministic path.
+        _composite?.Dispose();
+    }
+}

--- a/src/ReactiveUI.Primitives.Reactive/Disposables/LinqExtensions.ContainerDisposable.cs
+++ b/src/ReactiveUI.Primitives.Reactive/Disposables/LinqExtensions.ContainerDisposable.cs
@@ -1,0 +1,37 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using ReactiveUI.Primitives.Reactive.Disposables;
+
+namespace ReactiveUI.Primitives.Reactive;
+
+/// <summary>Miscellaneous Primitives extensions.</summary>
+public static partial class LinqExtensions
+{
+    /// <summary>Disposal-tracking operators for a disposable.</summary>
+    /// <typeparam name="T">The disposable type.</typeparam>
+    /// <param name="disposable">The disposable.</param>
+    extension<T>(T disposable)
+        where T : IDisposable
+    {
+        /// <summary>Disposes the IDisposable with the container.</summary>
+        /// <param name="disposables">The container.</param>
+        /// <returns>The original disposable.</returns>
+        /// <exception cref="ArgumentExceptionHelper"><paramref name="disposables"/> is <see langword="null"/>.</exception>
+        /// <remarks>
+        /// A <see cref="ContainerDisposable"/> converts to a System.Reactive <c>CompositeDisposable</c>, so
+        /// without this overload a call site that imports both this namespace and System.Reactive's fluent
+        /// disposal helpers has two equally-good candidates - the inherited
+        /// <c>DisposeWith(MultipleDisposable)</c> and System.Reactive's <c>DisposeWith(CompositeDisposable)</c>
+        /// - and is ambiguous. Taking the container exactly makes this an identity match, which wins outright.
+        /// </remarks>
+        public T DisposeWith(ContainerDisposable disposables)
+        {
+            ArgumentExceptionHelper.ThrowIfNull(disposables);
+
+            disposables.Add(disposable);
+            return disposable;
+        }
+    }
+}

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-android/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-android/PublicAPI.txt
@@ -425,6 +425,7 @@ namespace ReactiveUI.Primitives.Reactive
         extension<T>(T disposable) where T : System.IDisposable
         {
             public T DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
+            public T DisposeWith(ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable disposables) { }
         }
         extension(System.IObservable<object?> source)
         {
@@ -1596,6 +1597,20 @@ namespace ReactiveUI.Primitives.Reactive.Core
         public readonly System.IObservable<T> ToObservable() { }
         public readonly System.IObservable<T> ToObservable(System.Reactive.Concurrency.IScheduler scheduler) { }
         public override readonly string ToString() { }
+    }
+}
+namespace ReactiveUI.Primitives.Reactive.Disposables
+{
+    [System.Diagnostics.DebuggerDisplay("Count = {Count}, IsDisposed = {IsDisposed}")]
+    public sealed class ContainerDisposable : ReactiveUI.Primitives.Disposables.MultipleDisposable
+    {
+        public ContainerDisposable() { }
+        public ContainerDisposable(params System.IDisposable[] disposables) { }
+        public ContainerDisposable(System.IDisposable first, System.IDisposable second) { }
+        public ContainerDisposable(System.IDisposable first, System.IDisposable second, System.IDisposable third) { }
+        protected override void Dispose(bool disposing) { }
+        public System.Reactive.Disposables.CompositeDisposable ToCompositeDisposable() { }
+        public static implicit operator System.Reactive.Disposables.CompositeDisposable(ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable container) { }
     }
 }
 namespace ReactiveUI.Primitives.Reactive.Signals

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-ios/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-ios/PublicAPI.txt
@@ -425,6 +425,7 @@ namespace ReactiveUI.Primitives.Reactive
         extension<T>(T disposable) where T : System.IDisposable
         {
             public T DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
+            public T DisposeWith(ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable disposables) { }
         }
         extension(System.IObservable<object?> source)
         {
@@ -1590,6 +1591,20 @@ namespace ReactiveUI.Primitives.Reactive.Core
         public readonly System.IObservable<T> ToObservable() { }
         public readonly System.IObservable<T> ToObservable(System.Reactive.Concurrency.IScheduler scheduler) { }
         public override readonly string ToString() { }
+    }
+}
+namespace ReactiveUI.Primitives.Reactive.Disposables
+{
+    [System.Diagnostics.DebuggerDisplay("Count = {Count}, IsDisposed = {IsDisposed}")]
+    public sealed class ContainerDisposable : ReactiveUI.Primitives.Disposables.MultipleDisposable
+    {
+        public ContainerDisposable() { }
+        public ContainerDisposable(params System.IDisposable[] disposables) { }
+        public ContainerDisposable(System.IDisposable first, System.IDisposable second) { }
+        public ContainerDisposable(System.IDisposable first, System.IDisposable second, System.IDisposable third) { }
+        protected override void Dispose(bool disposing) { }
+        public System.Reactive.Disposables.CompositeDisposable ToCompositeDisposable() { }
+        public static implicit operator System.Reactive.Disposables.CompositeDisposable(ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable container) { }
     }
 }
 namespace ReactiveUI.Primitives.Reactive.Signals

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-maccatalyst/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-maccatalyst/PublicAPI.txt
@@ -425,6 +425,7 @@ namespace ReactiveUI.Primitives.Reactive
         extension<T>(T disposable) where T : System.IDisposable
         {
             public T DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
+            public T DisposeWith(ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable disposables) { }
         }
         extension(System.IObservable<object?> source)
         {
@@ -1590,6 +1591,20 @@ namespace ReactiveUI.Primitives.Reactive.Core
         public readonly System.IObservable<T> ToObservable() { }
         public readonly System.IObservable<T> ToObservable(System.Reactive.Concurrency.IScheduler scheduler) { }
         public override readonly string ToString() { }
+    }
+}
+namespace ReactiveUI.Primitives.Reactive.Disposables
+{
+    [System.Diagnostics.DebuggerDisplay("Count = {Count}, IsDisposed = {IsDisposed}")]
+    public sealed class ContainerDisposable : ReactiveUI.Primitives.Disposables.MultipleDisposable
+    {
+        public ContainerDisposable() { }
+        public ContainerDisposable(params System.IDisposable[] disposables) { }
+        public ContainerDisposable(System.IDisposable first, System.IDisposable second) { }
+        public ContainerDisposable(System.IDisposable first, System.IDisposable second, System.IDisposable third) { }
+        protected override void Dispose(bool disposing) { }
+        public System.Reactive.Disposables.CompositeDisposable ToCompositeDisposable() { }
+        public static implicit operator System.Reactive.Disposables.CompositeDisposable(ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable container) { }
     }
 }
 namespace ReactiveUI.Primitives.Reactive.Signals

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-macos/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-macos/PublicAPI.txt
@@ -425,6 +425,7 @@ namespace ReactiveUI.Primitives.Reactive
         extension<T>(T disposable) where T : System.IDisposable
         {
             public T DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
+            public T DisposeWith(ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable disposables) { }
         }
         extension(System.IObservable<object?> source)
         {
@@ -1590,6 +1591,20 @@ namespace ReactiveUI.Primitives.Reactive.Core
         public readonly System.IObservable<T> ToObservable() { }
         public readonly System.IObservable<T> ToObservable(System.Reactive.Concurrency.IScheduler scheduler) { }
         public override readonly string ToString() { }
+    }
+}
+namespace ReactiveUI.Primitives.Reactive.Disposables
+{
+    [System.Diagnostics.DebuggerDisplay("Count = {Count}, IsDisposed = {IsDisposed}")]
+    public sealed class ContainerDisposable : ReactiveUI.Primitives.Disposables.MultipleDisposable
+    {
+        public ContainerDisposable() { }
+        public ContainerDisposable(params System.IDisposable[] disposables) { }
+        public ContainerDisposable(System.IDisposable first, System.IDisposable second) { }
+        public ContainerDisposable(System.IDisposable first, System.IDisposable second, System.IDisposable third) { }
+        protected override void Dispose(bool disposing) { }
+        public System.Reactive.Disposables.CompositeDisposable ToCompositeDisposable() { }
+        public static implicit operator System.Reactive.Disposables.CompositeDisposable(ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable container) { }
     }
 }
 namespace ReactiveUI.Primitives.Reactive.Signals

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-tvos/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-tvos/PublicAPI.txt
@@ -425,6 +425,7 @@ namespace ReactiveUI.Primitives.Reactive
         extension<T>(T disposable) where T : System.IDisposable
         {
             public T DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
+            public T DisposeWith(ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable disposables) { }
         }
         extension(System.IObservable<object?> source)
         {
@@ -1590,6 +1591,20 @@ namespace ReactiveUI.Primitives.Reactive.Core
         public readonly System.IObservable<T> ToObservable() { }
         public readonly System.IObservable<T> ToObservable(System.Reactive.Concurrency.IScheduler scheduler) { }
         public override readonly string ToString() { }
+    }
+}
+namespace ReactiveUI.Primitives.Reactive.Disposables
+{
+    [System.Diagnostics.DebuggerDisplay("Count = {Count}, IsDisposed = {IsDisposed}")]
+    public sealed class ContainerDisposable : ReactiveUI.Primitives.Disposables.MultipleDisposable
+    {
+        public ContainerDisposable() { }
+        public ContainerDisposable(params System.IDisposable[] disposables) { }
+        public ContainerDisposable(System.IDisposable first, System.IDisposable second) { }
+        public ContainerDisposable(System.IDisposable first, System.IDisposable second, System.IDisposable third) { }
+        protected override void Dispose(bool disposing) { }
+        public System.Reactive.Disposables.CompositeDisposable ToCompositeDisposable() { }
+        public static implicit operator System.Reactive.Disposables.CompositeDisposable(ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable container) { }
     }
 }
 namespace ReactiveUI.Primitives.Reactive.Signals

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0/PublicAPI.txt
@@ -424,6 +424,7 @@ namespace ReactiveUI.Primitives.Reactive
         extension<T>(T disposable) where T : System.IDisposable
         {
             public T DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
+            public T DisposeWith(ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable disposables) { }
         }
         extension(System.IObservable<object?> source)
         {
@@ -1570,6 +1571,20 @@ namespace ReactiveUI.Primitives.Reactive.Core
         public readonly System.IObservable<T> ToObservable() { }
         public readonly System.IObservable<T> ToObservable(System.Reactive.Concurrency.IScheduler scheduler) { }
         public override readonly string ToString() { }
+    }
+}
+namespace ReactiveUI.Primitives.Reactive.Disposables
+{
+    [System.Diagnostics.DebuggerDisplay("Count = {Count}, IsDisposed = {IsDisposed}")]
+    public sealed class ContainerDisposable : ReactiveUI.Primitives.Disposables.MultipleDisposable
+    {
+        public ContainerDisposable() { }
+        public ContainerDisposable(params System.IDisposable[] disposables) { }
+        public ContainerDisposable(System.IDisposable first, System.IDisposable second) { }
+        public ContainerDisposable(System.IDisposable first, System.IDisposable second, System.IDisposable third) { }
+        protected override void Dispose(bool disposing) { }
+        public System.Reactive.Disposables.CompositeDisposable ToCompositeDisposable() { }
+        public static implicit operator System.Reactive.Disposables.CompositeDisposable(ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable container) { }
     }
 }
 namespace ReactiveUI.Primitives.Reactive.Signals

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-android/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-android/PublicAPI.txt
@@ -425,6 +425,7 @@ namespace ReactiveUI.Primitives.Reactive
         extension<T>(T disposable) where T : System.IDisposable
         {
             public T DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
+            public T DisposeWith(ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable disposables) { }
         }
         extension(System.IObservable<object?> source)
         {
@@ -1596,6 +1597,20 @@ namespace ReactiveUI.Primitives.Reactive.Core
         public readonly System.IObservable<T> ToObservable() { }
         public readonly System.IObservable<T> ToObservable(System.Reactive.Concurrency.IScheduler scheduler) { }
         public override readonly string ToString() { }
+    }
+}
+namespace ReactiveUI.Primitives.Reactive.Disposables
+{
+    [System.Diagnostics.DebuggerDisplay("Count = {Count}, IsDisposed = {IsDisposed}")]
+    public sealed class ContainerDisposable : ReactiveUI.Primitives.Disposables.MultipleDisposable
+    {
+        public ContainerDisposable() { }
+        public ContainerDisposable(params System.IDisposable[] disposables) { }
+        public ContainerDisposable(System.IDisposable first, System.IDisposable second) { }
+        public ContainerDisposable(System.IDisposable first, System.IDisposable second, System.IDisposable third) { }
+        protected override void Dispose(bool disposing) { }
+        public System.Reactive.Disposables.CompositeDisposable ToCompositeDisposable() { }
+        public static implicit operator System.Reactive.Disposables.CompositeDisposable(ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable container) { }
     }
 }
 namespace ReactiveUI.Primitives.Reactive.Signals

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-ios/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-ios/PublicAPI.txt
@@ -425,6 +425,7 @@ namespace ReactiveUI.Primitives.Reactive
         extension<T>(T disposable) where T : System.IDisposable
         {
             public T DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
+            public T DisposeWith(ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable disposables) { }
         }
         extension(System.IObservable<object?> source)
         {
@@ -1590,6 +1591,20 @@ namespace ReactiveUI.Primitives.Reactive.Core
         public readonly System.IObservable<T> ToObservable() { }
         public readonly System.IObservable<T> ToObservable(System.Reactive.Concurrency.IScheduler scheduler) { }
         public override readonly string ToString() { }
+    }
+}
+namespace ReactiveUI.Primitives.Reactive.Disposables
+{
+    [System.Diagnostics.DebuggerDisplay("Count = {Count}, IsDisposed = {IsDisposed}")]
+    public sealed class ContainerDisposable : ReactiveUI.Primitives.Disposables.MultipleDisposable
+    {
+        public ContainerDisposable() { }
+        public ContainerDisposable(params System.IDisposable[] disposables) { }
+        public ContainerDisposable(System.IDisposable first, System.IDisposable second) { }
+        public ContainerDisposable(System.IDisposable first, System.IDisposable second, System.IDisposable third) { }
+        protected override void Dispose(bool disposing) { }
+        public System.Reactive.Disposables.CompositeDisposable ToCompositeDisposable() { }
+        public static implicit operator System.Reactive.Disposables.CompositeDisposable(ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable container) { }
     }
 }
 namespace ReactiveUI.Primitives.Reactive.Signals

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-maccatalyst/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-maccatalyst/PublicAPI.txt
@@ -425,6 +425,7 @@ namespace ReactiveUI.Primitives.Reactive
         extension<T>(T disposable) where T : System.IDisposable
         {
             public T DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
+            public T DisposeWith(ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable disposables) { }
         }
         extension(System.IObservable<object?> source)
         {
@@ -1590,6 +1591,20 @@ namespace ReactiveUI.Primitives.Reactive.Core
         public readonly System.IObservable<T> ToObservable() { }
         public readonly System.IObservable<T> ToObservable(System.Reactive.Concurrency.IScheduler scheduler) { }
         public override readonly string ToString() { }
+    }
+}
+namespace ReactiveUI.Primitives.Reactive.Disposables
+{
+    [System.Diagnostics.DebuggerDisplay("Count = {Count}, IsDisposed = {IsDisposed}")]
+    public sealed class ContainerDisposable : ReactiveUI.Primitives.Disposables.MultipleDisposable
+    {
+        public ContainerDisposable() { }
+        public ContainerDisposable(params System.IDisposable[] disposables) { }
+        public ContainerDisposable(System.IDisposable first, System.IDisposable second) { }
+        public ContainerDisposable(System.IDisposable first, System.IDisposable second, System.IDisposable third) { }
+        protected override void Dispose(bool disposing) { }
+        public System.Reactive.Disposables.CompositeDisposable ToCompositeDisposable() { }
+        public static implicit operator System.Reactive.Disposables.CompositeDisposable(ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable container) { }
     }
 }
 namespace ReactiveUI.Primitives.Reactive.Signals

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-macos/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-macos/PublicAPI.txt
@@ -425,6 +425,7 @@ namespace ReactiveUI.Primitives.Reactive
         extension<T>(T disposable) where T : System.IDisposable
         {
             public T DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
+            public T DisposeWith(ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable disposables) { }
         }
         extension(System.IObservable<object?> source)
         {
@@ -1590,6 +1591,20 @@ namespace ReactiveUI.Primitives.Reactive.Core
         public readonly System.IObservable<T> ToObservable() { }
         public readonly System.IObservable<T> ToObservable(System.Reactive.Concurrency.IScheduler scheduler) { }
         public override readonly string ToString() { }
+    }
+}
+namespace ReactiveUI.Primitives.Reactive.Disposables
+{
+    [System.Diagnostics.DebuggerDisplay("Count = {Count}, IsDisposed = {IsDisposed}")]
+    public sealed class ContainerDisposable : ReactiveUI.Primitives.Disposables.MultipleDisposable
+    {
+        public ContainerDisposable() { }
+        public ContainerDisposable(params System.IDisposable[] disposables) { }
+        public ContainerDisposable(System.IDisposable first, System.IDisposable second) { }
+        public ContainerDisposable(System.IDisposable first, System.IDisposable second, System.IDisposable third) { }
+        protected override void Dispose(bool disposing) { }
+        public System.Reactive.Disposables.CompositeDisposable ToCompositeDisposable() { }
+        public static implicit operator System.Reactive.Disposables.CompositeDisposable(ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable container) { }
     }
 }
 namespace ReactiveUI.Primitives.Reactive.Signals

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-tvos/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-tvos/PublicAPI.txt
@@ -425,6 +425,7 @@ namespace ReactiveUI.Primitives.Reactive
         extension<T>(T disposable) where T : System.IDisposable
         {
             public T DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
+            public T DisposeWith(ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable disposables) { }
         }
         extension(System.IObservable<object?> source)
         {
@@ -1590,6 +1591,20 @@ namespace ReactiveUI.Primitives.Reactive.Core
         public readonly System.IObservable<T> ToObservable() { }
         public readonly System.IObservable<T> ToObservable(System.Reactive.Concurrency.IScheduler scheduler) { }
         public override readonly string ToString() { }
+    }
+}
+namespace ReactiveUI.Primitives.Reactive.Disposables
+{
+    [System.Diagnostics.DebuggerDisplay("Count = {Count}, IsDisposed = {IsDisposed}")]
+    public sealed class ContainerDisposable : ReactiveUI.Primitives.Disposables.MultipleDisposable
+    {
+        public ContainerDisposable() { }
+        public ContainerDisposable(params System.IDisposable[] disposables) { }
+        public ContainerDisposable(System.IDisposable first, System.IDisposable second) { }
+        public ContainerDisposable(System.IDisposable first, System.IDisposable second, System.IDisposable third) { }
+        protected override void Dispose(bool disposing) { }
+        public System.Reactive.Disposables.CompositeDisposable ToCompositeDisposable() { }
+        public static implicit operator System.Reactive.Disposables.CompositeDisposable(ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable container) { }
     }
 }
 namespace ReactiveUI.Primitives.Reactive.Signals

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0/PublicAPI.txt
@@ -424,6 +424,7 @@ namespace ReactiveUI.Primitives.Reactive
         extension<T>(T disposable) where T : System.IDisposable
         {
             public T DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
+            public T DisposeWith(ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable disposables) { }
         }
         extension(System.IObservable<object?> source)
         {
@@ -1570,6 +1571,20 @@ namespace ReactiveUI.Primitives.Reactive.Core
         public readonly System.IObservable<T> ToObservable() { }
         public readonly System.IObservable<T> ToObservable(System.Reactive.Concurrency.IScheduler scheduler) { }
         public override readonly string ToString() { }
+    }
+}
+namespace ReactiveUI.Primitives.Reactive.Disposables
+{
+    [System.Diagnostics.DebuggerDisplay("Count = {Count}, IsDisposed = {IsDisposed}")]
+    public sealed class ContainerDisposable : ReactiveUI.Primitives.Disposables.MultipleDisposable
+    {
+        public ContainerDisposable() { }
+        public ContainerDisposable(params System.IDisposable[] disposables) { }
+        public ContainerDisposable(System.IDisposable first, System.IDisposable second) { }
+        public ContainerDisposable(System.IDisposable first, System.IDisposable second, System.IDisposable third) { }
+        protected override void Dispose(bool disposing) { }
+        public System.Reactive.Disposables.CompositeDisposable ToCompositeDisposable() { }
+        public static implicit operator System.Reactive.Disposables.CompositeDisposable(ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable container) { }
     }
 }
 namespace ReactiveUI.Primitives.Reactive.Signals

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net462/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net462/PublicAPI.txt
@@ -409,6 +409,7 @@ namespace ReactiveUI.Primitives.Reactive
         extension<T>(T disposable) where T : System.IDisposable
         {
             public T DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
+            public T DisposeWith(ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable disposables) { }
         }
         extension(System.IObservable<object?> source)
         {
@@ -1552,6 +1553,20 @@ namespace ReactiveUI.Primitives.Reactive.Core
         public readonly System.IObservable<T> ToObservable() { }
         public readonly System.IObservable<T> ToObservable(System.Reactive.Concurrency.IScheduler scheduler) { }
         public override readonly string ToString() { }
+    }
+}
+namespace ReactiveUI.Primitives.Reactive.Disposables
+{
+    [System.Diagnostics.DebuggerDisplay("Count = {Count}, IsDisposed = {IsDisposed}")]
+    public sealed class ContainerDisposable : ReactiveUI.Primitives.Disposables.MultipleDisposable
+    {
+        public ContainerDisposable() { }
+        public ContainerDisposable(params System.IDisposable[] disposables) { }
+        public ContainerDisposable(System.IDisposable first, System.IDisposable second) { }
+        public ContainerDisposable(System.IDisposable first, System.IDisposable second, System.IDisposable third) { }
+        protected override void Dispose(bool disposing) { }
+        public System.Reactive.Disposables.CompositeDisposable ToCompositeDisposable() { }
+        public static implicit operator System.Reactive.Disposables.CompositeDisposable(ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable container) { }
     }
 }
 namespace ReactiveUI.Primitives.Reactive.Signals

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net472/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net472/PublicAPI.txt
@@ -409,6 +409,7 @@ namespace ReactiveUI.Primitives.Reactive
         extension<T>(T disposable) where T : System.IDisposable
         {
             public T DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
+            public T DisposeWith(ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable disposables) { }
         }
         extension(System.IObservable<object?> source)
         {
@@ -1552,6 +1553,20 @@ namespace ReactiveUI.Primitives.Reactive.Core
         public readonly System.IObservable<T> ToObservable() { }
         public readonly System.IObservable<T> ToObservable(System.Reactive.Concurrency.IScheduler scheduler) { }
         public override readonly string ToString() { }
+    }
+}
+namespace ReactiveUI.Primitives.Reactive.Disposables
+{
+    [System.Diagnostics.DebuggerDisplay("Count = {Count}, IsDisposed = {IsDisposed}")]
+    public sealed class ContainerDisposable : ReactiveUI.Primitives.Disposables.MultipleDisposable
+    {
+        public ContainerDisposable() { }
+        public ContainerDisposable(params System.IDisposable[] disposables) { }
+        public ContainerDisposable(System.IDisposable first, System.IDisposable second) { }
+        public ContainerDisposable(System.IDisposable first, System.IDisposable second, System.IDisposable third) { }
+        protected override void Dispose(bool disposing) { }
+        public System.Reactive.Disposables.CompositeDisposable ToCompositeDisposable() { }
+        public static implicit operator System.Reactive.Disposables.CompositeDisposable(ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable container) { }
     }
 }
 namespace ReactiveUI.Primitives.Reactive.Signals

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net48/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net48/PublicAPI.txt
@@ -409,6 +409,7 @@ namespace ReactiveUI.Primitives.Reactive
         extension<T>(T disposable) where T : System.IDisposable
         {
             public T DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
+            public T DisposeWith(ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable disposables) { }
         }
         extension(System.IObservable<object?> source)
         {
@@ -1552,6 +1553,20 @@ namespace ReactiveUI.Primitives.Reactive.Core
         public readonly System.IObservable<T> ToObservable() { }
         public readonly System.IObservable<T> ToObservable(System.Reactive.Concurrency.IScheduler scheduler) { }
         public override readonly string ToString() { }
+    }
+}
+namespace ReactiveUI.Primitives.Reactive.Disposables
+{
+    [System.Diagnostics.DebuggerDisplay("Count = {Count}, IsDisposed = {IsDisposed}")]
+    public sealed class ContainerDisposable : ReactiveUI.Primitives.Disposables.MultipleDisposable
+    {
+        public ContainerDisposable() { }
+        public ContainerDisposable(params System.IDisposable[] disposables) { }
+        public ContainerDisposable(System.IDisposable first, System.IDisposable second) { }
+        public ContainerDisposable(System.IDisposable first, System.IDisposable second, System.IDisposable third) { }
+        protected override void Dispose(bool disposing) { }
+        public System.Reactive.Disposables.CompositeDisposable ToCompositeDisposable() { }
+        public static implicit operator System.Reactive.Disposables.CompositeDisposable(ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable container) { }
     }
 }
 namespace ReactiveUI.Primitives.Reactive.Signals

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net481/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net481/PublicAPI.txt
@@ -409,6 +409,7 @@ namespace ReactiveUI.Primitives.Reactive
         extension<T>(T disposable) where T : System.IDisposable
         {
             public T DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
+            public T DisposeWith(ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable disposables) { }
         }
         extension(System.IObservable<object?> source)
         {
@@ -1552,6 +1553,20 @@ namespace ReactiveUI.Primitives.Reactive.Core
         public readonly System.IObservable<T> ToObservable() { }
         public readonly System.IObservable<T> ToObservable(System.Reactive.Concurrency.IScheduler scheduler) { }
         public override readonly string ToString() { }
+    }
+}
+namespace ReactiveUI.Primitives.Reactive.Disposables
+{
+    [System.Diagnostics.DebuggerDisplay("Count = {Count}, IsDisposed = {IsDisposed}")]
+    public sealed class ContainerDisposable : ReactiveUI.Primitives.Disposables.MultipleDisposable
+    {
+        public ContainerDisposable() { }
+        public ContainerDisposable(params System.IDisposable[] disposables) { }
+        public ContainerDisposable(System.IDisposable first, System.IDisposable second) { }
+        public ContainerDisposable(System.IDisposable first, System.IDisposable second, System.IDisposable third) { }
+        protected override void Dispose(bool disposing) { }
+        public System.Reactive.Disposables.CompositeDisposable ToCompositeDisposable() { }
+        public static implicit operator System.Reactive.Disposables.CompositeDisposable(ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable container) { }
     }
 }
 namespace ReactiveUI.Primitives.Reactive.Signals

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net8.0/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net8.0/PublicAPI.txt
@@ -409,6 +409,7 @@ namespace ReactiveUI.Primitives.Reactive
         extension<T>(T disposable) where T : System.IDisposable
         {
             public T DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
+            public T DisposeWith(ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable disposables) { }
         }
         extension(System.IObservable<object?> source)
         {
@@ -1552,6 +1553,20 @@ namespace ReactiveUI.Primitives.Reactive.Core
         public readonly System.IObservable<T> ToObservable() { }
         public readonly System.IObservable<T> ToObservable(System.Reactive.Concurrency.IScheduler scheduler) { }
         public override readonly string ToString() { }
+    }
+}
+namespace ReactiveUI.Primitives.Reactive.Disposables
+{
+    [System.Diagnostics.DebuggerDisplay("Count = {Count}, IsDisposed = {IsDisposed}")]
+    public sealed class ContainerDisposable : ReactiveUI.Primitives.Disposables.MultipleDisposable
+    {
+        public ContainerDisposable() { }
+        public ContainerDisposable(params System.IDisposable[] disposables) { }
+        public ContainerDisposable(System.IDisposable first, System.IDisposable second) { }
+        public ContainerDisposable(System.IDisposable first, System.IDisposable second, System.IDisposable third) { }
+        protected override void Dispose(bool disposing) { }
+        public System.Reactive.Disposables.CompositeDisposable ToCompositeDisposable() { }
+        public static implicit operator System.Reactive.Disposables.CompositeDisposable(ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable container) { }
     }
 }
 namespace ReactiveUI.Primitives.Reactive.Signals

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net9.0/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net9.0/PublicAPI.txt
@@ -424,6 +424,7 @@ namespace ReactiveUI.Primitives.Reactive
         extension<T>(T disposable) where T : System.IDisposable
         {
             public T DisposeWith(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables) { }
+            public T DisposeWith(ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable disposables) { }
         }
         extension(System.IObservable<object?> source)
         {
@@ -1570,6 +1571,20 @@ namespace ReactiveUI.Primitives.Reactive.Core
         public readonly System.IObservable<T> ToObservable() { }
         public readonly System.IObservable<T> ToObservable(System.Reactive.Concurrency.IScheduler scheduler) { }
         public override readonly string ToString() { }
+    }
+}
+namespace ReactiveUI.Primitives.Reactive.Disposables
+{
+    [System.Diagnostics.DebuggerDisplay("Count = {Count}, IsDisposed = {IsDisposed}")]
+    public sealed class ContainerDisposable : ReactiveUI.Primitives.Disposables.MultipleDisposable
+    {
+        public ContainerDisposable() { }
+        public ContainerDisposable(params System.IDisposable[] disposables) { }
+        public ContainerDisposable(System.IDisposable first, System.IDisposable second) { }
+        public ContainerDisposable(System.IDisposable first, System.IDisposable second, System.IDisposable third) { }
+        protected override void Dispose(bool disposing) { }
+        public System.Reactive.Disposables.CompositeDisposable ToCompositeDisposable() { }
+        public static implicit operator System.Reactive.Disposables.CompositeDisposable(ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable container) { }
     }
 }
 namespace ReactiveUI.Primitives.Reactive.Signals

--- a/src/tests/ReactiveUI.Primitives.Reactive.Tests/ContainerDisposableTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Reactive.Tests/ContainerDisposableTests.cs
@@ -1,0 +1,154 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Reactive.Disposables;
+using ReactiveUI.Primitives.Disposables;
+using ReactiveUI.Primitives.Reactive.Disposables;
+
+namespace ReactiveUI.Primitives.Reactive.Tests;
+
+/// <summary>Tests for the container that presents itself to System.Reactive as a composite.</summary>
+public class ContainerDisposableTests
+{
+    /// <summary>The number of disposables seeded by the two-argument constructor.</summary>
+    private const int PairCount = 2;
+
+    /// <summary>The number of disposables seeded by the three-argument constructor.</summary>
+    private const int TripleCount = 3;
+
+    /// <summary>The number of disposables seeded by the array constructor.</summary>
+    private const int BatchCount = 4;
+
+    /// <summary>The number of disposables seeded across every constructor.</summary>
+    private const int SeededCount = PairCount + TripleCount + BatchCount;
+
+    /// <summary>The number of registrations made directly on the container plus through its composite.</summary>
+    private const int DirectAndComposedCount = 2;
+
+    /// <summary>Verifies the container hands the same composite to every conversion.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task ConversionYieldsTheSameCompositeEveryTime()
+    {
+        using ContainerDisposable container = [];
+
+        CompositeDisposable first = container;
+        CompositeDisposable second = container;
+
+        await Assert.That(second).IsSameReferenceAs(first);
+        await Assert.That(container.ToCompositeDisposable()).IsSameReferenceAs(first);
+    }
+
+    /// <summary>Verifies disposing the container disposes everything registered through the composite.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task DisposingTheContainerDisposesTheCompositeContents()
+    {
+        ContainerDisposable container = [];
+        var disposalCount = 0;
+        CompositeDisposable composite = container;
+        composite.Add(new ActionDisposable(() => disposalCount++));
+
+        await Assert.That(disposalCount).IsEqualTo(0);
+
+        container.Dispose();
+
+        await Assert.That(disposalCount).IsEqualTo(1);
+        await Assert.That(composite.IsDisposed).IsTrue();
+    }
+
+    /// <summary>Verifies converting a disposed container yields a sink that disposes late arrivals.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task ConversionAfterDisposalDisposesLateArrivals()
+    {
+        ContainerDisposable container = [];
+        container.Dispose();
+        var disposalCount = 0;
+
+        CompositeDisposable composite = container;
+        composite.Add(new ActionDisposable(() => disposalCount++));
+
+        await Assert.That(composite.IsDisposed).IsTrue();
+        await Assert.That(disposalCount).IsEqualTo(1);
+        await Assert.That(container.ToCompositeDisposable()).IsSameReferenceAs(composite);
+    }
+
+    /// <summary>Verifies clearing the container replaces the composite it disposed rather than reusing it.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task ClearReplacesTheCompositeSoTheContainerStaysUsable()
+    {
+        using ContainerDisposable container = [];
+        var disposalCount = 0;
+        CompositeDisposable beforeClear = container;
+        beforeClear.Add(new ActionDisposable(() => disposalCount++));
+
+        container.Clear();
+
+        await Assert.That(disposalCount).IsEqualTo(1);
+        await Assert.That(beforeClear.IsDisposed).IsTrue();
+
+        CompositeDisposable afterClear = container;
+        afterClear.Add(new ActionDisposable(() => disposalCount++));
+
+        await Assert.That(afterClear).IsNotSameReferenceAs(beforeClear);
+        await Assert.That(afterClear.IsDisposed).IsFalse();
+        await Assert.That(disposalCount).IsEqualTo(1);
+    }
+
+    /// <summary>Verifies the conversion rejects a null container.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task ConversionThrowsForNullContainer()
+    {
+        var exception = Assert.Throws<ArgumentNullException>(static () =>
+            _ = (CompositeDisposable)(ContainerDisposable)null!);
+
+        await Assert.That(exception.ParamName).IsEqualTo("container");
+    }
+
+    /// <summary>Verifies the container still behaves as a group of disposables in its own right.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task ContainerTracksItsOwnRegistrationsAlongsideTheComposite()
+    {
+        ContainerDisposable container = [];
+        var disposalCount = 0;
+        ActionDisposable direct = new(() => disposalCount++);
+        container.Add(direct);
+        CompositeDisposable composite = container;
+        composite.Add(new ActionDisposable(() => disposalCount++));
+
+        await Assert.That(container.Contains(direct)).IsTrue();
+
+        container.Dispose();
+
+        await Assert.That(disposalCount).IsEqualTo(DirectAndComposedCount);
+    }
+
+    /// <summary>Verifies the constructors seed the container with the supplied disposables.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task ConstructorsSeedTheSuppliedDisposables()
+    {
+        var disposalCount = 0;
+
+        ActionDisposable First() => new(() => disposalCount++);
+
+        ContainerDisposable pair = new(First(), First());
+        ContainerDisposable triple = new(First(), First(), First());
+        ContainerDisposable batch = new([First(), First(), First(), First()]);
+
+        await Assert.That(pair.Count).IsEqualTo(PairCount);
+        await Assert.That(triple.Count).IsEqualTo(TripleCount);
+        await Assert.That(batch.Count).IsEqualTo(BatchCount);
+
+        pair.Dispose();
+        triple.Dispose();
+        batch.Dispose();
+
+        await Assert.That(disposalCount).IsEqualTo(SeededCount);
+    }
+}

--- a/src/tests/ReactiveUI.Primitives.Reactive.Tests/LinqExtensionsTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Reactive.Tests/LinqExtensionsTests.cs
@@ -3,9 +3,15 @@
 // See the LICENSE file in the project root for full license information.
 
 using System.Reactive;
+using System.Reactive.Disposables;
+
+// Imported so the DisposeWith tests below are compiled with System.Reactive's own fluent disposal helpers in
+// scope - that is the call-site shape the ContainerDisposable overload exists to keep unambiguous.
+using System.Reactive.Disposables.Fluent;
 using System.Reactive.Linq;
 using ReactiveUI.Primitives.Advanced;
 using ReactiveUI.Primitives.Disposables;
+using ReactiveUI.Primitives.Reactive.Disposables;
 using ReactiveUI.Primitives.Reactive.Signals;
 using ReactiveLinqExtensions = ReactiveUI.Primitives.Reactive.LinqExtensions;
 
@@ -52,6 +58,61 @@ public class LinqExtensionsTests
             disposable.DisposeWith((MultipleDisposable)null!));
 
         await Assert.That(exception.ParamName).IsEqualTo("disposables");
+    }
+
+    /// <summary>Verifies DisposeWith resolves to this overload for a container and tracks the original disposable.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task DisposeWithContainerReturnsConcreteDisposableAndTracksIt()
+    {
+        var disposalCount = 0;
+        ActionDisposable disposable = new(() => disposalCount++);
+        ContainerDisposable disposables = [];
+
+        var result = disposable.DisposeWith(disposables);
+
+        await Assert.That(result).IsSameReferenceAs(disposable);
+        await Assert.That(disposables.Contains(disposable)).IsTrue();
+
+        // Resolving to this overload rather than System.Reactive's is what keeps the registration on the
+        // container itself instead of the composite it would have been converted into.
+        await Assert.That(((CompositeDisposable)disposables).Count).IsEqualTo(0);
+
+        disposables.Dispose();
+
+        await Assert.That(disposalCount).IsEqualTo(1);
+    }
+
+    /// <summary>Verifies DisposeWith rejects a null container.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task DisposeWithThrowsForNullContainerDisposable()
+    {
+        using ActionDisposable disposable = new(static () => { });
+
+        var exception = Assert.Throws<ArgumentNullException>(() =>
+            disposable.DisposeWith((ContainerDisposable)null!));
+
+        await Assert.That(exception.ParamName).IsEqualTo("disposables");
+    }
+
+    /// <summary>Verifies a container converted to a composite still disposes what System.Reactive registered on it.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task DisposeWithComposedFromAContainerDisposesWithTheContainer()
+    {
+        ContainerDisposable disposables = [];
+        var disposalCount = 0;
+        ActionDisposable disposable = new(() => disposalCount++);
+
+        var result = disposable.DisposeWith((CompositeDisposable)disposables);
+
+        await Assert.That(result).IsSameReferenceAs(disposable);
+        await Assert.That(disposalCount).IsEqualTo(0);
+
+        disposables.Dispose();
+
+        await Assert.That(disposalCount).IsEqualTo(1);
     }
 
     /// <summary>Verifies fluent <c>SubscribeSafe</c> accepts nullable object values with Rx imports present.</summary>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature - new public API on `ReactiveUI.Primitives.Reactive`.

## What is the new behavior?

**`ReactiveUI.Primitives.Reactive` ships `ContainerDisposable`, a disposal group a System.Reactive consumer can use as a `CompositeDisposable`.**

- **`ContainerDisposable` is a `MultipleDisposable` that converts implicitly to a `CompositeDisposable` it owns.**
  - Hand it to `DisposeWith`, to a library that takes a `CompositeDisposable`, or to your own helper - no conversion at the call site.
  - The conversion is identity-stable, so every conversion of the same container yields the same composite.
  - The composite occupies a slot in the container, so anything registered through it is disposed when the container is. Registering after disposal disposes the registration immediately, matching `MultipleDisposable.Add`.
  - `Clear()` and `Remove()` dispose the composite along with everything else; the next conversion hands back a fresh one, so the container stays usable.
- **`DisposeWith` gains an overload that takes the container.** A container is convertible to `CompositeDisposable`, so without this overload a call site importing both `ReactiveUI.Primitives.Reactive` and System.Reactive's fluent disposal helpers has two equally-good candidates and does not compile. Taking the container exactly makes this an identity match, which wins outright.

The intended consumer is `ReactiveUI.Reactive`, whose `WhenActivated(Action<MultipleDisposable>)` overloads can hand out a `ContainerDisposable` instead. That is a follow-up in the ReactiveUI repo and is blocked on this shipping - ReactiveUI consumes Primitives as a package reference.

## What is the current behavior?

`MultipleDisposable` ships in `ReactiveUI.Disposables`, which deliberately has no System.Reactive dependency, so it cannot name `CompositeDisposable` and no conversion between them exists. Code that gets a `MultipleDisposable` from `WhenActivated` and calls System.Reactive's `DisposeWith` on it does not compile; the workaround is to import `ReactiveUI.Primitives.Reactive` for the Primitives `DisposeWith` instead.

Relates to reactiveui/ReactiveUI#4434.

## What might this PR break?

None. The change is additive:

- `ContainerDisposable` is new, and the existing `DisposeWith(MultipleDisposable)` overload is untouched.
- A container passed to `DisposeWith` binds to the new overload by identity, so the two overloads coexist whether or not System.Reactive's fluent disposal helpers are also imported.

Two things worth knowing when using it:

- The container's `ICollection<IDisposable>` view counts the composite as a single entry. `Count`, `Contains` and `Remove` do not see through it to registrations made on the composite.
- Conversion allocates the composite lazily, on first use, and only in the `.Reactive` flavour.

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [x] Tests have been added or updated (for bug fixes / features)
- [x] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information

The hand-written files are `ContainerDisposable.cs`, `LinqExtensions.ContainerDisposable.cs`, `ContainerDisposableTests.cs`, the added tests in `LinqExtensionsTests.cs`, and a README paragraph. The rest of the diff is the same two entries repeated across the per-TFM public API baselines.

`LinqExtensionsTests.cs` now imports `System.Reactive.Disposables.Fluent` deliberately: that import is what makes the overload-resolution guard a compile-time test rather than a comment.
