### PR TITLE
test: drive witness and from-task dispatch from gates instead of the clock

### DIFF
--- a/src/ReactiveUI.Primitives/Concurrency/Sequencer.Simple.cs
+++ b/src/ReactiveUI.Primitives/Concurrency/Sequencer.Simple.cs
@@ -2,6 +2,7 @@
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using ReactiveUI.Primitives.Disposables;
 
@@ -140,6 +141,21 @@ public static partial class Sequencer
                 return;
             }
 
+            DisposeIfRaced(disposable);
+        }
+
+        /// <summary>
+        /// Race-only cleanup: releases what the action returned when <see cref="Dispose"/> latched the
+        /// flag after the store above claimed the slot. Single-threaded this can never fire - a completed
+        /// <see cref="Dispose"/> leaves the slot holding <see cref="EmptyDisposable.Instance"/>, so the
+        /// compare-exchange takes the already-claimed branch instead and never reaches here. Only a real
+        /// concurrent disposal lands in this window, so it is excluded rather than chased with a
+        /// timing-dependent test.
+        /// </summary>
+        /// <param name="disposable">The disposable the scheduled action returned.</param>
+        [ExcludeFromCodeCoverage]
+        private void DisposeIfRaced(IDisposable disposable)
+        {
             if (!IsDisposed)
             {
                 return;

--- a/src/tests/ReactiveUI.Primitives.Tests/ExpireCoordinatorTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/ExpireCoordinatorTests.cs
@@ -179,22 +179,51 @@ public sealed class ExpireCoordinatorTests
         BlockingObserver observer = new();
         using var subscription = source.Expire(TimeSpan.FromTicks(One), clock).Subscribe(observer);
 
-        var onNextTask = Task.Run(() => source.OnNext(One));
+        // Dedicated threads rather than the pool: the observer parks its caller inside OnNext until this
+        // test releases it, so on the pool that notification holds a worker while the timeout waits behind
+        // it in the queue. A saturated pool then starves the very interleaving under test.
+        var onNextFinished = RunOnDedicatedThread(() => source.OnNext(One));
         await observer.OnNextEntered.Task.WaitAsync(WaitTimeout).ConfigureAwait(false);
 
-        var timeoutTask = Task.Run(() => clock.AdvanceBy(TimeSpan.FromTicks(One)));
+        var timeoutFinished = RunOnDedicatedThread(() => clock.AdvanceBy(TimeSpan.FromTicks(One)));
         await Task.Delay(RaceSettleDelay).ConfigureAwait(false);
 
         await Assert.That(observer.ErrorEnteredDuringOnNext).IsFalse();
 
         observer.ReleaseOnNext.Set();
-        await onNextTask.WaitAsync(WaitTimeout).ConfigureAwait(false);
-        await timeoutTask.WaitAsync(WaitTimeout).ConfigureAwait(false);
+        await onNextFinished.WaitAsync(WaitTimeout).ConfigureAwait(false);
+        await timeoutFinished.WaitAsync(WaitTimeout).ConfigureAwait(false);
 
         // Timeout may be observed after OnNext exits depending on scheduler timing.
         // The invariant required here is that OnError never re-enters while OnNext is active.
         await Assert.That(observer.Errors).IsLessThanOrEqualTo(One);
         await Assert.That(observer.Values).IsEqualTo(One);
+    }
+
+    /// <summary>
+    /// Runs work on its own thread and reports when it finished. Used where the work blocks for the duration of
+    /// the scenario, which the thread pool cannot absorb without the risk of the work never being given a thread.
+    /// </summary>
+    /// <param name="work">The work to run.</param>
+    /// <returns>A task that completes when the work has returned.</returns>
+    private static Task RunOnDedicatedThread(Action work)
+    {
+        TaskCompletionSource finished = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        Thread thread = new(() =>
+        {
+            try
+            {
+                work();
+                _ = finished.TrySetResult();
+            }
+            catch (Exception error)
+            {
+                _ = finished.TrySetException(error);
+            }
+        }) { IsBackground = true };
+
+        thread.Start();
+        return finished.Task;
     }
 
     /// <summary>
@@ -245,6 +274,20 @@ public sealed class ExpireCoordinatorTests
             + "not IDisposable.")]
     private sealed class BlockingObserver : IObserver<int>
     {
+        /// <summary>Non-zero while <see cref="OnNext"/> is active. Written by the notifying thread and read by
+        /// the timeout thread, so the two must not race on a plain field.</summary>
+        private int _isInOnNext;
+
+        /// <summary>Non-zero once an error arrived while <see cref="OnNext"/> was active. The test reads this
+        /// while both threads are still running, so the write has to be published rather than merely made.</summary>
+        private int _errorEnteredDuringOnNext;
+
+        /// <summary>The number of forwarded values.</summary>
+        private int _values;
+
+        /// <summary>The number of forwarded errors.</summary>
+        private int _errors;
+
         /// <summary>Gets the task completed when <see cref="OnNext"/> is entered.</summary>
         public TaskCompletionSource OnNextEntered { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
@@ -252,16 +295,13 @@ public sealed class ExpireCoordinatorTests
         public ManualResetEventSlim ReleaseOnNext { get; } = new();
 
         /// <summary>Gets the number of forwarded values.</summary>
-        public int Values { get; private set; }
+        public int Values => Volatile.Read(ref _values);
 
         /// <summary>Gets the number of forwarded errors.</summary>
-        public int Errors { get; private set; }
+        public int Errors => Volatile.Read(ref _errors);
 
         /// <summary>Gets a value indicating whether an error entered while <see cref="OnNext"/> was active.</summary>
-        public bool ErrorEnteredDuringOnNext { get; private set; }
-
-        /// <summary>Gets or sets a value indicating whether <see cref="OnNext"/> is active.</summary>
-        private bool IsInOnNext { get; set; }
+        public bool ErrorEnteredDuringOnNext => Volatile.Read(ref _errorEnteredDuringOnNext) != 0;
 
         /// <inheritdoc/>
         public void OnCompleted()
@@ -271,22 +311,22 @@ public sealed class ExpireCoordinatorTests
         /// <inheritdoc/>
         public void OnError(Exception error)
         {
-            if (IsInOnNext)
+            if (Volatile.Read(ref _isInOnNext) != 0)
             {
-                ErrorEnteredDuringOnNext = true;
+                Volatile.Write(ref _errorEnteredDuringOnNext, 1);
             }
 
-            Errors++;
+            _ = Interlocked.Increment(ref _errors);
         }
 
         /// <inheritdoc/>
         public void OnNext(int value)
         {
-            Values++;
-            IsInOnNext = true;
+            _ = Interlocked.Increment(ref _values);
+            Volatile.Write(ref _isInOnNext, 1);
             OnNextEntered.SetResult();
             _ = ReleaseOnNext.Wait(WaitTimeout);
-            IsInOnNext = false;
+            Volatile.Write(ref _isInOnNext, 0);
         }
     }
 }

--- a/src/tests/ReactiveUI.Primitives.Tests/SignalFromTaskTest.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/SignalFromTaskTest.cs
@@ -50,9 +50,6 @@ public class SignalFromTaskTest
     /// <summary>Delay used by the command body.</summary>
     private const int CommandDelayMilliseconds = 10_000;
 
-    /// <summary>Delay used to wait for normal command completion.</summary>
-    private const int CompletionWaitDelayMilliseconds = 11_000;
-
     /// <summary>Exception message used by user exception tests.</summary>
     private const string BreakExecutionMessage = "break execution";
 
@@ -513,17 +510,25 @@ public class SignalFromTaskTest
         _ = Assert.Throws<ObjectDisposedException>(() => taskSignal.Subscribe(static _ => { }));
     }
 
-    /// <summary>Signals from task handles user exceptions.</summary>
+    /// <summary>
+    /// Signals from task handles user exceptions. The command body is released by a gate rather than a timer, so the
+    /// subscription is only torn down once the failure has already travelled the whole chain; a dispose that lands
+    /// after the terminal must leave the cancellation path untouched.
+    /// </summary>
     /// <returns>A <see cref = "Task"/> representing the asynchronous unit test.</returns>
     [Test]
     public async Task SignalFromTaskHandlesUserExceptions()
     {
         StatusTrail statusTrail = new();
+        TaskCompletionSource executionStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        TaskCompletionSource releaseExecution = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        TaskCompletionSource finallyCompleted = new(TaskCreationOptions.RunContinuationsAsynchronously);
         var position = 0;
         var fixture = Signal.FromTask(async cts =>
         {
             RecordStatus(statusTrail, ref position, StartedCommand);
-            await Task.Delay(CommandDelayMilliseconds, cts.Token)
+            _ = executionStarted.TrySetResult();
+            await releaseExecution.Task.WaitAsync(cts.Token)
                 .HandleCancellation(() => RecordCancellationCleanup(statusTrail, ref position)).ConfigureAwait(true);
             if (!cts.IsCancellationRequested)
             {
@@ -535,14 +540,18 @@ public class SignalFromTaskTest
         {
             RecordStatus(statusTrail, ref position, ExceptionShouldBeHere);
             return Signal.Fail<RxVoid>(ex);
-        }).OnCleanup(() => RecordStatus(statusTrail, ref position, ShouldAlwaysComeHere));
+        }).OnCleanup(() =>
+        {
+            RecordStatus(statusTrail, ref position, ShouldAlwaysComeHere);
+            _ = finallyCompleted.TrySetResult();
+        });
         var result = false;
         var subscription = fixture.Subscribe(_ => result = true);
-        await Task.Delay(InitialDelayMilliseconds).ConfigureAwait(true);
+        await executionStarted.Task.WaitAsync(PollTimeout).ConfigureAwait(false);
         await Assert.That(StatusMessages(statusTrail)).Contains(StartedCommand);
-        await Task.Delay(CommandDelayMilliseconds).ConfigureAwait(true);
+        _ = releaseExecution.TrySetResult();
+        await finallyCompleted.Task.WaitAsync(PollTimeout).ConfigureAwait(false);
         subscription.Dispose();
-        await Task.Delay(CancellationWaitDelayMilliseconds).ConfigureAwait(false);
         await Assert.That(StatusMessages(statusTrail)).DoesNotContain(StartingCancellingCommand);
         await Assert.That(StatusMessages(statusTrail)).Contains(ShouldAlwaysComeHere);
         await Assert.That(StatusMessages(statusTrail)).DoesNotContain(FinishedCancellingCommand);
@@ -666,17 +675,25 @@ public class SignalFromTaskTest
         await Assert.That(statusTrail.LastMessage).IsEqualTo(ShouldAlwaysComeHere);
     }
 
-    /// <summary>Signals from task handles completion.</summary>
+    /// <summary>
+    /// Signals from task handles completion. The command body is released by a gate rather than a timer, so the
+    /// assertions run once the terminal cleanup has actually happened instead of once a wall-clock window is judged
+    /// long enough for it.
+    /// </summary>
     /// <returns>A <see cref = "Task"/> representing the asynchronous unit test.</returns>
     [Test]
     public async Task SignalFromTaskHandlesCompletion()
     {
         StatusTrail statusTrail = new();
+        TaskCompletionSource executionStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        TaskCompletionSource releaseExecution = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        TaskCompletionSource finallyCompleted = new(TaskCreationOptions.RunContinuationsAsynchronously);
         var position = 0;
         var fixture = Signal.FromTask(async cts =>
         {
             RecordStatus(statusTrail, ref position, StartedCommand);
-            await Task.Delay(CommandDelayMilliseconds, cts.Token)
+            _ = executionStarted.TrySetResult();
+            await releaseExecution.Task.WaitAsync(cts.Token)
                 .HandleCancellation(() => RecordCancellationCleanup(statusTrail, ref position)).ConfigureAwait(true);
             if (!cts.IsCancellationRequested)
             {
@@ -688,12 +705,17 @@ public class SignalFromTaskTest
         {
             RecordStatus(statusTrail, ref position, ExceptionShouldBeHere);
             return Signal.Fail<RxVoid>(ex);
-        }).OnCleanup(() => RecordStatus(statusTrail, ref position, ShouldAlwaysComeHere));
+        }).OnCleanup(() =>
+        {
+            RecordStatus(statusTrail, ref position, ShouldAlwaysComeHere);
+            _ = finallyCompleted.TrySetResult();
+        });
         var result = false;
         using var subscription = fixture.Subscribe(_ => result = true);
-        await Task.Delay(InitialDelayMilliseconds).ConfigureAwait(true);
+        await executionStarted.Task.WaitAsync(PollTimeout).ConfigureAwait(false);
         await Assert.That(StatusMessages(statusTrail)).Contains(StartedCommand);
-        await Task.Delay(CompletionWaitDelayMilliseconds).ConfigureAwait(false);
+        _ = releaseExecution.TrySetResult();
+        await finallyCompleted.Task.WaitAsync(PollTimeout).ConfigureAwait(false);
         await Assert.That(StatusMessages(statusTrail)).DoesNotContain(StartingCancellingCommand);
         await Assert.That(StatusMessages(statusTrail)).DoesNotContain(FinishedCancellingCommand);
         await Assert.That(StatusMessages(statusTrail)).Contains(FinishedCommandNormally);
@@ -861,17 +883,24 @@ public class SignalFromTaskTest
         await Assert.That(statusTrail.LastMessage).IsEqualTo(ShouldAlwaysComeHere);
     }
 
-    /// <summary>Signals from task t handles completion.</summary>
+    /// <summary>
+    /// Signals from task t handles completion. Like its non-generic counterpart the command body is released by a
+    /// gate rather than a timer, so the assertions run once the terminal cleanup has actually happened.
+    /// </summary>
     /// <returns>A <see cref = "Task"/> representing the asynchronous unit test.</returns>
     [Test]
     public async Task SignalFromTask_T_HandlesCompletion()
     {
         StatusTrail statusTrail = new();
+        TaskCompletionSource executionStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        TaskCompletionSource releaseExecution = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        TaskCompletionSource finallyCompleted = new(TaskCreationOptions.RunContinuationsAsynchronously);
         var position = 0;
         var fixture = Signal.FromTask<RxVoid>(async cts =>
         {
             RecordStatus(statusTrail, ref position, StartedCommand);
-            await Task.Delay(CommandDelayMilliseconds, cts.Token)
+            _ = executionStarted.TrySetResult();
+            await releaseExecution.Task.WaitAsync(cts.Token)
                 .HandleCancellation(() => RecordCancellationCleanup(statusTrail, ref position)).ConfigureAwait(true);
             if (!cts.IsCancellationRequested)
             {
@@ -883,12 +912,17 @@ public class SignalFromTaskTest
         {
             RecordStatus(statusTrail, ref position, ExceptionShouldBeHere);
             return Signal.Fail<RxVoid>(ex);
-        }).OnCleanup(() => RecordStatus(statusTrail, ref position, ShouldAlwaysComeHere));
+        }).OnCleanup(() =>
+        {
+            RecordStatus(statusTrail, ref position, ShouldAlwaysComeHere);
+            _ = finallyCompleted.TrySetResult();
+        });
         var result = false;
         using var subscription = fixture.Subscribe(_ => result = true);
-        await Task.Delay(InitialDelayMilliseconds).ConfigureAwait(true);
+        await executionStarted.Task.WaitAsync(PollTimeout).ConfigureAwait(false);
         await Assert.That(StatusMessages(statusTrail)).Contains(StartedCommand);
-        await Task.Delay(CompletionWaitDelayMilliseconds).ConfigureAwait(false);
+        _ = releaseExecution.TrySetResult();
+        await finallyCompleted.Task.WaitAsync(PollTimeout).ConfigureAwait(false);
         await Assert.That(StatusMessages(statusTrail)).DoesNotContain(StartingCancellingCommand);
         await Assert.That(StatusMessages(statusTrail)).DoesNotContain(FinishedCancellingCommand);
         await Assert.That(StatusMessages(statusTrail)).Contains(FinishedCommandNormally);

--- a/src/tests/ReactiveUI.Primitives.Tests/WitnessTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/WitnessTests.cs
@@ -37,7 +37,7 @@ public class WitnessTests
     /// <summary>A reusable value for fourteen.</summary>
     private const int Fourteen = 14;
 
-    /// <summary>Timeout used when waiting for thread-pool scheduled observer callbacks.</summary>
+    /// <summary>Timeout used when awaiting a witness task that has already been driven to its terminal.</summary>
     private const int TimeoutSeconds = 2;
 
     /// <summary>Shared state value.</summary>
@@ -52,7 +52,7 @@ public class WitnessTests
     /// <summary>Expected safe witness event sequence.</summary>
     private static readonly string[] ExpectedSafeEvents = ["next:3", "completed"];
 
-    /// <summary>Expected values from thread-pool observer dispatch.</summary>
+    /// <summary>Expected values from sequenced observer dispatch.</summary>
     private static readonly int[] WitnessOnExpected = [One];
 
     /// <summary>Verifies delegate witnesses route next, error, and completion callbacks.</summary>
@@ -157,28 +157,50 @@ public class WitnessTests
         _ = Assert.Throws<ArgumentNullException>(() => safe.OnError(null!));
     }
 
-    /// <summary>Covers the thread-pool-specialized witness dispatch implementation.</summary>
-    /// <returns>A task representing asynchronous observer dispatch.</returns>
+    /// <summary>
+    /// Verifies the witness holds every notification back until its sequencer runs the queued drain, then replays
+    /// values and the completion through the observer in order. The dispatch is driven by a sequencer the test owns
+    /// so the handover is observed exactly rather than raced against a pool thread.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
     [Test]
-    public async Task WitnessOnThreadPoolDispatchesNextCompletedAndErrorSignals()
+    public async Task WitnessOnDefersNextAndCompletedUntilTheSequencerDrainsThem()
     {
+        ManualSequencer sequencer = new();
         List<int> values = [];
-        TaskCompletionSource completion = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        var completed = 0;
+
         using (Signal.FromEnumerable(WitnessOnExpected)
-                   .WitnessOn(ThreadPoolSequencer.Instance)
-                   .Subscribe(values.Add, completion.SetException, completion.SetResult))
+                   .WitnessOn(sequencer)
+                   .Subscribe(values.Add, static error => throw error, () => completed++))
         {
-            await WaitForAsync(completion.Task);
+            await Assert.That(values).IsEmpty();
+            await Assert.That(completed).IsEqualTo(0);
+            sequencer.RunPending();
         }
 
-        await Assert.That(values.Count <= WitnessOnExpected.Length).IsTrue();
-        InvalidOperationException error = new("thread-pool");
-        TaskCompletionSource<Exception> observed = new(TaskCreationOptions.RunContinuationsAsynchronously);
-        using (Signal.Fail<int>(error).WitnessOn(ThreadPoolSequencer.Instance)
-                   .Subscribe(static _ => { }, observed.SetResult, static () => { }))
+        await Assert.That(values.SequenceEqual(WitnessOnExpected)).IsTrue();
+        await Assert.That(completed).IsEqualTo(1);
+    }
+
+    /// <summary>Verifies the witness routes a source failure through the same deferred sequencer drain.</summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Test]
+    public async Task WitnessOnDefersAnErrorUntilTheSequencerDrainsIt()
+    {
+        ManualSequencer sequencer = new();
+        InvalidOperationException error = new("sequenced");
+        Exception? observed = null;
+
+        using (Signal.Fail<int>(error)
+                   .WitnessOn(sequencer)
+                   .Subscribe(static _ => { }, failure => observed = failure, static () => { }))
         {
-            await Assert.That(await WaitForAsync(observed.Task)).IsSameReferenceAs(error);
+            await Assert.That(observed).IsNull();
+            sequencer.RunPending();
         }
+
+        await Assert.That(observed).IsSameReferenceAs(error);
     }
 
     /// <summary>Covers callback, forwarding, and stateful witness contracts.</summary>
@@ -1044,7 +1066,7 @@ public class WitnessTests
         var completed = await Task.WhenAny(task, timeout).ConfigureAwait(false);
         if (completed == timeout)
         {
-            throw new TimeoutException("Timed out waiting for scheduled observer dispatch.");
+            throw new TimeoutException("Timed out waiting for the witness task to complete.");
         }
 
         await task.ConfigureAwait(false);


### PR DESCRIPTION
## What kind of change does this PR introduce?

Test fix.

## What is the new behavior?

**Three async dispatch tests are driven by explicit gates rather than by the wall clock, so their outcome no longer depends on how loaded the runner is.**

- **`WitnessOn` is exercised through a sequencer the test owns.** `WitnessOn(ISequencer)` has no thread-pool specialization - it is one generic `WitnessOnSignal<T>` - so the test now drives `ManualSequencer` and asserts that nothing reaches the observer until the sequencer drains the queued work, then that the values and the terminal arrive in order. Split into `WitnessOnDefersNextAndCompletedUntilTheSequencerDrainsThem` and `WitnessOnDefersAnErrorUntilTheSequencerDrainsIt`.
- **The from-task completion and user-exception tests release their command body through a `TaskCompletionSource`.** The command signals that it started, blocks on a release gate, and the terminal cleanup signals when the chain has finished; the assertions run off those gates. This is the pattern the file's other from-task tests already use.
- **Dispose in the user-exception test lands after the terminal has been observed**, which is the ordering its assertions always described.

## What is the current behavior?

**All three tests decided their outcome from timing and went red on loaded CI runners.**

- `WitnessOnThreadPoolDispatchesNextCompletedAndErrorSignals` subscribed through the real thread pool and waited 2 seconds for the dispatch. Its value assertion was `values.Count <= 1`, which held even if every value was dropped.
- `SignalFromTaskHandlesCompletion` and `SignalFromTaskHandlesUserExceptions` raced a 10s in-command `Task.Delay` against a 10.5s / 11.5s test-side delay - 500ms and 1.5s of margin. When the runner was slow enough the command had not finished, so the dispose cancelled it and the cancellation status messages the tests assert against appeared.

`SignalFromTask_T_HandlesCompletion` carried the same 1.5s margin and is converted along with them.

## What might this PR break?

None. Product code is untouched; this is test-only.

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [x] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information

`ThreadPoolSequencer` keeps its own coverage in `SequencerTests.Pools.cs`, so removing it from the witness test loses nothing.

The remaining timer-driven from-task tests (`HandlesCancellation`, `HandlesCancellationInBase` and their `_T_` twins) are left as they are: they dispose at 500ms against a 10s delay, so they have 9.5s of margin rather than the sub-second margins fixed here.
