### PR TITLE
feat(advanced): expose the operator signals as public API

### DIFF
--- a/src/Primitives.Async.Shared/Advanced/FromAsyncSignal.cs
+++ b/src/Primitives.Async.Shared/Advanced/FromAsyncSignal.cs
@@ -9,7 +9,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 #endif
 
 /// <summary>Invokes a task-like operation for each subscription and emits <see cref="RxVoid.Default"/> after it completes.</summary>
-[System.Diagnostics.DebuggerDisplay("Factory = {Factory}")]
+[System.Diagnostics.DebuggerDisplay("FromAsyncSignal: Factory = {Factory}")]
 public sealed class FromAsyncSignal : IObservableAsync<RxVoid>
 {
     /// <summary>Initializes a new instance of the <see cref="FromAsyncSignal"/> class.</summary>

--- a/src/Primitives.Async.Shared/Advanced/FromAsyncSubscription.cs
+++ b/src/Primitives.Async.Shared/Advanced/FromAsyncSubscription.cs
@@ -9,7 +9,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 #endif
 
 /// <summary>Invokes an asynchronous operation and forwards the signal notification for one subscription.</summary>
-[System.Diagnostics.DebuggerDisplay("Factory = {Factory}")]
+[System.Diagnostics.DebuggerDisplay("FromAsyncSubscription: Factory = {Factory}")]
 public sealed class FromAsyncSubscription : TaskSignalSubscription<RxVoid>
 {
     /// <summary>Initializes a new instance of the <see cref="FromAsyncSubscription"/> class.</summary>

--- a/src/Primitives.Async.Shared/Advanced/StartSignal.cs
+++ b/src/Primitives.Async.Shared/Advanced/StartSignal.cs
@@ -9,7 +9,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 #endif
 
 /// <summary>Runs an action for each subscription and emits <see cref="RxVoid.Default"/> after it completes.</summary>
-[System.Diagnostics.DebuggerDisplay("Action = {Action}, TaskScheduler = {TaskScheduler}")]
+[System.Diagnostics.DebuggerDisplay("StartSignal: Action = {Action}, TaskScheduler = {TaskScheduler}")]
 public sealed class StartSignal : IObservableAsync<RxVoid>
 {
     /// <summary>Initializes a new instance of the <see cref="StartSignal"/> class.</summary>

--- a/src/Primitives.Async.Shared/Advanced/StartSubscription.cs
+++ b/src/Primitives.Async.Shared/Advanced/StartSubscription.cs
@@ -9,7 +9,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 #endif
 
 /// <summary>Runs an action and forwards the signal notification for one subscription.</summary>
-[System.Diagnostics.DebuggerDisplay("Action = {Action}, TaskScheduler = {TaskScheduler}")]
+[System.Diagnostics.DebuggerDisplay("StartSubscription: Action = {Action}, TaskScheduler = {TaskScheduler}")]
 public sealed class StartSubscription : TaskSignalSubscription<RxVoid>
 {
     /// <summary>Initializes a new instance of the <see cref="StartSubscription"/> class.</summary>

--- a/src/Primitives.Async.Shared/Advanced/TaskToAsyncSignal.cs
+++ b/src/Primitives.Async.Shared/Advanced/TaskToAsyncSignal.cs
@@ -9,7 +9,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 #endif
 
 /// <summary>Observes a task and emits <see cref="RxVoid.Default"/> when it completes successfully.</summary>
-[System.Diagnostics.DebuggerDisplay("SourceTask = {SourceTask}")]
+[System.Diagnostics.DebuggerDisplay("TaskToAsyncSignal: SourceTask = {SourceTask}")]
 public sealed class TaskToAsyncSignal : IObservableAsync<RxVoid>
 {
     /// <summary>Initializes a new instance of the <see cref="TaskToAsyncSignal"/> class.</summary>

--- a/src/Primitives.Async.Shared/Advanced/ToAsyncSignalSubscription.cs
+++ b/src/Primitives.Async.Shared/Advanced/ToAsyncSignalSubscription.cs
@@ -9,7 +9,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 #endif
 
 /// <summary>Waits for a task and forwards the signal notification for one subscription.</summary>
-[System.Diagnostics.DebuggerDisplay("SourceTask = {SourceTask}, Completed = {SourceTask.IsCompleted}")]
+[System.Diagnostics.DebuggerDisplay("ToAsyncSignalSubscription: SourceTask = {SourceTask}, Completed = {SourceTask.IsCompleted}")]
 public sealed class ToAsyncSignalSubscription : TaskSignalSubscription<RxVoid>
 {
     /// <summary>Initializes a new instance of the <see cref="ToAsyncSignalSubscription"/> class.</summary>

--- a/src/Primitives.Async.Shared/Advanced/WitnessOnSignal{T}.cs
+++ b/src/Primitives.Async.Shared/Advanced/WitnessOnSignal{T}.cs
@@ -10,7 +10,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 
 /// <summary>Switches source notifications onto an async context before forwarding them downstream.</summary>
 /// <typeparam name="T">The source element type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Source = {Source}, ForceYielding = {ForceYielding}")]
+[System.Diagnostics.DebuggerDisplay("WitnessOnSignal: Source = {Source}, ForceYielding = {ForceYielding}")]
 public sealed class WitnessOnSignal<T> : IObservableAsync<T>
 {
     /// <summary>Initializes a new instance of the <see cref="WitnessOnSignal{T}"/> class.</summary>

--- a/src/Primitives.Async.Shared/Advanced/WitnessOnWitness{T}.cs
+++ b/src/Primitives.Async.Shared/Advanced/WitnessOnWitness{T}.cs
@@ -10,7 +10,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 
 /// <summary>Switches each notification onto the configured async context before forwarding it.</summary>
 /// <typeparam name="T">The observed element type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("AsyncContext = {AsyncContext}, ForceYielding = {ForceYielding}")]
+[System.Diagnostics.DebuggerDisplay("WitnessOnWitness: AsyncContext = {AsyncContext}, ForceYielding = {ForceYielding}")]
 public sealed class WitnessOnWitness<T> : WitnessAsync<T>
 {
     /// <summary>Initializes a new instance of the <see cref="WitnessOnWitness{T}"/> class.</summary>

--- a/src/Primitives.Async.Shared/AsyncContext.cs
+++ b/src/Primitives.Async.Shared/AsyncContext.cs
@@ -22,7 +22,7 @@ namespace ReactiveUI.Primitives.Async;
 /// SynchronizationContext, TaskScheduler, or ISequencer. The Default context represents the absence of a specific
 /// synchronization or scheduling context, and typically corresponds to the default task scheduler.</remarks>
 [System.Diagnostics.DebuggerDisplay(
-    "SynchronizationContext = {SynchronizationContext}, TaskScheduler = {TaskScheduler}, Sequencer = {Sequencer}")]
+"AsyncContext: SynchronizationContext = {SynchronizationContext}, TaskScheduler = {TaskScheduler}, Sequencer = {Sequencer}")]
 public sealed record AsyncContext
 {
     /// <summary>Initializes a new instance of the <see cref="AsyncContext"/> class.</summary>
@@ -131,7 +131,7 @@ public sealed record AsyncContext
     /// continuation is scheduled, the continuation is invoked immediately and an OperationCanceledException will be
     /// thrown when GetResult is called. This type is intended for advanced scenarios where precise control over
     /// asynchronous context switching is required.</remarks>
-    [System.Diagnostics.DebuggerDisplay("IsCompleted = {IsCompleted}, ForceYielding = {ForceYielding}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncContextSwitcherAwaitable: IsCompleted = {IsCompleted}, ForceYielding = {ForceYielding}")]
     public readonly record struct AsyncContextSwitcherAwaitable(
         AsyncContext AsyncContext,
         bool ForceYielding,

--- a/src/Primitives.Platform.Reactive.Shared/CoalescingDispatchScheduler.cs
+++ b/src/Primitives.Platform.Reactive.Shared/CoalescingDispatchScheduler.cs
@@ -14,7 +14,7 @@ namespace ReactiveUI.Primitives.Reactive.Concurrency;
 /// and drained one batch per post. A sealed platform scheduler supplies its dispatcher <see cref="Post"/> (and
 /// optionally a native delayed path via <see cref="ScheduleOnDispatcher"/>).
 /// </summary>
-[System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
+[System.Diagnostics.DebuggerDisplay("CoalescingDispatchScheduler: ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
 public abstract class CoalescingDispatchScheduler : LocalScheduler
 {
     /// <summary>Ready work items awaiting a UI-thread drain.</summary>

--- a/src/Primitives.Shared/Advanced/AfterSignal.cs
+++ b/src/Primitives.Shared/Advanced/AfterSignal.cs
@@ -11,7 +11,7 @@ namespace ReactiveUI.Primitives.Advanced;
 #endif
 
 /// <summary>Emits timer ticks for the <c>After</c> factory overloads.</summary>
-[System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Period = {_period}")]
+[System.Diagnostics.DebuggerDisplay("AfterSignal: DueTime = {_dueTime}, Period = {_period}")]
 public sealed class AfterSignal : IRequireCurrentThread<long>
 {
     /// <summary>The delay before the single tick.</summary>

--- a/src/Primitives.Shared/Advanced/AfterSubscription.cs
+++ b/src/Primitives.Shared/Advanced/AfterSubscription.cs
@@ -11,7 +11,7 @@ namespace ReactiveUI.Primitives.Advanced;
 #endif
 
 /// <summary>Subscription handle for an <see cref="AfterSignal"/> timer.</summary>
-[System.Diagnostics.DebuggerDisplay("Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
+[System.Diagnostics.DebuggerDisplay("AfterSubscription: Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
 public sealed class AfterSubscription : IDisposable
 {
     /// <summary>Initializes a new instance of the <see cref="AfterSubscription"/> class.</summary>

--- a/src/Primitives.Shared/Advanced/AsyncCreateSignal{T}.cs
+++ b/src/Primitives.Shared/Advanced/AsyncCreateSignal{T}.cs
@@ -10,7 +10,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Creates an observable from an asynchronous subscription function.</summary>
 /// <typeparam name="T">The value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("SubscribeAsync = {SubscribeAsync}")]
+[System.Diagnostics.DebuggerDisplay("AsyncCreateSignal: SubscribeAsync = {SubscribeAsync}")]
 public sealed class AsyncCreateSignal<T> : IObservable<T>
 {
     /// <summary>Initializes a new instance of the <see cref="AsyncCreateSignal{T}"/> class.</summary>

--- a/src/Primitives.Shared/Advanced/AsyncDeferSignal{T}.cs
+++ b/src/Primitives.Shared/Advanced/AsyncDeferSignal{T}.cs
@@ -10,7 +10,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Creates a signal whose source is produced asynchronously for each subscription.</summary>
 /// <typeparam name="T">The value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("ObservableFactory = {ObservableFactory}")]
+[System.Diagnostics.DebuggerDisplay("AsyncDeferSignal: ObservableFactory = {ObservableFactory}")]
 public sealed class AsyncDeferSignal<T> : IObservable<T>
 {
     /// <summary>Initializes a new instance of the <see cref="AsyncDeferSignal{T}"/> class.</summary>

--- a/src/Primitives.Shared/Advanced/AsyncSubscriptionLifetime.cs
+++ b/src/Primitives.Shared/Advanced/AsyncSubscriptionLifetime.cs
@@ -14,7 +14,7 @@ namespace ReactiveUI.Primitives.Advanced;
 /// <remarks>
 /// Call <see cref="Complete"/> exactly once after asynchronous setup has finished, even when setup faults or is canceled.
 /// </remarks>
-[System.Diagnostics.DebuggerDisplay("Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
+[System.Diagnostics.DebuggerDisplay("AsyncSubscriptionLifetime: Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
 public sealed class AsyncSubscriptionLifetime : IDisposable
 {
     /// <summary>The cancellation source passed to the asynchronous subscription.</summary>

--- a/src/Primitives.Shared/Advanced/AutoConnectSignal{T}.cs
+++ b/src/Primitives.Shared/Advanced/AutoConnectSignal{T}.cs
@@ -10,7 +10,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Tracks auto-connect subscription state.</summary>
 /// <typeparam name="T">The value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Count = {_count}, Connected = {_connected}")]
+[System.Diagnostics.DebuggerDisplay("AutoConnectSignal: Count = {_count}, Connected = {_connected}")]
 public sealed class AutoConnectSignal<T> : IObservable<T>
 {
     /// <summary>Current subscriber count.</summary>

--- a/src/Primitives.Shared/Advanced/AutoShareSignal{T}.cs
+++ b/src/Primitives.Shared/Advanced/AutoShareSignal{T}.cs
@@ -10,7 +10,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Tracks reference-counted connection state.</summary>
 /// <typeparam name="T">The value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Count = {_count}, Connection = {_connection}")]
+[System.Diagnostics.DebuggerDisplay("AutoShareSignal: Count = {_count}, Connection = {_connection}")]
 public sealed class AutoShareSignal<T> : IObservable<T>
 {
     /// <summary>Synchronizes reference-count state.</summary>

--- a/src/Primitives.Shared/Advanced/AutoShareSubscription{T}.cs
+++ b/src/Primitives.Shared/Advanced/AutoShareSubscription{T}.cs
@@ -12,7 +12,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Reference-counted subscription handle.</summary>
 /// <typeparam name="T">The value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Owner = {_owner}, Subscription = {Subscription}")]
+[System.Diagnostics.DebuggerDisplay("AutoShareSubscription: Owner = {_owner}, Subscription = {Subscription}")]
 public sealed class AutoShareSubscription<T> : IDisposable
 {
     /// <summary>The owning gate; nulled once on dispose.</summary>

--- a/src/Primitives.Shared/Advanced/BlendSignal{T}.cs
+++ b/src/Primitives.Shared/Advanced/BlendSignal{T}.cs
@@ -10,7 +10,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Merges inner observable sources from an outer observable concurrently.</summary>
 /// <typeparam name="T">The value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+[System.Diagnostics.DebuggerDisplay("BlendSignal: Sources = {Sources}")]
 public sealed class BlendSignal<T> : IObservable<T>
 {
     /// <summary>Initializes a new instance of the <see cref="BlendSignal{T}"/> class.</summary>

--- a/src/Primitives.Shared/Advanced/BlendWitness{T}.cs
+++ b/src/Primitives.Shared/Advanced/BlendWitness{T}.cs
@@ -12,7 +12,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Mediates concurrent merging for <see cref="BlendSignal{T}"/> and <see cref="EnumerableBlendSignal{T}"/>.</summary>
 /// <typeparam name="T">The value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
+[System.Diagnostics.DebuggerDisplay("BlendWitness: ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
 public sealed class BlendWitness<T> : IDisposable
 {
     /// <summary>Serializes downstream callbacks and guards counters.</summary>

--- a/src/Primitives.Shared/Advanced/BufferEachWitness{T}.cs
+++ b/src/Primitives.Shared/Advanced/BufferEachWitness{T}.cs
@@ -12,7 +12,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Witness that emits each source value as a single-item buffer.</summary>
 /// <typeparam name="T">The source value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+[System.Diagnostics.DebuggerDisplay("BufferEachWitness: Stopped = {_stopped}, Observer = {Observer}")]
 public sealed class BufferEachWitness<T> : IObserver<T>, IDisposable
 {
     /// <summary>The upstream subscription slot.</summary>

--- a/src/Primitives.Shared/Advanced/BufferSignal{T}.cs
+++ b/src/Primitives.Shared/Advanced/BufferSignal{T}.cs
@@ -10,7 +10,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Concrete signal for time-windowed buffer operators.</summary>
 /// <typeparam name="T">The source value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Window = {Window}, Source = {Source}")]
+[System.Diagnostics.DebuggerDisplay("BufferSignal: Window = {Window}, Source = {Source}")]
 public sealed class BufferSignal<T> : IObservable<IList<T>>
 {
     /// <summary>Initializes a new instance of the <see cref="BufferSignal{T}"/> class.</summary>

--- a/src/Primitives.Shared/Advanced/CastSignal{TResult}.cs
+++ b/src/Primitives.Shared/Advanced/CastSignal{TResult}.cs
@@ -10,7 +10,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Observable sink that casts object values to the requested result type.</summary>
 /// <typeparam name="TResult">The result value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+[System.Diagnostics.DebuggerDisplay("CastSignal: Source = {Source}")]
 public sealed class CastSignal<TResult> : IRequireCurrentThread<TResult>
 {
     /// <summary>Initializes a new instance of the <see cref="CastSignal{TResult}"/> class.</summary>

--- a/src/Primitives.Shared/Advanced/CastWitness{TResult}.cs
+++ b/src/Primitives.Shared/Advanced/CastWitness{TResult}.cs
@@ -12,7 +12,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Observer wrapper for object casts.</summary>
 /// <typeparam name="TResult">The result value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+[System.Diagnostics.DebuggerDisplay("CastWitness: Stopped = {_stopped}, Observer = {Observer}")]
 public sealed class CastWitness<TResult> : IObserver<object?>, IDisposable
 {
     /// <summary>Non-zero after terminal notification or disposal.</summary>

--- a/src/Primitives.Shared/Advanced/ChainSignal{T}.cs
+++ b/src/Primitives.Shared/Advanced/ChainSignal{T}.cs
@@ -11,7 +11,7 @@ namespace ReactiveUI.Primitives.Advanced;
 /// <summary>Concatenates observable sources in source order.</summary>
 /// <typeparam name="T">The value type.</typeparam>
 [System.Diagnostics.DebuggerDisplay(
-    "Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
+"ChainSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
 public sealed class ChainSignal<T> : IObservable<T>
 {
     /// <summary>Initializes a new instance of the <see cref="ChainSignal{T}"/> class from an outer observable.</summary>

--- a/src/Primitives.Shared/Advanced/ChainWitness{T}.cs
+++ b/src/Primitives.Shared/Advanced/ChainWitness{T}.cs
@@ -12,7 +12,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Mediates sequential concatenation for <see cref="ChainSignal{T}"/>.</summary>
 /// <typeparam name="T">The value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
+[System.Diagnostics.DebuggerDisplay("ChainWitness: IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
 public sealed class ChainWitness<T> : IDisposable
 {
     /// <summary>Guards the queue and active/completed flags.</summary>

--- a/src/Primitives.Shared/Advanced/CollectSignal{T}.cs
+++ b/src/Primitives.Shared/Advanced/CollectSignal{T}.cs
@@ -10,7 +10,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Collects source values into time-windowed batches.</summary>
 /// <typeparam name="T">The source value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Source = {Source}, TimeSpan = {TimeSpan}")]
+[System.Diagnostics.DebuggerDisplay("CollectSignal: Source = {Source}, TimeSpan = {TimeSpan}")]
 public sealed class CollectSignal<T> : IObservable<IList<T>>
 {
     /// <summary>Initializes a new instance of the <see cref="CollectSignal{T}"/> class.</summary>

--- a/src/Primitives.Shared/Advanced/CollectWitness{T}.cs
+++ b/src/Primitives.Shared/Advanced/CollectWitness{T}.cs
@@ -12,7 +12,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Observer that collects source values into batches.</summary>
 /// <typeparam name="T">The source value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Buffered = {Values.Count}")]
+[System.Diagnostics.DebuggerDisplay("CollectWitness: Stopped = {_stopped}, Buffered = {Values.Count}")]
 public sealed class CollectWitness<T> : IObserver<T>, IDisposable
 {
     /// <summary>Serializes access to buffered values and terminal state.</summary>

--- a/src/Primitives.Shared/Advanced/CreateSink{T}.cs
+++ b/src/Primitives.Shared/Advanced/CreateSink{T}.cs
@@ -17,7 +17,7 @@ namespace ReactiveUI.Primitives.Advanced;
 /// implementation that hands an observer to a caller-supplied subscribe delegate.
 /// </summary>
 /// <typeparam name="T">The value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+[System.Diagnostics.DebuggerDisplay("CreateSink: Stopped = {_stopped}, Observer = {_observer}")]
 public sealed class CreateSink<T> : IDisposable, IObserver<T>
 {
     /// <summary>A value indicating whether a throwing downstream <c>OnNext</c> releases the subscription.</summary>

--- a/src/Primitives.Shared/Advanced/CreateWitness{T}.cs
+++ b/src/Primitives.Shared/Advanced/CreateWitness{T}.cs
@@ -12,7 +12,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Observer wrapper used by create-style signals.</summary>
 /// <typeparam name="T">The value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+[System.Diagnostics.DebuggerDisplay("CreateWitness: Stopped = {_stopped}, Observer = {Observer}")]
 public sealed class CreateWitness<T> : IDisposable, IObserver<T>
 {
     /// <summary>Cancellation resource assigned by the subscription factory.</summary>

--- a/src/Primitives.Shared/Advanced/EmitIfQuietSignal{T}.cs
+++ b/src/Primitives.Shared/Advanced/EmitIfQuietSignal{T}.cs
@@ -10,7 +10,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Emits only the latest value after a quiet period.</summary>
 /// <typeparam name="T">The source value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("DueTime = {DueTime}, Source = {Source}")]
+[System.Diagnostics.DebuggerDisplay("EmitIfQuietSignal: DueTime = {DueTime}, Source = {Source}")]
 public sealed class EmitIfQuietSignal<T> : IObservable<T>
 {
     /// <summary>Initializes a new instance of the <see cref="EmitIfQuietSignal{T}"/> class.</summary>

--- a/src/Primitives.Shared/Advanced/EmitIfQuietWitness{T}.cs
+++ b/src/Primitives.Shared/Advanced/EmitIfQuietWitness{T}.cs
@@ -12,7 +12,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Observer that emits only the latest value after a quiet period.</summary>
 /// <typeparam name="T">The source value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
+[System.Diagnostics.DebuggerDisplay("EmitIfQuietWitness: HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
 public sealed class EmitIfQuietWitness<T> : IObserver<T>, IDisposable
 {
     /// <summary>Serializes access to latest value and terminal state.</summary>

--- a/src/Primitives.Shared/Advanced/EmptySignal{T}.cs
+++ b/src/Primitives.Shared/Advanced/EmptySignal{T}.cs
@@ -12,7 +12,8 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Represents the EmptySignal class.</summary>
 /// <typeparam name="T">The T type.</typeparam>
-internal sealed class EmptySignal<T> : IRequireCurrentThread<T>
+[System.Diagnostics.DebuggerDisplay("EmptySignal: Scheduler = {_scheduler}")]
+public sealed class EmptySignal<T> : IRequireCurrentThread<T>
 {
     /// <summary>Stores state for the signal implementation.</summary>
     private readonly ISequencer _scheduler;

--- a/src/Primitives.Shared/Advanced/EnumerableBlendSignal{T}.cs
+++ b/src/Primitives.Shared/Advanced/EnumerableBlendSignal{T}.cs
@@ -10,7 +10,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Merges enumerable observable sources concurrently.</summary>
 /// <typeparam name="T">The value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+[System.Diagnostics.DebuggerDisplay("EnumerableBlendSignal: Sources = {Sources}")]
 public sealed class EnumerableBlendSignal<T> : IObservable<T>
 {
     /// <summary>Initializes a new instance of the <see cref="EnumerableBlendSignal{T}"/> class.</summary>

--- a/src/Primitives.Shared/Advanced/EverySignal.cs
+++ b/src/Primitives.Shared/Advanced/EverySignal.cs
@@ -16,7 +16,8 @@ namespace ReactiveUI.Primitives.Advanced;
 /// </summary>
 /// <param name="period">The interval between ticks.</param>
 /// <param name="scheduler">The sequencer used to schedule ticks.</param>
-internal sealed class EverySignal(TimeSpan period, ISequencer scheduler) : IRequireCurrentThread<long>
+[System.Diagnostics.DebuggerDisplay("EverySignal: Period = {_period}, Scheduler = {_scheduler}")]
+public sealed class EverySignal(TimeSpan period, ISequencer scheduler) : IRequireCurrentThread<long>
 {
     /// <summary>The interval between ticks.</summary>
     private readonly TimeSpan _period = period;

--- a/src/Primitives.Shared/Advanced/ExpireCoordinator{T}.cs
+++ b/src/Primitives.Shared/Advanced/ExpireCoordinator{T}.cs
@@ -10,7 +10,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Coordinates timeout delivery with one active timer.</summary>
 /// <typeparam name="T">The source value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
+[System.Diagnostics.DebuggerDisplay("ExpireCoordinator: Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
 public sealed class ExpireCoordinator<T> : IObserver<T>, IDisposable
 {
     /// <summary>The synchronization gate for downstream observer calls.</summary>

--- a/src/Primitives.Shared/Advanced/ExpireSignal{T}.cs
+++ b/src/Primitives.Shared/Advanced/ExpireSignal{T}.cs
@@ -10,7 +10,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Timeout signal with a direct subscription path.</summary>
 /// <typeparam name="T">The source value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Source = {_source}")]
+[System.Diagnostics.DebuggerDisplay("ExpireSignal: DueTime = {_dueTime}, Source = {_source}")]
 public sealed class ExpireSignal<T> : IRequireCurrentThread<T>
 {
     /// <summary>The source observable.</summary>

--- a/src/Primitives.Shared/Advanced/FinallySignal{T}.cs
+++ b/src/Primitives.Shared/Advanced/FinallySignal{T}.cs
@@ -14,7 +14,8 @@ namespace ReactiveUI.Primitives.Advanced;
 /// <typeparam name="T">The T type.</typeparam>
 /// <param name="source">The source value.</param>
 /// <param name="finallyAction">The finallyAction value.</param>
-internal sealed class FinallySignal<T>(IObservable<T> source, Action finallyAction) : IRequireCurrentThread<T>
+[System.Diagnostics.DebuggerDisplay("FinallySignal: Source = {_source}")]
+public sealed class FinallySignal<T>(IObservable<T> source, Action finallyAction) : IRequireCurrentThread<T>
 {
     /// <summary>Stores state for the signal implementation.</summary>
     private readonly IObservable<T> _source = source;

--- a/src/Primitives.Shared/Advanced/ForkJoinSignal{TLeft,TRight,TResult}.cs
+++ b/src/Primitives.Shared/Advanced/ForkJoinSignal{TLeft,TRight,TResult}.cs
@@ -12,7 +12,7 @@ namespace ReactiveUI.Primitives.Advanced;
 /// <typeparam name="TLeft">The left value type.</typeparam>
 /// <typeparam name="TRight">The right value type.</typeparam>
 /// <typeparam name="TResult">The result value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+[System.Diagnostics.DebuggerDisplay("ForkJoinSignal: Left = {Left}, Right = {Right}")]
 public sealed class ForkJoinSignal<TLeft, TRight, TResult> : IObservable<TResult>
 {
     /// <summary>Initializes a new instance of the <see cref="ForkJoinSignal{TLeft, TRight, TResult}"/> class.</summary>

--- a/src/Primitives.Shared/Advanced/ForkJoinWitness{TLeft,TRight,TResult}.cs
+++ b/src/Primitives.Shared/Advanced/ForkJoinWitness{TLeft,TRight,TResult}.cs
@@ -12,7 +12,7 @@ namespace ReactiveUI.Primitives.Advanced;
 /// <typeparam name="TLeft">The left value type.</typeparam>
 /// <typeparam name="TRight">The right value type.</typeparam>
 /// <typeparam name="TResult">The result value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
+[System.Diagnostics.DebuggerDisplay("ForkJoinWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
 public sealed class ForkJoinWitness<TLeft, TRight, TResult>
 {
     /// <summary>The synchronization gate.</summary>

--- a/src/Primitives.Shared/Advanced/FromAsyncExternalCancellationSignal{T}.cs
+++ b/src/Primitives.Shared/Advanced/FromAsyncExternalCancellationSignal{T}.cs
@@ -10,7 +10,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Cold task-backed signal that forwards an external cancellation token as an observer error.</summary>
 /// <typeparam name="T">The task result type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("CancellationRequested = {CancellationToken.IsCancellationRequested}")]
+[System.Diagnostics.DebuggerDisplay("FromAsyncExternalCancellationSignal: CancellationRequested = {CancellationToken.IsCancellationRequested}")]
 public sealed class FromAsyncExternalCancellationSignal<T> : IObservable<T>
 {
     /// <summary>Initializes a new instance of the <see cref="FromAsyncExternalCancellationSignal{T}"/> class.</summary>

--- a/src/Primitives.Shared/Advanced/FromAsyncSignal{T}.cs
+++ b/src/Primitives.Shared/Advanced/FromAsyncSignal{T}.cs
@@ -10,7 +10,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Cold task-backed signal that gives each subscription its own cancellable token.</summary>
 /// <typeparam name="T">The task result type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
+[System.Diagnostics.DebuggerDisplay("FromAsyncSignal: TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
 public sealed class FromAsyncSignal<T> : IObservable<T>
 {
     /// <summary>Initializes a new instance of the <see cref="FromAsyncSignal{T}"/> class.</summary>

--- a/src/Primitives.Shared/Advanced/FromAsyncSubscription{T}.cs
+++ b/src/Primitives.Shared/Advanced/FromAsyncSubscription{T}.cs
@@ -10,7 +10,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Subscription that invokes a cold task factory and forwards its terminal result.</summary>
 /// <typeparam name="T">The task result type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
+[System.Diagnostics.DebuggerDisplay("FromAsyncSubscription: Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
 public sealed class FromAsyncSubscription<T> : IDisposable
 {
     /// <summary>Initializes a new instance of the <see cref="FromAsyncSubscription{T}"/> class.</summary>

--- a/src/Primitives.Shared/Advanced/FromEventPatternSignal{TEventHandler,TEventArgs}.cs
+++ b/src/Primitives.Shared/Advanced/FromEventPatternSignal{TEventHandler,TEventArgs}.cs
@@ -16,7 +16,7 @@ namespace ReactiveUI.Primitives.Advanced;
 /// <summary>Converts an event add/remove pair into event-pattern notifications.</summary>
 /// <typeparam name="TEventHandler">The event delegate type.</typeparam>
 /// <typeparam name="TEventArgs">The event argument type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
+[System.Diagnostics.DebuggerDisplay("FromEventPatternSignal: AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
 public sealed class FromEventPatternSignal<TEventHandler, TEventArgs> : IObservable<EventPattern<TEventArgs>>
     where TEventHandler : Delegate
     where TEventArgs : EventArgs

--- a/src/Primitives.Shared/Advanced/GuardedWitness{T}.cs
+++ b/src/Primitives.Shared/Advanced/GuardedWitness{T}.cs
@@ -16,7 +16,7 @@ namespace ReactiveUI.Primitives.Advanced;
 /// usable by any signal implementation that needs terminate-and-release semantics around a downstream observer.
 /// </summary>
 /// <typeparam name="T">The value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Disposed = {_disposed}, Observer = {_observer}")]
+[System.Diagnostics.DebuggerDisplay("GuardedWitness: Disposed = {_disposed}, Observer = {_observer}")]
 public sealed class GuardedWitness<T> : IObserver<T>, IDisposable
 {
     /// <summary>Stores the downstream observer.</summary>

--- a/src/Primitives.Shared/Advanced/IgnoreValuesSignal{T}.cs
+++ b/src/Primitives.Shared/Advanced/IgnoreValuesSignal{T}.cs
@@ -10,7 +10,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Signal that ignores source values and forwards terminal notifications.</summary>
 /// <typeparam name="T">The value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+[System.Diagnostics.DebuggerDisplay("IgnoreValuesSignal: Source = {Source}")]
 public sealed class IgnoreValuesSignal<T> : IObservable<T>
 {
     /// <summary>Initializes a new instance of the <see cref="IgnoreValuesSignal{T}"/> class.</summary>

--- a/src/Primitives.Shared/Advanced/IsEmptySignal{T}.cs
+++ b/src/Primitives.Shared/Advanced/IsEmptySignal{T}.cs
@@ -10,7 +10,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Signal that emits whether the source completed without values.</summary>
 /// <typeparam name="T">The source value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+[System.Diagnostics.DebuggerDisplay("IsEmptySignal: Source = {Source}")]
 public sealed class IsEmptySignal<T> : IRequireCurrentThread<bool>
 {
     /// <summary>Initializes a new instance of the <see cref="IsEmptySignal{T}"/> class.</summary>

--- a/src/Primitives.Shared/Advanced/IsEmptyWitness{T}.cs
+++ b/src/Primitives.Shared/Advanced/IsEmptyWitness{T}.cs
@@ -12,7 +12,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Observer wrapper for detecting whether a source completes without values.</summary>
 /// <typeparam name="T">The source value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Subscription = {Subscription}")]
+[System.Diagnostics.DebuggerDisplay("IsEmptyWitness: Stopped = {_stopped}, Subscription = {Subscription}")]
 public sealed class IsEmptyWitness<T> : IObserver<T>, IDisposable
 {
     /// <summary>Stores the stopped flag for interlocked/ref helper calls.</summary>

--- a/src/Primitives.Shared/Advanced/LeadSignal{T}.cs
+++ b/src/Primitives.Shared/Advanced/LeadSignal{T}.cs
@@ -10,7 +10,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Signal that emits one leading value before subscribing to the source.</summary>
 /// <typeparam name="T">The source value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Value = {Value}, Source = {Source}")]
+[System.Diagnostics.DebuggerDisplay("LeadSignal: Value = {Value}, Source = {Source}")]
 public sealed class LeadSignal<T> : IInlineSignal<T>
 {
     /// <summary>Initializes a new instance of the <see cref="LeadSignal{T}"/> class.</summary>

--- a/src/Primitives.Shared/Advanced/LoopSignal{T}.cs
+++ b/src/Primitives.Shared/Advanced/LoopSignal{T}.cs
@@ -12,7 +12,8 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Represents an infinite repetition signal.</summary>
 /// <typeparam name="T">The value type.</typeparam>
-internal sealed class LoopSignal<T> : IRequireCurrentThread<T>
+[System.Diagnostics.DebuggerDisplay("LoopSignal: Value = {Value}")]
+public sealed class LoopSignal<T> : IRequireCurrentThread<T>
 {
     /// <summary>Whether subscription must run on the current thread.</summary>
     private readonly bool _currentThreadRequired;

--- a/src/Primitives.Shared/Advanced/MapIndexedSignal{TSource,TResult}.cs
+++ b/src/Primitives.Shared/Advanced/MapIndexedSignal{TSource,TResult}.cs
@@ -15,7 +15,7 @@ namespace ReactiveUI.Primitives.Advanced;
 /// <typeparam name="TResult">The projected value type.</typeparam>
 /// <param name="source">The source observable.</param>
 /// <param name="selector">The indexed selector.</param>
-[System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+[System.Diagnostics.DebuggerDisplay("MapIndexedSignal: Source = {_source}")]
 public sealed class MapIndexedSignal<TSource, TResult>(IObservable<TSource> source, Func<TSource, int, TResult> selector) : IRequireCurrentThread<TResult>
 {
     /// <summary>The source observable.</summary>

--- a/src/Primitives.Shared/Advanced/MapIndexedWitness{TSource,TResult}.cs
+++ b/src/Primitives.Shared/Advanced/MapIndexedWitness{TSource,TResult}.cs
@@ -13,7 +13,7 @@ namespace ReactiveUI.Primitives.Advanced;
 /// <typeparam name="TResult">The projected value type.</typeparam>
 /// <param name="observer">The downstream observer.</param>
 /// <param name="selector">The indexed selector.</param>
-[System.Diagnostics.DebuggerDisplay("Index = {_index}, Stopped = {_stopped}")]
+[System.Diagnostics.DebuggerDisplay("MapIndexedWitness: Index = {_index}, Stopped = {_stopped}")]
 public sealed class MapIndexedWitness<TSource, TResult>(IObserver<TResult> observer, Func<TSource, int, TResult> selector) : IObserver<TSource>
 {
     /// <summary>The downstream observer.</summary>

--- a/src/Primitives.Shared/Advanced/MaxConcurrentBlendCoordinator{T}.cs
+++ b/src/Primitives.Shared/Advanced/MaxConcurrentBlendCoordinator{T}.cs
@@ -10,7 +10,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Coordinates bounded-concurrency merging of enumerable observable sources.</summary>
 /// <typeparam name="T">The value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
+[System.Diagnostics.DebuggerDisplay("MaxConcurrentBlendCoordinator: Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
 public sealed class MaxConcurrentBlendCoordinator<T> : IDisposable
 {
     /// <summary>Serializes enumeration, counters, and downstream callbacks.</summary>

--- a/src/Primitives.Shared/Advanced/MaxConcurrentEnumerableBlendSignal{T}.cs
+++ b/src/Primitives.Shared/Advanced/MaxConcurrentEnumerableBlendSignal{T}.cs
@@ -12,7 +12,7 @@ namespace ReactiveUI.Primitives.Advanced;
 /// <typeparam name="T">The value type.</typeparam>
 /// <param name="sources">The sources to merge.</param>
 /// <param name="maxConcurrent">The maximum number of active inner subscriptions.</param>
-[System.Diagnostics.DebuggerDisplay("Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
+[System.Diagnostics.DebuggerDisplay("MaxConcurrentEnumerableBlendSignal: Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
 public sealed class MaxConcurrentEnumerableBlendSignal<T>(IEnumerable<IObservable<T>> sources, int maxConcurrent) : IObservable<T>
 {
     /// <summary>The sources to merge.</summary>

--- a/src/Primitives.Shared/Advanced/MergeCoordinator{T}.cs
+++ b/src/Primitives.Shared/Advanced/MergeCoordinator{T}.cs
@@ -12,7 +12,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Coordinates concurrent merge subscriptions.</summary>
 /// <typeparam name="T">The value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Active = {Active}, Done = {Done}")]
+[System.Diagnostics.DebuggerDisplay("MergeCoordinator: Active = {Active}, Done = {Done}")]
 public sealed class MergeCoordinator<T> : IDisposable
 {
     /// <summary>Serializes downstream callbacks and counters.</summary>

--- a/src/Primitives.Shared/Advanced/MergeSignal{T}.cs
+++ b/src/Primitives.Shared/Advanced/MergeSignal{T}.cs
@@ -10,7 +10,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Concrete signal for Rx-named merge overloads.</summary>
 /// <typeparam name="T">The value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
+[System.Diagnostics.DebuggerDisplay("MergeSignal: Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
 public sealed class MergeSignal<T> : IObservable<T>
 {
     /// <summary>Initializes a new instance of the <see cref="MergeSignal{T}"/> class.</summary>

--- a/src/Primitives.Shared/Advanced/OnErrorResumeNextSignal{T}.cs
+++ b/src/Primitives.Shared/Advanced/OnErrorResumeNextSignal{T}.cs
@@ -12,7 +12,8 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Continues through observable sources after either completion or error.</summary>
 /// <typeparam name="T">The value type.</typeparam>
-internal sealed class OnErrorResumeNextSignal<T> : IRequireCurrentThread<T>
+[System.Diagnostics.DebuggerDisplay("OnErrorResumeNextSignal: Sources = {_sources}")]
+public sealed class OnErrorResumeNextSignal<T> : IRequireCurrentThread<T>
 {
     /// <summary>The sources to subscribe in order.</summary>
     private readonly IEnumerable<IObservable<T>> _sources;

--- a/src/Primitives.Shared/Advanced/PairSignal{TLeft,TRight,TResult}.cs
+++ b/src/Primitives.Shared/Advanced/PairSignal{TLeft,TRight,TResult}.cs
@@ -12,7 +12,7 @@ namespace ReactiveUI.Primitives.Advanced;
 /// <typeparam name="TLeft">The left value type.</typeparam>
 /// <typeparam name="TRight">The right value type.</typeparam>
 /// <typeparam name="TResult">The result value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+[System.Diagnostics.DebuggerDisplay("PairSignal: Left = {Left}, Right = {Right}")]
 public sealed class PairSignal<TLeft, TRight, TResult> : IObservable<TResult>
 {
     /// <summary>Initializes a new instance of the <see cref="PairSignal{TLeft, TRight, TResult}"/> class.</summary>

--- a/src/Primitives.Shared/Advanced/PairWitness{TLeft,TRight,TResult}.cs
+++ b/src/Primitives.Shared/Advanced/PairWitness{TLeft,TRight,TResult}.cs
@@ -12,7 +12,7 @@ namespace ReactiveUI.Primitives.Advanced;
 /// <typeparam name="TLeft">The left value type.</typeparam>
 /// <typeparam name="TRight">The right value type.</typeparam>
 /// <typeparam name="TResult">The result value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
+[System.Diagnostics.DebuggerDisplay("PairWitness: IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
 public sealed class PairWitness<TLeft, TRight, TResult>
 {
     /// <summary>The synchronization gate.</summary>

--- a/src/Primitives.Shared/Advanced/PublishSelectorSignal{TSource,TResult}.cs
+++ b/src/Primitives.Shared/Advanced/PublishSelectorSignal{TSource,TResult}.cs
@@ -11,7 +11,7 @@ namespace ReactiveUI.Primitives.Advanced;
 /// <summary>Connects a published source around a selector subscription.</summary>
 /// <typeparam name="TSource">The source value type.</typeparam>
 /// <typeparam name="TResult">The selected value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}")]
+[System.Diagnostics.DebuggerDisplay("PublishSelectorSignal: Source = {Source}, Selector = {Selector}")]
 public sealed class PublishSelectorSignal<TSource, TResult> : IObservable<TResult>
 {
     /// <summary>Initializes a new instance of the <see cref="PublishSelectorSignal{TSource,TResult}"/> class.</summary>

--- a/src/Primitives.Shared/Advanced/RaceSignal{T}.cs
+++ b/src/Primitives.Shared/Advanced/RaceSignal{T}.cs
@@ -10,7 +10,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Mirrors the first source that produces any notification.</summary>
 /// <typeparam name="T">The value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
+[System.Diagnostics.DebuggerDisplay("RaceSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
 public sealed class RaceSignal<T> : IObservable<T>
 {
     /// <summary>Initializes a new instance of the <see cref="RaceSignal{T}"/> class from an outer observable.</summary>

--- a/src/Primitives.Shared/Advanced/RaceWitness{T}.cs
+++ b/src/Primitives.Shared/Advanced/RaceWitness{T}.cs
@@ -12,7 +12,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Mediates candidate subscriptions for <see cref="RaceSignal{T}"/>.</summary>
 /// <typeparam name="T">The value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Arms = {_arms}")]
+[System.Diagnostics.DebuggerDisplay("RaceWitness: Arms = {_arms}")]
 public sealed class RaceWitness<T> : IDisposable
 {
     /// <summary>The shared race-arm bookkeeping.</summary>

--- a/src/Primitives.Shared/Advanced/RangeCombineLatestSignal{TResult}.cs
+++ b/src/Primitives.Shared/Advanced/RangeCombineLatestSignal{TResult}.cs
@@ -12,7 +12,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Combines two synchronous integer ranges using System.Reactive <c>CombineLatest</c> semantics.</summary>
 /// <typeparam name="TResult">The result value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+[System.Diagnostics.DebuggerDisplay("RangeCombineLatestSignal: Left = {Left}, Right = {Right}")]
 public sealed class RangeCombineLatestSignal<TResult> : IObservable<TResult>
 {
     /// <summary>Initializes a new instance of the <see cref="RangeCombineLatestSignal{TResult}"/> class.</summary>

--- a/src/Primitives.Shared/Advanced/RangeForkJoinSignal{TResult}.cs
+++ b/src/Primitives.Shared/Advanced/RangeForkJoinSignal{TResult}.cs
@@ -10,7 +10,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Fork-joins two synchronous integer ranges by projecting their final values.</summary>
 /// <typeparam name="TResult">The result value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
+[System.Diagnostics.DebuggerDisplay("RangeForkJoinSignal: Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
 public sealed class RangeForkJoinSignal<TResult> : IObservable<TResult>
 {
     /// <summary>Initializes a new instance of the <see cref="RangeForkJoinSignal{TResult}"/> class.</summary>

--- a/src/Primitives.Shared/Advanced/RangeSyncLatestSignal{TResult}.cs
+++ b/src/Primitives.Shared/Advanced/RangeSyncLatestSignal{TResult}.cs
@@ -12,7 +12,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Combines two synchronous integer ranges using latest-value semantics.</summary>
 /// <typeparam name="TResult">The result value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+[System.Diagnostics.DebuggerDisplay("RangeSyncLatestSignal: Left = {Left}, Right = {Right}")]
 public sealed class RangeSyncLatestSignal<TResult> : IObservable<TResult>
 {
     /// <summary>Initializes a new instance of the <see cref="RangeSyncLatestSignal{TResult}"/> class.</summary>

--- a/src/Primitives.Shared/Advanced/RangeWithLatestSignal{TResult}.cs
+++ b/src/Primitives.Shared/Advanced/RangeWithLatestSignal{TResult}.cs
@@ -10,7 +10,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Combines each left range value with the final value from the right range.</summary>
 /// <typeparam name="TResult">The result value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+[System.Diagnostics.DebuggerDisplay("RangeWithLatestSignal: Left = {Left}, Right = {Right}")]
 public sealed class RangeWithLatestSignal<TResult> : IObservable<TResult>
 {
     /// <summary>Initializes a new instance of the <see cref="RangeWithLatestSignal{TResult}"/> class.</summary>

--- a/src/Primitives.Shared/Advanced/RecoverSignal{T,TException}.cs
+++ b/src/Primitives.Shared/Advanced/RecoverSignal{T,TException}.cs
@@ -19,7 +19,8 @@ namespace ReactiveUI.Primitives.Advanced;
 /// <typeparam name="TException">The handled exception type.</typeparam>
 /// <param name="source">The source observable.</param>
 /// <param name="handler">The handler that selects the fallback sequence for a caught error.</param>
-internal sealed class RecoverSignal<T, TException>(IObservable<T> source, Func<TException, IObservable<T>> handler) : IRequireCurrentThread<T>
+[System.Diagnostics.DebuggerDisplay("RecoverSignal: Source = {_source}")]
+public sealed class RecoverSignal<T, TException>(IObservable<T> source, Func<TException, IObservable<T>> handler) : IRequireCurrentThread<T>
     where TException : Exception
 {
     /// <summary>The source observable.</summary>

--- a/src/Primitives.Shared/Advanced/RepeatSourceCoordinator{T}.cs
+++ b/src/Primitives.Shared/Advanced/RepeatSourceCoordinator{T}.cs
@@ -10,7 +10,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Coordinates sequential subscriptions for <see cref="RepeatSourceSignal{T}"/>.</summary>
 /// <typeparam name="T">The value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Remaining = {_remaining}, Disposed = {_disposed}")]
+[System.Diagnostics.DebuggerDisplay("RepeatSourceCoordinator: Remaining = {_remaining}, Disposed = {_disposed}")]
 public sealed class RepeatSourceCoordinator<T> : IDisposable
 {
     /// <summary>The source sequence.</summary>

--- a/src/Primitives.Shared/Advanced/RepeatSourceSignal{T}.cs
+++ b/src/Primitives.Shared/Advanced/RepeatSourceSignal{T}.cs
@@ -12,7 +12,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Repeats a source observable by resubscribing after each successful completion.</summary>
 /// <typeparam name="T">The value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Source = {_source}, RepeatCount = {_repeatCount}")]
+[System.Diagnostics.DebuggerDisplay("RepeatSourceSignal: Source = {_source}, RepeatCount = {_repeatCount}")]
 public sealed class RepeatSourceSignal<T> : IRequireCurrentThread<T>
 {
     /// <summary>The source sequence.</summary>

--- a/src/Primitives.Shared/Advanced/RepeatSourceWitness{T}.cs
+++ b/src/Primitives.Shared/Advanced/RepeatSourceWitness{T}.cs
@@ -10,7 +10,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Per-subscription witness that suppresses duplicate terminal notifications.</summary>
 /// <typeparam name="T">The value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Generation = {_generation}, Terminated = {_terminated}")]
+[System.Diagnostics.DebuggerDisplay("RepeatSourceWitness: Generation = {_generation}, Terminated = {_terminated}")]
 public sealed class RepeatSourceWitness<T> : IObserver<T>
 {
     /// <summary>The owning repeat coordinator.</summary>

--- a/src/Primitives.Shared/Advanced/ResumeSignal{T}.cs
+++ b/src/Primitives.Shared/Advanced/ResumeSignal{T}.cs
@@ -18,7 +18,8 @@ namespace ReactiveUI.Primitives.Advanced;
 /// <typeparam name="T">The value type.</typeparam>
 /// <param name="source">The source observable.</param>
 /// <param name="fallback">The fallback observable subscribed to after the source errors.</param>
-internal sealed class ResumeSignal<T>(IObservable<T> source, IObservable<T> fallback) : IRequireCurrentThread<T>
+[System.Diagnostics.DebuggerDisplay("ResumeSignal: Source = {_source}, Fallback = {_fallback}")]
+public sealed class ResumeSignal<T>(IObservable<T> source, IObservable<T> fallback) : IRequireCurrentThread<T>
 {
     /// <summary>The source observable.</summary>
     private readonly IObservable<T> _source = source;

--- a/src/Primitives.Shared/Advanced/ReturnSignal{T}.cs
+++ b/src/Primitives.Shared/Advanced/ReturnSignal{T}.cs
@@ -12,7 +12,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>An observable that emits a single value then completes on the supplied scheduler; the concrete backing for the scheduled emit path.</summary>
 /// <typeparam name="T">The emitted value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Value = {_value}, Scheduler = {_scheduler}")]
+[System.Diagnostics.DebuggerDisplay("ReturnSignal: Value = {_value}, Scheduler = {_scheduler}")]
 public sealed class ReturnSignal<T> : IRequireCurrentThread<T>
 {
     /// <summary>Stores state for the signal implementation.</summary>

--- a/src/Primitives.Shared/Advanced/ScheduledEnumerableSignal{T}.cs
+++ b/src/Primitives.Shared/Advanced/ScheduledEnumerableSignal{T}.cs
@@ -10,7 +10,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Scheduled enumerable-backed signal used by observable conversion overloads.</summary>
 /// <typeparam name="T">The value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Values = {Values}, Scheduler = {Scheduler}")]
+[System.Diagnostics.DebuggerDisplay("ScheduledEnumerableSignal: Values = {Values}, Scheduler = {Scheduler}")]
 public sealed class ScheduledEnumerableSignal<T> : IObservable<T>
 {
     /// <summary>Initializes a new instance of the <see cref="ScheduledEnumerableSignal{T}"/> class.</summary>

--- a/src/Primitives.Shared/Advanced/SelectManyCoordinator{TSource,TResult}.cs
+++ b/src/Primitives.Shared/Advanced/SelectManyCoordinator{TSource,TResult}.cs
@@ -13,7 +13,7 @@ namespace ReactiveUI.Primitives.Advanced;
 /// <summary>Coordinates concurrent observable <c>SelectMany</c> subscriptions.</summary>
 /// <typeparam name="TSource">The source value type.</typeparam>
 /// <typeparam name="TResult">The result value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+[System.Diagnostics.DebuggerDisplay("SelectManyCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
 public sealed class SelectManyCoordinator<TSource, TResult> : IObserver<TSource>, IDisposable
 {
     /// <summary>Serializes downstream callbacks and counters.</summary>

--- a/src/Primitives.Shared/Advanced/SelectManyEnumerableSignal{TSource,TResult}.cs
+++ b/src/Primitives.Shared/Advanced/SelectManyEnumerableSignal{TSource,TResult}.cs
@@ -13,7 +13,7 @@ namespace ReactiveUI.Primitives.Advanced;
 /// <typeparam name="TResult">The result value type.</typeparam>
 /// <param name="source">The source observable.</param>
 /// <param name="selector">The enumerable projection.</param>
-[System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+[System.Diagnostics.DebuggerDisplay("SelectManyEnumerableSignal: Source = {_source}")]
 public sealed class SelectManyEnumerableSignal<TSource, TResult>(IObservable<TSource> source, Func<TSource, IEnumerable<TResult>> selector) : IObservable<TResult>
 {
     /// <summary>The source observable.</summary>

--- a/src/Primitives.Shared/Advanced/SelectManyEnumerableWitness{TSource,TResult}.cs
+++ b/src/Primitives.Shared/Advanced/SelectManyEnumerableWitness{TSource,TResult}.cs
@@ -15,7 +15,7 @@ namespace ReactiveUI.Primitives.Advanced;
 /// <typeparam name="TResult">The result value type.</typeparam>
 /// <param name="observer">The downstream observer.</param>
 /// <param name="selector">The enumerable projection.</param>
-[System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+[System.Diagnostics.DebuggerDisplay("SelectManyEnumerableWitness: Stopped = {_stopped}, Observer = {_observer}")]
 public sealed class SelectManyEnumerableWitness<TSource, TResult>(IObserver<TResult> observer, Func<TSource, IEnumerable<TResult>> selector) : IObserver<TSource>, IDisposable
 {
     /// <summary>The downstream observer.</summary>

--- a/src/Primitives.Shared/Advanced/SelectManyResultCoordinator{TSource,TCollection,TResult}.cs
+++ b/src/Primitives.Shared/Advanced/SelectManyResultCoordinator{TSource,TCollection,TResult}.cs
@@ -14,7 +14,7 @@ namespace ReactiveUI.Primitives.Advanced;
 /// <typeparam name="TSource">The source value type.</typeparam>
 /// <typeparam name="TCollection">The inner value type.</typeparam>
 /// <typeparam name="TResult">The result value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+[System.Diagnostics.DebuggerDisplay("SelectManyResultCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
 public sealed class SelectManyResultCoordinator<TSource, TCollection, TResult> : IObserver<TSource>, IDisposable
 {
     /// <summary>Serializes downstream callbacks and counters.</summary>

--- a/src/Primitives.Shared/Advanced/SelectManyResultSignal{TSource,TCollection,TResult}.cs
+++ b/src/Primitives.Shared/Advanced/SelectManyResultSignal{TSource,TCollection,TResult}.cs
@@ -12,7 +12,7 @@ namespace ReactiveUI.Primitives.Advanced;
 /// <typeparam name="TSource">The source value type.</typeparam>
 /// <typeparam name="TCollection">The inner value type.</typeparam>
 /// <typeparam name="TResult">The result value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Source = {Source}, CollectionSelector = {CollectionSelector}")]
+[System.Diagnostics.DebuggerDisplay("SelectManyResultSignal: Source = {Source}, CollectionSelector = {CollectionSelector}")]
 public sealed class SelectManyResultSignal<TSource, TCollection, TResult> : IObservable<TResult>
 {
     /// <summary>Initializes a new instance of the <see cref="SelectManyResultSignal{TSource, TCollection, TResult}"/> class.</summary>

--- a/src/Primitives.Shared/Advanced/SelectManySignal{TSource,TResult}.cs
+++ b/src/Primitives.Shared/Advanced/SelectManySignal{TSource,TResult}.cs
@@ -11,7 +11,7 @@ namespace ReactiveUI.Primitives.Advanced;
 /// <summary>Concrete signal for concurrent observable <c>SelectMany</c>.</summary>
 /// <typeparam name="TSource">The source value type.</typeparam>
 /// <typeparam name="TResult">The result value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
+[System.Diagnostics.DebuggerDisplay("SelectManySignal: Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
 public sealed class SelectManySignal<TSource, TResult> : IObservable<TResult>
 {
     /// <summary>Initializes a new instance of the <see cref="SelectManySignal{TSource, TResult}"/> class.</summary>

--- a/src/Primitives.Shared/Advanced/SequenceSignal.cs
+++ b/src/Primitives.Shared/Advanced/SequenceSignal.cs
@@ -9,7 +9,7 @@ namespace ReactiveUI.Primitives.Advanced;
 #endif
 
 /// <summary>Emits a scheduled integer sequence.</summary>
-[System.Diagnostics.DebuggerDisplay("Start = {Start}, Count = {Count}")]
+[System.Diagnostics.DebuggerDisplay("SequenceSignal: Start = {Start}, Count = {Count}")]
 public sealed class SequenceSignal : IRequireCurrentThread<int>
 {
     /// <summary>Initializes a new instance of the <see cref="SequenceSignal"/> class.</summary>

--- a/src/Primitives.Shared/Advanced/SparkSignal{T}.cs
+++ b/src/Primitives.Shared/Advanced/SparkSignal{T}.cs
@@ -10,7 +10,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Signal that materializes source notifications into <see cref="Spark{T}"/> values.</summary>
 /// <typeparam name="T">The value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+[System.Diagnostics.DebuggerDisplay("SparkSignal: Source = {Source}")]
 public sealed class SparkSignal<T> : IObservable<Spark<T>>
 {
     /// <summary>Initializes a new instance of the <see cref="SparkSignal{T}"/> class.</summary>

--- a/src/Primitives.Shared/Advanced/SparkWitness.cs
+++ b/src/Primitives.Shared/Advanced/SparkWitness.cs
@@ -12,7 +12,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Sink that materializes notifications into <see cref="Spark{T}"/> values.</summary>
 /// <typeparam name="T">The value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+[System.Diagnostics.DebuggerDisplay("SparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
 public sealed class SparkWitness<T> : IObserver<T>, IDisposable
 {
     /// <summary>The downstream observer.</summary>

--- a/src/Primitives.Shared/Advanced/StartSignal.cs
+++ b/src/Primitives.Shared/Advanced/StartSignal.cs
@@ -9,7 +9,7 @@ namespace ReactiveUI.Primitives.Advanced;
 #endif
 
 /// <summary>Runs an action on a scheduler and emits an <see cref="RxVoid"/> value when it completes.</summary>
-[System.Diagnostics.DebuggerDisplay("Action = {Action}, Scheduler = {Scheduler}")]
+[System.Diagnostics.DebuggerDisplay("StartSignal: Action = {Action}, Scheduler = {Scheduler}")]
 public sealed class StartSignal : IRequireCurrentThread<RxVoid>
 {
     /// <summary>Initializes a new instance of the <see cref="StartSignal"/> class.</summary>

--- a/src/Primitives.Shared/Advanced/StartSignal{T}.cs
+++ b/src/Primitives.Shared/Advanced/StartSignal{T}.cs
@@ -10,7 +10,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Runs a function on a scheduler and emits its result.</summary>
 /// <typeparam name="T">The result type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Function = {Function}, Scheduler = {Scheduler}")]
+[System.Diagnostics.DebuggerDisplay("StartSignal: Function = {Function}, Scheduler = {Scheduler}")]
 public sealed class StartSignal<T> : IRequireCurrentThread<T>
 {
     /// <summary>Initializes a new instance of the <see cref="StartSignal{T}"/> class.</summary>

--- a/src/Primitives.Shared/Advanced/SubscribeSafeWitness{T}.cs
+++ b/src/Primitives.Shared/Advanced/SubscribeSafeWitness{T}.cs
@@ -12,7 +12,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Observer that turns downstream <c>OnNext</c> exceptions into a terminal error and upstream disposal.</summary>
 /// <typeparam name="T">The value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+[System.Diagnostics.DebuggerDisplay("SubscribeSafeWitness: Stopped = {_stopped}, Observer = {_observer}")]
 public sealed class SubscribeSafeWitness<T> : IObserver<T>, IDisposable
 {
     /// <summary>The wrapped observer.</summary>

--- a/src/Primitives.Shared/Advanced/SwitchMapSignal{TSource,TResult}.cs
+++ b/src/Primitives.Shared/Advanced/SwitchMapSignal{TSource,TResult}.cs
@@ -17,7 +17,7 @@ namespace ReactiveUI.Primitives.Advanced;
 /// Fuses the projection into the switch: one object and one observer hop, where a projection followed by a
 /// separate switch costs two of each and an intermediate sequence of observables.
 /// </remarks>
-[System.Diagnostics.DebuggerDisplay("Source = {_source}, SkipNullSources = {_skipNullSources}")]
+[System.Diagnostics.DebuggerDisplay("SwitchMapSignal: Source = {_source}, SkipNullSources = {_skipNullSources}")]
 public sealed class SwitchMapSignal<TSource, TResult> : IObservable<TResult>
 {
     /// <summary>The source whose values are projected to inner observables.</summary>

--- a/src/Primitives.Shared/Advanced/SwitchSignal{T}.cs
+++ b/src/Primitives.Shared/Advanced/SwitchSignal{T}.cs
@@ -10,7 +10,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Mirrors only the latest inner observable from an outer source.</summary>
 /// <typeparam name="T">The value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+[System.Diagnostics.DebuggerDisplay("SwitchSignal: Sources = {Sources}")]
 public sealed class SwitchSignal<T> : IObservable<T>
 {
     /// <summary>Initializes a new instance of the <see cref="SwitchSignal{T}"/> class.</summary>

--- a/src/Primitives.Shared/Advanced/SwitchWitness{T}.cs
+++ b/src/Primitives.Shared/Advanced/SwitchWitness{T}.cs
@@ -10,7 +10,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Mediates latest-inner subscription switching for <see cref="SwitchSignal{T}"/>.</summary>
 /// <typeparam name="T">The value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Version = {_version}, IsDone = {IsDone}")]
+[System.Diagnostics.DebuggerDisplay("SwitchWitness: Version = {_version}, IsDone = {IsDone}")]
 public sealed class SwitchWitness<T> : IDisposable
 {
     /// <summary>The synchronization gate.</summary>

--- a/src/Primitives.Shared/Advanced/SyncLatestSignal{TLeft,TRight,TResult}.cs
+++ b/src/Primitives.Shared/Advanced/SyncLatestSignal{TLeft,TRight,TResult}.cs
@@ -12,7 +12,7 @@ namespace ReactiveUI.Primitives.Advanced;
 /// <typeparam name="TLeft">The left value type.</typeparam>
 /// <typeparam name="TRight">The right value type.</typeparam>
 /// <typeparam name="TResult">The result value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+[System.Diagnostics.DebuggerDisplay("SyncLatestSignal: Left = {Left}, Right = {Right}")]
 public sealed class SyncLatestSignal<TLeft, TRight, TResult> : IObservable<TResult>
 {
     /// <summary>Initializes a new instance of the <see cref="SyncLatestSignal{TLeft, TRight, TResult}"/> class.</summary>

--- a/src/Primitives.Shared/Advanced/SyncLatestWitness{TLeft,TRight,TResult}.cs
+++ b/src/Primitives.Shared/Advanced/SyncLatestWitness{TLeft,TRight,TResult}.cs
@@ -12,7 +12,7 @@ namespace ReactiveUI.Primitives.Advanced;
 /// <typeparam name="TLeft">The left value type.</typeparam>
 /// <typeparam name="TRight">The right value type.</typeparam>
 /// <typeparam name="TResult">The result value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
+[System.Diagnostics.DebuggerDisplay("SyncLatestWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
 public sealed class SyncLatestWitness<TLeft, TRight, TResult>
 {
     /// <summary>The synchronization gate.</summary>

--- a/src/Primitives.Shared/Advanced/SynchronizeGateSignal{T}.cs
+++ b/src/Primitives.Shared/Advanced/SynchronizeGateSignal{T}.cs
@@ -10,7 +10,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Signal that serializes source notifications behind a shared gate.</summary>
 /// <typeparam name="T">The value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Source = {Source}, Gate = {Gate}")]
+[System.Diagnostics.DebuggerDisplay("SynchronizeGateSignal: Source = {Source}, Gate = {Gate}")]
 public sealed class SynchronizeGateSignal<T> : IObservable<T>
 {
     /// <summary>Initializes a new instance of the <see cref="SynchronizeGateSignal{T}"/> class.</summary>

--- a/src/Primitives.Shared/Advanced/SynchronizeObjectSignal{T}.cs
+++ b/src/Primitives.Shared/Advanced/SynchronizeObjectSignal{T}.cs
@@ -12,7 +12,7 @@ namespace ReactiveUI.Primitives.Advanced;
 /// <typeparam name="T">The value type.</typeparam>
 /// <param name="source">The source observable.</param>
 /// <param name="gate">The gate shared across subscriptions and other synchronized sequences.</param>
-[System.Diagnostics.DebuggerDisplay("Source = {_source}, Gate = {_gate}")]
+[System.Diagnostics.DebuggerDisplay("SynchronizeObjectSignal: Source = {_source}, Gate = {_gate}")]
 public sealed class SynchronizeObjectSignal<T>(IObservable<T> source, object gate) : IObservable<T>
 {
     /// <summary>The source observable.</summary>

--- a/src/Primitives.Shared/Advanced/SynchronizeObjectWitness{T}.cs
+++ b/src/Primitives.Shared/Advanced/SynchronizeObjectWitness{T}.cs
@@ -14,7 +14,7 @@ namespace ReactiveUI.Primitives.Advanced;
 /// <typeparam name="T">The value type.</typeparam>
 /// <param name="observer">The downstream observer.</param>
 /// <param name="gate">The gate shared with other synchronized observers.</param>
-[System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+[System.Diagnostics.DebuggerDisplay("SynchronizeObjectWitness: Observer = {_observer}, Subscription = {_subscription}")]
 public sealed class SynchronizeObjectWitness<T>(IObserver<T> observer, object gate) : IObserver<T>, IDisposable
 {
     /// <summary>The downstream observer.</summary>

--- a/src/Primitives.Shared/Advanced/SynchronizeSignal{T}.cs
+++ b/src/Primitives.Shared/Advanced/SynchronizeSignal{T}.cs
@@ -10,7 +10,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Signal that serializes source notifications behind a private per-subscription gate.</summary>
 /// <typeparam name="T">The value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+[System.Diagnostics.DebuggerDisplay("SynchronizeSignal: Source = {Source}")]
 public sealed class SynchronizeSignal<T> : IObservable<T>
 {
     /// <summary>Initializes a new instance of the <see cref="SynchronizeSignal{T}"/> class.</summary>

--- a/src/Primitives.Shared/Advanced/TapSignal{T}.cs
+++ b/src/Primitives.Shared/Advanced/TapSignal{T}.cs
@@ -10,7 +10,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Pass-through signal that invokes side effects for forwarded notifications.</summary>
 /// <typeparam name="T">The value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+[System.Diagnostics.DebuggerDisplay("TapSignal: Source = {Source}")]
 public sealed class TapSignal<T> : IObservable<T>
 {
     /// <summary>Initializes a new instance of the <see cref="TapSignal{T}"/> class.</summary>

--- a/src/Primitives.Shared/Advanced/TaskAnyWitness{T}.cs
+++ b/src/Primitives.Shared/Advanced/TaskAnyWitness{T}.cs
@@ -12,7 +12,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Task-producing terminal sink that completes with whether a source produced a matching value.</summary>
 /// <typeparam name="T">The source value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Task = {Task}")]
+[System.Diagnostics.DebuggerDisplay("TaskAnyWitness: Stopped = {_stopped}, Task = {Task}")]
 public sealed class TaskAnyWitness<T> : IObserver<T>, IDisposable
 {
     /// <summary>The task completed by this sink.</summary>

--- a/src/Primitives.Shared/Advanced/TaskChainCoordinator{T}.cs
+++ b/src/Primitives.Shared/Advanced/TaskChainCoordinator{T}.cs
@@ -12,7 +12,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Coordinates sequential task-source concatenation without a map adapter.</summary>
 /// <typeparam name="T">The task result type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
+[System.Diagnostics.DebuggerDisplay("TaskChainCoordinator: Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
 public sealed class TaskChainCoordinator<T> : IDisposable
 {
     /// <summary>Guards the queue and active/completed flags.</summary>

--- a/src/Primitives.Shared/Advanced/TaskChainSignal{T}.cs
+++ b/src/Primitives.Shared/Advanced/TaskChainSignal{T}.cs
@@ -10,7 +10,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Task-source <c>Chain</c>/<c>Concat</c> signal.</summary>
 /// <typeparam name="T">The task result type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Sources = {_sources}")]
+[System.Diagnostics.DebuggerDisplay("TaskChainSignal: Sources = {_sources}")]
 public sealed class TaskChainSignal<T> : IObservable<T>
 {
     /// <summary>The outer task source.</summary>

--- a/src/Primitives.Shared/Advanced/TaskCountWitness{T}.cs
+++ b/src/Primitives.Shared/Advanced/TaskCountWitness{T}.cs
@@ -12,7 +12,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Task-producing terminal sink that completes with the number of matching source values.</summary>
 /// <typeparam name="T">The source value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Count = {_count}, Stopped = {_stopped}")]
+[System.Diagnostics.DebuggerDisplay("TaskCountWitness: Count = {_count}, Stopped = {_stopped}")]
 public sealed class TaskCountWitness<T> : IObserver<T>, IDisposable
 {
     /// <summary>The task completed by this sink.</summary>

--- a/src/Primitives.Shared/Advanced/TaskInstanceSignal{T}.cs
+++ b/src/Primitives.Shared/Advanced/TaskInstanceSignal{T}.cs
@@ -10,7 +10,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Signal that emits the result of an existing task instance.</summary>
 /// <typeparam name="T">The task result type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Task = {Task}")]
+[System.Diagnostics.DebuggerDisplay("TaskInstanceSignal: Task = {Task}")]
 public sealed class TaskInstanceSignal<T> : IObservable<T>
 {
     /// <summary>Initializes a new instance of the <see cref="TaskInstanceSignal{T}"/> class.</summary>

--- a/src/Primitives.Shared/Advanced/TaskInstanceSubscription.cs
+++ b/src/Primitives.Shared/Advanced/TaskInstanceSubscription.cs
@@ -11,7 +11,7 @@ namespace ReactiveUI.Primitives.Advanced;
 #endif
 
 /// <summary>Subscription handle for an existing task-instance signal.</summary>
-[System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}")]
+[System.Diagnostics.DebuggerDisplay("TaskInstanceSubscription: Stopped = {_stopped}")]
 public sealed class TaskInstanceSubscription : IDisposable
 {
     /// <summary>Non-zero after disposal or terminal notification.</summary>

--- a/src/Primitives.Shared/Advanced/ThrowSignal{T}.cs
+++ b/src/Primitives.Shared/Advanced/ThrowSignal{T}.cs
@@ -12,7 +12,8 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Represents the ThrowSignal class.</summary>
 /// <typeparam name="T">The T type.</typeparam>
-internal sealed class ThrowSignal<T> : IRequireCurrentThread<T>
+[System.Diagnostics.DebuggerDisplay("ThrowSignal: Error = {_error}, Scheduler = {_scheduler}")]
+public sealed class ThrowSignal<T> : IRequireCurrentThread<T>
 {
     /// <summary>Stores state for the signal implementation.</summary>
     private readonly Exception _error;

--- a/src/Primitives.Shared/Advanced/TimeIntervalSignal{T}.cs
+++ b/src/Primitives.Shared/Advanced/TimeIntervalSignal{T}.cs
@@ -10,7 +10,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Signal that measures elapsed time between source values.</summary>
 /// <typeparam name="T">The value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Source = {Source}, Sequencer = {Sequencer}")]
+[System.Diagnostics.DebuggerDisplay("TimeIntervalSignal: Source = {Source}, Sequencer = {Sequencer}")]
 public sealed class TimeIntervalSignal<T> : IObservable<TimeInterval<T>>
 {
     /// <summary>Initializes a new instance of the <see cref="TimeIntervalSignal{T}"/> class.</summary>

--- a/src/Primitives.Shared/Advanced/TimeIntervalWitness.cs
+++ b/src/Primitives.Shared/Advanced/TimeIntervalWitness.cs
@@ -12,7 +12,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Sink that annotates each value with the elapsed interval since the previous value.</summary>
 /// <typeparam name="T">The value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("First = {_first}, Last = {_last}")]
+[System.Diagnostics.DebuggerDisplay("TimeIntervalWitness: First = {_first}, Last = {_last}")]
 public sealed class TimeIntervalWitness<T> : IObserver<T>, IDisposable
 {
     /// <summary>The downstream observer.</summary>

--- a/src/Primitives.Shared/Advanced/UnsparkSignal{T}.cs
+++ b/src/Primitives.Shared/Advanced/UnsparkSignal{T}.cs
@@ -10,7 +10,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Signal that dematerializes <see cref="Spark{T}"/> values into ordinary notifications.</summary>
 /// <typeparam name="T">The value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+[System.Diagnostics.DebuggerDisplay("UnsparkSignal: Source = {Source}")]
 public sealed class UnsparkSignal<T> : IObservable<T>
 {
     /// <summary>Initializes a new instance of the <see cref="UnsparkSignal{T}"/> class.</summary>

--- a/src/Primitives.Shared/Advanced/UnsparkWitness.cs
+++ b/src/Primitives.Shared/Advanced/UnsparkWitness.cs
@@ -12,7 +12,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Sink that dematerializes <see cref="Spark{T}"/> values into notifications.</summary>
 /// <typeparam name="T">The value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+[System.Diagnostics.DebuggerDisplay("UnsparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
 public sealed class UnsparkWitness<T> : IObserver<Spark<T>>, IDisposable
 {
     /// <summary>The downstream observer.</summary>

--- a/src/Primitives.Shared/Signals/PrioritySemaphoreSignal{T}.cs
+++ b/src/Primitives.Shared/Signals/PrioritySemaphoreSignal{T}.cs
@@ -12,7 +12,7 @@ namespace ReactiveUI.Primitives.Signals;
 
 /// <summary>A signal that limits forwarded values with priority-based semaphore semantics.</summary>
 /// <typeparam name="T">The comparable value type used for priority ordering.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
+[System.Diagnostics.DebuggerDisplay("PrioritySemaphoreSignal: Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
 public sealed class PrioritySemaphoreSignal<T> : ISignal<T>
     where T : IComparable<T>
 {

--- a/src/Primitives.Shared/Signals/ScheduledSignal{T}.cs
+++ b/src/Primitives.Shared/Signals/ScheduledSignal{T}.cs
@@ -12,7 +12,7 @@ namespace ReactiveUI.Primitives.Signals;
 
 /// <summary>A signal which emits items using the specified scheduler.</summary>
 /// <typeparam name="T">The type of item to emit.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
+[System.Diagnostics.DebuggerDisplay("ScheduledSignal: Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
 public class ScheduledSignal<T> : ISignal<T>
 {
     /// <summary>Guards default-observer and subscription-count state.</summary>

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/AsyncEnumerableSignal{T}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/AsyncEnumerableSignal{T}.cs
@@ -6,7 +6,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 
 /// <summary>An observable that emits values from an asynchronous enumerable for each subscription.</summary>
 /// <typeparam name="T">The element type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+[System.Diagnostics.DebuggerDisplay("AsyncEnumerableSignal: Source = {Source}")]
 public sealed class AsyncEnumerableSignal<T> : IObservableAsync<T>
 {
     /// <summary>Initializes a new instance of the <see cref="AsyncEnumerableSignal{T}"/> class.</summary>

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/AsyncEnumerableSubscription{T}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/AsyncEnumerableSubscription{T}.cs
@@ -6,7 +6,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 
 /// <summary>A subscription that emits the contents of an asynchronous enumerable.</summary>
 /// <typeparam name="T">The element type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+[System.Diagnostics.DebuggerDisplay("AsyncEnumerableSubscription: Source = {Source}")]
 public sealed class AsyncEnumerableSubscription<T> : TaskSignalSubscription<T>
 {
     /// <summary>Initializes a new instance of the <see cref="AsyncEnumerableSubscription{T}"/> class.</summary>

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/AsyncSerialGate.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/AsyncSerialGate.cs
@@ -13,7 +13,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 /// <see cref="SemaphoreSlim"/> touch); the contended path waits on a signal-only semaphore and retries
 /// the CAS after each signal. Same-thread reentry is granted via the owner-thread-id and a recursion counter.
 /// </summary>
-[System.Diagnostics.DebuggerDisplay("OwnerThreadId = {_ownerThreadId}, Waiters = {_waiters}, RecursionDepth = {_recursionDepth}")]
+[System.Diagnostics.DebuggerDisplay("AsyncSerialGate: OwnerThreadId = {_ownerThreadId}, Waiters = {_waiters}, RecursionDepth = {_recursionDepth}")]
 public sealed class AsyncSerialGate : IDisposable
 {
     /// <summary>Signal-only semaphore; released once per recorded waiter to wake one.</summary>
@@ -133,7 +133,7 @@ public sealed class AsyncSerialGate : IDisposable
     }
 
     /// <summary>Releases a previously acquired <see cref="AsyncSerialGate"/> when disposed.</summary>
-    [System.Diagnostics.DebuggerDisplay("Parent = {_parent}")]
+    [System.Diagnostics.DebuggerDisplay("Lease: Parent = {_parent}")]
     public readonly record struct Lease : IDisposable
     {
         /// <summary>The parent <see cref="AsyncSerialGate"/> whose lock is released when this lease is disposed.</summary>

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/BackgroundJobSignal{T}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/BackgroundJobSignal{T}.cs
@@ -6,7 +6,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 
 /// <summary>An observable that runs a supplied asynchronous job for each subscription.</summary>
 /// <typeparam name="T">The element type emitted by the job.</typeparam>
-[System.Diagnostics.DebuggerDisplay("StartSynchronously = {StartSynchronously}, TaskScheduler = {TaskScheduler}")]
+[System.Diagnostics.DebuggerDisplay("BackgroundJobSignal: StartSynchronously = {StartSynchronously}, TaskScheduler = {TaskScheduler}")]
 public sealed class BackgroundJobSignal<T> : IObservableAsync<T>
 {
     /// <summary>Initializes a new instance of the <see cref="BackgroundJobSignal{T}"/> class.</summary>

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/CallbackWitnessAsync.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/CallbackWitnessAsync.cs
@@ -9,7 +9,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 /// <param name="onNextAsync">The asynchronous function invoked for each element.</param>
 /// <param name="onErrorResumeAsync">An optional asynchronous function invoked when a resumable error occurs.</param>
 /// <param name="onCompletedAsync">An optional asynchronous function invoked when the sequence completes.</param>
-[System.Diagnostics.DebuggerDisplay("HasDisposed = {HasDisposed}")]
+[System.Diagnostics.DebuggerDisplay("CallbackWitnessAsync: HasDisposed = {HasDisposed}")]
 public sealed class CallbackWitnessAsync<T>(
     Func<T, CancellationToken, ValueTask> onNextAsync,
     Func<Exception, CancellationToken, ValueTask>? onErrorResumeAsync = null,

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/DoOnSubscribeAsyncSignal{T}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/DoOnSubscribeAsyncSignal{T}.cs
@@ -6,7 +6,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 
 /// <summary>An observable that invokes an asynchronous side effect before subscribing to its source.</summary>
 /// <typeparam name="T">The element type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Source = {Source}, Action = {Action}")]
+[System.Diagnostics.DebuggerDisplay("DoOnSubscribeAsyncSignal: Source = {Source}, Action = {Action}")]
 public sealed class DoOnSubscribeAsyncSignal<T> : IObservableAsync<T>
 {
     /// <summary>Initializes a new instance of the <see cref="DoOnSubscribeAsyncSignal{T}"/> class.</summary>

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/DoOnSubscribeSignal{T}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/DoOnSubscribeSignal{T}.cs
@@ -6,7 +6,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 
 /// <summary>An observable that invokes a synchronous side effect before subscribing to its source.</summary>
 /// <typeparam name="T">The element type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Source = {Source}, Action = {Action}")]
+[System.Diagnostics.DebuggerDisplay("DoOnSubscribeSignal: Source = {Source}, Action = {Action}")]
 public sealed class DoOnSubscribeSignal<T> : IObservableAsync<T>
 {
     /// <summary>Initializes a new instance of the <see cref="DoOnSubscribeSignal{T}"/> class.</summary>

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/EnumerableSignal{T}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/EnumerableSignal{T}.cs
@@ -6,7 +6,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 
 /// <summary>An observable that emits values from an enumerable for each subscription.</summary>
 /// <typeparam name="T">The element type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+[System.Diagnostics.DebuggerDisplay("EnumerableSignal: Source = {Source}")]
 public sealed class EnumerableSignal<T> : IObservableAsync<T>
 {
     /// <summary>Initializes a new instance of the <see cref="EnumerableSignal{T}"/> class.</summary>

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/EnumerableSubscription{T}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/EnumerableSubscription{T}.cs
@@ -6,7 +6,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 
 /// <summary>A subscription that emits the contents of an enumerable.</summary>
 /// <typeparam name="T">The element type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+[System.Diagnostics.DebuggerDisplay("EnumerableSubscription: Source = {Source}")]
 public sealed class EnumerableSubscription<T> : TaskSignalSubscription<T>
 {
     /// <summary>Initializes a new instance of the <see cref="EnumerableSubscription{T}"/> class.</summary>

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/FlatMapCoordinator{TResult}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/FlatMapCoordinator{TResult}.cs
@@ -9,7 +9,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 
 /// <summary>Coordinates outer and inner subscriptions for flat-map operations.</summary>
 /// <typeparam name="TResult">The result element type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("ActiveInnerCount = {ActiveInnerCount}, OuterCompleted = {OuterCompleted}, Disposed = {Disposed}")]
+[System.Diagnostics.DebuggerDisplay("FlatMapCoordinator: ActiveInnerCount = {ActiveInnerCount}, OuterCompleted = {OuterCompleted}, Disposed = {Disposed}")]
 public sealed class FlatMapCoordinator<TResult> : IAsyncDisposable
 {
     /// <summary>Protects mutable lifecycle state.</summary>

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/FlatMapSignal{TSource,TResult}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/FlatMapSignal{TSource,TResult}.cs
@@ -7,7 +7,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 /// <summary>An observable that projects source values to inner observables and merges those inner observables.</summary>
 /// <typeparam name="TSource">The source element type.</typeparam>
 /// <typeparam name="TResult">The result element type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Source = {Source}, SyncSelector = {SyncSelector}, AsyncSelector = {AsyncSelector}")]
+[System.Diagnostics.DebuggerDisplay("FlatMapSignal: Source = {Source}, SyncSelector = {SyncSelector}, AsyncSelector = {AsyncSelector}")]
 public sealed class FlatMapSignal<TSource, TResult> : IObservableAsync<TResult>
 {
     /// <summary>Initializes a new instance of the <see cref="FlatMapSignal{TSource,TResult}"/> class.</summary>

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/FlatMapWitness{TResult}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/FlatMapWitness{TResult}.cs
@@ -6,7 +6,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 
 /// <summary>Inner observer that relays projected values to a flat-map coordinator.</summary>
 /// <typeparam name="TResult">The result element type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Coordinator = {Coordinator}")]
+[System.Diagnostics.DebuggerDisplay("FlatMapWitness: Coordinator = {Coordinator}")]
 public sealed class FlatMapWitness<TResult> : WitnessAsync<TResult>
 {
     /// <summary>Initializes a new instance of the <see cref="FlatMapWitness{TResult}"/> class.</summary>

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/FlatMapWitness{TSource,TResult}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/FlatMapWitness{TSource,TResult}.cs
@@ -7,7 +7,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 /// <summary>Outer observer that projects source values to inner observables.</summary>
 /// <typeparam name="TSource">The source element type.</typeparam>
 /// <typeparam name="TResult">The result element type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Coordinator = {Coordinator}, SyncSelector = {SyncSelector}, AsyncSelector = {AsyncSelector}")]
+[System.Diagnostics.DebuggerDisplay("FlatMapWitness: Coordinator = {Coordinator}, SyncSelector = {SyncSelector}, AsyncSelector = {AsyncSelector}")]
 public sealed class FlatMapWitness<TSource, TResult> : WitnessAsync<TSource>
 {
     /// <summary>Initializes a new instance of the <see cref="FlatMapWitness{TSource,TResult}"/> class.</summary>

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/ForwardingWitnessAsync.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/ForwardingWitnessAsync.cs
@@ -10,7 +10,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 /// The protected constructor, rather than <c>abstract</c>, is what keeps it from being used on its own.
 /// </summary>
 /// <typeparam name="T">The observed element type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Downstream = {Downstream}")]
+[System.Diagnostics.DebuggerDisplay("ForwardingWitnessAsync: Downstream = {Downstream}")]
 public class ForwardingWitnessAsync<T> : WitnessAsync<T>
 {
     /// <summary>Initializes a new instance of the <see cref="ForwardingWitnessAsync{T}"/> class.</summary>

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/FromAsyncSignal{T}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/FromAsyncSignal{T}.cs
@@ -6,7 +6,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 
 /// <summary>An observable that invokes an asynchronous value factory for each subscription.</summary>
 /// <typeparam name="T">The value type emitted by the factory.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Factory = {Factory}")]
+[System.Diagnostics.DebuggerDisplay("FromAsyncSignal: Factory = {Factory}")]
 public sealed class FromAsyncSignal<T> : IObservableAsync<T>
 {
     /// <summary>Initializes a new instance of the <see cref="FromAsyncSignal{T}"/> class.</summary>

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/FromAsyncSubscription{T}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/FromAsyncSubscription{T}.cs
@@ -6,7 +6,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 
 /// <summary>A subscription that invokes an asynchronous value factory and emits its result.</summary>
 /// <typeparam name="T">The value type emitted by the factory.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Factory = {Factory}")]
+[System.Diagnostics.DebuggerDisplay("FromAsyncSubscription: Factory = {Factory}")]
 public sealed class FromAsyncSubscription<T> : TaskSignalSubscription<T>
 {
     /// <summary>Initializes a new instance of the <see cref="FromAsyncSubscription{T}"/> class.</summary>

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/IntervalSignal.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/IntervalSignal.cs
@@ -5,7 +5,7 @@
 namespace ReactiveUI.Primitives.Async.Advanced;
 
 /// <summary>An observable that emits incrementing ticks at a fixed interval.</summary>
-[System.Diagnostics.DebuggerDisplay("Period = {Period}, TimeProvider = {TimeProvider}")]
+[System.Diagnostics.DebuggerDisplay("IntervalSignal: Period = {Period}, TimeProvider = {TimeProvider}")]
 public sealed class IntervalSignal : IObservableAsync<long>
 {
     /// <summary>Initializes a new instance of the <see cref="IntervalSignal"/> class.</summary>

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/IntervalSubscription.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/IntervalSubscription.cs
@@ -5,7 +5,7 @@
 namespace ReactiveUI.Primitives.Async.Advanced;
 
 /// <summary>A subscription that emits incrementing ticks at a fixed interval.</summary>
-[System.Diagnostics.DebuggerDisplay("Period = {Period}, TimeProvider = {TimeProvider}")]
+[System.Diagnostics.DebuggerDisplay("IntervalSubscription: Period = {Period}, TimeProvider = {TimeProvider}")]
 public sealed class IntervalSubscription : TaskSignalSubscription<long>
 {
     /// <summary>Initializes a new instance of the <see cref="IntervalSubscription"/> class.</summary>

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/LeadSignal{T}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/LeadSignal{T}.cs
@@ -6,7 +6,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 
 /// <summary>An observable that emits leading values before subscribing to the source sequence.</summary>
 /// <typeparam name="T">The element type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Source = {Source}, Values = {Values}")]
+[System.Diagnostics.DebuggerDisplay("LeadSignal: Source = {Source}, Values = {Values}")]
 public sealed class LeadSignal<T> : IObservableAsync<T>
 {
     /// <summary>Initializes a new instance of the <see cref="LeadSignal{T}"/> class.</summary>

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/LeadSubscription{T}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/LeadSubscription{T}.cs
@@ -8,7 +8,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 
 /// <summary>Subscription that emits leading values and then relays the source sequence.</summary>
 /// <typeparam name="T">The element type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Disposed = {Disposed}, Pipeline = {Pipeline}")]
+[System.Diagnostics.DebuggerDisplay("LeadSubscription: Disposed = {Disposed}, Pipeline = {Pipeline}")]
 public sealed class LeadSubscription<T> : IAsyncDisposable
 {
     /// <summary>Protects disposal state.</summary>

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/LogErrorsSignal{T}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/LogErrorsSignal{T}.cs
@@ -8,7 +8,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 
 /// <summary>An observable that logs resumable errors without changing the source sequence.</summary>
 /// <typeparam name="T">The element type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Source = {Source}, Logger = {Logger}")]
+[System.Diagnostics.DebuggerDisplay("LogErrorsSignal: Source = {Source}, Logger = {Logger}")]
 public sealed class LogErrorsSignal<T> : IObservableAsync<T>
 {
     /// <summary>Initializes a new instance of the <see cref="LogErrorsSignal{T}"/> class.</summary>

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/LogErrorsWitness{T}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/LogErrorsWitness{T}.cs
@@ -6,7 +6,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 
 /// <summary>An observer that logs resumable errors before forwarding them downstream.</summary>
 /// <typeparam name="T">The element type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Downstream = {Downstream}, Logger = {Logger}")]
+[System.Diagnostics.DebuggerDisplay("LogErrorsWitness: Downstream = {Downstream}, Logger = {Logger}")]
 public sealed class LogErrorsWitness<T> : WitnessAsync<T>
 {
     /// <summary>Initializes a new instance of the <see cref="LogErrorsWitness{T}"/> class.</summary>

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/PooledDelaySource.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/PooledDelaySource.cs
@@ -24,7 +24,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 /// flag. The loser is a no-op. After the caller awaits the returned <see cref="ValueTask"/>, the
 /// instance is reset and pushed back to the pool inside <see cref="GetResult(short)"/>.</para>
 /// </remarks>
-[System.Diagnostics.DebuggerDisplay("Completed = {_completed}, Timer = {_timer}")]
+[System.Diagnostics.DebuggerDisplay("PooledDelaySource: Completed = {_completed}, Timer = {_timer}")]
 public sealed class PooledDelaySource : IValueTaskSource
 {
     /// <summary>State value for <see cref="_completed"/> meaning "no terminal event yet".</summary>

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/ReattemptSignal{T}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/ReattemptSignal{T}.cs
@@ -6,7 +6,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 
 /// <summary>An observable that resubscribes to the source after terminal failures.</summary>
 /// <typeparam name="T">The element type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Source = {Source}, RetryCount = {RetryCount}")]
+[System.Diagnostics.DebuggerDisplay("ReattemptSignal: Source = {Source}, RetryCount = {RetryCount}")]
 public sealed class ReattemptSignal<T> : IObservableAsync<T>
 {
     /// <summary>Initializes a new instance of the <see cref="ReattemptSignal{T}"/> class.</summary>

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/ReattemptSubscription{T}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/ReattemptSubscription{T}.cs
@@ -9,7 +9,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 
 /// <summary>Coordinates retry subscriptions for <see cref="ReattemptSignal{T}"/>.</summary>
 /// <typeparam name="T">The element type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Source = {Source}, Remaining = {Remaining}")]
+[System.Diagnostics.DebuggerDisplay("ReattemptSubscription: Source = {Source}, Remaining = {Remaining}")]
 public sealed class ReattemptSubscription<T> : IAsyncDisposable
 {
     /// <summary>Initializes a new instance of the <see cref="ReattemptSubscription{T}"/> class.</summary>

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/ReattemptWitness{T}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/ReattemptWitness{T}.cs
@@ -6,7 +6,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 
 /// <summary>Observer for a single retry attempt.</summary>
 /// <typeparam name="T">The element type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Subscription = {Subscription}")]
+[System.Diagnostics.DebuggerDisplay("ReattemptWitness: Subscription = {Subscription}")]
 public sealed class ReattemptWitness<T> : WitnessAsync<T>
 {
     /// <summary>Initializes a new instance of the <see cref="ReattemptWitness{T}"/> class.</summary>

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/SequenceSignal.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/SequenceSignal.cs
@@ -5,7 +5,7 @@
 namespace ReactiveUI.Primitives.Async.Advanced;
 
 /// <summary>An observable that emits a contiguous integer sequence for each subscription.</summary>
-[System.Diagnostics.DebuggerDisplay("StartValue = {StartValue}, Count = {Count}")]
+[System.Diagnostics.DebuggerDisplay("SequenceSignal: StartValue = {StartValue}, Count = {Count}")]
 public sealed class SequenceSignal : IObservableAsync<int>
 {
     /// <summary>Initializes a new instance of the <see cref="SequenceSignal"/> class.</summary>

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/SequenceSubscription.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/SequenceSubscription.cs
@@ -5,7 +5,7 @@
 namespace ReactiveUI.Primitives.Async.Advanced;
 
 /// <summary>A subscription that emits a contiguous integer sequence.</summary>
-[System.Diagnostics.DebuggerDisplay("StartValue = {StartValue}, Count = {Count}")]
+[System.Diagnostics.DebuggerDisplay("SequenceSubscription: StartValue = {StartValue}, Count = {Count}")]
 public sealed class SequenceSubscription : TaskSignalSubscription<int>
 {
     /// <summary>Initializes a new instance of the <see cref="SequenceSubscription"/> class.</summary>

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/SingleElementWitness.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/SingleElementWitness.cs
@@ -19,7 +19,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 /// </param>
 /// <param name="defaultValue">The value to return on empty when <paramref name="requireExactlyOne"/> is <c>false</c>.</param>
 /// <param name="cancellationToken">A cancellation token for the operation.</param>
-[System.Diagnostics.DebuggerDisplay("HasValue = {_hasValue}, Value = {_value}")]
+[System.Diagnostics.DebuggerDisplay("SingleElementWitness: HasValue = {_hasValue}, Value = {_value}")]
 public sealed class SingleElementWitness<T>(
     Func<T, bool>? predicate,
     bool requireExactlyOne,

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/StartSignal{TResult}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/StartSignal{TResult}.cs
@@ -6,7 +6,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 
 /// <summary>An observable that invokes a synchronous function and emits its result for each subscription.</summary>
 /// <typeparam name="TResult">The result type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Function = {Function}, TaskScheduler = {TaskScheduler}")]
+[System.Diagnostics.DebuggerDisplay("StartSignal: Function = {Function}, TaskScheduler = {TaskScheduler}")]
 public sealed class StartSignal<TResult> : IObservableAsync<TResult>
 {
     /// <summary>Initializes a new instance of the <see cref="StartSignal{TResult}"/> class.</summary>

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/StartSubscription{TResult}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/StartSubscription{TResult}.cs
@@ -6,7 +6,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 
 /// <summary>A subscription that invokes a synchronous function and emits its result.</summary>
 /// <typeparam name="TResult">The result type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Function = {Function}, TaskScheduler = {TaskScheduler}")]
+[System.Diagnostics.DebuggerDisplay("StartSubscription: Function = {Function}, TaskScheduler = {TaskScheduler}")]
 public sealed class StartSubscription<TResult> : TaskSignalSubscription<TResult>
 {
     /// <summary>Initializes a new instance of the <see cref="StartSubscription{TResult}"/> class.</summary>

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest10Coordinator{T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,TResult}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest10Coordinator{T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,TResult}.cs
@@ -18,7 +18,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 /// <typeparam name="T9">Element type of source 9.</typeparam>
 /// <typeparam name="T10">Element type of source 10.</typeparam>
 /// <typeparam name="TResult">The projected element type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("SourceCount = {SourceCount}, Sources = {Sources}")]
+[System.Diagnostics.DebuggerDisplay("SyncLatest10Coordinator: SourceCount = {SourceCount}, Sources = {Sources}")]
 public sealed class
     SyncLatest10Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> : SyncLatestCoordinatorBase<TResult>
 {

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest10Signal{T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,TResult}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest10Signal{T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,TResult}.cs
@@ -16,7 +16,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 /// <typeparam name="T9">Element type of source 9.</typeparam>
 /// <typeparam name="T10">Element type of source 10.</typeparam>
 /// <typeparam name="TResult">The projected element type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+[System.Diagnostics.DebuggerDisplay("SyncLatest10Signal: Sources = {Sources}, Selector = {Selector}")]
 public sealed class SyncLatest10Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> : IObservableAsync<TResult>
 {
     /// <summary>Initializes a new instance of the <see cref="SyncLatest10Signal{T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult}"/> class.</summary>

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest10State{T1,T2,T3,T4,T5,T6,T7,T8,T9,T10}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest10State{T1,T2,T3,T4,T5,T6,T7,T8,T9,T10}.cs
@@ -25,7 +25,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 /// <param name="Source8">Source observable 8.</param>
 /// <param name="Source9">Source observable 9.</param>
 /// <param name="Source10">Source observable 10.</param>
-[System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source10 = {Source10}")]
+[System.Diagnostics.DebuggerDisplay("SyncLatest10State: Source1 = {Source1}, Source10 = {Source10}")]
 public readonly record struct SyncLatest10State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
     IObservableAsync<T1> Source1,
     IObservableAsync<T2> Source2,

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest11Coordinator{T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,TResult}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest11Coordinator{T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,TResult}.cs
@@ -19,7 +19,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 /// <typeparam name="T10">Element type of source 10.</typeparam>
 /// <typeparam name="T11">Element type of source 11.</typeparam>
 /// <typeparam name="TResult">The projected element type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("SourceCount = {SourceCount}, Sources = {Sources}")]
+[System.Diagnostics.DebuggerDisplay("SyncLatest11Coordinator: SourceCount = {SourceCount}, Sources = {Sources}")]
 public sealed class
     SyncLatest11Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> : SyncLatestCoordinatorBase<TResult>
 {

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest11Signal{T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,TResult}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest11Signal{T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,TResult}.cs
@@ -17,7 +17,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 /// <typeparam name="T10">Element type of source 10.</typeparam>
 /// <typeparam name="T11">Element type of source 11.</typeparam>
 /// <typeparam name="TResult">The projected element type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+[System.Diagnostics.DebuggerDisplay("SyncLatest11Signal: Sources = {Sources}, Selector = {Selector}")]
 public sealed class
     SyncLatest11Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> : IObservableAsync<TResult>
 {

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest11State{T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest11State{T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11}.cs
@@ -27,7 +27,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 /// <param name="Source9">Source observable 9.</param>
 /// <param name="Source10">Source observable 10.</param>
 /// <param name="Source11">Source observable 11.</param>
-[System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source2 = {Source2}, Source11 = {Source11}")]
+[System.Diagnostics.DebuggerDisplay("SyncLatest11State: Source1 = {Source1}, Source2 = {Source2}, Source11 = {Source11}")]
 public readonly record struct SyncLatest11State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(
     IObservableAsync<T1> Source1,
     IObservableAsync<T2> Source2,

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest12Coordinator{T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,TResult}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest12Coordinator{T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,TResult}.cs
@@ -20,7 +20,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 /// <typeparam name="T11">Element type of source 11.</typeparam>
 /// <typeparam name="T12">Element type of source 12.</typeparam>
 /// <typeparam name="TResult">The projected element type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Lifecycle = {Lifecycle}")]
+[System.Diagnostics.DebuggerDisplay("SyncLatest12Coordinator: Sources = {Sources}, Lifecycle = {Lifecycle}")]
 public sealed class
     SyncLatest12Coordinator<
         T1,

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest12Signal{T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,TResult}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest12Signal{T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,TResult}.cs
@@ -18,7 +18,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 /// <typeparam name="T11">Element type of source 11.</typeparam>
 /// <typeparam name="T12">Element type of source 12.</typeparam>
 /// <typeparam name="TResult">The projected element type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+[System.Diagnostics.DebuggerDisplay("SyncLatest12Signal: Sources = {Sources}")]
 public sealed class
     SyncLatest12Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> : IObservableAsync<TResult>
 {

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest12State{T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest12State{T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12}.cs
@@ -29,7 +29,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 /// <param name="Source10">Source observable 10.</param>
 /// <param name="Source11">Source observable 11.</param>
 /// <param name="Source12">Source observable 12.</param>
-[System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source12 = {Source12}")]
+[System.Diagnostics.DebuggerDisplay("SyncLatest12State: Source1 = {Source1}, Source12 = {Source12}")]
 public readonly record struct SyncLatest12State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(
     IObservableAsync<T1> Source1,
     IObservableAsync<T2> Source2,

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest13Coordinator{T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,TResult}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest13Coordinator{T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,TResult}.cs
@@ -21,7 +21,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 /// <typeparam name="T12">Element type of source 12.</typeparam>
 /// <typeparam name="T13">Element type of source 13.</typeparam>
 /// <typeparam name="TResult">The projected element type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value13 = {Value13}")]
+[System.Diagnostics.DebuggerDisplay("SyncLatest13Coordinator: Value1 = {Value1}, Value13 = {Value13}")]
 public sealed class
     SyncLatest13Coordinator<
         T1,

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest13Signal{T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,TResult}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest13Signal{T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,TResult}.cs
@@ -19,7 +19,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 /// <typeparam name="T12">Element type of source 12.</typeparam>
 /// <typeparam name="T13">Element type of source 13.</typeparam>
 /// <typeparam name="TResult">The projected element type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+[System.Diagnostics.DebuggerDisplay("SyncLatest13Signal: Sources = {Sources}, Selector = {Selector}")]
 public sealed class
     SyncLatest13Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> : IObservableAsync<TResult>
 {

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest13State{T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest13State{T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13}.cs
@@ -31,7 +31,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 /// <param name="Source11">Source observable 11.</param>
 /// <param name="Source12">Source observable 12.</param>
 /// <param name="Source13">Source observable 13.</param>
-[System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source13 = {Source13}")]
+[System.Diagnostics.DebuggerDisplay("SyncLatest13State: Source1 = {Source1}, Source13 = {Source13}")]
 public readonly record struct SyncLatest13State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(
     IObservableAsync<T1> Source1,
     IObservableAsync<T2> Source2,

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest14Coordinator{T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,TResult}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest14Coordinator{T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,TResult}.cs
@@ -22,7 +22,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 /// <typeparam name="T13">Element type of source 13.</typeparam>
 /// <typeparam name="T14">Element type of source 14.</typeparam>
 /// <typeparam name="TResult">The projected element type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Lifecycle = {Lifecycle}")]
+[System.Diagnostics.DebuggerDisplay("SyncLatest14Coordinator: Sources = {Sources}, Lifecycle = {Lifecycle}")]
 public sealed class
     SyncLatest14Coordinator<
         T1,

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest14Signal{T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,TResult}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest14Signal{T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,TResult}.cs
@@ -20,7 +20,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 /// <typeparam name="T13">Element type of source 13.</typeparam>
 /// <typeparam name="T14">Element type of source 14.</typeparam>
 /// <typeparam name="TResult">The projected element type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+[System.Diagnostics.DebuggerDisplay("SyncLatest14Signal: Sources = {Sources}, Selector = {Selector}")]
 public sealed class
     SyncLatest14Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> : IObservableAsync<TResult>
 {

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest14State{T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest14State{T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14}.cs
@@ -33,7 +33,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 /// <param name="Source12">Source observable 12.</param>
 /// <param name="Source13">Source observable 13.</param>
 /// <param name="Source14">Source observable 14.</param>
-[System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source14 = {Source14}")]
+[System.Diagnostics.DebuggerDisplay("SyncLatest14State: Source1 = {Source1}, Source14 = {Source14}")]
 public readonly record struct SyncLatest14State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(
     IObservableAsync<T1> Source1,
     IObservableAsync<T2> Source2,

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest15Coordinator{T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,TResult}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest15Coordinator{T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,TResult}.cs
@@ -23,7 +23,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 /// <typeparam name="T14">Element type of source 14.</typeparam>
 /// <typeparam name="T15">Element type of source 15.</typeparam>
 /// <typeparam name="TResult">The projected element type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value15 = {Value15}")]
+[System.Diagnostics.DebuggerDisplay("SyncLatest15Coordinator: Value1 = {Value1}, Value15 = {Value15}")]
 public sealed class
     SyncLatest15Coordinator<
         T1,

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest15Signal{T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,TResult}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest15Signal{T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,TResult}.cs
@@ -21,7 +21,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 /// <typeparam name="T14">Element type of source 14.</typeparam>
 /// <typeparam name="T15">Element type of source 15.</typeparam>
 /// <typeparam name="TResult">The projected element type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+[System.Diagnostics.DebuggerDisplay("SyncLatest15Signal: Sources = {Sources}, Selector = {Selector}")]
 public sealed class
     SyncLatest15Signal<
         T1,

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest15State{T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest15State{T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15}.cs
@@ -35,7 +35,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 /// <param name="Source13">Source observable 13.</param>
 /// <param name="Source14">Source observable 14.</param>
 /// <param name="Source15">Source observable 15.</param>
-[System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source15 = {Source15}")]
+[System.Diagnostics.DebuggerDisplay("SyncLatest15State: Source1 = {Source1}, Source15 = {Source15}")]
 public readonly record struct SyncLatest15State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(
     IObservableAsync<T1> Source1,
     IObservableAsync<T2> Source2,

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest16Coordinator{T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,TResult}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest16Coordinator{T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,TResult}.cs
@@ -24,7 +24,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 /// <typeparam name="T15">Element type of source 15.</typeparam>
 /// <typeparam name="T16">Element type of source 16.</typeparam>
 /// <typeparam name="TResult">The projected element type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value16 = {Value16}")]
+[System.Diagnostics.DebuggerDisplay("SyncLatest16Coordinator: Value1 = {Value1}, Value16 = {Value16}")]
 public sealed class SyncLatest16Coordinator<
     T1,
     T2,

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest16Signal{T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,TResult}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest16Signal{T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,TResult}.cs
@@ -22,7 +22,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 /// <typeparam name="T15">Element type of source 15.</typeparam>
 /// <typeparam name="T16">Element type of source 16.</typeparam>
 /// <typeparam name="TResult">The projected element type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+[System.Diagnostics.DebuggerDisplay("SyncLatest16Signal: Sources = {Sources}, Selector = {Selector}")]
 public sealed class
     SyncLatest16Signal<
         T1,

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest16State{T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest16State{T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16}.cs
@@ -37,7 +37,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 /// <param name="Source14">Source observable 14.</param>
 /// <param name="Source15">Source observable 15.</param>
 /// <param name="Source16">Source observable 16.</param>
-[System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source16 = {Source16}")]
+[System.Diagnostics.DebuggerDisplay("SyncLatest16State: Source1 = {Source1}, Source16 = {Source16}")]
 public readonly record struct SyncLatest16State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(
     IObservableAsync<T1> Source1,
     IObservableAsync<T2> Source2,

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest2Coordinator{T1,T2,TResult}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest2Coordinator{T1,T2,TResult}.cs
@@ -8,7 +8,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 /// <typeparam name="T1">Element type of source 1.</typeparam>
 /// <typeparam name="T2">Element type of source 2.</typeparam>
 /// <typeparam name="TResult">The projected element type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+[System.Diagnostics.DebuggerDisplay("SyncLatest2Coordinator: Sources = {Sources}, Selector = {Selector}")]
 public sealed class SyncLatest2Coordinator<T1, T2, TResult> : SyncLatestCoordinatorBase<TResult>
 {
     /// <summary>Number of upstream sources this coordinator combines.</summary>

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest2Signal{T1,T2,TResult}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest2Signal{T1,T2,TResult}.cs
@@ -8,7 +8,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 /// <typeparam name="T1">Element type of source 1.</typeparam>
 /// <typeparam name="T2">Element type of source 2.</typeparam>
 /// <typeparam name="TResult">The projected element type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+[System.Diagnostics.DebuggerDisplay("SyncLatest2Signal: Sources = {Sources}, Selector = {Selector}")]
 public sealed class SyncLatest2Signal<T1, T2, TResult> : IObservableAsync<TResult>
 {
     /// <summary>Initializes a new instance of the <see cref="SyncLatest2Signal{T1, T2, TResult}"/> class.</summary>

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest2State{T1,T2}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest2State{T1,T2}.cs
@@ -9,7 +9,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 /// <typeparam name="T2">Element type of source 2.</typeparam>
 /// <param name="Source1">Source observable 1.</param>
 /// <param name="Source2">Source observable 2.</param>
-[System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source2 = {Source2}")]
+[System.Diagnostics.DebuggerDisplay("SyncLatest2State: Source1 = {Source1}, Source2 = {Source2}")]
 public readonly record struct SyncLatest2State<T1, T2>(
     IObservableAsync<T1> Source1,
     IObservableAsync<T2> Source2);

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest3Coordinator{T1,T2,T3,TResult}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest3Coordinator{T1,T2,T3,TResult}.cs
@@ -9,7 +9,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 /// <typeparam name="T2">Element type of source 2.</typeparam>
 /// <typeparam name="T3">Element type of source 3.</typeparam>
 /// <typeparam name="TResult">The projected element type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value3 = {Value3}")]
+[System.Diagnostics.DebuggerDisplay("SyncLatest3Coordinator: Value1 = {Value1}, Value3 = {Value3}")]
 public sealed class SyncLatest3Coordinator<T1, T2, T3, TResult> : SyncLatestCoordinatorBase<TResult>
 {
     /// <summary>Number of upstream sources this coordinator combines.</summary>

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest3Signal{T1,T2,T3,TResult}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest3Signal{T1,T2,T3,TResult}.cs
@@ -9,7 +9,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 /// <typeparam name="T2">Element type of source 2.</typeparam>
 /// <typeparam name="T3">Element type of source 3.</typeparam>
 /// <typeparam name="TResult">The projected element type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+[System.Diagnostics.DebuggerDisplay("SyncLatest3Signal: Sources = {Sources}, Selector = {Selector}")]
 public sealed class SyncLatest3Signal<T1, T2, T3, TResult> : IObservableAsync<TResult>
 {
     /// <summary>Initializes a new instance of the <see cref="SyncLatest3Signal{T1, T2, T3, TResult}"/> class.</summary>

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest3State{T1,T2,T3}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest3State{T1,T2,T3}.cs
@@ -11,7 +11,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 /// <param name="Source1">Source observable 1.</param>
 /// <param name="Source2">Source observable 2.</param>
 /// <param name="Source3">Source observable 3.</param>
-[System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source2 = {Source2}, Source3 = {Source3}")]
+[System.Diagnostics.DebuggerDisplay("SyncLatest3State: Source1 = {Source1}, Source2 = {Source2}, Source3 = {Source3}")]
 public readonly record struct SyncLatest3State<T1, T2, T3>(
     IObservableAsync<T1> Source1,
     IObservableAsync<T2> Source2,

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest4Coordinator{T1,T2,T3,T4,TResult}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest4Coordinator{T1,T2,T3,T4,TResult}.cs
@@ -10,7 +10,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 /// <typeparam name="T3">Element type of source 3.</typeparam>
 /// <typeparam name="T4">Element type of source 4.</typeparam>
 /// <typeparam name="TResult">The projected element type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value4 = {Value4}")]
+[System.Diagnostics.DebuggerDisplay("SyncLatest4Coordinator: Value1 = {Value1}, Value4 = {Value4}")]
 public sealed class SyncLatest4Coordinator<T1, T2, T3, T4, TResult> : SyncLatestCoordinatorBase<TResult>
 {
     /// <summary>Number of upstream sources this coordinator combines.</summary>

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest4Signal{T1,T2,T3,T4,TResult}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest4Signal{T1,T2,T3,T4,TResult}.cs
@@ -10,7 +10,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 /// <typeparam name="T3">Element type of source 3.</typeparam>
 /// <typeparam name="T4">Element type of source 4.</typeparam>
 /// <typeparam name="TResult">The projected element type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+[System.Diagnostics.DebuggerDisplay("SyncLatest4Signal: Sources = {Sources}, Selector = {Selector}")]
 public sealed class SyncLatest4Signal<T1, T2, T3, T4, TResult> : IObservableAsync<TResult>
 {
     /// <summary>Initializes a new instance of the <see cref="SyncLatest4Signal{T1, T2, T3, T4, TResult}"/> class.</summary>

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest4State{T1,T2,T3,T4}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest4State{T1,T2,T3,T4}.cs
@@ -13,7 +13,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 /// <param name="Source2">Source observable 2.</param>
 /// <param name="Source3">Source observable 3.</param>
 /// <param name="Source4">Source observable 4.</param>
-[System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source2 = {Source2}, Source3 = {Source3}, Source4 = {Source4}")]
+[System.Diagnostics.DebuggerDisplay("SyncLatest4State: Source1 = {Source1}, Source2 = {Source2}, Source3 = {Source3}, Source4 = {Source4}")]
 public readonly record struct SyncLatest4State<T1, T2, T3, T4>(
     IObservableAsync<T1> Source1,
     IObservableAsync<T2> Source2,

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest5Coordinator{T1,T2,T3,T4,T5,TResult}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest5Coordinator{T1,T2,T3,T4,T5,TResult}.cs
@@ -11,7 +11,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 /// <typeparam name="T4">Element type of source 4.</typeparam>
 /// <typeparam name="T5">Element type of source 5.</typeparam>
 /// <typeparam name="TResult">The projected element type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value5 = {Value5}")]
+[System.Diagnostics.DebuggerDisplay("SyncLatest5Coordinator: Value1 = {Value1}, Value5 = {Value5}")]
 public sealed class SyncLatest5Coordinator<T1, T2, T3, T4, T5, TResult> : SyncLatestCoordinatorBase<TResult>
 {
     /// <summary>Number of upstream sources this coordinator combines.</summary>

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest5Signal{T1,T2,T3,T4,T5,TResult}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest5Signal{T1,T2,T3,T4,T5,TResult}.cs
@@ -11,7 +11,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 /// <typeparam name="T4">Element type of source 4.</typeparam>
 /// <typeparam name="T5">Element type of source 5.</typeparam>
 /// <typeparam name="TResult">The projected element type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+[System.Diagnostics.DebuggerDisplay("SyncLatest5Signal: Sources = {Sources}, Selector = {Selector}")]
 public sealed class SyncLatest5Signal<T1, T2, T3, T4, T5, TResult> : IObservableAsync<TResult>
 {
     /// <summary>Initializes a new instance of the <see cref="SyncLatest5Signal{T1, T2, T3, T4, T5, TResult}"/> class.</summary>

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest5State{T1,T2,T3,T4,T5}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest5State{T1,T2,T3,T4,T5}.cs
@@ -15,7 +15,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 /// <param name="Source3">Source observable 3.</param>
 /// <param name="Source4">Source observable 4.</param>
 /// <param name="Source5">Source observable 5.</param>
-[System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source5 = {Source5}")]
+[System.Diagnostics.DebuggerDisplay("SyncLatest5State: Source1 = {Source1}, Source5 = {Source5}")]
 public readonly record struct SyncLatest5State<T1, T2, T3, T4, T5>(
     IObservableAsync<T1> Source1,
     IObservableAsync<T2> Source2,

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest6Coordinator{T1,T2,T3,T4,T5,T6,TResult}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest6Coordinator{T1,T2,T3,T4,T5,T6,TResult}.cs
@@ -12,7 +12,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 /// <typeparam name="T5">Element type of source 5.</typeparam>
 /// <typeparam name="T6">Element type of source 6.</typeparam>
 /// <typeparam name="TResult">The projected element type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value6 = {Value6}")]
+[System.Diagnostics.DebuggerDisplay("SyncLatest6Coordinator: Value1 = {Value1}, Value6 = {Value6}")]
 public sealed class SyncLatest6Coordinator<T1, T2, T3, T4, T5, T6, TResult> : SyncLatestCoordinatorBase<TResult>
 {
     /// <summary>Number of upstream sources this coordinator combines.</summary>

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest6Signal{T1,T2,T3,T4,T5,T6,TResult}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest6Signal{T1,T2,T3,T4,T5,T6,TResult}.cs
@@ -12,7 +12,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 /// <typeparam name="T5">Element type of source 5.</typeparam>
 /// <typeparam name="T6">Element type of source 6.</typeparam>
 /// <typeparam name="TResult">The projected element type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+[System.Diagnostics.DebuggerDisplay("SyncLatest6Signal: Sources = {Sources}, Selector = {Selector}")]
 public sealed class SyncLatest6Signal<T1, T2, T3, T4, T5, T6, TResult> : IObservableAsync<TResult>
 {
     /// <summary>Initializes a new instance of the <see cref="SyncLatest6Signal{T1, T2, T3, T4, T5, T6, TResult}"/> class.</summary>

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest6State{T1,T2,T3,T4,T5,T6}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest6State{T1,T2,T3,T4,T5,T6}.cs
@@ -17,7 +17,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 /// <param name="Source4">Source observable 4.</param>
 /// <param name="Source5">Source observable 5.</param>
 /// <param name="Source6">Source observable 6.</param>
-[System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source6 = {Source6}")]
+[System.Diagnostics.DebuggerDisplay("SyncLatest6State: Source1 = {Source1}, Source6 = {Source6}")]
 public readonly record struct SyncLatest6State<T1, T2, T3, T4, T5, T6>(
     IObservableAsync<T1> Source1,
     IObservableAsync<T2> Source2,

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest7Coordinator{T1,T2,T3,T4,T5,T6,T7,TResult}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest7Coordinator{T1,T2,T3,T4,T5,T6,T7,TResult}.cs
@@ -13,7 +13,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 /// <typeparam name="T6">Element type of source 6.</typeparam>
 /// <typeparam name="T7">Element type of source 7.</typeparam>
 /// <typeparam name="TResult">The projected element type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+[System.Diagnostics.DebuggerDisplay("SyncLatest7Coordinator: Sources = {Sources}, Selector = {Selector}")]
 public sealed class SyncLatest7Coordinator<T1, T2, T3, T4, T5, T6, T7, TResult> : SyncLatestCoordinatorBase<TResult>
 {
     /// <summary>Number of upstream sources this coordinator combines.</summary>

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest7Signal{T1,T2,T3,T4,T5,T6,T7,TResult}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest7Signal{T1,T2,T3,T4,T5,T6,T7,TResult}.cs
@@ -13,7 +13,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 /// <typeparam name="T6">Element type of source 6.</typeparam>
 /// <typeparam name="T7">Element type of source 7.</typeparam>
 /// <typeparam name="TResult">The projected element type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+[System.Diagnostics.DebuggerDisplay("SyncLatest7Signal: Sources = {Sources}, Selector = {Selector}")]
 public sealed class SyncLatest7Signal<T1, T2, T3, T4, T5, T6, T7, TResult> : IObservableAsync<TResult>
 {
     /// <summary>Initializes a new instance of the <see cref="SyncLatest7Signal{T1, T2, T3, T4, T5, T6, T7, TResult}"/> class.</summary>

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest7State{T1,T2,T3,T4,T5,T6,T7}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest7State{T1,T2,T3,T4,T5,T6,T7}.cs
@@ -19,7 +19,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 /// <param name="Source5">Source observable 5.</param>
 /// <param name="Source6">Source observable 6.</param>
 /// <param name="Source7">Source observable 7.</param>
-[System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source7 = {Source7}")]
+[System.Diagnostics.DebuggerDisplay("SyncLatest7State: Source1 = {Source1}, Source7 = {Source7}")]
 public readonly record struct SyncLatest7State<T1, T2, T3, T4, T5, T6, T7>(
     IObservableAsync<T1> Source1,
     IObservableAsync<T2> Source2,

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest8Coordinator{T1,T2,T3,T4,T5,T6,T7,T8,TResult}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest8Coordinator{T1,T2,T3,T4,T5,T6,T7,T8,TResult}.cs
@@ -14,7 +14,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 /// <typeparam name="T7">Element type of source 7.</typeparam>
 /// <typeparam name="T8">Element type of source 8.</typeparam>
 /// <typeparam name="TResult">The projected element type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+[System.Diagnostics.DebuggerDisplay("SyncLatest8Coordinator: Sources = {Sources}, Selector = {Selector}")]
 public sealed class SyncLatest8Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, TResult> : SyncLatestCoordinatorBase<TResult>
 {
     /// <summary>Number of upstream sources this coordinator combines.</summary>

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest8Signal{T1,T2,T3,T4,T5,T6,T7,T8,TResult}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest8Signal{T1,T2,T3,T4,T5,T6,T7,T8,TResult}.cs
@@ -14,7 +14,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 /// <typeparam name="T7">Element type of source 7.</typeparam>
 /// <typeparam name="T8">Element type of source 8.</typeparam>
 /// <typeparam name="TResult">The projected element type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+[System.Diagnostics.DebuggerDisplay("SyncLatest8Signal: Sources = {Sources}, Selector = {Selector}")]
 public sealed class SyncLatest8Signal<T1, T2, T3, T4, T5, T6, T7, T8, TResult> : IObservableAsync<TResult>
 {
     /// <summary>Initializes a new instance of the <see cref="SyncLatest8Signal{T1, T2, T3, T4, T5, T6, T7, T8, TResult}"/> class.</summary>

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest8State{T1,T2,T3,T4,T5,T6,T7,T8}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest8State{T1,T2,T3,T4,T5,T6,T7,T8}.cs
@@ -21,7 +21,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 /// <param name="Source6">Source observable 6.</param>
 /// <param name="Source7">Source observable 7.</param>
 /// <param name="Source8">Source observable 8.</param>
-[System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source8 = {Source8}")]
+[System.Diagnostics.DebuggerDisplay("SyncLatest8State: Source1 = {Source1}, Source8 = {Source8}")]
 public readonly record struct SyncLatest8State<T1, T2, T3, T4, T5, T6, T7, T8>(
     IObservableAsync<T1> Source1,
     IObservableAsync<T2> Source2,

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest9Coordinator{T1,T2,T3,T4,T5,T6,T7,T8,T9,TResult}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest9Coordinator{T1,T2,T3,T4,T5,T6,T7,T8,T9,TResult}.cs
@@ -15,7 +15,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 /// <typeparam name="T8">Element type of source 8.</typeparam>
 /// <typeparam name="T9">Element type of source 9.</typeparam>
 /// <typeparam name="TResult">The projected element type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value9 = {Value9}")]
+[System.Diagnostics.DebuggerDisplay("SyncLatest9Coordinator: Value1 = {Value1}, Value9 = {Value9}")]
 public sealed class
     SyncLatest9Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> : SyncLatestCoordinatorBase<TResult>
 {

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest9Signal{T1,T2,T3,T4,T5,T6,T7,T8,T9,TResult}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest9Signal{T1,T2,T3,T4,T5,T6,T7,T8,T9,TResult}.cs
@@ -15,7 +15,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 /// <typeparam name="T8">Element type of source 8.</typeparam>
 /// <typeparam name="T9">Element type of source 9.</typeparam>
 /// <typeparam name="TResult">The projected element type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+[System.Diagnostics.DebuggerDisplay("SyncLatest9Signal: Sources = {Sources}, Selector = {Selector}")]
 public sealed class SyncLatest9Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> : IObservableAsync<TResult>
 {
     /// <summary>Initializes a new instance of the <see cref="SyncLatest9Signal{T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult}"/> class.</summary>

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest9State{T1,T2,T3,T4,T5,T6,T7,T8,T9}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatest9State{T1,T2,T3,T4,T5,T6,T7,T8,T9}.cs
@@ -23,7 +23,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 /// <param name="Source7">Source observable 7.</param>
 /// <param name="Source8">Source observable 8.</param>
 /// <param name="Source9">Source observable 9.</param>
-[System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source9 = {Source9}")]
+[System.Diagnostics.DebuggerDisplay("SyncLatest9State: Source1 = {Source1}, Source9 = {Source9}")]
 public readonly record struct SyncLatest9State<T1, T2, T3, T4, T5, T6, T7, T8, T9>(
     IObservableAsync<T1> Source1,
     IObservableAsync<T2> Source2,

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatestCoordinatorBase.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatestCoordinatorBase.cs
@@ -12,7 +12,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 /// <see cref="DisposeAsync"/> live here once instead of repeated 15× across <c>CombineLatest2..16</c>.
 /// </summary>
 /// <typeparam name="TResult">The downstream element type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("SourceCount = {Lifecycle.Subscriptions.Length}, HasDisposed = {Lifecycle.HasDisposed}")]
+[System.Diagnostics.DebuggerDisplay("SyncLatestCoordinatorBase: SourceCount = {Lifecycle.Subscriptions.Length}, HasDisposed = {Lifecycle.HasDisposed}")]
 public abstract class SyncLatestCoordinatorBase<TResult> : IAsyncDisposable
 {
     /// <summary>Initializes a new instance of the <see cref="SyncLatestCoordinatorBase{TResult}"/> class.</summary>

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatestEnumerableCoordinator{TSource,TResult}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatestEnumerableCoordinator{TSource,TResult}.cs
@@ -10,7 +10,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 /// <summary>Coordinates subscriptions and projected snapshot emission for enumerable <c>SyncLatest</c> sources.</summary>
 /// <typeparam name="TSource">The source element type.</typeparam>
 /// <typeparam name="TResult">The projected result type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Sources = {Sources.Length}, Completed = {_completedCount}, Disposed = {_disposed}")]
+[System.Diagnostics.DebuggerDisplay("SyncLatestEnumerableCoordinator: Sources = {Sources.Length}, Completed = {_completedCount}, Disposed = {_disposed}")]
 public sealed class SyncLatestEnumerableCoordinator<TSource, TResult> : IAsyncDisposable
 {
     /// <summary>Synchronization gate.</summary>

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatestEnumerableSignal{TSource,TResult}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatestEnumerableSignal{TSource,TResult}.cs
@@ -9,7 +9,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 /// <summary>Async observable that combines latest values from an enumerable of sources and projects through a selector.</summary>
 /// <typeparam name="TSource">The source element type.</typeparam>
 /// <typeparam name="TResult">The projected result type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("SourceCount = {Sources.Length}")]
+[System.Diagnostics.DebuggerDisplay("SyncLatestEnumerableSignal: SourceCount = {Sources.Length}")]
 public sealed class SyncLatestEnumerableSignal<TSource, TResult> : IObservableAsync<TResult>
 {
     /// <summary>Initializes a new instance of the <see cref="SyncLatestEnumerableSignal{TSource, TResult}"/> class.</summary>

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatestEnumerableWitness{TSource,TResult}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatestEnumerableWitness{TSource,TResult}.cs
@@ -9,7 +9,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 /// <summary>Per-source observer for enumerable <c>SyncLatest</c> sources.</summary>
 /// <typeparam name="TSource">The source element type.</typeparam>
 /// <typeparam name="TResult">The downstream element type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Index = {Index}, Parent = {Parent}")]
+[System.Diagnostics.DebuggerDisplay("SyncLatestEnumerableWitness: Index = {Index}, Parent = {Parent}")]
 public sealed class SyncLatestEnumerableWitness<TSource, TResult> : IObserverAsync<TSource>
 {
     /// <summary>Initializes a new instance of the <see cref="SyncLatestEnumerableWitness{TSource, TResult}"/> class.</summary>

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatestLifecycle.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/SyncLatestLifecycle.cs
@@ -14,7 +14,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 /// fan-out, completion-bitmask handling) lives in one place.
 /// </summary>
 /// <typeparam name="TResult">The downstream element type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("SourceCount = {Subscriptions.Length}, HasDisposed = {HasDisposed}")]
+[System.Diagnostics.DebuggerDisplay("SyncLatestLifecycle: SourceCount = {Subscriptions.Length}, HasDisposed = {HasDisposed}")]
 public sealed class SyncLatestLifecycle<TResult> : IAsyncDisposable
 {
     /// <summary>Serializes downstream notifications so OnNext / OnError / OnCompleted never overlap.</summary>

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/TakeUntilLifecycle.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/TakeUntilLifecycle.cs
@@ -13,7 +13,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 /// in one place.
 /// </summary>
 /// <typeparam name="T">The downstream element type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Observer = {_observer}, DisposeRequested = {DisposeToken.IsCancellationRequested}")]
+[System.Diagnostics.DebuggerDisplay("TakeUntilLifecycle: Observer = {_observer}, DisposeRequested = {DisposeToken.IsCancellationRequested}")]
 public sealed class TakeUntilLifecycle<T> : IAsyncDisposable
 {
     /// <summary>Cancellation source for subscription disposal; cancelled exactly once.</summary>

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/TaskResultCompletionSource.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/TaskResultCompletionSource.cs
@@ -9,7 +9,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 /// <summary>Coordinates task completion for terminal observers and disposes the owning subscription when complete.</summary>
 /// <typeparam name="T">The result value type.</typeparam>
 /// <param name="cancellationToken">The cancellation token that can cancel the pending result.</param>
-[System.Diagnostics.DebuggerDisplay("IsCompleted = {_taskSource.Task.IsCompleted}")]
+[System.Diagnostics.DebuggerDisplay("TaskResultCompletionSource: IsCompleted = {_taskSource.Task.IsCompleted}")]
 public sealed class TaskResultCompletionSource<T>(CancellationToken cancellationToken)
 {
     /// <summary>The task completion source used to publish the terminal result.</summary>

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/TaskResultSignal{T}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/TaskResultSignal{T}.cs
@@ -6,7 +6,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 
 /// <summary>An observable that emits the result of a task for each subscription.</summary>
 /// <typeparam name="T">The task result type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Task = {Task}")]
+[System.Diagnostics.DebuggerDisplay("TaskResultSignal: Task = {Task}")]
 public sealed class TaskResultSignal<T> : IObservableAsync<T>
 {
     /// <summary>Initializes a new instance of the <see cref="TaskResultSignal{T}"/> class.</summary>

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/TaskResultSubscription{T}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/TaskResultSubscription{T}.cs
@@ -6,7 +6,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 
 /// <summary>A subscription that awaits a task and emits its result.</summary>
 /// <typeparam name="T">The task result type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Task = {Task}")]
+[System.Diagnostics.DebuggerDisplay("TaskResultSubscription: Task = {Task}")]
 public sealed class TaskResultSubscription<T> : TaskSignalSubscription<T>
 {
     /// <summary>Initializes a new instance of the <see cref="TaskResultSubscription{T}"/> class.</summary>

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/TaskResultWitnessAsyncBase.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/TaskResultWitnessAsyncBase.cs
@@ -11,7 +11,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 /// <typeparam name="T">The type of elements received from the observable sequence.</typeparam>
 /// <typeparam name="TTaskValue">The type of the result value produced by this witness.</typeparam>
 /// <param name="cancellationToken">A cancellation token used to cancel the waiting operation.</param>
-[System.Diagnostics.DebuggerDisplay("Completion = {_completion}")]
+[System.Diagnostics.DebuggerDisplay("TaskResultWitnessAsyncBase: Completion = {_completion}")]
 public abstract class TaskResultWitnessAsyncBase<T, TTaskValue>(CancellationToken cancellationToken) : WitnessAsync<T>
 {
     /// <summary>The completion helper used to produce and cancel the observer's single result value.</summary>

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/TaskSignalSubscription{T}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/TaskSignalSubscription{T}.cs
@@ -14,7 +14,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 /// subscriptions that coordinate observer notifications and resource cleanup. Disposal cancels any ongoing
 /// operations and ensures that all resources are released before completion. Derived classes should implement the
 /// core execution logic in <see cref="ExecuteAsyncCore"/>.</remarks>
-[System.Diagnostics.DebuggerDisplay("Disposed = {_disposed}, Completed = {_tcs.Task.IsCompleted}")]
+[System.Diagnostics.DebuggerDisplay("TaskSignalSubscription: Disposed = {_disposed}, Completed = {_tcs.Task.IsCompleted}")]
 public abstract class TaskSignalSubscription<T>(IObserverAsync<T> observer) : IAsyncDisposable
 {
     /// <summary>The task completion source used to signal when the subscription's asynchronous operation has finished.</summary>

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/TimerSignal.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/TimerSignal.cs
@@ -5,7 +5,7 @@
 namespace ReactiveUI.Primitives.Async.Advanced;
 
 /// <summary>An observable that emits one or more timer ticks.</summary>
-[System.Diagnostics.DebuggerDisplay("DueTime = {DueTime}, Period = {Period}")]
+[System.Diagnostics.DebuggerDisplay("TimerSignal: DueTime = {DueTime}, Period = {Period}")]
 public sealed class TimerSignal : IObservableAsync<long>
 {
     /// <summary>Initializes a new instance of the <see cref="TimerSignal"/> class.</summary>

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/TimerSubscription.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/TimerSubscription.cs
@@ -5,7 +5,7 @@
 namespace ReactiveUI.Primitives.Async.Advanced;
 
 /// <summary>A subscription that emits one or more timer ticks.</summary>
-[System.Diagnostics.DebuggerDisplay("DueTime = {DueTime}, Period = {Period}")]
+[System.Diagnostics.DebuggerDisplay("TimerSubscription: DueTime = {DueTime}, Period = {Period}")]
 public sealed class TimerSubscription : TaskSignalSubscription<long>
 {
     /// <summary>Initializes a new instance of the <see cref="TimerSubscription"/> class.</summary>

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/UsingSignal{TResource,T}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/UsingSignal{TResource,T}.cs
@@ -7,7 +7,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 /// <summary>An observable that creates and disposes an asynchronous resource for each subscription.</summary>
 /// <typeparam name="TResource">The resource type.</typeparam>
 /// <typeparam name="T">The element type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("ResourceFactory = {ResourceFactory}, SignalFactory = {SignalFactory}")]
+[System.Diagnostics.DebuggerDisplay("UsingSignal: ResourceFactory = {ResourceFactory}, SignalFactory = {SignalFactory}")]
 public sealed class UsingSignal<TResource, T> : IObservableAsync<T>
     where TResource : IAsyncDisposable
 {

--- a/src/ReactiveUI.Primitives.Async.Core/Advanced/UsingWitness{TResource,T}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Advanced/UsingWitness{TResource,T}.cs
@@ -7,7 +7,7 @@ namespace ReactiveUI.Primitives.Async.Advanced;
 /// <summary>Observer that disposes a resource with the source subscription.</summary>
 /// <typeparam name="TResource">The resource type.</typeparam>
 /// <typeparam name="T">The element type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Resource = {Resource}")]
+[System.Diagnostics.DebuggerDisplay("UsingWitness: Resource = {Resource}")]
 public sealed class UsingWitness<TResource, T> : ForwardingWitnessAsync<T>
     where TResource : IAsyncDisposable
 {

--- a/src/ReactiveUI.Primitives.Async.Core/ConnectableSignalAsync.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/ConnectableSignalAsync.cs
@@ -17,7 +17,7 @@ namespace ReactiveUI.Primitives.Async;
 /// be useful for sharing a single subscription among multiple observers or for deferring the start of data emission
 /// until explicitly connected. Implementations may vary in how connections are managed and whether multiple connections
 /// are supported concurrently.</remarks>
-[System.Diagnostics.DebuggerDisplay("State = {State}")]
+[System.Diagnostics.DebuggerDisplay("ConnectableSignalAsync: State = {State}")]
 public sealed class ConnectableSignalAsync<T> : IObservableAsync<T>, IDisposable
 {
     /// <summary>Initializes a new instance of the <see cref="ConnectableSignalAsync{T}"/> class.</summary>

--- a/src/ReactiveUI.Primitives.Async.Core/Disposables/MultipleDisposableAsync.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Disposables/MultipleDisposableAsync.cs
@@ -13,7 +13,7 @@ namespace ReactiveUI.Primitives.Async.Disposables;
 /// <remarks>Use this class to manage the lifetime of multiple <see cref="IAsyncDisposable"/> resources, ensuring
 /// that all are disposed when the collection is disposed. Once disposed, the collection cannot be used to add or remove
 /// items. This class is not read-only and is safe for concurrent access from multiple threads.</remarks>
-[System.Diagnostics.DebuggerDisplay("Count = {_count}, IsDisposed = {_isDisposed}")]
+[System.Diagnostics.DebuggerDisplay("MultipleDisposableAsync: Count = {_count}, IsDisposed = {_isDisposed}")]
 public sealed class MultipleDisposableAsync : IAsyncDisposable
 {
     /// <summary>Capacity allocated on first <see cref="AddAsync"/>. Chosen as the typical upper bound

--- a/src/ReactiveUI.Primitives.Async.Core/Disposables/SingleAssignmentDisposableAsync.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Disposables/SingleAssignmentDisposableAsync.cs
@@ -15,7 +15,7 @@ namespace ReactiveUI.Primitives.Async.Disposables;
 /// once, and where disposal may occur before or after the assignment. If disposed before assignment, any subsequently
 /// assigned resource will be disposed immediately. This class is not thread-safe for concurrent assignment and
 /// disposal; external synchronization is required if used from multiple threads.</remarks>
-[System.Diagnostics.DebuggerDisplay("IsDisposed = {IsDisposed}, Current = {_current}")]
+[System.Diagnostics.DebuggerDisplay("SingleAssignmentDisposableAsync: IsDisposed = {IsDisposed}, Current = {_current}")]
 public sealed class SingleAssignmentDisposableAsync : IAsyncDisposable
 {
     /// <summary>The currently assigned disposable resource, or the disposed sentinel if already disposed.</summary>

--- a/src/ReactiveUI.Primitives.Async.Core/Disposables/SingleReplaceableDisposableAsync.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Disposables/SingleReplaceableDisposableAsync.cs
@@ -15,7 +15,7 @@ namespace ReactiveUI.Primitives.Async.Disposables;
 /// further disposables from being set. This class is useful for scenarios where a resource needs to be replaced or
 /// updated over time, ensuring that only one resource is active and properly disposed of at any given moment. All
 /// operations are safe to use concurrently from multiple threads.</remarks>
-[System.Diagnostics.DebuggerDisplay("Current = {_current}")]
+[System.Diagnostics.DebuggerDisplay("SingleReplaceableDisposableAsync: Current = {_current}")]
 public class SingleReplaceableDisposableAsync : IAsyncDisposable
 {
     /// <summary>The currently tracked disposable resource, or the disposed sentinel if already disposed.</summary>

--- a/src/ReactiveUI.Primitives.Async.Core/Operators/ChainEnumerableSignal{T}.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Operators/ChainEnumerableSignal{T}.cs
@@ -18,7 +18,7 @@ namespace ReactiveUI.Primitives.Async;
 /// from each source are emitted in order and that subsequent observables are not subscribed to until the preceding one
 /// has completed. If any observable in the sequence signals an error, the concatenation terminates and the error is
 /// propagated to the observer.</remarks>
-[System.Diagnostics.DebuggerDisplay("Signals = {_signals}")]
+[System.Diagnostics.DebuggerDisplay("ChainEnumerableSignal: Signals = {_signals}")]
 public sealed class ChainEnumerableSignal<T>(IEnumerable<IObservableAsync<T>> signals) : IObservableAsync<T>
 {
     /// <summary>The enumerable collection of signal sequences to concatenate.</summary>

--- a/src/ReactiveUI.Primitives.Async.Core/Operators/GroupedAsyncSignal.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Operators/GroupedAsyncSignal.cs
@@ -12,7 +12,7 @@ namespace ReactiveUI.Primitives.Async;
 /// <typeparam name="TValue">The type of the elements contained in the grouped observable sequence.</typeparam>
 /// <remarks>Each instance corresponds to a group within the parent observable, identified by its key. Observers
 /// can subscribe to receive elements belonging to the group associated with the specified key.</remarks>
-[System.Diagnostics.DebuggerDisplay("Key = {Key}")]
+[System.Diagnostics.DebuggerDisplay("GroupedAsyncSignal: Key = {Key}")]
 public sealed class GroupedAsyncSignal<TKey, TValue> : IObservableAsync<TValue>
 {
     /// <summary>Initializes a new instance of the <see cref="GroupedAsyncSignal{TKey,TValue}"/> class.</summary>

--- a/src/ReactiveUI.Primitives.Async.Core/Operators/TakeUntilOptions.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Operators/TakeUntilOptions.cs
@@ -7,7 +7,7 @@ namespace ReactiveUI.Primitives.Async;
 /// <summary>Provides configuration options for controlling the behavior of the TakeUntil operator.</summary>
 /// <remarks>This type allows customization of how the source sequence responds to failures in the 'other'
 /// sequence when using TakeUntil. It is immutable and thread-safe.</remarks>
-[System.Diagnostics.DebuggerDisplay("SourceFailsWhenOtherFails = {SourceFailsWhenOtherFails}")]
+[System.Diagnostics.DebuggerDisplay("TakeUntilOptions: SourceFailsWhenOtherFails = {SourceFailsWhenOtherFails}")]
 public sealed record TakeUntilOptions
 {
     /// <summary>Gets the default configuration options for the TakeUntil operation.</summary>

--- a/src/ReactiveUI.Primitives.Async.Core/PublicAPI/net10.0/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Async.Core/PublicAPI/net10.0/PublicAPI.txt
@@ -3,7 +3,7 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Primitives.Tests")]
 namespace ReactiveUI.Primitives.Async
 {
-    [System.Diagnostics.DebuggerDisplay("Signals = {_signals}")]
+    [System.Diagnostics.DebuggerDisplay("ChainEnumerableSignal: Signals = {_signals}")]
     public sealed class ChainEnumerableSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public ChainEnumerableSignal(System.Collections.Generic.IEnumerable<ReactiveUI.Primitives.Async.IObservableAsync<T>> signals) { }
@@ -22,7 +22,7 @@ namespace ReactiveUI.Primitives.Async
         public ConcurrentWitnessCallsException(string message) { }
         public ConcurrentWitnessCallsException(string message, System.Exception innerException) { }
     }
-    [System.Diagnostics.DebuggerDisplay("State = {State}")]
+    [System.Diagnostics.DebuggerDisplay("ConnectableSignalAsync: State = {State}")]
     public sealed class ConnectableSignalAsync<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>, System.IDisposable
     {
         public ConnectableSignalAsync(ReactiveUI.Primitives.Async.IObservableAsync<T> source, ReactiveUI.Primitives.Async.Signals.ISignalAsync<T> signal) { }
@@ -40,7 +40,7 @@ namespace ReactiveUI.Primitives.Async
             public System.IAsyncDisposable ToDisposableAsync() { }
         }
     }
-    [System.Diagnostics.DebuggerDisplay("Key = {Key}")]
+    [System.Diagnostics.DebuggerDisplay("GroupedAsyncSignal: Key = {Key}")]
     public sealed class GroupedAsyncSignal<TKey, TValue> : ReactiveUI.Primitives.Async.IObservableAsync<TValue>
     {
         public TKey Key { get; }
@@ -825,7 +825,7 @@ namespace ReactiveUI.Primitives.Async
         public SwitchToSignal(ReactiveUI.Primitives.Async.IObservableAsync<ReactiveUI.Primitives.Async.IObservableAsync<T>> source) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceFailsWhenOtherFails = {SourceFailsWhenOtherFails}")]
+    [System.Diagnostics.DebuggerDisplay("TakeUntilOptions: SourceFailsWhenOtherFails = {SourceFailsWhenOtherFails}")]
     public record TakeUntilOptions : System.IEquatable<ReactiveUI.Primitives.Async.TakeUntilOptions>
     {
         public bool SourceFailsWhenOtherFails { get; init; }
@@ -835,7 +835,7 @@ namespace ReactiveUI.Primitives.Async
     {
         public static void Register(System.Action<System.Exception> unhandledExceptionHandler) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Disposed = {_disposed}, CallState = {_callState}")]
+    [System.Diagnostics.DebuggerDisplay("WitnessAsync: Disposed = {_disposed}, CallState = {_callState}")]
     public abstract class WitnessAsync<T> : ReactiveUI.Primitives.Async.Advanced.IReentrantAsyncDisposable, ReactiveUI.Primitives.Async.IObserverAsync<T>
     {
         protected WitnessAsync() { }
@@ -859,19 +859,19 @@ namespace ReactiveUI.Primitives.Async
 }
 namespace ReactiveUI.Primitives.Async.Advanced
 {
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncEnumerableSignal: Source = {Source}")]
     public sealed class AsyncEnumerableSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public AsyncEnumerableSignal(System.Collections.Generic.IAsyncEnumerable<T> source) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncEnumerableSubscription: Source = {Source}")]
     public sealed class AsyncEnumerableSubscription<T> : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<T>
     {
         public AsyncEnumerableSubscription(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Collections.Generic.IAsyncEnumerable<T> source) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("OwnerThreadId = {_ownerThreadId}, Waiters = {_waiters}, RecursionDepth = {_recursionDepth}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncSerialGate: OwnerThreadId = {_ownerThreadId}, Waiters = {_waiters}, RecursionDepth = {_recursionDepth}")]
     public sealed class AsyncSerialGate : System.IDisposable
     {
         public AsyncSerialGate() { }
@@ -879,7 +879,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.Threading.Tasks.ValueTask<ReactiveUI.Primitives.Async.Advanced.AsyncSerialGate.Lease> EnterAsync() { }
         public System.Threading.Tasks.ValueTask<ReactiveUI.Primitives.Async.Advanced.AsyncSerialGate.Lease> EnterAsync(System.Threading.CancellationToken cancellationToken) { }
-        [System.Diagnostics.DebuggerDisplay("Parent = {_parent}")]
+        [System.Diagnostics.DebuggerDisplay("Lease: Parent = {_parent}")]
         public readonly record struct Lease : System.IDisposable, System.IEquatable<ReactiveUI.Primitives.Async.Advanced.AsyncSerialGate.Lease>
         {
             public Lease(ReactiveUI.Primitives.Async.Advanced.AsyncSerialGate parent) { }
@@ -887,13 +887,13 @@ namespace ReactiveUI.Primitives.Async.Advanced
             public readonly void Dispose() { }
         }
     }
-    [System.Diagnostics.DebuggerDisplay("StartSynchronously = {StartSynchronously}, TaskScheduler = {TaskScheduler}")]
+    [System.Diagnostics.DebuggerDisplay("BackgroundJobSignal: StartSynchronously = {StartSynchronously}, TaskScheduler = {TaskScheduler}")]
     public sealed class BackgroundJobSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public BackgroundJobSignal(System.Func<ReactiveUI.Primitives.Async.IObserverAsync<T>, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> job, bool startSynchronously, System.Threading.Tasks.TaskScheduler? taskScheduler) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasDisposed = {HasDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("CallbackWitnessAsync: HasDisposed = {HasDisposed}")]
     public sealed class CallbackWitnessAsync<T> : ReactiveUI.Primitives.Async.WitnessAsync<T>
     {
         public CallbackWitnessAsync(System.Func<T, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> onNextAsync, System.Func<System.Exception, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask>? onErrorResumeAsync = null, System.Func<ReactiveUI.Primitives.Result, System.Threading.Tasks.ValueTask>? onCompletedAsync = null) { }
@@ -901,31 +901,31 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(T value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Action = {Action}")]
+    [System.Diagnostics.DebuggerDisplay("DoOnSubscribeAsyncSignal: Source = {Source}, Action = {Action}")]
     public sealed class DoOnSubscribeAsyncSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public DoOnSubscribeAsyncSignal(ReactiveUI.Primitives.Async.IObservableAsync<T> source, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> action) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Action = {Action}")]
+    [System.Diagnostics.DebuggerDisplay("DoOnSubscribeSignal: Source = {Source}, Action = {Action}")]
     public sealed class DoOnSubscribeSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public DoOnSubscribeSignal(ReactiveUI.Primitives.Async.IObservableAsync<T> source, System.Action action) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("EnumerableSignal: Source = {Source}")]
     public sealed class EnumerableSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public EnumerableSignal(System.Collections.Generic.IEnumerable<T> source) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("EnumerableSubscription: Source = {Source}")]
     public sealed class EnumerableSubscription<T> : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<T>
     {
         public EnumerableSubscription(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Collections.Generic.IEnumerable<T> source) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ActiveInnerCount = {ActiveInnerCount}, OuterCompleted = {OuterCompleted}, Disposed = {Disposed}")]
+    [System.Diagnostics.DebuggerDisplay("FlatMapCoordinator: ActiveInnerCount = {ActiveInnerCount}, OuterCompleted = {OuterCompleted}, Disposed = {Disposed}")]
     public sealed class FlatMapCoordinator<TResult> : System.IAsyncDisposable
     {
         public FlatMapCoordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer) { }
@@ -941,14 +941,14 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public System.Threading.Tasks.ValueTask SetOuterObserverAsync(System.IAsyncDisposable observer) { }
         public System.Threading.Tasks.ValueTask SubscribeInnerAsync(ReactiveUI.Primitives.Async.IObservableAsync<TResult> inner) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, SyncSelector = {SyncSelector}, AsyncSelector = {AsyncSelector}")]
+    [System.Diagnostics.DebuggerDisplay("FlatMapSignal: Source = {Source}, SyncSelector = {SyncSelector}, AsyncSelector = {AsyncSelector}")]
     public sealed class FlatMapSignal<TSource, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public FlatMapSignal(ReactiveUI.Primitives.Async.IObservableAsync<TSource> source, System.Func<TSource, ReactiveUI.Primitives.Async.IObservableAsync<TResult>> selector) { }
         public FlatMapSignal(ReactiveUI.Primitives.Async.IObservableAsync<TSource> source, System.Func<TSource, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<ReactiveUI.Primitives.Async.IObservableAsync<TResult>>> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Coordinator = {Coordinator}")]
+    [System.Diagnostics.DebuggerDisplay("FlatMapWitness: Coordinator = {Coordinator}")]
     public sealed class FlatMapWitness<TResult> : ReactiveUI.Primitives.Async.WitnessAsync<TResult>
     {
         public FlatMapWitness(ReactiveUI.Primitives.Async.Advanced.FlatMapCoordinator<TResult> coordinator) { }
@@ -956,7 +956,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(TResult value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Coordinator = {Coordinator}, SyncSelector = {SyncSelector}, AsyncSelector = {AsyncSelector}")]
+    [System.Diagnostics.DebuggerDisplay("FlatMapWitness: Coordinator = {Coordinator}, SyncSelector = {SyncSelector}, AsyncSelector = {AsyncSelector}")]
     public sealed class FlatMapWitness<TSource, TResult> : ReactiveUI.Primitives.Async.WitnessAsync<TSource>
     {
         public FlatMapWitness(ReactiveUI.Primitives.Async.Advanced.FlatMapCoordinator<TResult> coordinator, System.Func<TSource, ReactiveUI.Primitives.Async.IObservableAsync<TResult>>? syncSelector, System.Func<TSource, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<ReactiveUI.Primitives.Async.IObservableAsync<TResult>>>? asyncSelector) { }
@@ -964,7 +964,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(TSource value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Downstream = {Downstream}")]
+    [System.Diagnostics.DebuggerDisplay("ForwardingWitnessAsync: Downstream = {Downstream}")]
     public class ForwardingWitnessAsync<T> : ReactiveUI.Primitives.Async.WitnessAsync<T>
     {
         protected ForwardingWitnessAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> downstream) { }
@@ -973,13 +973,13 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(T value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Factory = {Factory}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSignal: Factory = {Factory}")]
     public sealed class FromAsyncSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<T>> factory) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Factory = {Factory}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSubscription: Factory = {Factory}")]
     public sealed class FromAsyncSubscription<T> : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<T>
     {
         public FromAsyncSubscription(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<T>> factory) { }
@@ -989,39 +989,39 @@ namespace ReactiveUI.Primitives.Async.Advanced
     {
         System.Threading.Tasks.ValueTask DisposeFromNotificationAsync() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Period = {Period}, TimeProvider = {TimeProvider}")]
+    [System.Diagnostics.DebuggerDisplay("IntervalSignal: Period = {Period}, TimeProvider = {TimeProvider}")]
     public sealed class IntervalSignal : ReactiveUI.Primitives.Async.IObservableAsync<long>
     {
         public IntervalSignal(System.TimeSpan period, System.TimeProvider? timeProvider) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<System.Int64>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<long> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Period = {Period}, TimeProvider = {TimeProvider}")]
+    [System.Diagnostics.DebuggerDisplay("IntervalSubscription: Period = {Period}, TimeProvider = {TimeProvider}")]
     public sealed class IntervalSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<long>
     {
         public IntervalSubscription(ReactiveUI.Primitives.Async.IObserverAsync<long> observer, System.TimeSpan period, System.TimeProvider? timeProvider) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<long> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Values = {Values}")]
+    [System.Diagnostics.DebuggerDisplay("LeadSignal: Source = {Source}, Values = {Values}")]
     public sealed class LeadSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public LeadSignal(ReactiveUI.Primitives.Async.IObservableAsync<T> source, System.Collections.Generic.IEnumerable<T> values) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Disposed = {Disposed}, Pipeline = {Pipeline}")]
+    [System.Diagnostics.DebuggerDisplay("LeadSubscription: Disposed = {Disposed}, Pipeline = {Pipeline}")]
     public sealed class LeadSubscription<T> : System.IAsyncDisposable
     {
         public LeadSubscription(ReactiveUI.Primitives.Async.IObservableAsync<T> source, System.Collections.Generic.IEnumerable<T> values, ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken subscriptionToken) { }
         public System.Threading.Tasks.ValueTask DisposeAsync() { }
         public void Start() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Logger = {Logger}")]
+    [System.Diagnostics.DebuggerDisplay("LogErrorsSignal: Source = {Source}, Logger = {Logger}")]
     public sealed class LogErrorsSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public LogErrorsSignal(ReactiveUI.Primitives.Async.IObservableAsync<T> source, System.Action<System.Exception> logger) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Downstream = {Downstream}, Logger = {Logger}")]
+    [System.Diagnostics.DebuggerDisplay("LogErrorsWitness: Downstream = {Downstream}, Logger = {Logger}")]
     public sealed class LogErrorsWitness<T> : ReactiveUI.Primitives.Async.WitnessAsync<T>
     {
         public LogErrorsWitness(ReactiveUI.Primitives.Async.IObserverAsync<T> downstream, System.Action<System.Exception> logger) { }
@@ -1029,7 +1029,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(T value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {_completed}, Timer = {_timer}")]
+    [System.Diagnostics.DebuggerDisplay("PooledDelaySource: Completed = {_completed}, Timer = {_timer}")]
     public sealed class PooledDelaySource : System.Threading.Tasks.Sources.IValueTaskSource
     {
         public System.Threading.Tasks.ValueTask BeginAsync(System.TimeSpan delay, System.TimeProvider timeProvider, System.Threading.CancellationToken cancellationToken) { }
@@ -1040,13 +1040,13 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public void OnCompleted(System.Action<object?> continuation, object? state, short token, System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags flags) { }
         public static ReactiveUI.Primitives.Async.Advanced.PooledDelaySource Rent() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, RetryCount = {RetryCount}")]
+    [System.Diagnostics.DebuggerDisplay("ReattemptSignal: Source = {Source}, RetryCount = {RetryCount}")]
     public sealed class ReattemptSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public ReattemptSignal(ReactiveUI.Primitives.Async.IObservableAsync<T> source, int retryCount) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Remaining = {Remaining}")]
+    [System.Diagnostics.DebuggerDisplay("ReattemptSubscription: Source = {Source}, Remaining = {Remaining}")]
     public sealed class ReattemptSubscription<T> : System.IAsyncDisposable
     {
         public ReattemptSubscription(ReactiveUI.Primitives.Async.IObservableAsync<T> source, ReactiveUI.Primitives.Async.IObserverAsync<T> observer, int retryCount, System.Threading.CancellationToken cancellationToken) { }
@@ -1059,7 +1059,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public System.Threading.Tasks.ValueTask RelayNextAsync(T value, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.ValueTask SubscribeOnceAsync() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("ReattemptWitness: Subscription = {Subscription}")]
     public sealed class ReattemptWitness<T> : ReactiveUI.Primitives.Async.WitnessAsync<T>
     {
         public ReattemptWitness(ReactiveUI.Primitives.Async.Advanced.ReattemptSubscription<T> subscription) { }
@@ -1071,19 +1071,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
     {
         public RelayWitnessAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("StartValue = {StartValue}, Count = {Count}")]
+    [System.Diagnostics.DebuggerDisplay("SequenceSignal: StartValue = {StartValue}, Count = {Count}")]
     public sealed class SequenceSignal : ReactiveUI.Primitives.Async.IObservableAsync<int>
     {
         public SequenceSignal(int start, int count) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<System.Int32>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<int> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("StartValue = {StartValue}, Count = {Count}")]
+    [System.Diagnostics.DebuggerDisplay("SequenceSubscription: StartValue = {StartValue}, Count = {Count}")]
     public sealed class SequenceSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<int>
     {
         public SequenceSubscription(ReactiveUI.Primitives.Async.IObserverAsync<int> observer, int start, int count) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<int> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasValue = {_hasValue}, Value = {_value}")]
+    [System.Diagnostics.DebuggerDisplay("SingleElementWitness: HasValue = {_hasValue}, Value = {_value}")]
     public sealed class SingleElementWitness<T> : ReactiveUI.Primitives.Async.Advanced.TaskResultWitnessAsyncBase<T, T?>
     {
         public SingleElementWitness(System.Func<T, bool>? predicate, bool requireExactlyOne, T? defaultValue, System.Threading.CancellationToken cancellationToken) { }
@@ -1091,31 +1091,31 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(T value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Function = {Function}, TaskScheduler = {TaskScheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Function = {Function}, TaskScheduler = {TaskScheduler}")]
     public sealed class StartSignal<TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public StartSignal(System.Func<TResult> function, System.Threading.Tasks.TaskScheduler? taskScheduler) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Function = {Function}, TaskScheduler = {TaskScheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSubscription: Function = {Function}, TaskScheduler = {TaskScheduler}")]
     public sealed class StartSubscription<TResult> : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<TResult>
     {
         public StartSubscription(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Func<TResult> function, System.Threading.Tasks.TaskScheduler? taskScheduler) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceCount = {SourceCount}, Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest10Coordinator: SourceCount = {SourceCount}, Sources = {Sources}")]
     public sealed class SyncLatest10Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest10Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest10State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest10Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest10Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest10Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest10State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source10 = {Source10}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest10State: Source1 = {Source1}, Source10 = {Source10}")]
     public readonly record struct SyncLatest10State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest10State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>>
     {
         public SyncLatest10State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8, ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9, ReactiveUI.Primitives.Async.IObservableAsync<T10> Source10) { }
@@ -1130,19 +1130,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceCount = {SourceCount}, Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest11Coordinator: SourceCount = {SourceCount}, Sources = {Sources}")]
     public sealed class SyncLatest11Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest11Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest11State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest11Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest11Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest11Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest11State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source2 = {Source2}, Source11 = {Source11}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest11State: Source1 = {Source1}, Source2 = {Source2}, Source11 = {Source11}")]
     public readonly record struct SyncLatest11State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest11State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>>
     {
         public SyncLatest11State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8, ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9, ReactiveUI.Primitives.Async.IObservableAsync<T10> Source10, ReactiveUI.Primitives.Async.IObservableAsync<T11> Source11) { }
@@ -1158,19 +1158,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Lifecycle = {Lifecycle}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest12Coordinator: Sources = {Sources}, Lifecycle = {Lifecycle}")]
     public sealed class SyncLatest12Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest12Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest12State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest12Signal: Sources = {Sources}")]
     public sealed class SyncLatest12Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest12Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest12State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source12 = {Source12}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest12State: Source1 = {Source1}, Source12 = {Source12}")]
     public readonly record struct SyncLatest12State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest12State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>>
     {
         public SyncLatest12State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8, ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9, ReactiveUI.Primitives.Async.IObservableAsync<T10> Source10, ReactiveUI.Primitives.Async.IObservableAsync<T11> Source11, ReactiveUI.Primitives.Async.IObservableAsync<T12> Source12) { }
@@ -1187,19 +1187,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value13 = {Value13}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest13Coordinator: Value1 = {Value1}, Value13 = {Value13}")]
     public sealed class SyncLatest13Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest13Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest13State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest13Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest13Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest13Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest13State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source13 = {Source13}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest13State: Source1 = {Source1}, Source13 = {Source13}")]
     public readonly record struct SyncLatest13State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest13State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>>
     {
         public SyncLatest13State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8, ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9, ReactiveUI.Primitives.Async.IObservableAsync<T10> Source10, ReactiveUI.Primitives.Async.IObservableAsync<T11> Source11, ReactiveUI.Primitives.Async.IObservableAsync<T12> Source12, ReactiveUI.Primitives.Async.IObservableAsync<T13> Source13) { }
@@ -1217,19 +1217,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Lifecycle = {Lifecycle}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest14Coordinator: Sources = {Sources}, Lifecycle = {Lifecycle}")]
     public sealed class SyncLatest14Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest14Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest14State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest14Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest14Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest14Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest14State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source14 = {Source14}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest14State: Source1 = {Source1}, Source14 = {Source14}")]
     public readonly record struct SyncLatest14State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest14State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>>
     {
         public SyncLatest14State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8, ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9, ReactiveUI.Primitives.Async.IObservableAsync<T10> Source10, ReactiveUI.Primitives.Async.IObservableAsync<T11> Source11, ReactiveUI.Primitives.Async.IObservableAsync<T12> Source12, ReactiveUI.Primitives.Async.IObservableAsync<T13> Source13, ReactiveUI.Primitives.Async.IObservableAsync<T14> Source14) { }
@@ -1248,19 +1248,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value15 = {Value15}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest15Coordinator: Value1 = {Value1}, Value15 = {Value15}")]
     public sealed class SyncLatest15Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest15Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest15State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest15Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest15Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest15Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest15State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source15 = {Source15}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest15State: Source1 = {Source1}, Source15 = {Source15}")]
     public readonly record struct SyncLatest15State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest15State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>>
     {
         public SyncLatest15State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8, ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9, ReactiveUI.Primitives.Async.IObservableAsync<T10> Source10, ReactiveUI.Primitives.Async.IObservableAsync<T11> Source11, ReactiveUI.Primitives.Async.IObservableAsync<T12> Source12, ReactiveUI.Primitives.Async.IObservableAsync<T13> Source13, ReactiveUI.Primitives.Async.IObservableAsync<T14> Source14, ReactiveUI.Primitives.Async.IObservableAsync<T15> Source15) { }
@@ -1280,19 +1280,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value16 = {Value16}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest16Coordinator: Value1 = {Value1}, Value16 = {Value16}")]
     public sealed class SyncLatest16Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest16Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest16State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest16Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest16Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest16Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest16State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source16 = {Source16}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest16State: Source1 = {Source1}, Source16 = {Source16}")]
     public readonly record struct SyncLatest16State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest16State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>>
     {
         public SyncLatest16State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8, ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9, ReactiveUI.Primitives.Async.IObservableAsync<T10> Source10, ReactiveUI.Primitives.Async.IObservableAsync<T11> Source11, ReactiveUI.Primitives.Async.IObservableAsync<T12> Source12, ReactiveUI.Primitives.Async.IObservableAsync<T13> Source13, ReactiveUI.Primitives.Async.IObservableAsync<T14> Source14, ReactiveUI.Primitives.Async.IObservableAsync<T15> Source15, ReactiveUI.Primitives.Async.IObservableAsync<T16> Source16) { }
@@ -1313,38 +1313,38 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest2Coordinator: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest2Coordinator<T1, T2, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest2Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest2State<T1, T2> sources, System.Func<T1, T2, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest2Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest2Signal<T1, T2, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest2Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest2State<T1, T2> sources, System.Func<T1, T2, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source2 = {Source2}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest2State: Source1 = {Source1}, Source2 = {Source2}")]
     public readonly record struct SyncLatest2State<T1, T2> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest2State<T1, T2>>
     {
         public SyncLatest2State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2) { }
         public ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value3 = {Value3}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest3Coordinator: Value1 = {Value1}, Value3 = {Value3}")]
     public sealed class SyncLatest3Coordinator<T1, T2, T3, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest3Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest3State<T1, T2, T3> sources, System.Func<T1, T2, T3, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest3Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest3Signal<T1, T2, T3, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest3Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest3State<T1, T2, T3> sources, System.Func<T1, T2, T3, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source2 = {Source2}, Source3 = {Source3}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest3State: Source1 = {Source1}, Source2 = {Source2}, Source3 = {Source3}")]
     public readonly record struct SyncLatest3State<T1, T2, T3> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest3State<T1, T2, T3>>
     {
         public SyncLatest3State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3) { }
@@ -1352,19 +1352,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value4 = {Value4}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest4Coordinator: Value1 = {Value1}, Value4 = {Value4}")]
     public sealed class SyncLatest4Coordinator<T1, T2, T3, T4, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest4Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest4State<T1, T2, T3, T4> sources, System.Func<T1, T2, T3, T4, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest4Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest4Signal<T1, T2, T3, T4, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest4Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest4State<T1, T2, T3, T4> sources, System.Func<T1, T2, T3, T4, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source2 = {Source2}, Source3 = {Source3}, Source4 = {Source4}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest4State: Source1 = {Source1}, Source2 = {Source2}, Source3 = {Source3}, Source4 = {Source4}")]
     public readonly record struct SyncLatest4State<T1, T2, T3, T4> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest4State<T1, T2, T3, T4>>
     {
         public SyncLatest4State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4) { }
@@ -1373,19 +1373,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value5 = {Value5}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest5Coordinator: Value1 = {Value1}, Value5 = {Value5}")]
     public sealed class SyncLatest5Coordinator<T1, T2, T3, T4, T5, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest5Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest5State<T1, T2, T3, T4, T5> sources, System.Func<T1, T2, T3, T4, T5, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest5Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest5Signal<T1, T2, T3, T4, T5, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest5Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest5State<T1, T2, T3, T4, T5> sources, System.Func<T1, T2, T3, T4, T5, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source5 = {Source5}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest5State: Source1 = {Source1}, Source5 = {Source5}")]
     public readonly record struct SyncLatest5State<T1, T2, T3, T4, T5> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest5State<T1, T2, T3, T4, T5>>
     {
         public SyncLatest5State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5) { }
@@ -1395,19 +1395,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value6 = {Value6}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest6Coordinator: Value1 = {Value1}, Value6 = {Value6}")]
     public sealed class SyncLatest6Coordinator<T1, T2, T3, T4, T5, T6, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest6Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest6State<T1, T2, T3, T4, T5, T6> sources, System.Func<T1, T2, T3, T4, T5, T6, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest6Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest6Signal<T1, T2, T3, T4, T5, T6, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest6Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest6State<T1, T2, T3, T4, T5, T6> sources, System.Func<T1, T2, T3, T4, T5, T6, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source6 = {Source6}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest6State: Source1 = {Source1}, Source6 = {Source6}")]
     public readonly record struct SyncLatest6State<T1, T2, T3, T4, T5, T6> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest6State<T1, T2, T3, T4, T5, T6>>
     {
         public SyncLatest6State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6) { }
@@ -1418,19 +1418,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest7Coordinator: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest7Coordinator<T1, T2, T3, T4, T5, T6, T7, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest7Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest7State<T1, T2, T3, T4, T5, T6, T7> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest7Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest7Signal<T1, T2, T3, T4, T5, T6, T7, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest7Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest7State<T1, T2, T3, T4, T5, T6, T7> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source7 = {Source7}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest7State: Source1 = {Source1}, Source7 = {Source7}")]
     public readonly record struct SyncLatest7State<T1, T2, T3, T4, T5, T6, T7> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest7State<T1, T2, T3, T4, T5, T6, T7>>
     {
         public SyncLatest7State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7) { }
@@ -1442,19 +1442,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest8Coordinator: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest8Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest8Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest8State<T1, T2, T3, T4, T5, T6, T7, T8> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest8Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest8Signal<T1, T2, T3, T4, T5, T6, T7, T8, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest8Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest8State<T1, T2, T3, T4, T5, T6, T7, T8> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source8 = {Source8}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest8State: Source1 = {Source1}, Source8 = {Source8}")]
     public readonly record struct SyncLatest8State<T1, T2, T3, T4, T5, T6, T7, T8> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest8State<T1, T2, T3, T4, T5, T6, T7, T8>>
     {
         public SyncLatest8State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8) { }
@@ -1467,19 +1467,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value9 = {Value9}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest9Coordinator: Value1 = {Value1}, Value9 = {Value9}")]
     public sealed class SyncLatest9Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest9Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest9State<T1, T2, T3, T4, T5, T6, T7, T8, T9> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest9Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest9Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest9Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest9State<T1, T2, T3, T4, T5, T6, T7, T8, T9> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source9 = {Source9}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest9State: Source1 = {Source1}, Source9 = {Source9}")]
     public readonly record struct SyncLatest9State<T1, T2, T3, T4, T5, T6, T7, T8, T9> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest9State<T1, T2, T3, T4, T5, T6, T7, T8, T9>>
     {
         public SyncLatest9State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8, ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9) { }
@@ -1493,7 +1493,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceCount = {Lifecycle.Subscriptions.Length}, HasDisposed = {Lifecycle.HasDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestCoordinatorBase: SourceCount = {Lifecycle.Subscriptions.Length}, HasDisposed = {Lifecycle.HasDisposed}")]
     public abstract class SyncLatestCoordinatorBase<TResult> : System.IAsyncDisposable
     {
         protected SyncLatestCoordinatorBase(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, int sourceCount) { }
@@ -1501,7 +1501,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected abstract System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.ValueTask SubscribeSourcesAsync(System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources.Length}, Completed = {_completedCount}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestEnumerableCoordinator: Sources = {Sources.Length}, Completed = {_completedCount}, Disposed = {_disposed}")]
     public sealed class SyncLatestEnumerableCoordinator<TSource, TResult> : System.IAsyncDisposable
     {
         public SyncLatestEnumerableCoordinator(ReactiveUI.Primitives.Async.IObservableAsync<TSource>[] sources, ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Func<System.Collections.Generic.IReadOnlyList<TSource>, TResult> resultSelector) { }
@@ -1509,13 +1509,13 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public System.Threading.Tasks.ValueTask DisposeAsync() { }
         public System.Threading.Tasks.ValueTask SubscribeSourcesAsync(System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceCount = {Sources.Length}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestEnumerableSignal: SourceCount = {Sources.Length}")]
     public sealed class SyncLatestEnumerableSignal<TSource, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatestEnumerableSignal(System.Collections.Generic.IEnumerable<ReactiveUI.Primitives.Async.IObservableAsync<TSource>> sources, System.Func<System.Collections.Generic.IReadOnlyList<TSource>, TResult> resultSelector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Index = {Index}, Parent = {Parent}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestEnumerableWitness: Index = {Index}, Parent = {Parent}")]
     public sealed class SyncLatestEnumerableWitness<TSource, TResult> : ReactiveUI.Primitives.Async.IObserverAsync<TSource>
     {
         public SyncLatestEnumerableWitness(ReactiveUI.Primitives.Async.Advanced.SyncLatestEnumerableCoordinator<TSource, TResult> parent, int index) { }
@@ -1535,7 +1535,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(TSource value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceCount = {Subscriptions.Length}, HasDisposed = {HasDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestLifecycle: SourceCount = {Subscriptions.Length}, HasDisposed = {HasDisposed}")]
     public sealed class SyncLatestLifecycle<TResult> : System.IAsyncDisposable
     {
         public SyncLatestLifecycle(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, int sourceCount) { }
@@ -1557,7 +1557,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(TSource value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, DisposeRequested = {DisposeToken.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("TakeUntilLifecycle: Observer = {_observer}, DisposeRequested = {DisposeToken.IsCancellationRequested}")]
     public sealed class TakeUntilLifecycle<T> : System.IAsyncDisposable
     {
         public TakeUntilLifecycle(ReactiveUI.Primitives.Async.IObserverAsync<T> observer) { }
@@ -1575,7 +1575,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(T value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsCompleted = {_taskSource.Task.IsCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("TaskResultCompletionSource: IsCompleted = {_taskSource.Task.IsCompleted}")]
     public sealed class TaskResultCompletionSource<T>
     {
         public TaskResultCompletionSource(System.Threading.CancellationToken cancellationToken) { }
@@ -1583,19 +1583,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public System.Threading.Tasks.ValueTask SetExceptionAndDisposeAsync(System.Exception exception, ReactiveUI.Primitives.Async.Advanced.IReentrantAsyncDisposable owner) { }
         public System.Threading.Tasks.ValueTask SetResultAndDisposeAsync(T value, ReactiveUI.Primitives.Async.Advanced.IReentrantAsyncDisposable owner) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskResultSignal: Task = {Task}")]
     public sealed class TaskResultSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public TaskResultSignal(System.Threading.Tasks.Task<T> task) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskResultSubscription: Task = {Task}")]
     public sealed class TaskResultSubscription<T> : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<T>
     {
         public TaskResultSubscription(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.Tasks.Task<T> task) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completion = {_completion}")]
+    [System.Diagnostics.DebuggerDisplay("TaskResultWitnessAsyncBase: Completion = {_completion}")]
     public abstract class TaskResultWitnessAsyncBase<T, TTaskValue> : ReactiveUI.Primitives.Async.WitnessAsync<T>
     {
         protected TaskResultWitnessAsyncBase(System.Threading.CancellationToken cancellationToken) { }
@@ -1610,7 +1610,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
     {
         public static ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<T> StartNew<T>(System.Func<ReactiveUI.Primitives.Async.IObserverAsync<T>, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> executeAsyncCore, ReactiveUI.Primitives.Async.IObserverAsync<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Disposed = {_disposed}, Completed = {_tcs.Task.IsCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("TaskSignalSubscription: Disposed = {_disposed}, Completed = {_tcs.Task.IsCompleted}")]
     public abstract class TaskSignalSubscription<T> : System.IAsyncDisposable
     {
         protected TaskSignalSubscription(ReactiveUI.Primitives.Async.IObserverAsync<T> observer) { }
@@ -1618,25 +1618,25 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected abstract System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
         public void Start() { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {DueTime}, Period = {Period}")]
+    [System.Diagnostics.DebuggerDisplay("TimerSignal: DueTime = {DueTime}, Period = {Period}")]
     public sealed class TimerSignal : ReactiveUI.Primitives.Async.IObservableAsync<long>
     {
         public TimerSignal(System.TimeSpan dueTime, System.TimeSpan? period, System.TimeProvider timeProvider) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<System.Int64>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<long> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {DueTime}, Period = {Period}")]
+    [System.Diagnostics.DebuggerDisplay("TimerSubscription: DueTime = {DueTime}, Period = {Period}")]
     public sealed class TimerSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<long>
     {
         public TimerSubscription(ReactiveUI.Primitives.Async.IObserverAsync<long> observer, System.TimeSpan dueTime, System.TimeSpan? period, System.TimeProvider timeProvider) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<long> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ResourceFactory = {ResourceFactory}, SignalFactory = {SignalFactory}")]
+    [System.Diagnostics.DebuggerDisplay("UsingSignal: ResourceFactory = {ResourceFactory}, SignalFactory = {SignalFactory}")]
     public sealed class UsingSignal<TResource, T> : ReactiveUI.Primitives.Async.IObservableAsync<T> where TResource : System.IAsyncDisposable
     {
         public UsingSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResource>> resourceFactory, System.Func<TResource, ReactiveUI.Primitives.Async.IObservableAsync<T>> signalFactory) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Resource = {Resource}")]
+    [System.Diagnostics.DebuggerDisplay("UsingWitness: Resource = {Resource}")]
     public sealed class UsingWitness<TResource, T> : ReactiveUI.Primitives.Async.Advanced.ForwardingWitnessAsync<T> where TResource : System.IAsyncDisposable
     {
         public UsingWitness(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, TResource resource) { }
@@ -1661,7 +1661,7 @@ namespace ReactiveUI.Primitives.Async.Disposables
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public static System.Threading.Tasks.ValueTask SwapAsync(ref System.IAsyncDisposable? slot, System.IAsyncDisposable? value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, IsDisposed = {_isDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("MultipleDisposableAsync: Count = {_count}, IsDisposed = {_isDisposed}")]
     public sealed class MultipleDisposableAsync : System.IAsyncDisposable
     {
         public MultipleDisposableAsync() { }
@@ -1678,7 +1678,7 @@ namespace ReactiveUI.Primitives.Async.Disposables
         public System.Collections.Generic.IEnumerator<System.IAsyncDisposable> GetEnumerator() { }
         public System.Threading.Tasks.ValueTask<bool> Remove(System.IAsyncDisposable item) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsDisposed = {IsDisposed}, Current = {_current}")]
+    [System.Diagnostics.DebuggerDisplay("SingleAssignmentDisposableAsync: IsDisposed = {IsDisposed}, Current = {_current}")]
     public sealed class SingleAssignmentDisposableAsync : System.IAsyncDisposable
     {
         public SingleAssignmentDisposableAsync() { }
@@ -1689,7 +1689,7 @@ namespace ReactiveUI.Primitives.Async.Disposables
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.Threading.Tasks.ValueTask SetDisposableAsync(System.IAsyncDisposable? value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Current = {_current}")]
+    [System.Diagnostics.DebuggerDisplay("SingleReplaceableDisposableAsync: Current = {_current}")]
     public class SingleReplaceableDisposableAsync : System.IAsyncDisposable
     {
         public SingleReplaceableDisposableAsync() { }
@@ -1715,7 +1715,7 @@ namespace ReactiveUI.Primitives.Async.Helpers
 }
 namespace ReactiveUI.Primitives.Async.Signals
 {
-    [System.Diagnostics.DebuggerDisplay("PublishingOption = {PublishingOption}, IsStateless = {IsStateless}")]
+    [System.Diagnostics.DebuggerDisplay("BehaviorSignalCreationOptions: PublishingOption = {PublishingOption}, IsStateless = {IsStateless}")]
     public record BehaviorSignalCreationOptions : System.IEquatable<ReactiveUI.Primitives.Async.Signals.BehaviorSignalCreationOptions>
     {
         public required bool IsStateless { get; init; }
@@ -1731,7 +1731,7 @@ namespace ReactiveUI.Primitives.Async.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public static System.Threading.Tasks.ValueTask ForwardOnNextConcurrently<T>(System.Collections.Immutable.ImmutableArray<ReactiveUI.Primitives.Async.IObserverAsync<T>> observers, T value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("LastValue = {_state.LastValue}, IsDisposed = {_state.IsDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ConcurrentReplayLatestSignalAsync: LastValue = {_state.LastValue}, IsDisposed = {_state.IsDisposed}")]
     public sealed class ConcurrentReplayLatestSignalAsync<T> : ReactiveUI.Primitives.Async.Signals.ISignalAsync<T>
     {
         public ConcurrentReplayLatestSignalAsync(ReactiveUI.Primitives.Optional<T> startValue) { }
@@ -1747,7 +1747,7 @@ namespace ReactiveUI.Primitives.Async.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_state.Observers.Length}, Result = {_state.Result}")]
+    [System.Diagnostics.DebuggerDisplay("ConcurrentSignalAsync: Observers = {_state.Observers.Length}, Result = {_state.Result}")]
     public sealed class ConcurrentSignalAsync<T> : ReactiveUI.Primitives.Async.Signals.ISignalAsync<T>
     {
         public ConcurrentSignalAsync() { }
@@ -1763,7 +1763,7 @@ namespace ReactiveUI.Primitives.Async.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_state.Value}, IsDisposed = {_state.IsDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ConcurrentStatelessReplayLatestSignalAsync: Value = {_state.Value}, IsDisposed = {_state.IsDisposed}")]
     public sealed class ConcurrentStatelessReplayLatestSignalAsync<T> : ReactiveUI.Primitives.Async.Signals.ISignalAsync<T>
     {
         public ConcurrentStatelessReplayLatestSignalAsync(ReactiveUI.Primitives.Optional<T> startValue) { }
@@ -1779,7 +1779,7 @@ namespace ReactiveUI.Primitives.Async.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_state.Observers.Length}")]
+    [System.Diagnostics.DebuggerDisplay("ConcurrentStatelessSignalAsync: Observers = {_state.Observers.Length}")]
     public sealed class ConcurrentStatelessSignalAsync<T> : ReactiveUI.Primitives.Async.Signals.ISignalAsync<T>
     {
         public ConcurrentStatelessSignalAsync() { }
@@ -1804,14 +1804,14 @@ namespace ReactiveUI.Primitives.Async.Signals
         Serial = 0,
         Concurrent = 1,
     }
-    [System.Diagnostics.DebuggerDisplay("PublishingOption = {PublishingOption}, IsStateless = {IsStateless}")]
+    [System.Diagnostics.DebuggerDisplay("ReplayLatestSignalCreationOptions: PublishingOption = {PublishingOption}, IsStateless = {IsStateless}")]
     public record ReplayLatestSignalCreationOptions : System.IEquatable<ReactiveUI.Primitives.Async.Signals.ReplayLatestSignalCreationOptions>
     {
         public required bool IsStateless { get; init; }
         public required ReactiveUI.Primitives.Async.Signals.PublishingOption PublishingOption { get; init; }
         public static ReactiveUI.Primitives.Async.Signals.ReplayLatestSignalCreationOptions Default { get; }
     }
-    [System.Diagnostics.DebuggerDisplay("LastValue = {_state.LastValue}, IsDisposed = {_state.IsDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("SerialReplayLatestSignalAsync: LastValue = {_state.LastValue}, IsDisposed = {_state.IsDisposed}")]
     public sealed class SerialReplayLatestSignalAsync<T> : ReactiveUI.Primitives.Async.Signals.ISignalAsync<T>
     {
         public SerialReplayLatestSignalAsync(ReactiveUI.Primitives.Optional<T> startValue) { }
@@ -1827,7 +1827,7 @@ namespace ReactiveUI.Primitives.Async.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_state.Observers.Length}, Result = {_state.Result}")]
+    [System.Diagnostics.DebuggerDisplay("SerialSignalAsync: Observers = {_state.Observers.Length}, Result = {_state.Result}")]
     public sealed class SerialSignalAsync<T> : ReactiveUI.Primitives.Async.Signals.ISignalAsync<T>
     {
         public SerialSignalAsync() { }
@@ -1843,7 +1843,7 @@ namespace ReactiveUI.Primitives.Async.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("State = {_state}")]
+    [System.Diagnostics.DebuggerDisplay("SerialStatelessReplayLatestSignalAsync: State = {_state}")]
     public sealed class SerialStatelessReplayLatestSignalAsync<T> : ReactiveUI.Primitives.Async.Signals.ISignalAsync<T>
     {
         public SerialStatelessReplayLatestSignalAsync(ReactiveUI.Primitives.Optional<T> startValue) { }
@@ -1859,7 +1859,7 @@ namespace ReactiveUI.Primitives.Async.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_state.Observers.Length}")]
+    [System.Diagnostics.DebuggerDisplay("SerialStatelessSignalAsync: Observers = {_state.Observers.Length}")]
     public sealed class SerialStatelessSignalAsync<T> : ReactiveUI.Primitives.Async.Signals.ISignalAsync<T>
     {
         public SerialStatelessSignalAsync() { }
@@ -1887,7 +1887,7 @@ namespace ReactiveUI.Primitives.Async.Signals
         public static ReactiveUI.Primitives.Async.Signals.ISignalAsync<T> CreateReplayLatest<T>() { }
         public static ReactiveUI.Primitives.Async.Signals.ISignalAsync<T> CreateReplayLatest<T>(ReactiveUI.Primitives.Async.Signals.ReplayLatestSignalCreationOptions? options) { }
     }
-    [System.Diagnostics.DebuggerDisplay("PublishingOption = {PublishingOption}, IsStateless = {IsStateless}")]
+    [System.Diagnostics.DebuggerDisplay("SignalCreationOptions: PublishingOption = {PublishingOption}, IsStateless = {IsStateless}")]
     public record SignalCreationOptions : System.IEquatable<ReactiveUI.Primitives.Async.Signals.SignalCreationOptions>
     {
         public required bool IsStateless { get; init; }

--- a/src/ReactiveUI.Primitives.Async.Core/PublicAPI/net11.0/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Async.Core/PublicAPI/net11.0/PublicAPI.txt
@@ -3,7 +3,7 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Primitives.Tests")]
 namespace ReactiveUI.Primitives.Async
 {
-    [System.Diagnostics.DebuggerDisplay("Signals = {_signals}")]
+    [System.Diagnostics.DebuggerDisplay("ChainEnumerableSignal: Signals = {_signals}")]
     public sealed class ChainEnumerableSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public ChainEnumerableSignal(System.Collections.Generic.IEnumerable<ReactiveUI.Primitives.Async.IObservableAsync<T>> signals) { }
@@ -22,7 +22,7 @@ namespace ReactiveUI.Primitives.Async
         public ConcurrentWitnessCallsException(string message) { }
         public ConcurrentWitnessCallsException(string message, System.Exception innerException) { }
     }
-    [System.Diagnostics.DebuggerDisplay("State = {State}")]
+    [System.Diagnostics.DebuggerDisplay("ConnectableSignalAsync: State = {State}")]
     public sealed class ConnectableSignalAsync<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>, System.IDisposable
     {
         public ConnectableSignalAsync(ReactiveUI.Primitives.Async.IObservableAsync<T> source, ReactiveUI.Primitives.Async.Signals.ISignalAsync<T> signal) { }
@@ -40,7 +40,7 @@ namespace ReactiveUI.Primitives.Async
             public System.IAsyncDisposable ToDisposableAsync() { }
         }
     }
-    [System.Diagnostics.DebuggerDisplay("Key = {Key}")]
+    [System.Diagnostics.DebuggerDisplay("GroupedAsyncSignal: Key = {Key}")]
     public sealed class GroupedAsyncSignal<TKey, TValue> : ReactiveUI.Primitives.Async.IObservableAsync<TValue>
     {
         public TKey Key { get; }
@@ -825,7 +825,7 @@ namespace ReactiveUI.Primitives.Async
         public SwitchToSignal(ReactiveUI.Primitives.Async.IObservableAsync<ReactiveUI.Primitives.Async.IObservableAsync<T>> source) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceFailsWhenOtherFails = {SourceFailsWhenOtherFails}")]
+    [System.Diagnostics.DebuggerDisplay("TakeUntilOptions: SourceFailsWhenOtherFails = {SourceFailsWhenOtherFails}")]
     public record TakeUntilOptions : System.IEquatable<ReactiveUI.Primitives.Async.TakeUntilOptions>
     {
         public bool SourceFailsWhenOtherFails { get; init; }
@@ -835,7 +835,7 @@ namespace ReactiveUI.Primitives.Async
     {
         public static void Register(System.Action<System.Exception> unhandledExceptionHandler) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Disposed = {_disposed}, CallState = {_callState}")]
+    [System.Diagnostics.DebuggerDisplay("WitnessAsync: Disposed = {_disposed}, CallState = {_callState}")]
     public abstract class WitnessAsync<T> : ReactiveUI.Primitives.Async.Advanced.IReentrantAsyncDisposable, ReactiveUI.Primitives.Async.IObserverAsync<T>
     {
         protected WitnessAsync() { }
@@ -859,19 +859,19 @@ namespace ReactiveUI.Primitives.Async
 }
 namespace ReactiveUI.Primitives.Async.Advanced
 {
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncEnumerableSignal: Source = {Source}")]
     public sealed class AsyncEnumerableSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public AsyncEnumerableSignal(System.Collections.Generic.IAsyncEnumerable<T> source) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncEnumerableSubscription: Source = {Source}")]
     public sealed class AsyncEnumerableSubscription<T> : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<T>
     {
         public AsyncEnumerableSubscription(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Collections.Generic.IAsyncEnumerable<T> source) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("OwnerThreadId = {_ownerThreadId}, Waiters = {_waiters}, RecursionDepth = {_recursionDepth}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncSerialGate: OwnerThreadId = {_ownerThreadId}, Waiters = {_waiters}, RecursionDepth = {_recursionDepth}")]
     public sealed class AsyncSerialGate : System.IDisposable
     {
         public AsyncSerialGate() { }
@@ -879,7 +879,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.Threading.Tasks.ValueTask<ReactiveUI.Primitives.Async.Advanced.AsyncSerialGate.Lease> EnterAsync() { }
         public System.Threading.Tasks.ValueTask<ReactiveUI.Primitives.Async.Advanced.AsyncSerialGate.Lease> EnterAsync(System.Threading.CancellationToken cancellationToken) { }
-        [System.Diagnostics.DebuggerDisplay("Parent = {_parent}")]
+        [System.Diagnostics.DebuggerDisplay("Lease: Parent = {_parent}")]
         public readonly record struct Lease : System.IDisposable, System.IEquatable<ReactiveUI.Primitives.Async.Advanced.AsyncSerialGate.Lease>
         {
             public Lease(ReactiveUI.Primitives.Async.Advanced.AsyncSerialGate parent) { }
@@ -887,13 +887,13 @@ namespace ReactiveUI.Primitives.Async.Advanced
             public readonly void Dispose() { }
         }
     }
-    [System.Diagnostics.DebuggerDisplay("StartSynchronously = {StartSynchronously}, TaskScheduler = {TaskScheduler}")]
+    [System.Diagnostics.DebuggerDisplay("BackgroundJobSignal: StartSynchronously = {StartSynchronously}, TaskScheduler = {TaskScheduler}")]
     public sealed class BackgroundJobSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public BackgroundJobSignal(System.Func<ReactiveUI.Primitives.Async.IObserverAsync<T>, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> job, bool startSynchronously, System.Threading.Tasks.TaskScheduler? taskScheduler) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasDisposed = {HasDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("CallbackWitnessAsync: HasDisposed = {HasDisposed}")]
     public sealed class CallbackWitnessAsync<T> : ReactiveUI.Primitives.Async.WitnessAsync<T>
     {
         public CallbackWitnessAsync(System.Func<T, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> onNextAsync, System.Func<System.Exception, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask>? onErrorResumeAsync = null, System.Func<ReactiveUI.Primitives.Result, System.Threading.Tasks.ValueTask>? onCompletedAsync = null) { }
@@ -901,31 +901,31 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(T value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Action = {Action}")]
+    [System.Diagnostics.DebuggerDisplay("DoOnSubscribeAsyncSignal: Source = {Source}, Action = {Action}")]
     public sealed class DoOnSubscribeAsyncSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public DoOnSubscribeAsyncSignal(ReactiveUI.Primitives.Async.IObservableAsync<T> source, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> action) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Action = {Action}")]
+    [System.Diagnostics.DebuggerDisplay("DoOnSubscribeSignal: Source = {Source}, Action = {Action}")]
     public sealed class DoOnSubscribeSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public DoOnSubscribeSignal(ReactiveUI.Primitives.Async.IObservableAsync<T> source, System.Action action) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("EnumerableSignal: Source = {Source}")]
     public sealed class EnumerableSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public EnumerableSignal(System.Collections.Generic.IEnumerable<T> source) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("EnumerableSubscription: Source = {Source}")]
     public sealed class EnumerableSubscription<T> : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<T>
     {
         public EnumerableSubscription(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Collections.Generic.IEnumerable<T> source) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ActiveInnerCount = {ActiveInnerCount}, OuterCompleted = {OuterCompleted}, Disposed = {Disposed}")]
+    [System.Diagnostics.DebuggerDisplay("FlatMapCoordinator: ActiveInnerCount = {ActiveInnerCount}, OuterCompleted = {OuterCompleted}, Disposed = {Disposed}")]
     public sealed class FlatMapCoordinator<TResult> : System.IAsyncDisposable
     {
         public FlatMapCoordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer) { }
@@ -941,14 +941,14 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public System.Threading.Tasks.ValueTask SetOuterObserverAsync(System.IAsyncDisposable observer) { }
         public System.Threading.Tasks.ValueTask SubscribeInnerAsync(ReactiveUI.Primitives.Async.IObservableAsync<TResult> inner) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, SyncSelector = {SyncSelector}, AsyncSelector = {AsyncSelector}")]
+    [System.Diagnostics.DebuggerDisplay("FlatMapSignal: Source = {Source}, SyncSelector = {SyncSelector}, AsyncSelector = {AsyncSelector}")]
     public sealed class FlatMapSignal<TSource, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public FlatMapSignal(ReactiveUI.Primitives.Async.IObservableAsync<TSource> source, System.Func<TSource, ReactiveUI.Primitives.Async.IObservableAsync<TResult>> selector) { }
         public FlatMapSignal(ReactiveUI.Primitives.Async.IObservableAsync<TSource> source, System.Func<TSource, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<ReactiveUI.Primitives.Async.IObservableAsync<TResult>>> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Coordinator = {Coordinator}")]
+    [System.Diagnostics.DebuggerDisplay("FlatMapWitness: Coordinator = {Coordinator}")]
     public sealed class FlatMapWitness<TResult> : ReactiveUI.Primitives.Async.WitnessAsync<TResult>
     {
         public FlatMapWitness(ReactiveUI.Primitives.Async.Advanced.FlatMapCoordinator<TResult> coordinator) { }
@@ -956,7 +956,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(TResult value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Coordinator = {Coordinator}, SyncSelector = {SyncSelector}, AsyncSelector = {AsyncSelector}")]
+    [System.Diagnostics.DebuggerDisplay("FlatMapWitness: Coordinator = {Coordinator}, SyncSelector = {SyncSelector}, AsyncSelector = {AsyncSelector}")]
     public sealed class FlatMapWitness<TSource, TResult> : ReactiveUI.Primitives.Async.WitnessAsync<TSource>
     {
         public FlatMapWitness(ReactiveUI.Primitives.Async.Advanced.FlatMapCoordinator<TResult> coordinator, System.Func<TSource, ReactiveUI.Primitives.Async.IObservableAsync<TResult>>? syncSelector, System.Func<TSource, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<ReactiveUI.Primitives.Async.IObservableAsync<TResult>>>? asyncSelector) { }
@@ -964,7 +964,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(TSource value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Downstream = {Downstream}")]
+    [System.Diagnostics.DebuggerDisplay("ForwardingWitnessAsync: Downstream = {Downstream}")]
     public class ForwardingWitnessAsync<T> : ReactiveUI.Primitives.Async.WitnessAsync<T>
     {
         protected ForwardingWitnessAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> downstream) { }
@@ -973,13 +973,13 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(T value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Factory = {Factory}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSignal: Factory = {Factory}")]
     public sealed class FromAsyncSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<T>> factory) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Factory = {Factory}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSubscription: Factory = {Factory}")]
     public sealed class FromAsyncSubscription<T> : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<T>
     {
         public FromAsyncSubscription(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<T>> factory) { }
@@ -989,39 +989,39 @@ namespace ReactiveUI.Primitives.Async.Advanced
     {
         System.Threading.Tasks.ValueTask DisposeFromNotificationAsync() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Period = {Period}, TimeProvider = {TimeProvider}")]
+    [System.Diagnostics.DebuggerDisplay("IntervalSignal: Period = {Period}, TimeProvider = {TimeProvider}")]
     public sealed class IntervalSignal : ReactiveUI.Primitives.Async.IObservableAsync<long>
     {
         public IntervalSignal(System.TimeSpan period, System.TimeProvider? timeProvider) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<System.Int64>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<long> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Period = {Period}, TimeProvider = {TimeProvider}")]
+    [System.Diagnostics.DebuggerDisplay("IntervalSubscription: Period = {Period}, TimeProvider = {TimeProvider}")]
     public sealed class IntervalSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<long>
     {
         public IntervalSubscription(ReactiveUI.Primitives.Async.IObserverAsync<long> observer, System.TimeSpan period, System.TimeProvider? timeProvider) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<long> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Values = {Values}")]
+    [System.Diagnostics.DebuggerDisplay("LeadSignal: Source = {Source}, Values = {Values}")]
     public sealed class LeadSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public LeadSignal(ReactiveUI.Primitives.Async.IObservableAsync<T> source, System.Collections.Generic.IEnumerable<T> values) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Disposed = {Disposed}, Pipeline = {Pipeline}")]
+    [System.Diagnostics.DebuggerDisplay("LeadSubscription: Disposed = {Disposed}, Pipeline = {Pipeline}")]
     public sealed class LeadSubscription<T> : System.IAsyncDisposable
     {
         public LeadSubscription(ReactiveUI.Primitives.Async.IObservableAsync<T> source, System.Collections.Generic.IEnumerable<T> values, ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken subscriptionToken) { }
         public System.Threading.Tasks.ValueTask DisposeAsync() { }
         public void Start() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Logger = {Logger}")]
+    [System.Diagnostics.DebuggerDisplay("LogErrorsSignal: Source = {Source}, Logger = {Logger}")]
     public sealed class LogErrorsSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public LogErrorsSignal(ReactiveUI.Primitives.Async.IObservableAsync<T> source, System.Action<System.Exception> logger) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Downstream = {Downstream}, Logger = {Logger}")]
+    [System.Diagnostics.DebuggerDisplay("LogErrorsWitness: Downstream = {Downstream}, Logger = {Logger}")]
     public sealed class LogErrorsWitness<T> : ReactiveUI.Primitives.Async.WitnessAsync<T>
     {
         public LogErrorsWitness(ReactiveUI.Primitives.Async.IObserverAsync<T> downstream, System.Action<System.Exception> logger) { }
@@ -1029,7 +1029,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(T value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {_completed}, Timer = {_timer}")]
+    [System.Diagnostics.DebuggerDisplay("PooledDelaySource: Completed = {_completed}, Timer = {_timer}")]
     public sealed class PooledDelaySource : System.Threading.Tasks.Sources.IValueTaskSource
     {
         public System.Threading.Tasks.ValueTask BeginAsync(System.TimeSpan delay, System.TimeProvider timeProvider, System.Threading.CancellationToken cancellationToken) { }
@@ -1040,13 +1040,13 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public void OnCompleted(System.Action<object?> continuation, object? state, short token, System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags flags) { }
         public static ReactiveUI.Primitives.Async.Advanced.PooledDelaySource Rent() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, RetryCount = {RetryCount}")]
+    [System.Diagnostics.DebuggerDisplay("ReattemptSignal: Source = {Source}, RetryCount = {RetryCount}")]
     public sealed class ReattemptSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public ReattemptSignal(ReactiveUI.Primitives.Async.IObservableAsync<T> source, int retryCount) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Remaining = {Remaining}")]
+    [System.Diagnostics.DebuggerDisplay("ReattemptSubscription: Source = {Source}, Remaining = {Remaining}")]
     public sealed class ReattemptSubscription<T> : System.IAsyncDisposable
     {
         public ReattemptSubscription(ReactiveUI.Primitives.Async.IObservableAsync<T> source, ReactiveUI.Primitives.Async.IObserverAsync<T> observer, int retryCount, System.Threading.CancellationToken cancellationToken) { }
@@ -1059,7 +1059,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public System.Threading.Tasks.ValueTask RelayNextAsync(T value, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.ValueTask SubscribeOnceAsync() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("ReattemptWitness: Subscription = {Subscription}")]
     public sealed class ReattemptWitness<T> : ReactiveUI.Primitives.Async.WitnessAsync<T>
     {
         public ReattemptWitness(ReactiveUI.Primitives.Async.Advanced.ReattemptSubscription<T> subscription) { }
@@ -1071,19 +1071,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
     {
         public RelayWitnessAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("StartValue = {StartValue}, Count = {Count}")]
+    [System.Diagnostics.DebuggerDisplay("SequenceSignal: StartValue = {StartValue}, Count = {Count}")]
     public sealed class SequenceSignal : ReactiveUI.Primitives.Async.IObservableAsync<int>
     {
         public SequenceSignal(int start, int count) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<System.Int32>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<int> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("StartValue = {StartValue}, Count = {Count}")]
+    [System.Diagnostics.DebuggerDisplay("SequenceSubscription: StartValue = {StartValue}, Count = {Count}")]
     public sealed class SequenceSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<int>
     {
         public SequenceSubscription(ReactiveUI.Primitives.Async.IObserverAsync<int> observer, int start, int count) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<int> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasValue = {_hasValue}, Value = {_value}")]
+    [System.Diagnostics.DebuggerDisplay("SingleElementWitness: HasValue = {_hasValue}, Value = {_value}")]
     public sealed class SingleElementWitness<T> : ReactiveUI.Primitives.Async.Advanced.TaskResultWitnessAsyncBase<T, T?>
     {
         public SingleElementWitness(System.Func<T, bool>? predicate, bool requireExactlyOne, T? defaultValue, System.Threading.CancellationToken cancellationToken) { }
@@ -1091,31 +1091,31 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(T value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Function = {Function}, TaskScheduler = {TaskScheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Function = {Function}, TaskScheduler = {TaskScheduler}")]
     public sealed class StartSignal<TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public StartSignal(System.Func<TResult> function, System.Threading.Tasks.TaskScheduler? taskScheduler) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Function = {Function}, TaskScheduler = {TaskScheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSubscription: Function = {Function}, TaskScheduler = {TaskScheduler}")]
     public sealed class StartSubscription<TResult> : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<TResult>
     {
         public StartSubscription(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Func<TResult> function, System.Threading.Tasks.TaskScheduler? taskScheduler) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceCount = {SourceCount}, Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest10Coordinator: SourceCount = {SourceCount}, Sources = {Sources}")]
     public sealed class SyncLatest10Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest10Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest10State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest10Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest10Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest10Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest10State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source10 = {Source10}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest10State: Source1 = {Source1}, Source10 = {Source10}")]
     public readonly record struct SyncLatest10State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest10State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>>
     {
         public SyncLatest10State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8, ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9, ReactiveUI.Primitives.Async.IObservableAsync<T10> Source10) { }
@@ -1130,19 +1130,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceCount = {SourceCount}, Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest11Coordinator: SourceCount = {SourceCount}, Sources = {Sources}")]
     public sealed class SyncLatest11Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest11Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest11State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest11Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest11Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest11Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest11State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source2 = {Source2}, Source11 = {Source11}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest11State: Source1 = {Source1}, Source2 = {Source2}, Source11 = {Source11}")]
     public readonly record struct SyncLatest11State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest11State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>>
     {
         public SyncLatest11State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8, ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9, ReactiveUI.Primitives.Async.IObservableAsync<T10> Source10, ReactiveUI.Primitives.Async.IObservableAsync<T11> Source11) { }
@@ -1158,19 +1158,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Lifecycle = {Lifecycle}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest12Coordinator: Sources = {Sources}, Lifecycle = {Lifecycle}")]
     public sealed class SyncLatest12Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest12Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest12State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest12Signal: Sources = {Sources}")]
     public sealed class SyncLatest12Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest12Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest12State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source12 = {Source12}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest12State: Source1 = {Source1}, Source12 = {Source12}")]
     public readonly record struct SyncLatest12State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest12State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>>
     {
         public SyncLatest12State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8, ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9, ReactiveUI.Primitives.Async.IObservableAsync<T10> Source10, ReactiveUI.Primitives.Async.IObservableAsync<T11> Source11, ReactiveUI.Primitives.Async.IObservableAsync<T12> Source12) { }
@@ -1187,19 +1187,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value13 = {Value13}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest13Coordinator: Value1 = {Value1}, Value13 = {Value13}")]
     public sealed class SyncLatest13Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest13Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest13State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest13Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest13Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest13Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest13State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source13 = {Source13}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest13State: Source1 = {Source1}, Source13 = {Source13}")]
     public readonly record struct SyncLatest13State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest13State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>>
     {
         public SyncLatest13State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8, ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9, ReactiveUI.Primitives.Async.IObservableAsync<T10> Source10, ReactiveUI.Primitives.Async.IObservableAsync<T11> Source11, ReactiveUI.Primitives.Async.IObservableAsync<T12> Source12, ReactiveUI.Primitives.Async.IObservableAsync<T13> Source13) { }
@@ -1217,19 +1217,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Lifecycle = {Lifecycle}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest14Coordinator: Sources = {Sources}, Lifecycle = {Lifecycle}")]
     public sealed class SyncLatest14Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest14Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest14State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest14Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest14Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest14Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest14State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source14 = {Source14}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest14State: Source1 = {Source1}, Source14 = {Source14}")]
     public readonly record struct SyncLatest14State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest14State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>>
     {
         public SyncLatest14State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8, ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9, ReactiveUI.Primitives.Async.IObservableAsync<T10> Source10, ReactiveUI.Primitives.Async.IObservableAsync<T11> Source11, ReactiveUI.Primitives.Async.IObservableAsync<T12> Source12, ReactiveUI.Primitives.Async.IObservableAsync<T13> Source13, ReactiveUI.Primitives.Async.IObservableAsync<T14> Source14) { }
@@ -1248,19 +1248,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value15 = {Value15}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest15Coordinator: Value1 = {Value1}, Value15 = {Value15}")]
     public sealed class SyncLatest15Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest15Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest15State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest15Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest15Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest15Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest15State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source15 = {Source15}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest15State: Source1 = {Source1}, Source15 = {Source15}")]
     public readonly record struct SyncLatest15State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest15State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>>
     {
         public SyncLatest15State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8, ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9, ReactiveUI.Primitives.Async.IObservableAsync<T10> Source10, ReactiveUI.Primitives.Async.IObservableAsync<T11> Source11, ReactiveUI.Primitives.Async.IObservableAsync<T12> Source12, ReactiveUI.Primitives.Async.IObservableAsync<T13> Source13, ReactiveUI.Primitives.Async.IObservableAsync<T14> Source14, ReactiveUI.Primitives.Async.IObservableAsync<T15> Source15) { }
@@ -1280,19 +1280,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value16 = {Value16}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest16Coordinator: Value1 = {Value1}, Value16 = {Value16}")]
     public sealed class SyncLatest16Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest16Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest16State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest16Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest16Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest16Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest16State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source16 = {Source16}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest16State: Source1 = {Source1}, Source16 = {Source16}")]
     public readonly record struct SyncLatest16State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest16State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>>
     {
         public SyncLatest16State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8, ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9, ReactiveUI.Primitives.Async.IObservableAsync<T10> Source10, ReactiveUI.Primitives.Async.IObservableAsync<T11> Source11, ReactiveUI.Primitives.Async.IObservableAsync<T12> Source12, ReactiveUI.Primitives.Async.IObservableAsync<T13> Source13, ReactiveUI.Primitives.Async.IObservableAsync<T14> Source14, ReactiveUI.Primitives.Async.IObservableAsync<T15> Source15, ReactiveUI.Primitives.Async.IObservableAsync<T16> Source16) { }
@@ -1313,38 +1313,38 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest2Coordinator: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest2Coordinator<T1, T2, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest2Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest2State<T1, T2> sources, System.Func<T1, T2, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest2Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest2Signal<T1, T2, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest2Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest2State<T1, T2> sources, System.Func<T1, T2, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source2 = {Source2}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest2State: Source1 = {Source1}, Source2 = {Source2}")]
     public readonly record struct SyncLatest2State<T1, T2> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest2State<T1, T2>>
     {
         public SyncLatest2State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2) { }
         public ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value3 = {Value3}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest3Coordinator: Value1 = {Value1}, Value3 = {Value3}")]
     public sealed class SyncLatest3Coordinator<T1, T2, T3, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest3Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest3State<T1, T2, T3> sources, System.Func<T1, T2, T3, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest3Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest3Signal<T1, T2, T3, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest3Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest3State<T1, T2, T3> sources, System.Func<T1, T2, T3, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source2 = {Source2}, Source3 = {Source3}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest3State: Source1 = {Source1}, Source2 = {Source2}, Source3 = {Source3}")]
     public readonly record struct SyncLatest3State<T1, T2, T3> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest3State<T1, T2, T3>>
     {
         public SyncLatest3State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3) { }
@@ -1352,19 +1352,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value4 = {Value4}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest4Coordinator: Value1 = {Value1}, Value4 = {Value4}")]
     public sealed class SyncLatest4Coordinator<T1, T2, T3, T4, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest4Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest4State<T1, T2, T3, T4> sources, System.Func<T1, T2, T3, T4, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest4Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest4Signal<T1, T2, T3, T4, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest4Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest4State<T1, T2, T3, T4> sources, System.Func<T1, T2, T3, T4, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source2 = {Source2}, Source3 = {Source3}, Source4 = {Source4}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest4State: Source1 = {Source1}, Source2 = {Source2}, Source3 = {Source3}, Source4 = {Source4}")]
     public readonly record struct SyncLatest4State<T1, T2, T3, T4> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest4State<T1, T2, T3, T4>>
     {
         public SyncLatest4State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4) { }
@@ -1373,19 +1373,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value5 = {Value5}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest5Coordinator: Value1 = {Value1}, Value5 = {Value5}")]
     public sealed class SyncLatest5Coordinator<T1, T2, T3, T4, T5, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest5Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest5State<T1, T2, T3, T4, T5> sources, System.Func<T1, T2, T3, T4, T5, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest5Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest5Signal<T1, T2, T3, T4, T5, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest5Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest5State<T1, T2, T3, T4, T5> sources, System.Func<T1, T2, T3, T4, T5, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source5 = {Source5}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest5State: Source1 = {Source1}, Source5 = {Source5}")]
     public readonly record struct SyncLatest5State<T1, T2, T3, T4, T5> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest5State<T1, T2, T3, T4, T5>>
     {
         public SyncLatest5State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5) { }
@@ -1395,19 +1395,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value6 = {Value6}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest6Coordinator: Value1 = {Value1}, Value6 = {Value6}")]
     public sealed class SyncLatest6Coordinator<T1, T2, T3, T4, T5, T6, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest6Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest6State<T1, T2, T3, T4, T5, T6> sources, System.Func<T1, T2, T3, T4, T5, T6, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest6Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest6Signal<T1, T2, T3, T4, T5, T6, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest6Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest6State<T1, T2, T3, T4, T5, T6> sources, System.Func<T1, T2, T3, T4, T5, T6, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source6 = {Source6}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest6State: Source1 = {Source1}, Source6 = {Source6}")]
     public readonly record struct SyncLatest6State<T1, T2, T3, T4, T5, T6> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest6State<T1, T2, T3, T4, T5, T6>>
     {
         public SyncLatest6State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6) { }
@@ -1418,19 +1418,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest7Coordinator: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest7Coordinator<T1, T2, T3, T4, T5, T6, T7, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest7Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest7State<T1, T2, T3, T4, T5, T6, T7> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest7Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest7Signal<T1, T2, T3, T4, T5, T6, T7, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest7Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest7State<T1, T2, T3, T4, T5, T6, T7> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source7 = {Source7}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest7State: Source1 = {Source1}, Source7 = {Source7}")]
     public readonly record struct SyncLatest7State<T1, T2, T3, T4, T5, T6, T7> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest7State<T1, T2, T3, T4, T5, T6, T7>>
     {
         public SyncLatest7State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7) { }
@@ -1442,19 +1442,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest8Coordinator: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest8Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest8Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest8State<T1, T2, T3, T4, T5, T6, T7, T8> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest8Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest8Signal<T1, T2, T3, T4, T5, T6, T7, T8, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest8Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest8State<T1, T2, T3, T4, T5, T6, T7, T8> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source8 = {Source8}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest8State: Source1 = {Source1}, Source8 = {Source8}")]
     public readonly record struct SyncLatest8State<T1, T2, T3, T4, T5, T6, T7, T8> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest8State<T1, T2, T3, T4, T5, T6, T7, T8>>
     {
         public SyncLatest8State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8) { }
@@ -1467,19 +1467,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value9 = {Value9}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest9Coordinator: Value1 = {Value1}, Value9 = {Value9}")]
     public sealed class SyncLatest9Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest9Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest9State<T1, T2, T3, T4, T5, T6, T7, T8, T9> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest9Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest9Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest9Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest9State<T1, T2, T3, T4, T5, T6, T7, T8, T9> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source9 = {Source9}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest9State: Source1 = {Source1}, Source9 = {Source9}")]
     public readonly record struct SyncLatest9State<T1, T2, T3, T4, T5, T6, T7, T8, T9> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest9State<T1, T2, T3, T4, T5, T6, T7, T8, T9>>
     {
         public SyncLatest9State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8, ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9) { }
@@ -1493,7 +1493,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceCount = {Lifecycle.Subscriptions.Length}, HasDisposed = {Lifecycle.HasDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestCoordinatorBase: SourceCount = {Lifecycle.Subscriptions.Length}, HasDisposed = {Lifecycle.HasDisposed}")]
     public abstract class SyncLatestCoordinatorBase<TResult> : System.IAsyncDisposable
     {
         protected SyncLatestCoordinatorBase(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, int sourceCount) { }
@@ -1501,7 +1501,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected abstract System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.ValueTask SubscribeSourcesAsync(System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources.Length}, Completed = {_completedCount}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestEnumerableCoordinator: Sources = {Sources.Length}, Completed = {_completedCount}, Disposed = {_disposed}")]
     public sealed class SyncLatestEnumerableCoordinator<TSource, TResult> : System.IAsyncDisposable
     {
         public SyncLatestEnumerableCoordinator(ReactiveUI.Primitives.Async.IObservableAsync<TSource>[] sources, ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Func<System.Collections.Generic.IReadOnlyList<TSource>, TResult> resultSelector) { }
@@ -1509,13 +1509,13 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public System.Threading.Tasks.ValueTask DisposeAsync() { }
         public System.Threading.Tasks.ValueTask SubscribeSourcesAsync(System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceCount = {Sources.Length}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestEnumerableSignal: SourceCount = {Sources.Length}")]
     public sealed class SyncLatestEnumerableSignal<TSource, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatestEnumerableSignal(System.Collections.Generic.IEnumerable<ReactiveUI.Primitives.Async.IObservableAsync<TSource>> sources, System.Func<System.Collections.Generic.IReadOnlyList<TSource>, TResult> resultSelector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Index = {Index}, Parent = {Parent}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestEnumerableWitness: Index = {Index}, Parent = {Parent}")]
     public sealed class SyncLatestEnumerableWitness<TSource, TResult> : ReactiveUI.Primitives.Async.IObserverAsync<TSource>
     {
         public SyncLatestEnumerableWitness(ReactiveUI.Primitives.Async.Advanced.SyncLatestEnumerableCoordinator<TSource, TResult> parent, int index) { }
@@ -1535,7 +1535,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(TSource value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceCount = {Subscriptions.Length}, HasDisposed = {HasDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestLifecycle: SourceCount = {Subscriptions.Length}, HasDisposed = {HasDisposed}")]
     public sealed class SyncLatestLifecycle<TResult> : System.IAsyncDisposable
     {
         public SyncLatestLifecycle(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, int sourceCount) { }
@@ -1557,7 +1557,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(TSource value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, DisposeRequested = {DisposeToken.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("TakeUntilLifecycle: Observer = {_observer}, DisposeRequested = {DisposeToken.IsCancellationRequested}")]
     public sealed class TakeUntilLifecycle<T> : System.IAsyncDisposable
     {
         public TakeUntilLifecycle(ReactiveUI.Primitives.Async.IObserverAsync<T> observer) { }
@@ -1575,7 +1575,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(T value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsCompleted = {_taskSource.Task.IsCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("TaskResultCompletionSource: IsCompleted = {_taskSource.Task.IsCompleted}")]
     public sealed class TaskResultCompletionSource<T>
     {
         public TaskResultCompletionSource(System.Threading.CancellationToken cancellationToken) { }
@@ -1583,19 +1583,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public System.Threading.Tasks.ValueTask SetExceptionAndDisposeAsync(System.Exception exception, ReactiveUI.Primitives.Async.Advanced.IReentrantAsyncDisposable owner) { }
         public System.Threading.Tasks.ValueTask SetResultAndDisposeAsync(T value, ReactiveUI.Primitives.Async.Advanced.IReentrantAsyncDisposable owner) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskResultSignal: Task = {Task}")]
     public sealed class TaskResultSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public TaskResultSignal(System.Threading.Tasks.Task<T> task) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskResultSubscription: Task = {Task}")]
     public sealed class TaskResultSubscription<T> : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<T>
     {
         public TaskResultSubscription(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.Tasks.Task<T> task) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completion = {_completion}")]
+    [System.Diagnostics.DebuggerDisplay("TaskResultWitnessAsyncBase: Completion = {_completion}")]
     public abstract class TaskResultWitnessAsyncBase<T, TTaskValue> : ReactiveUI.Primitives.Async.WitnessAsync<T>
     {
         protected TaskResultWitnessAsyncBase(System.Threading.CancellationToken cancellationToken) { }
@@ -1610,7 +1610,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
     {
         public static ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<T> StartNew<T>(System.Func<ReactiveUI.Primitives.Async.IObserverAsync<T>, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> executeAsyncCore, ReactiveUI.Primitives.Async.IObserverAsync<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Disposed = {_disposed}, Completed = {_tcs.Task.IsCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("TaskSignalSubscription: Disposed = {_disposed}, Completed = {_tcs.Task.IsCompleted}")]
     public abstract class TaskSignalSubscription<T> : System.IAsyncDisposable
     {
         protected TaskSignalSubscription(ReactiveUI.Primitives.Async.IObserverAsync<T> observer) { }
@@ -1618,25 +1618,25 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected abstract System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
         public void Start() { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {DueTime}, Period = {Period}")]
+    [System.Diagnostics.DebuggerDisplay("TimerSignal: DueTime = {DueTime}, Period = {Period}")]
     public sealed class TimerSignal : ReactiveUI.Primitives.Async.IObservableAsync<long>
     {
         public TimerSignal(System.TimeSpan dueTime, System.TimeSpan? period, System.TimeProvider timeProvider) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<System.Int64>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<long> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {DueTime}, Period = {Period}")]
+    [System.Diagnostics.DebuggerDisplay("TimerSubscription: DueTime = {DueTime}, Period = {Period}")]
     public sealed class TimerSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<long>
     {
         public TimerSubscription(ReactiveUI.Primitives.Async.IObserverAsync<long> observer, System.TimeSpan dueTime, System.TimeSpan? period, System.TimeProvider timeProvider) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<long> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ResourceFactory = {ResourceFactory}, SignalFactory = {SignalFactory}")]
+    [System.Diagnostics.DebuggerDisplay("UsingSignal: ResourceFactory = {ResourceFactory}, SignalFactory = {SignalFactory}")]
     public sealed class UsingSignal<TResource, T> : ReactiveUI.Primitives.Async.IObservableAsync<T> where TResource : System.IAsyncDisposable
     {
         public UsingSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResource>> resourceFactory, System.Func<TResource, ReactiveUI.Primitives.Async.IObservableAsync<T>> signalFactory) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Resource = {Resource}")]
+    [System.Diagnostics.DebuggerDisplay("UsingWitness: Resource = {Resource}")]
     public sealed class UsingWitness<TResource, T> : ReactiveUI.Primitives.Async.Advanced.ForwardingWitnessAsync<T> where TResource : System.IAsyncDisposable
     {
         public UsingWitness(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, TResource resource) { }
@@ -1661,7 +1661,7 @@ namespace ReactiveUI.Primitives.Async.Disposables
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public static System.Threading.Tasks.ValueTask SwapAsync(ref System.IAsyncDisposable? slot, System.IAsyncDisposable? value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, IsDisposed = {_isDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("MultipleDisposableAsync: Count = {_count}, IsDisposed = {_isDisposed}")]
     public sealed class MultipleDisposableAsync : System.IAsyncDisposable
     {
         public MultipleDisposableAsync() { }
@@ -1678,7 +1678,7 @@ namespace ReactiveUI.Primitives.Async.Disposables
         public System.Collections.Generic.IEnumerator<System.IAsyncDisposable> GetEnumerator() { }
         public System.Threading.Tasks.ValueTask<bool> Remove(System.IAsyncDisposable item) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsDisposed = {IsDisposed}, Current = {_current}")]
+    [System.Diagnostics.DebuggerDisplay("SingleAssignmentDisposableAsync: IsDisposed = {IsDisposed}, Current = {_current}")]
     public sealed class SingleAssignmentDisposableAsync : System.IAsyncDisposable
     {
         public SingleAssignmentDisposableAsync() { }
@@ -1689,7 +1689,7 @@ namespace ReactiveUI.Primitives.Async.Disposables
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.Threading.Tasks.ValueTask SetDisposableAsync(System.IAsyncDisposable? value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Current = {_current}")]
+    [System.Diagnostics.DebuggerDisplay("SingleReplaceableDisposableAsync: Current = {_current}")]
     public class SingleReplaceableDisposableAsync : System.IAsyncDisposable
     {
         public SingleReplaceableDisposableAsync() { }
@@ -1715,7 +1715,7 @@ namespace ReactiveUI.Primitives.Async.Helpers
 }
 namespace ReactiveUI.Primitives.Async.Signals
 {
-    [System.Diagnostics.DebuggerDisplay("PublishingOption = {PublishingOption}, IsStateless = {IsStateless}")]
+    [System.Diagnostics.DebuggerDisplay("BehaviorSignalCreationOptions: PublishingOption = {PublishingOption}, IsStateless = {IsStateless}")]
     public record BehaviorSignalCreationOptions : System.IEquatable<ReactiveUI.Primitives.Async.Signals.BehaviorSignalCreationOptions>
     {
         public required bool IsStateless { get; init; }
@@ -1731,7 +1731,7 @@ namespace ReactiveUI.Primitives.Async.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public static System.Threading.Tasks.ValueTask ForwardOnNextConcurrently<T>(System.Collections.Immutable.ImmutableArray<ReactiveUI.Primitives.Async.IObserverAsync<T>> observers, T value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("LastValue = {_state.LastValue}, IsDisposed = {_state.IsDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ConcurrentReplayLatestSignalAsync: LastValue = {_state.LastValue}, IsDisposed = {_state.IsDisposed}")]
     public sealed class ConcurrentReplayLatestSignalAsync<T> : ReactiveUI.Primitives.Async.Signals.ISignalAsync<T>
     {
         public ConcurrentReplayLatestSignalAsync(ReactiveUI.Primitives.Optional<T> startValue) { }
@@ -1747,7 +1747,7 @@ namespace ReactiveUI.Primitives.Async.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_state.Observers.Length}, Result = {_state.Result}")]
+    [System.Diagnostics.DebuggerDisplay("ConcurrentSignalAsync: Observers = {_state.Observers.Length}, Result = {_state.Result}")]
     public sealed class ConcurrentSignalAsync<T> : ReactiveUI.Primitives.Async.Signals.ISignalAsync<T>
     {
         public ConcurrentSignalAsync() { }
@@ -1763,7 +1763,7 @@ namespace ReactiveUI.Primitives.Async.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_state.Value}, IsDisposed = {_state.IsDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ConcurrentStatelessReplayLatestSignalAsync: Value = {_state.Value}, IsDisposed = {_state.IsDisposed}")]
     public sealed class ConcurrentStatelessReplayLatestSignalAsync<T> : ReactiveUI.Primitives.Async.Signals.ISignalAsync<T>
     {
         public ConcurrentStatelessReplayLatestSignalAsync(ReactiveUI.Primitives.Optional<T> startValue) { }
@@ -1779,7 +1779,7 @@ namespace ReactiveUI.Primitives.Async.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_state.Observers.Length}")]
+    [System.Diagnostics.DebuggerDisplay("ConcurrentStatelessSignalAsync: Observers = {_state.Observers.Length}")]
     public sealed class ConcurrentStatelessSignalAsync<T> : ReactiveUI.Primitives.Async.Signals.ISignalAsync<T>
     {
         public ConcurrentStatelessSignalAsync() { }
@@ -1804,14 +1804,14 @@ namespace ReactiveUI.Primitives.Async.Signals
         Serial = 0,
         Concurrent = 1,
     }
-    [System.Diagnostics.DebuggerDisplay("PublishingOption = {PublishingOption}, IsStateless = {IsStateless}")]
+    [System.Diagnostics.DebuggerDisplay("ReplayLatestSignalCreationOptions: PublishingOption = {PublishingOption}, IsStateless = {IsStateless}")]
     public record ReplayLatestSignalCreationOptions : System.IEquatable<ReactiveUI.Primitives.Async.Signals.ReplayLatestSignalCreationOptions>
     {
         public required bool IsStateless { get; init; }
         public required ReactiveUI.Primitives.Async.Signals.PublishingOption PublishingOption { get; init; }
         public static ReactiveUI.Primitives.Async.Signals.ReplayLatestSignalCreationOptions Default { get; }
     }
-    [System.Diagnostics.DebuggerDisplay("LastValue = {_state.LastValue}, IsDisposed = {_state.IsDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("SerialReplayLatestSignalAsync: LastValue = {_state.LastValue}, IsDisposed = {_state.IsDisposed}")]
     public sealed class SerialReplayLatestSignalAsync<T> : ReactiveUI.Primitives.Async.Signals.ISignalAsync<T>
     {
         public SerialReplayLatestSignalAsync(ReactiveUI.Primitives.Optional<T> startValue) { }
@@ -1827,7 +1827,7 @@ namespace ReactiveUI.Primitives.Async.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_state.Observers.Length}, Result = {_state.Result}")]
+    [System.Diagnostics.DebuggerDisplay("SerialSignalAsync: Observers = {_state.Observers.Length}, Result = {_state.Result}")]
     public sealed class SerialSignalAsync<T> : ReactiveUI.Primitives.Async.Signals.ISignalAsync<T>
     {
         public SerialSignalAsync() { }
@@ -1843,7 +1843,7 @@ namespace ReactiveUI.Primitives.Async.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("State = {_state}")]
+    [System.Diagnostics.DebuggerDisplay("SerialStatelessReplayLatestSignalAsync: State = {_state}")]
     public sealed class SerialStatelessReplayLatestSignalAsync<T> : ReactiveUI.Primitives.Async.Signals.ISignalAsync<T>
     {
         public SerialStatelessReplayLatestSignalAsync(ReactiveUI.Primitives.Optional<T> startValue) { }
@@ -1859,7 +1859,7 @@ namespace ReactiveUI.Primitives.Async.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_state.Observers.Length}")]
+    [System.Diagnostics.DebuggerDisplay("SerialStatelessSignalAsync: Observers = {_state.Observers.Length}")]
     public sealed class SerialStatelessSignalAsync<T> : ReactiveUI.Primitives.Async.Signals.ISignalAsync<T>
     {
         public SerialStatelessSignalAsync() { }
@@ -1887,7 +1887,7 @@ namespace ReactiveUI.Primitives.Async.Signals
         public static ReactiveUI.Primitives.Async.Signals.ISignalAsync<T> CreateReplayLatest<T>() { }
         public static ReactiveUI.Primitives.Async.Signals.ISignalAsync<T> CreateReplayLatest<T>(ReactiveUI.Primitives.Async.Signals.ReplayLatestSignalCreationOptions? options) { }
     }
-    [System.Diagnostics.DebuggerDisplay("PublishingOption = {PublishingOption}, IsStateless = {IsStateless}")]
+    [System.Diagnostics.DebuggerDisplay("SignalCreationOptions: PublishingOption = {PublishingOption}, IsStateless = {IsStateless}")]
     public record SignalCreationOptions : System.IEquatable<ReactiveUI.Primitives.Async.Signals.SignalCreationOptions>
     {
         public required bool IsStateless { get; init; }

--- a/src/ReactiveUI.Primitives.Async.Core/PublicAPI/net462/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Async.Core/PublicAPI/net462/PublicAPI.txt
@@ -3,7 +3,7 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Primitives.Tests")]
 namespace ReactiveUI.Primitives.Async
 {
-    [System.Diagnostics.DebuggerDisplay("Signals = {_signals}")]
+    [System.Diagnostics.DebuggerDisplay("ChainEnumerableSignal: Signals = {_signals}")]
     public sealed class ChainEnumerableSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public ChainEnumerableSignal(System.Collections.Generic.IEnumerable<ReactiveUI.Primitives.Async.IObservableAsync<T>> signals) { }
@@ -23,7 +23,7 @@ namespace ReactiveUI.Primitives.Async
         protected ConcurrentWitnessCallsException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public ConcurrentWitnessCallsException(string message, System.Exception innerException) { }
     }
-    [System.Diagnostics.DebuggerDisplay("State = {State}")]
+    [System.Diagnostics.DebuggerDisplay("ConnectableSignalAsync: State = {State}")]
     public sealed class ConnectableSignalAsync<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>, System.IDisposable
     {
         public ConnectableSignalAsync(ReactiveUI.Primitives.Async.IObservableAsync<T> source, ReactiveUI.Primitives.Async.Signals.ISignalAsync<T> signal) { }
@@ -41,7 +41,7 @@ namespace ReactiveUI.Primitives.Async
             public System.IAsyncDisposable ToDisposableAsync() { }
         }
     }
-    [System.Diagnostics.DebuggerDisplay("Key = {Key}")]
+    [System.Diagnostics.DebuggerDisplay("GroupedAsyncSignal: Key = {Key}")]
     public sealed class GroupedAsyncSignal<TKey, TValue> : ReactiveUI.Primitives.Async.IObservableAsync<TValue>
     {
         public TKey Key { get; }
@@ -826,7 +826,7 @@ namespace ReactiveUI.Primitives.Async
         public SwitchToSignal(ReactiveUI.Primitives.Async.IObservableAsync<ReactiveUI.Primitives.Async.IObservableAsync<T>> source) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceFailsWhenOtherFails = {SourceFailsWhenOtherFails}")]
+    [System.Diagnostics.DebuggerDisplay("TakeUntilOptions: SourceFailsWhenOtherFails = {SourceFailsWhenOtherFails}")]
     public record TakeUntilOptions : System.IEquatable<ReactiveUI.Primitives.Async.TakeUntilOptions>
     {
         public bool SourceFailsWhenOtherFails { get; init; }
@@ -836,7 +836,7 @@ namespace ReactiveUI.Primitives.Async
     {
         public static void Register(System.Action<System.Exception> unhandledExceptionHandler) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Disposed = {_disposed}, CallState = {_callState}")]
+    [System.Diagnostics.DebuggerDisplay("WitnessAsync: Disposed = {_disposed}, CallState = {_callState}")]
     public abstract class WitnessAsync<T> : ReactiveUI.Primitives.Async.Advanced.IReentrantAsyncDisposable, ReactiveUI.Primitives.Async.IObserverAsync<T>
     {
         protected WitnessAsync() { }
@@ -860,19 +860,19 @@ namespace ReactiveUI.Primitives.Async
 }
 namespace ReactiveUI.Primitives.Async.Advanced
 {
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncEnumerableSignal: Source = {Source}")]
     public sealed class AsyncEnumerableSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public AsyncEnumerableSignal(System.Collections.Generic.IAsyncEnumerable<T> source) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncEnumerableSubscription: Source = {Source}")]
     public sealed class AsyncEnumerableSubscription<T> : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<T>
     {
         public AsyncEnumerableSubscription(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Collections.Generic.IAsyncEnumerable<T> source) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("OwnerThreadId = {_ownerThreadId}, Waiters = {_waiters}, RecursionDepth = {_recursionDepth}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncSerialGate: OwnerThreadId = {_ownerThreadId}, Waiters = {_waiters}, RecursionDepth = {_recursionDepth}")]
     public sealed class AsyncSerialGate : System.IDisposable
     {
         public AsyncSerialGate() { }
@@ -880,7 +880,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.Threading.Tasks.ValueTask<ReactiveUI.Primitives.Async.Advanced.AsyncSerialGate.Lease> EnterAsync() { }
         public System.Threading.Tasks.ValueTask<ReactiveUI.Primitives.Async.Advanced.AsyncSerialGate.Lease> EnterAsync(System.Threading.CancellationToken cancellationToken) { }
-        [System.Diagnostics.DebuggerDisplay("Parent = {_parent}")]
+        [System.Diagnostics.DebuggerDisplay("Lease: Parent = {_parent}")]
         public readonly record struct Lease : System.IDisposable, System.IEquatable<ReactiveUI.Primitives.Async.Advanced.AsyncSerialGate.Lease>
         {
             public Lease(ReactiveUI.Primitives.Async.Advanced.AsyncSerialGate parent) { }
@@ -888,13 +888,13 @@ namespace ReactiveUI.Primitives.Async.Advanced
             public readonly void Dispose() { }
         }
     }
-    [System.Diagnostics.DebuggerDisplay("StartSynchronously = {StartSynchronously}, TaskScheduler = {TaskScheduler}")]
+    [System.Diagnostics.DebuggerDisplay("BackgroundJobSignal: StartSynchronously = {StartSynchronously}, TaskScheduler = {TaskScheduler}")]
     public sealed class BackgroundJobSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public BackgroundJobSignal(System.Func<ReactiveUI.Primitives.Async.IObserverAsync<T>, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> job, bool startSynchronously, System.Threading.Tasks.TaskScheduler? taskScheduler) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasDisposed = {HasDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("CallbackWitnessAsync: HasDisposed = {HasDisposed}")]
     public sealed class CallbackWitnessAsync<T> : ReactiveUI.Primitives.Async.WitnessAsync<T>
     {
         public CallbackWitnessAsync(System.Func<T, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> onNextAsync, System.Func<System.Exception, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask>? onErrorResumeAsync = null, System.Func<ReactiveUI.Primitives.Result, System.Threading.Tasks.ValueTask>? onCompletedAsync = null) { }
@@ -902,31 +902,31 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(T value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Action = {Action}")]
+    [System.Diagnostics.DebuggerDisplay("DoOnSubscribeAsyncSignal: Source = {Source}, Action = {Action}")]
     public sealed class DoOnSubscribeAsyncSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public DoOnSubscribeAsyncSignal(ReactiveUI.Primitives.Async.IObservableAsync<T> source, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> action) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Action = {Action}")]
+    [System.Diagnostics.DebuggerDisplay("DoOnSubscribeSignal: Source = {Source}, Action = {Action}")]
     public sealed class DoOnSubscribeSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public DoOnSubscribeSignal(ReactiveUI.Primitives.Async.IObservableAsync<T> source, System.Action action) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("EnumerableSignal: Source = {Source}")]
     public sealed class EnumerableSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public EnumerableSignal(System.Collections.Generic.IEnumerable<T> source) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("EnumerableSubscription: Source = {Source}")]
     public sealed class EnumerableSubscription<T> : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<T>
     {
         public EnumerableSubscription(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Collections.Generic.IEnumerable<T> source) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ActiveInnerCount = {ActiveInnerCount}, OuterCompleted = {OuterCompleted}, Disposed = {Disposed}")]
+    [System.Diagnostics.DebuggerDisplay("FlatMapCoordinator: ActiveInnerCount = {ActiveInnerCount}, OuterCompleted = {OuterCompleted}, Disposed = {Disposed}")]
     public sealed class FlatMapCoordinator<TResult> : System.IAsyncDisposable
     {
         public FlatMapCoordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer) { }
@@ -942,14 +942,14 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public System.Threading.Tasks.ValueTask SetOuterObserverAsync(System.IAsyncDisposable observer) { }
         public System.Threading.Tasks.ValueTask SubscribeInnerAsync(ReactiveUI.Primitives.Async.IObservableAsync<TResult> inner) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, SyncSelector = {SyncSelector}, AsyncSelector = {AsyncSelector}")]
+    [System.Diagnostics.DebuggerDisplay("FlatMapSignal: Source = {Source}, SyncSelector = {SyncSelector}, AsyncSelector = {AsyncSelector}")]
     public sealed class FlatMapSignal<TSource, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public FlatMapSignal(ReactiveUI.Primitives.Async.IObservableAsync<TSource> source, System.Func<TSource, ReactiveUI.Primitives.Async.IObservableAsync<TResult>> selector) { }
         public FlatMapSignal(ReactiveUI.Primitives.Async.IObservableAsync<TSource> source, System.Func<TSource, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<ReactiveUI.Primitives.Async.IObservableAsync<TResult>>> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Coordinator = {Coordinator}")]
+    [System.Diagnostics.DebuggerDisplay("FlatMapWitness: Coordinator = {Coordinator}")]
     public sealed class FlatMapWitness<TResult> : ReactiveUI.Primitives.Async.WitnessAsync<TResult>
     {
         public FlatMapWitness(ReactiveUI.Primitives.Async.Advanced.FlatMapCoordinator<TResult> coordinator) { }
@@ -957,7 +957,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(TResult value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Coordinator = {Coordinator}, SyncSelector = {SyncSelector}, AsyncSelector = {AsyncSelector}")]
+    [System.Diagnostics.DebuggerDisplay("FlatMapWitness: Coordinator = {Coordinator}, SyncSelector = {SyncSelector}, AsyncSelector = {AsyncSelector}")]
     public sealed class FlatMapWitness<TSource, TResult> : ReactiveUI.Primitives.Async.WitnessAsync<TSource>
     {
         public FlatMapWitness(ReactiveUI.Primitives.Async.Advanced.FlatMapCoordinator<TResult> coordinator, System.Func<TSource, ReactiveUI.Primitives.Async.IObservableAsync<TResult>>? syncSelector, System.Func<TSource, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<ReactiveUI.Primitives.Async.IObservableAsync<TResult>>>? asyncSelector) { }
@@ -965,7 +965,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(TSource value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Downstream = {Downstream}")]
+    [System.Diagnostics.DebuggerDisplay("ForwardingWitnessAsync: Downstream = {Downstream}")]
     public class ForwardingWitnessAsync<T> : ReactiveUI.Primitives.Async.WitnessAsync<T>
     {
         protected ForwardingWitnessAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> downstream) { }
@@ -974,13 +974,13 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(T value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Factory = {Factory}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSignal: Factory = {Factory}")]
     public sealed class FromAsyncSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<T>> factory) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Factory = {Factory}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSubscription: Factory = {Factory}")]
     public sealed class FromAsyncSubscription<T> : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<T>
     {
         public FromAsyncSubscription(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<T>> factory) { }
@@ -990,39 +990,39 @@ namespace ReactiveUI.Primitives.Async.Advanced
     {
         System.Threading.Tasks.ValueTask DisposeFromNotificationAsync() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Period = {Period}, TimeProvider = {TimeProvider}")]
+    [System.Diagnostics.DebuggerDisplay("IntervalSignal: Period = {Period}, TimeProvider = {TimeProvider}")]
     public sealed class IntervalSignal : ReactiveUI.Primitives.Async.IObservableAsync<long>
     {
         public IntervalSignal(System.TimeSpan period, System.TimeProvider? timeProvider) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<System.Int64>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<long> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Period = {Period}, TimeProvider = {TimeProvider}")]
+    [System.Diagnostics.DebuggerDisplay("IntervalSubscription: Period = {Period}, TimeProvider = {TimeProvider}")]
     public sealed class IntervalSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<long>
     {
         public IntervalSubscription(ReactiveUI.Primitives.Async.IObserverAsync<long> observer, System.TimeSpan period, System.TimeProvider? timeProvider) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<long> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Values = {Values}")]
+    [System.Diagnostics.DebuggerDisplay("LeadSignal: Source = {Source}, Values = {Values}")]
     public sealed class LeadSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public LeadSignal(ReactiveUI.Primitives.Async.IObservableAsync<T> source, System.Collections.Generic.IEnumerable<T> values) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Disposed = {Disposed}, Pipeline = {Pipeline}")]
+    [System.Diagnostics.DebuggerDisplay("LeadSubscription: Disposed = {Disposed}, Pipeline = {Pipeline}")]
     public sealed class LeadSubscription<T> : System.IAsyncDisposable
     {
         public LeadSubscription(ReactiveUI.Primitives.Async.IObservableAsync<T> source, System.Collections.Generic.IEnumerable<T> values, ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken subscriptionToken) { }
         public System.Threading.Tasks.ValueTask DisposeAsync() { }
         public void Start() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Logger = {Logger}")]
+    [System.Diagnostics.DebuggerDisplay("LogErrorsSignal: Source = {Source}, Logger = {Logger}")]
     public sealed class LogErrorsSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public LogErrorsSignal(ReactiveUI.Primitives.Async.IObservableAsync<T> source, System.Action<System.Exception> logger) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Downstream = {Downstream}, Logger = {Logger}")]
+    [System.Diagnostics.DebuggerDisplay("LogErrorsWitness: Downstream = {Downstream}, Logger = {Logger}")]
     public sealed class LogErrorsWitness<T> : ReactiveUI.Primitives.Async.WitnessAsync<T>
     {
         public LogErrorsWitness(ReactiveUI.Primitives.Async.IObserverAsync<T> downstream, System.Action<System.Exception> logger) { }
@@ -1030,7 +1030,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(T value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {_completed}, Timer = {_timer}")]
+    [System.Diagnostics.DebuggerDisplay("PooledDelaySource: Completed = {_completed}, Timer = {_timer}")]
     public sealed class PooledDelaySource : System.Threading.Tasks.Sources.IValueTaskSource
     {
         public System.Threading.Tasks.ValueTask BeginAsync(System.TimeSpan delay, System.TimeProvider timeProvider, System.Threading.CancellationToken cancellationToken) { }
@@ -1041,13 +1041,13 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public void OnCompleted(System.Action<object?> continuation, object? state, short token, System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags flags) { }
         public static ReactiveUI.Primitives.Async.Advanced.PooledDelaySource Rent() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, RetryCount = {RetryCount}")]
+    [System.Diagnostics.DebuggerDisplay("ReattemptSignal: Source = {Source}, RetryCount = {RetryCount}")]
     public sealed class ReattemptSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public ReattemptSignal(ReactiveUI.Primitives.Async.IObservableAsync<T> source, int retryCount) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Remaining = {Remaining}")]
+    [System.Diagnostics.DebuggerDisplay("ReattemptSubscription: Source = {Source}, Remaining = {Remaining}")]
     public sealed class ReattemptSubscription<T> : System.IAsyncDisposable
     {
         public ReattemptSubscription(ReactiveUI.Primitives.Async.IObservableAsync<T> source, ReactiveUI.Primitives.Async.IObserverAsync<T> observer, int retryCount, System.Threading.CancellationToken cancellationToken) { }
@@ -1060,7 +1060,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public System.Threading.Tasks.ValueTask RelayNextAsync(T value, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.ValueTask SubscribeOnceAsync() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("ReattemptWitness: Subscription = {Subscription}")]
     public sealed class ReattemptWitness<T> : ReactiveUI.Primitives.Async.WitnessAsync<T>
     {
         public ReattemptWitness(ReactiveUI.Primitives.Async.Advanced.ReattemptSubscription<T> subscription) { }
@@ -1072,19 +1072,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
     {
         public RelayWitnessAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("StartValue = {StartValue}, Count = {Count}")]
+    [System.Diagnostics.DebuggerDisplay("SequenceSignal: StartValue = {StartValue}, Count = {Count}")]
     public sealed class SequenceSignal : ReactiveUI.Primitives.Async.IObservableAsync<int>
     {
         public SequenceSignal(int start, int count) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<System.Int32>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<int> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("StartValue = {StartValue}, Count = {Count}")]
+    [System.Diagnostics.DebuggerDisplay("SequenceSubscription: StartValue = {StartValue}, Count = {Count}")]
     public sealed class SequenceSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<int>
     {
         public SequenceSubscription(ReactiveUI.Primitives.Async.IObserverAsync<int> observer, int start, int count) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<int> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasValue = {_hasValue}, Value = {_value}")]
+    [System.Diagnostics.DebuggerDisplay("SingleElementWitness: HasValue = {_hasValue}, Value = {_value}")]
     public sealed class SingleElementWitness<T> : ReactiveUI.Primitives.Async.Advanced.TaskResultWitnessAsyncBase<T, T?>
     {
         public SingleElementWitness(System.Func<T, bool>? predicate, bool requireExactlyOne, T? defaultValue, System.Threading.CancellationToken cancellationToken) { }
@@ -1092,31 +1092,31 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(T value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Function = {Function}, TaskScheduler = {TaskScheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Function = {Function}, TaskScheduler = {TaskScheduler}")]
     public sealed class StartSignal<TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public StartSignal(System.Func<TResult> function, System.Threading.Tasks.TaskScheduler? taskScheduler) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Function = {Function}, TaskScheduler = {TaskScheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSubscription: Function = {Function}, TaskScheduler = {TaskScheduler}")]
     public sealed class StartSubscription<TResult> : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<TResult>
     {
         public StartSubscription(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Func<TResult> function, System.Threading.Tasks.TaskScheduler? taskScheduler) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceCount = {SourceCount}, Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest10Coordinator: SourceCount = {SourceCount}, Sources = {Sources}")]
     public sealed class SyncLatest10Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest10Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest10State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest10Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest10Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest10Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest10State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source10 = {Source10}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest10State: Source1 = {Source1}, Source10 = {Source10}")]
     public readonly record struct SyncLatest10State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest10State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>>
     {
         public SyncLatest10State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8, ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9, ReactiveUI.Primitives.Async.IObservableAsync<T10> Source10) { }
@@ -1131,19 +1131,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceCount = {SourceCount}, Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest11Coordinator: SourceCount = {SourceCount}, Sources = {Sources}")]
     public sealed class SyncLatest11Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest11Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest11State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest11Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest11Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest11Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest11State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source2 = {Source2}, Source11 = {Source11}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest11State: Source1 = {Source1}, Source2 = {Source2}, Source11 = {Source11}")]
     public readonly record struct SyncLatest11State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest11State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>>
     {
         public SyncLatest11State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8, ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9, ReactiveUI.Primitives.Async.IObservableAsync<T10> Source10, ReactiveUI.Primitives.Async.IObservableAsync<T11> Source11) { }
@@ -1159,19 +1159,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Lifecycle = {Lifecycle}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest12Coordinator: Sources = {Sources}, Lifecycle = {Lifecycle}")]
     public sealed class SyncLatest12Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest12Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest12State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest12Signal: Sources = {Sources}")]
     public sealed class SyncLatest12Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest12Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest12State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source12 = {Source12}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest12State: Source1 = {Source1}, Source12 = {Source12}")]
     public readonly record struct SyncLatest12State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest12State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>>
     {
         public SyncLatest12State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8, ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9, ReactiveUI.Primitives.Async.IObservableAsync<T10> Source10, ReactiveUI.Primitives.Async.IObservableAsync<T11> Source11, ReactiveUI.Primitives.Async.IObservableAsync<T12> Source12) { }
@@ -1188,19 +1188,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value13 = {Value13}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest13Coordinator: Value1 = {Value1}, Value13 = {Value13}")]
     public sealed class SyncLatest13Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest13Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest13State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest13Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest13Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest13Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest13State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source13 = {Source13}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest13State: Source1 = {Source1}, Source13 = {Source13}")]
     public readonly record struct SyncLatest13State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest13State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>>
     {
         public SyncLatest13State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8, ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9, ReactiveUI.Primitives.Async.IObservableAsync<T10> Source10, ReactiveUI.Primitives.Async.IObservableAsync<T11> Source11, ReactiveUI.Primitives.Async.IObservableAsync<T12> Source12, ReactiveUI.Primitives.Async.IObservableAsync<T13> Source13) { }
@@ -1218,19 +1218,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Lifecycle = {Lifecycle}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest14Coordinator: Sources = {Sources}, Lifecycle = {Lifecycle}")]
     public sealed class SyncLatest14Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest14Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest14State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest14Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest14Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest14Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest14State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source14 = {Source14}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest14State: Source1 = {Source1}, Source14 = {Source14}")]
     public readonly record struct SyncLatest14State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest14State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>>
     {
         public SyncLatest14State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8, ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9, ReactiveUI.Primitives.Async.IObservableAsync<T10> Source10, ReactiveUI.Primitives.Async.IObservableAsync<T11> Source11, ReactiveUI.Primitives.Async.IObservableAsync<T12> Source12, ReactiveUI.Primitives.Async.IObservableAsync<T13> Source13, ReactiveUI.Primitives.Async.IObservableAsync<T14> Source14) { }
@@ -1249,19 +1249,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value15 = {Value15}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest15Coordinator: Value1 = {Value1}, Value15 = {Value15}")]
     public sealed class SyncLatest15Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest15Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest15State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest15Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest15Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest15Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest15State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source15 = {Source15}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest15State: Source1 = {Source1}, Source15 = {Source15}")]
     public readonly record struct SyncLatest15State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest15State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>>
     {
         public SyncLatest15State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8, ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9, ReactiveUI.Primitives.Async.IObservableAsync<T10> Source10, ReactiveUI.Primitives.Async.IObservableAsync<T11> Source11, ReactiveUI.Primitives.Async.IObservableAsync<T12> Source12, ReactiveUI.Primitives.Async.IObservableAsync<T13> Source13, ReactiveUI.Primitives.Async.IObservableAsync<T14> Source14, ReactiveUI.Primitives.Async.IObservableAsync<T15> Source15) { }
@@ -1281,19 +1281,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value16 = {Value16}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest16Coordinator: Value1 = {Value1}, Value16 = {Value16}")]
     public sealed class SyncLatest16Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest16Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest16State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest16Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest16Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest16Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest16State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source16 = {Source16}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest16State: Source1 = {Source1}, Source16 = {Source16}")]
     public readonly record struct SyncLatest16State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest16State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>>
     {
         public SyncLatest16State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8, ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9, ReactiveUI.Primitives.Async.IObservableAsync<T10> Source10, ReactiveUI.Primitives.Async.IObservableAsync<T11> Source11, ReactiveUI.Primitives.Async.IObservableAsync<T12> Source12, ReactiveUI.Primitives.Async.IObservableAsync<T13> Source13, ReactiveUI.Primitives.Async.IObservableAsync<T14> Source14, ReactiveUI.Primitives.Async.IObservableAsync<T15> Source15, ReactiveUI.Primitives.Async.IObservableAsync<T16> Source16) { }
@@ -1314,38 +1314,38 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest2Coordinator: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest2Coordinator<T1, T2, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest2Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest2State<T1, T2> sources, System.Func<T1, T2, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest2Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest2Signal<T1, T2, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest2Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest2State<T1, T2> sources, System.Func<T1, T2, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source2 = {Source2}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest2State: Source1 = {Source1}, Source2 = {Source2}")]
     public readonly record struct SyncLatest2State<T1, T2> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest2State<T1, T2>>
     {
         public SyncLatest2State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2) { }
         public ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value3 = {Value3}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest3Coordinator: Value1 = {Value1}, Value3 = {Value3}")]
     public sealed class SyncLatest3Coordinator<T1, T2, T3, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest3Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest3State<T1, T2, T3> sources, System.Func<T1, T2, T3, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest3Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest3Signal<T1, T2, T3, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest3Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest3State<T1, T2, T3> sources, System.Func<T1, T2, T3, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source2 = {Source2}, Source3 = {Source3}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest3State: Source1 = {Source1}, Source2 = {Source2}, Source3 = {Source3}")]
     public readonly record struct SyncLatest3State<T1, T2, T3> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest3State<T1, T2, T3>>
     {
         public SyncLatest3State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3) { }
@@ -1353,19 +1353,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value4 = {Value4}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest4Coordinator: Value1 = {Value1}, Value4 = {Value4}")]
     public sealed class SyncLatest4Coordinator<T1, T2, T3, T4, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest4Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest4State<T1, T2, T3, T4> sources, System.Func<T1, T2, T3, T4, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest4Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest4Signal<T1, T2, T3, T4, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest4Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest4State<T1, T2, T3, T4> sources, System.Func<T1, T2, T3, T4, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source2 = {Source2}, Source3 = {Source3}, Source4 = {Source4}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest4State: Source1 = {Source1}, Source2 = {Source2}, Source3 = {Source3}, Source4 = {Source4}")]
     public readonly record struct SyncLatest4State<T1, T2, T3, T4> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest4State<T1, T2, T3, T4>>
     {
         public SyncLatest4State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4) { }
@@ -1374,19 +1374,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value5 = {Value5}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest5Coordinator: Value1 = {Value1}, Value5 = {Value5}")]
     public sealed class SyncLatest5Coordinator<T1, T2, T3, T4, T5, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest5Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest5State<T1, T2, T3, T4, T5> sources, System.Func<T1, T2, T3, T4, T5, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest5Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest5Signal<T1, T2, T3, T4, T5, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest5Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest5State<T1, T2, T3, T4, T5> sources, System.Func<T1, T2, T3, T4, T5, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source5 = {Source5}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest5State: Source1 = {Source1}, Source5 = {Source5}")]
     public readonly record struct SyncLatest5State<T1, T2, T3, T4, T5> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest5State<T1, T2, T3, T4, T5>>
     {
         public SyncLatest5State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5) { }
@@ -1396,19 +1396,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value6 = {Value6}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest6Coordinator: Value1 = {Value1}, Value6 = {Value6}")]
     public sealed class SyncLatest6Coordinator<T1, T2, T3, T4, T5, T6, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest6Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest6State<T1, T2, T3, T4, T5, T6> sources, System.Func<T1, T2, T3, T4, T5, T6, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest6Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest6Signal<T1, T2, T3, T4, T5, T6, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest6Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest6State<T1, T2, T3, T4, T5, T6> sources, System.Func<T1, T2, T3, T4, T5, T6, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source6 = {Source6}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest6State: Source1 = {Source1}, Source6 = {Source6}")]
     public readonly record struct SyncLatest6State<T1, T2, T3, T4, T5, T6> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest6State<T1, T2, T3, T4, T5, T6>>
     {
         public SyncLatest6State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6) { }
@@ -1419,19 +1419,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest7Coordinator: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest7Coordinator<T1, T2, T3, T4, T5, T6, T7, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest7Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest7State<T1, T2, T3, T4, T5, T6, T7> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest7Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest7Signal<T1, T2, T3, T4, T5, T6, T7, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest7Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest7State<T1, T2, T3, T4, T5, T6, T7> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source7 = {Source7}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest7State: Source1 = {Source1}, Source7 = {Source7}")]
     public readonly record struct SyncLatest7State<T1, T2, T3, T4, T5, T6, T7> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest7State<T1, T2, T3, T4, T5, T6, T7>>
     {
         public SyncLatest7State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7) { }
@@ -1443,19 +1443,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest8Coordinator: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest8Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest8Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest8State<T1, T2, T3, T4, T5, T6, T7, T8> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest8Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest8Signal<T1, T2, T3, T4, T5, T6, T7, T8, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest8Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest8State<T1, T2, T3, T4, T5, T6, T7, T8> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source8 = {Source8}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest8State: Source1 = {Source1}, Source8 = {Source8}")]
     public readonly record struct SyncLatest8State<T1, T2, T3, T4, T5, T6, T7, T8> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest8State<T1, T2, T3, T4, T5, T6, T7, T8>>
     {
         public SyncLatest8State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8) { }
@@ -1468,19 +1468,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value9 = {Value9}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest9Coordinator: Value1 = {Value1}, Value9 = {Value9}")]
     public sealed class SyncLatest9Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest9Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest9State<T1, T2, T3, T4, T5, T6, T7, T8, T9> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest9Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest9Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest9Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest9State<T1, T2, T3, T4, T5, T6, T7, T8, T9> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source9 = {Source9}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest9State: Source1 = {Source1}, Source9 = {Source9}")]
     public readonly record struct SyncLatest9State<T1, T2, T3, T4, T5, T6, T7, T8, T9> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest9State<T1, T2, T3, T4, T5, T6, T7, T8, T9>>
     {
         public SyncLatest9State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8, ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9) { }
@@ -1494,7 +1494,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceCount = {Lifecycle.Subscriptions.Length}, HasDisposed = {Lifecycle.HasDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestCoordinatorBase: SourceCount = {Lifecycle.Subscriptions.Length}, HasDisposed = {Lifecycle.HasDisposed}")]
     public abstract class SyncLatestCoordinatorBase<TResult> : System.IAsyncDisposable
     {
         protected SyncLatestCoordinatorBase(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, int sourceCount) { }
@@ -1502,7 +1502,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected abstract System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.ValueTask SubscribeSourcesAsync(System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources.Length}, Completed = {_completedCount}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestEnumerableCoordinator: Sources = {Sources.Length}, Completed = {_completedCount}, Disposed = {_disposed}")]
     public sealed class SyncLatestEnumerableCoordinator<TSource, TResult> : System.IAsyncDisposable
     {
         public SyncLatestEnumerableCoordinator(ReactiveUI.Primitives.Async.IObservableAsync<TSource>[] sources, ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Func<System.Collections.Generic.IReadOnlyList<TSource>, TResult> resultSelector) { }
@@ -1510,13 +1510,13 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public System.Threading.Tasks.ValueTask DisposeAsync() { }
         public System.Threading.Tasks.ValueTask SubscribeSourcesAsync(System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceCount = {Sources.Length}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestEnumerableSignal: SourceCount = {Sources.Length}")]
     public sealed class SyncLatestEnumerableSignal<TSource, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatestEnumerableSignal(System.Collections.Generic.IEnumerable<ReactiveUI.Primitives.Async.IObservableAsync<TSource>> sources, System.Func<System.Collections.Generic.IReadOnlyList<TSource>, TResult> resultSelector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Index = {Index}, Parent = {Parent}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestEnumerableWitness: Index = {Index}, Parent = {Parent}")]
     public sealed class SyncLatestEnumerableWitness<TSource, TResult> : ReactiveUI.Primitives.Async.IObserverAsync<TSource>
     {
         public SyncLatestEnumerableWitness(ReactiveUI.Primitives.Async.Advanced.SyncLatestEnumerableCoordinator<TSource, TResult> parent, int index) { }
@@ -1536,7 +1536,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(TSource value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceCount = {Subscriptions.Length}, HasDisposed = {HasDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestLifecycle: SourceCount = {Subscriptions.Length}, HasDisposed = {HasDisposed}")]
     public sealed class SyncLatestLifecycle<TResult> : System.IAsyncDisposable
     {
         public SyncLatestLifecycle(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, int sourceCount) { }
@@ -1558,7 +1558,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(TSource value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, DisposeRequested = {DisposeToken.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("TakeUntilLifecycle: Observer = {_observer}, DisposeRequested = {DisposeToken.IsCancellationRequested}")]
     public sealed class TakeUntilLifecycle<T> : System.IAsyncDisposable
     {
         public TakeUntilLifecycle(ReactiveUI.Primitives.Async.IObserverAsync<T> observer) { }
@@ -1576,7 +1576,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(T value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsCompleted = {_taskSource.Task.IsCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("TaskResultCompletionSource: IsCompleted = {_taskSource.Task.IsCompleted}")]
     public sealed class TaskResultCompletionSource<T>
     {
         public TaskResultCompletionSource(System.Threading.CancellationToken cancellationToken) { }
@@ -1584,19 +1584,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public System.Threading.Tasks.ValueTask SetExceptionAndDisposeAsync(System.Exception exception, ReactiveUI.Primitives.Async.Advanced.IReentrantAsyncDisposable owner) { }
         public System.Threading.Tasks.ValueTask SetResultAndDisposeAsync(T value, ReactiveUI.Primitives.Async.Advanced.IReentrantAsyncDisposable owner) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskResultSignal: Task = {Task}")]
     public sealed class TaskResultSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public TaskResultSignal(System.Threading.Tasks.Task<T> task) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskResultSubscription: Task = {Task}")]
     public sealed class TaskResultSubscription<T> : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<T>
     {
         public TaskResultSubscription(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.Tasks.Task<T> task) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completion = {_completion}")]
+    [System.Diagnostics.DebuggerDisplay("TaskResultWitnessAsyncBase: Completion = {_completion}")]
     public abstract class TaskResultWitnessAsyncBase<T, TTaskValue> : ReactiveUI.Primitives.Async.WitnessAsync<T>
     {
         protected TaskResultWitnessAsyncBase(System.Threading.CancellationToken cancellationToken) { }
@@ -1611,7 +1611,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
     {
         public static ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<T> StartNew<T>(System.Func<ReactiveUI.Primitives.Async.IObserverAsync<T>, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> executeAsyncCore, ReactiveUI.Primitives.Async.IObserverAsync<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Disposed = {_disposed}, Completed = {_tcs.Task.IsCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("TaskSignalSubscription: Disposed = {_disposed}, Completed = {_tcs.Task.IsCompleted}")]
     public abstract class TaskSignalSubscription<T> : System.IAsyncDisposable
     {
         protected TaskSignalSubscription(ReactiveUI.Primitives.Async.IObserverAsync<T> observer) { }
@@ -1619,25 +1619,25 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected abstract System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
         public void Start() { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {DueTime}, Period = {Period}")]
+    [System.Diagnostics.DebuggerDisplay("TimerSignal: DueTime = {DueTime}, Period = {Period}")]
     public sealed class TimerSignal : ReactiveUI.Primitives.Async.IObservableAsync<long>
     {
         public TimerSignal(System.TimeSpan dueTime, System.TimeSpan? period, System.TimeProvider timeProvider) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<System.Int64>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<long> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {DueTime}, Period = {Period}")]
+    [System.Diagnostics.DebuggerDisplay("TimerSubscription: DueTime = {DueTime}, Period = {Period}")]
     public sealed class TimerSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<long>
     {
         public TimerSubscription(ReactiveUI.Primitives.Async.IObserverAsync<long> observer, System.TimeSpan dueTime, System.TimeSpan? period, System.TimeProvider timeProvider) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<long> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ResourceFactory = {ResourceFactory}, SignalFactory = {SignalFactory}")]
+    [System.Diagnostics.DebuggerDisplay("UsingSignal: ResourceFactory = {ResourceFactory}, SignalFactory = {SignalFactory}")]
     public sealed class UsingSignal<TResource, T> : ReactiveUI.Primitives.Async.IObservableAsync<T> where TResource : System.IAsyncDisposable
     {
         public UsingSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResource>> resourceFactory, System.Func<TResource, ReactiveUI.Primitives.Async.IObservableAsync<T>> signalFactory) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Resource = {Resource}")]
+    [System.Diagnostics.DebuggerDisplay("UsingWitness: Resource = {Resource}")]
     public sealed class UsingWitness<TResource, T> : ReactiveUI.Primitives.Async.Advanced.ForwardingWitnessAsync<T> where TResource : System.IAsyncDisposable
     {
         public UsingWitness(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, TResource resource) { }
@@ -1662,7 +1662,7 @@ namespace ReactiveUI.Primitives.Async.Disposables
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public static System.Threading.Tasks.ValueTask SwapAsync(ref System.IAsyncDisposable? slot, System.IAsyncDisposable? value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, IsDisposed = {_isDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("MultipleDisposableAsync: Count = {_count}, IsDisposed = {_isDisposed}")]
     public sealed class MultipleDisposableAsync : System.IAsyncDisposable
     {
         public MultipleDisposableAsync() { }
@@ -1679,7 +1679,7 @@ namespace ReactiveUI.Primitives.Async.Disposables
         public System.Collections.Generic.IEnumerator<System.IAsyncDisposable> GetEnumerator() { }
         public System.Threading.Tasks.ValueTask<bool> Remove(System.IAsyncDisposable item) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsDisposed = {IsDisposed}, Current = {_current}")]
+    [System.Diagnostics.DebuggerDisplay("SingleAssignmentDisposableAsync: IsDisposed = {IsDisposed}, Current = {_current}")]
     public sealed class SingleAssignmentDisposableAsync : System.IAsyncDisposable
     {
         public SingleAssignmentDisposableAsync() { }
@@ -1690,7 +1690,7 @@ namespace ReactiveUI.Primitives.Async.Disposables
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.Threading.Tasks.ValueTask SetDisposableAsync(System.IAsyncDisposable? value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Current = {_current}")]
+    [System.Diagnostics.DebuggerDisplay("SingleReplaceableDisposableAsync: Current = {_current}")]
     public class SingleReplaceableDisposableAsync : System.IAsyncDisposable
     {
         public SingleReplaceableDisposableAsync() { }
@@ -1716,7 +1716,7 @@ namespace ReactiveUI.Primitives.Async.Helpers
 }
 namespace ReactiveUI.Primitives.Async.Signals
 {
-    [System.Diagnostics.DebuggerDisplay("PublishingOption = {PublishingOption}, IsStateless = {IsStateless}")]
+    [System.Diagnostics.DebuggerDisplay("BehaviorSignalCreationOptions: PublishingOption = {PublishingOption}, IsStateless = {IsStateless}")]
     public record BehaviorSignalCreationOptions : System.IEquatable<ReactiveUI.Primitives.Async.Signals.BehaviorSignalCreationOptions>
     {
         public required bool IsStateless { get; init; }
@@ -1732,7 +1732,7 @@ namespace ReactiveUI.Primitives.Async.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public static System.Threading.Tasks.ValueTask ForwardOnNextConcurrently<T>(System.Collections.Immutable.ImmutableArray<ReactiveUI.Primitives.Async.IObserverAsync<T>> observers, T value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("LastValue = {_state.LastValue}, IsDisposed = {_state.IsDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ConcurrentReplayLatestSignalAsync: LastValue = {_state.LastValue}, IsDisposed = {_state.IsDisposed}")]
     public sealed class ConcurrentReplayLatestSignalAsync<T> : ReactiveUI.Primitives.Async.Signals.ISignalAsync<T>
     {
         public ConcurrentReplayLatestSignalAsync(ReactiveUI.Primitives.Optional<T> startValue) { }
@@ -1748,7 +1748,7 @@ namespace ReactiveUI.Primitives.Async.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_state.Observers.Length}, Result = {_state.Result}")]
+    [System.Diagnostics.DebuggerDisplay("ConcurrentSignalAsync: Observers = {_state.Observers.Length}, Result = {_state.Result}")]
     public sealed class ConcurrentSignalAsync<T> : ReactiveUI.Primitives.Async.Signals.ISignalAsync<T>
     {
         public ConcurrentSignalAsync() { }
@@ -1764,7 +1764,7 @@ namespace ReactiveUI.Primitives.Async.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_state.Value}, IsDisposed = {_state.IsDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ConcurrentStatelessReplayLatestSignalAsync: Value = {_state.Value}, IsDisposed = {_state.IsDisposed}")]
     public sealed class ConcurrentStatelessReplayLatestSignalAsync<T> : ReactiveUI.Primitives.Async.Signals.ISignalAsync<T>
     {
         public ConcurrentStatelessReplayLatestSignalAsync(ReactiveUI.Primitives.Optional<T> startValue) { }
@@ -1780,7 +1780,7 @@ namespace ReactiveUI.Primitives.Async.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_state.Observers.Length}")]
+    [System.Diagnostics.DebuggerDisplay("ConcurrentStatelessSignalAsync: Observers = {_state.Observers.Length}")]
     public sealed class ConcurrentStatelessSignalAsync<T> : ReactiveUI.Primitives.Async.Signals.ISignalAsync<T>
     {
         public ConcurrentStatelessSignalAsync() { }
@@ -1805,14 +1805,14 @@ namespace ReactiveUI.Primitives.Async.Signals
         Serial = 0,
         Concurrent = 1,
     }
-    [System.Diagnostics.DebuggerDisplay("PublishingOption = {PublishingOption}, IsStateless = {IsStateless}")]
+    [System.Diagnostics.DebuggerDisplay("ReplayLatestSignalCreationOptions: PublishingOption = {PublishingOption}, IsStateless = {IsStateless}")]
     public record ReplayLatestSignalCreationOptions : System.IEquatable<ReactiveUI.Primitives.Async.Signals.ReplayLatestSignalCreationOptions>
     {
         public required bool IsStateless { get; init; }
         public required ReactiveUI.Primitives.Async.Signals.PublishingOption PublishingOption { get; init; }
         public static ReactiveUI.Primitives.Async.Signals.ReplayLatestSignalCreationOptions Default { get; }
     }
-    [System.Diagnostics.DebuggerDisplay("LastValue = {_state.LastValue}, IsDisposed = {_state.IsDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("SerialReplayLatestSignalAsync: LastValue = {_state.LastValue}, IsDisposed = {_state.IsDisposed}")]
     public sealed class SerialReplayLatestSignalAsync<T> : ReactiveUI.Primitives.Async.Signals.ISignalAsync<T>
     {
         public SerialReplayLatestSignalAsync(ReactiveUI.Primitives.Optional<T> startValue) { }
@@ -1828,7 +1828,7 @@ namespace ReactiveUI.Primitives.Async.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_state.Observers.Length}, Result = {_state.Result}")]
+    [System.Diagnostics.DebuggerDisplay("SerialSignalAsync: Observers = {_state.Observers.Length}, Result = {_state.Result}")]
     public sealed class SerialSignalAsync<T> : ReactiveUI.Primitives.Async.Signals.ISignalAsync<T>
     {
         public SerialSignalAsync() { }
@@ -1844,7 +1844,7 @@ namespace ReactiveUI.Primitives.Async.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("State = {_state}")]
+    [System.Diagnostics.DebuggerDisplay("SerialStatelessReplayLatestSignalAsync: State = {_state}")]
     public sealed class SerialStatelessReplayLatestSignalAsync<T> : ReactiveUI.Primitives.Async.Signals.ISignalAsync<T>
     {
         public SerialStatelessReplayLatestSignalAsync(ReactiveUI.Primitives.Optional<T> startValue) { }
@@ -1860,7 +1860,7 @@ namespace ReactiveUI.Primitives.Async.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_state.Observers.Length}")]
+    [System.Diagnostics.DebuggerDisplay("SerialStatelessSignalAsync: Observers = {_state.Observers.Length}")]
     public sealed class SerialStatelessSignalAsync<T> : ReactiveUI.Primitives.Async.Signals.ISignalAsync<T>
     {
         public SerialStatelessSignalAsync() { }
@@ -1888,7 +1888,7 @@ namespace ReactiveUI.Primitives.Async.Signals
         public static ReactiveUI.Primitives.Async.Signals.ISignalAsync<T> CreateReplayLatest<T>() { }
         public static ReactiveUI.Primitives.Async.Signals.ISignalAsync<T> CreateReplayLatest<T>(ReactiveUI.Primitives.Async.Signals.ReplayLatestSignalCreationOptions? options) { }
     }
-    [System.Diagnostics.DebuggerDisplay("PublishingOption = {PublishingOption}, IsStateless = {IsStateless}")]
+    [System.Diagnostics.DebuggerDisplay("SignalCreationOptions: PublishingOption = {PublishingOption}, IsStateless = {IsStateless}")]
     public record SignalCreationOptions : System.IEquatable<ReactiveUI.Primitives.Async.Signals.SignalCreationOptions>
     {
         public required bool IsStateless { get; init; }

--- a/src/ReactiveUI.Primitives.Async.Core/PublicAPI/net472/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Async.Core/PublicAPI/net472/PublicAPI.txt
@@ -3,7 +3,7 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Primitives.Tests")]
 namespace ReactiveUI.Primitives.Async
 {
-    [System.Diagnostics.DebuggerDisplay("Signals = {_signals}")]
+    [System.Diagnostics.DebuggerDisplay("ChainEnumerableSignal: Signals = {_signals}")]
     public sealed class ChainEnumerableSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public ChainEnumerableSignal(System.Collections.Generic.IEnumerable<ReactiveUI.Primitives.Async.IObservableAsync<T>> signals) { }
@@ -23,7 +23,7 @@ namespace ReactiveUI.Primitives.Async
         protected ConcurrentWitnessCallsException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public ConcurrentWitnessCallsException(string message, System.Exception innerException) { }
     }
-    [System.Diagnostics.DebuggerDisplay("State = {State}")]
+    [System.Diagnostics.DebuggerDisplay("ConnectableSignalAsync: State = {State}")]
     public sealed class ConnectableSignalAsync<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>, System.IDisposable
     {
         public ConnectableSignalAsync(ReactiveUI.Primitives.Async.IObservableAsync<T> source, ReactiveUI.Primitives.Async.Signals.ISignalAsync<T> signal) { }
@@ -41,7 +41,7 @@ namespace ReactiveUI.Primitives.Async
             public System.IAsyncDisposable ToDisposableAsync() { }
         }
     }
-    [System.Diagnostics.DebuggerDisplay("Key = {Key}")]
+    [System.Diagnostics.DebuggerDisplay("GroupedAsyncSignal: Key = {Key}")]
     public sealed class GroupedAsyncSignal<TKey, TValue> : ReactiveUI.Primitives.Async.IObservableAsync<TValue>
     {
         public TKey Key { get; }
@@ -826,7 +826,7 @@ namespace ReactiveUI.Primitives.Async
         public SwitchToSignal(ReactiveUI.Primitives.Async.IObservableAsync<ReactiveUI.Primitives.Async.IObservableAsync<T>> source) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceFailsWhenOtherFails = {SourceFailsWhenOtherFails}")]
+    [System.Diagnostics.DebuggerDisplay("TakeUntilOptions: SourceFailsWhenOtherFails = {SourceFailsWhenOtherFails}")]
     public record TakeUntilOptions : System.IEquatable<ReactiveUI.Primitives.Async.TakeUntilOptions>
     {
         public bool SourceFailsWhenOtherFails { get; init; }
@@ -836,7 +836,7 @@ namespace ReactiveUI.Primitives.Async
     {
         public static void Register(System.Action<System.Exception> unhandledExceptionHandler) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Disposed = {_disposed}, CallState = {_callState}")]
+    [System.Diagnostics.DebuggerDisplay("WitnessAsync: Disposed = {_disposed}, CallState = {_callState}")]
     public abstract class WitnessAsync<T> : ReactiveUI.Primitives.Async.Advanced.IReentrantAsyncDisposable, ReactiveUI.Primitives.Async.IObserverAsync<T>
     {
         protected WitnessAsync() { }
@@ -860,19 +860,19 @@ namespace ReactiveUI.Primitives.Async
 }
 namespace ReactiveUI.Primitives.Async.Advanced
 {
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncEnumerableSignal: Source = {Source}")]
     public sealed class AsyncEnumerableSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public AsyncEnumerableSignal(System.Collections.Generic.IAsyncEnumerable<T> source) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncEnumerableSubscription: Source = {Source}")]
     public sealed class AsyncEnumerableSubscription<T> : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<T>
     {
         public AsyncEnumerableSubscription(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Collections.Generic.IAsyncEnumerable<T> source) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("OwnerThreadId = {_ownerThreadId}, Waiters = {_waiters}, RecursionDepth = {_recursionDepth}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncSerialGate: OwnerThreadId = {_ownerThreadId}, Waiters = {_waiters}, RecursionDepth = {_recursionDepth}")]
     public sealed class AsyncSerialGate : System.IDisposable
     {
         public AsyncSerialGate() { }
@@ -880,7 +880,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.Threading.Tasks.ValueTask<ReactiveUI.Primitives.Async.Advanced.AsyncSerialGate.Lease> EnterAsync() { }
         public System.Threading.Tasks.ValueTask<ReactiveUI.Primitives.Async.Advanced.AsyncSerialGate.Lease> EnterAsync(System.Threading.CancellationToken cancellationToken) { }
-        [System.Diagnostics.DebuggerDisplay("Parent = {_parent}")]
+        [System.Diagnostics.DebuggerDisplay("Lease: Parent = {_parent}")]
         public readonly record struct Lease : System.IDisposable, System.IEquatable<ReactiveUI.Primitives.Async.Advanced.AsyncSerialGate.Lease>
         {
             public Lease(ReactiveUI.Primitives.Async.Advanced.AsyncSerialGate parent) { }
@@ -888,13 +888,13 @@ namespace ReactiveUI.Primitives.Async.Advanced
             public readonly void Dispose() { }
         }
     }
-    [System.Diagnostics.DebuggerDisplay("StartSynchronously = {StartSynchronously}, TaskScheduler = {TaskScheduler}")]
+    [System.Diagnostics.DebuggerDisplay("BackgroundJobSignal: StartSynchronously = {StartSynchronously}, TaskScheduler = {TaskScheduler}")]
     public sealed class BackgroundJobSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public BackgroundJobSignal(System.Func<ReactiveUI.Primitives.Async.IObserverAsync<T>, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> job, bool startSynchronously, System.Threading.Tasks.TaskScheduler? taskScheduler) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasDisposed = {HasDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("CallbackWitnessAsync: HasDisposed = {HasDisposed}")]
     public sealed class CallbackWitnessAsync<T> : ReactiveUI.Primitives.Async.WitnessAsync<T>
     {
         public CallbackWitnessAsync(System.Func<T, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> onNextAsync, System.Func<System.Exception, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask>? onErrorResumeAsync = null, System.Func<ReactiveUI.Primitives.Result, System.Threading.Tasks.ValueTask>? onCompletedAsync = null) { }
@@ -902,31 +902,31 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(T value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Action = {Action}")]
+    [System.Diagnostics.DebuggerDisplay("DoOnSubscribeAsyncSignal: Source = {Source}, Action = {Action}")]
     public sealed class DoOnSubscribeAsyncSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public DoOnSubscribeAsyncSignal(ReactiveUI.Primitives.Async.IObservableAsync<T> source, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> action) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Action = {Action}")]
+    [System.Diagnostics.DebuggerDisplay("DoOnSubscribeSignal: Source = {Source}, Action = {Action}")]
     public sealed class DoOnSubscribeSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public DoOnSubscribeSignal(ReactiveUI.Primitives.Async.IObservableAsync<T> source, System.Action action) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("EnumerableSignal: Source = {Source}")]
     public sealed class EnumerableSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public EnumerableSignal(System.Collections.Generic.IEnumerable<T> source) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("EnumerableSubscription: Source = {Source}")]
     public sealed class EnumerableSubscription<T> : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<T>
     {
         public EnumerableSubscription(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Collections.Generic.IEnumerable<T> source) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ActiveInnerCount = {ActiveInnerCount}, OuterCompleted = {OuterCompleted}, Disposed = {Disposed}")]
+    [System.Diagnostics.DebuggerDisplay("FlatMapCoordinator: ActiveInnerCount = {ActiveInnerCount}, OuterCompleted = {OuterCompleted}, Disposed = {Disposed}")]
     public sealed class FlatMapCoordinator<TResult> : System.IAsyncDisposable
     {
         public FlatMapCoordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer) { }
@@ -942,14 +942,14 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public System.Threading.Tasks.ValueTask SetOuterObserverAsync(System.IAsyncDisposable observer) { }
         public System.Threading.Tasks.ValueTask SubscribeInnerAsync(ReactiveUI.Primitives.Async.IObservableAsync<TResult> inner) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, SyncSelector = {SyncSelector}, AsyncSelector = {AsyncSelector}")]
+    [System.Diagnostics.DebuggerDisplay("FlatMapSignal: Source = {Source}, SyncSelector = {SyncSelector}, AsyncSelector = {AsyncSelector}")]
     public sealed class FlatMapSignal<TSource, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public FlatMapSignal(ReactiveUI.Primitives.Async.IObservableAsync<TSource> source, System.Func<TSource, ReactiveUI.Primitives.Async.IObservableAsync<TResult>> selector) { }
         public FlatMapSignal(ReactiveUI.Primitives.Async.IObservableAsync<TSource> source, System.Func<TSource, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<ReactiveUI.Primitives.Async.IObservableAsync<TResult>>> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Coordinator = {Coordinator}")]
+    [System.Diagnostics.DebuggerDisplay("FlatMapWitness: Coordinator = {Coordinator}")]
     public sealed class FlatMapWitness<TResult> : ReactiveUI.Primitives.Async.WitnessAsync<TResult>
     {
         public FlatMapWitness(ReactiveUI.Primitives.Async.Advanced.FlatMapCoordinator<TResult> coordinator) { }
@@ -957,7 +957,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(TResult value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Coordinator = {Coordinator}, SyncSelector = {SyncSelector}, AsyncSelector = {AsyncSelector}")]
+    [System.Diagnostics.DebuggerDisplay("FlatMapWitness: Coordinator = {Coordinator}, SyncSelector = {SyncSelector}, AsyncSelector = {AsyncSelector}")]
     public sealed class FlatMapWitness<TSource, TResult> : ReactiveUI.Primitives.Async.WitnessAsync<TSource>
     {
         public FlatMapWitness(ReactiveUI.Primitives.Async.Advanced.FlatMapCoordinator<TResult> coordinator, System.Func<TSource, ReactiveUI.Primitives.Async.IObservableAsync<TResult>>? syncSelector, System.Func<TSource, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<ReactiveUI.Primitives.Async.IObservableAsync<TResult>>>? asyncSelector) { }
@@ -965,7 +965,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(TSource value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Downstream = {Downstream}")]
+    [System.Diagnostics.DebuggerDisplay("ForwardingWitnessAsync: Downstream = {Downstream}")]
     public class ForwardingWitnessAsync<T> : ReactiveUI.Primitives.Async.WitnessAsync<T>
     {
         protected ForwardingWitnessAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> downstream) { }
@@ -974,13 +974,13 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(T value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Factory = {Factory}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSignal: Factory = {Factory}")]
     public sealed class FromAsyncSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<T>> factory) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Factory = {Factory}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSubscription: Factory = {Factory}")]
     public sealed class FromAsyncSubscription<T> : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<T>
     {
         public FromAsyncSubscription(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<T>> factory) { }
@@ -990,39 +990,39 @@ namespace ReactiveUI.Primitives.Async.Advanced
     {
         System.Threading.Tasks.ValueTask DisposeFromNotificationAsync() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Period = {Period}, TimeProvider = {TimeProvider}")]
+    [System.Diagnostics.DebuggerDisplay("IntervalSignal: Period = {Period}, TimeProvider = {TimeProvider}")]
     public sealed class IntervalSignal : ReactiveUI.Primitives.Async.IObservableAsync<long>
     {
         public IntervalSignal(System.TimeSpan period, System.TimeProvider? timeProvider) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<System.Int64>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<long> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Period = {Period}, TimeProvider = {TimeProvider}")]
+    [System.Diagnostics.DebuggerDisplay("IntervalSubscription: Period = {Period}, TimeProvider = {TimeProvider}")]
     public sealed class IntervalSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<long>
     {
         public IntervalSubscription(ReactiveUI.Primitives.Async.IObserverAsync<long> observer, System.TimeSpan period, System.TimeProvider? timeProvider) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<long> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Values = {Values}")]
+    [System.Diagnostics.DebuggerDisplay("LeadSignal: Source = {Source}, Values = {Values}")]
     public sealed class LeadSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public LeadSignal(ReactiveUI.Primitives.Async.IObservableAsync<T> source, System.Collections.Generic.IEnumerable<T> values) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Disposed = {Disposed}, Pipeline = {Pipeline}")]
+    [System.Diagnostics.DebuggerDisplay("LeadSubscription: Disposed = {Disposed}, Pipeline = {Pipeline}")]
     public sealed class LeadSubscription<T> : System.IAsyncDisposable
     {
         public LeadSubscription(ReactiveUI.Primitives.Async.IObservableAsync<T> source, System.Collections.Generic.IEnumerable<T> values, ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken subscriptionToken) { }
         public System.Threading.Tasks.ValueTask DisposeAsync() { }
         public void Start() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Logger = {Logger}")]
+    [System.Diagnostics.DebuggerDisplay("LogErrorsSignal: Source = {Source}, Logger = {Logger}")]
     public sealed class LogErrorsSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public LogErrorsSignal(ReactiveUI.Primitives.Async.IObservableAsync<T> source, System.Action<System.Exception> logger) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Downstream = {Downstream}, Logger = {Logger}")]
+    [System.Diagnostics.DebuggerDisplay("LogErrorsWitness: Downstream = {Downstream}, Logger = {Logger}")]
     public sealed class LogErrorsWitness<T> : ReactiveUI.Primitives.Async.WitnessAsync<T>
     {
         public LogErrorsWitness(ReactiveUI.Primitives.Async.IObserverAsync<T> downstream, System.Action<System.Exception> logger) { }
@@ -1030,7 +1030,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(T value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {_completed}, Timer = {_timer}")]
+    [System.Diagnostics.DebuggerDisplay("PooledDelaySource: Completed = {_completed}, Timer = {_timer}")]
     public sealed class PooledDelaySource : System.Threading.Tasks.Sources.IValueTaskSource
     {
         public System.Threading.Tasks.ValueTask BeginAsync(System.TimeSpan delay, System.TimeProvider timeProvider, System.Threading.CancellationToken cancellationToken) { }
@@ -1041,13 +1041,13 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public void OnCompleted(System.Action<object?> continuation, object? state, short token, System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags flags) { }
         public static ReactiveUI.Primitives.Async.Advanced.PooledDelaySource Rent() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, RetryCount = {RetryCount}")]
+    [System.Diagnostics.DebuggerDisplay("ReattemptSignal: Source = {Source}, RetryCount = {RetryCount}")]
     public sealed class ReattemptSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public ReattemptSignal(ReactiveUI.Primitives.Async.IObservableAsync<T> source, int retryCount) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Remaining = {Remaining}")]
+    [System.Diagnostics.DebuggerDisplay("ReattemptSubscription: Source = {Source}, Remaining = {Remaining}")]
     public sealed class ReattemptSubscription<T> : System.IAsyncDisposable
     {
         public ReattemptSubscription(ReactiveUI.Primitives.Async.IObservableAsync<T> source, ReactiveUI.Primitives.Async.IObserverAsync<T> observer, int retryCount, System.Threading.CancellationToken cancellationToken) { }
@@ -1060,7 +1060,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public System.Threading.Tasks.ValueTask RelayNextAsync(T value, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.ValueTask SubscribeOnceAsync() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("ReattemptWitness: Subscription = {Subscription}")]
     public sealed class ReattemptWitness<T> : ReactiveUI.Primitives.Async.WitnessAsync<T>
     {
         public ReattemptWitness(ReactiveUI.Primitives.Async.Advanced.ReattemptSubscription<T> subscription) { }
@@ -1072,19 +1072,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
     {
         public RelayWitnessAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("StartValue = {StartValue}, Count = {Count}")]
+    [System.Diagnostics.DebuggerDisplay("SequenceSignal: StartValue = {StartValue}, Count = {Count}")]
     public sealed class SequenceSignal : ReactiveUI.Primitives.Async.IObservableAsync<int>
     {
         public SequenceSignal(int start, int count) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<System.Int32>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<int> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("StartValue = {StartValue}, Count = {Count}")]
+    [System.Diagnostics.DebuggerDisplay("SequenceSubscription: StartValue = {StartValue}, Count = {Count}")]
     public sealed class SequenceSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<int>
     {
         public SequenceSubscription(ReactiveUI.Primitives.Async.IObserverAsync<int> observer, int start, int count) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<int> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasValue = {_hasValue}, Value = {_value}")]
+    [System.Diagnostics.DebuggerDisplay("SingleElementWitness: HasValue = {_hasValue}, Value = {_value}")]
     public sealed class SingleElementWitness<T> : ReactiveUI.Primitives.Async.Advanced.TaskResultWitnessAsyncBase<T, T?>
     {
         public SingleElementWitness(System.Func<T, bool>? predicate, bool requireExactlyOne, T? defaultValue, System.Threading.CancellationToken cancellationToken) { }
@@ -1092,31 +1092,31 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(T value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Function = {Function}, TaskScheduler = {TaskScheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Function = {Function}, TaskScheduler = {TaskScheduler}")]
     public sealed class StartSignal<TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public StartSignal(System.Func<TResult> function, System.Threading.Tasks.TaskScheduler? taskScheduler) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Function = {Function}, TaskScheduler = {TaskScheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSubscription: Function = {Function}, TaskScheduler = {TaskScheduler}")]
     public sealed class StartSubscription<TResult> : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<TResult>
     {
         public StartSubscription(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Func<TResult> function, System.Threading.Tasks.TaskScheduler? taskScheduler) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceCount = {SourceCount}, Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest10Coordinator: SourceCount = {SourceCount}, Sources = {Sources}")]
     public sealed class SyncLatest10Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest10Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest10State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest10Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest10Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest10Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest10State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source10 = {Source10}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest10State: Source1 = {Source1}, Source10 = {Source10}")]
     public readonly record struct SyncLatest10State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest10State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>>
     {
         public SyncLatest10State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8, ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9, ReactiveUI.Primitives.Async.IObservableAsync<T10> Source10) { }
@@ -1131,19 +1131,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceCount = {SourceCount}, Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest11Coordinator: SourceCount = {SourceCount}, Sources = {Sources}")]
     public sealed class SyncLatest11Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest11Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest11State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest11Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest11Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest11Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest11State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source2 = {Source2}, Source11 = {Source11}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest11State: Source1 = {Source1}, Source2 = {Source2}, Source11 = {Source11}")]
     public readonly record struct SyncLatest11State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest11State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>>
     {
         public SyncLatest11State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8, ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9, ReactiveUI.Primitives.Async.IObservableAsync<T10> Source10, ReactiveUI.Primitives.Async.IObservableAsync<T11> Source11) { }
@@ -1159,19 +1159,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Lifecycle = {Lifecycle}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest12Coordinator: Sources = {Sources}, Lifecycle = {Lifecycle}")]
     public sealed class SyncLatest12Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest12Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest12State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest12Signal: Sources = {Sources}")]
     public sealed class SyncLatest12Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest12Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest12State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source12 = {Source12}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest12State: Source1 = {Source1}, Source12 = {Source12}")]
     public readonly record struct SyncLatest12State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest12State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>>
     {
         public SyncLatest12State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8, ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9, ReactiveUI.Primitives.Async.IObservableAsync<T10> Source10, ReactiveUI.Primitives.Async.IObservableAsync<T11> Source11, ReactiveUI.Primitives.Async.IObservableAsync<T12> Source12) { }
@@ -1188,19 +1188,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value13 = {Value13}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest13Coordinator: Value1 = {Value1}, Value13 = {Value13}")]
     public sealed class SyncLatest13Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest13Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest13State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest13Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest13Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest13Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest13State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source13 = {Source13}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest13State: Source1 = {Source1}, Source13 = {Source13}")]
     public readonly record struct SyncLatest13State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest13State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>>
     {
         public SyncLatest13State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8, ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9, ReactiveUI.Primitives.Async.IObservableAsync<T10> Source10, ReactiveUI.Primitives.Async.IObservableAsync<T11> Source11, ReactiveUI.Primitives.Async.IObservableAsync<T12> Source12, ReactiveUI.Primitives.Async.IObservableAsync<T13> Source13) { }
@@ -1218,19 +1218,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Lifecycle = {Lifecycle}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest14Coordinator: Sources = {Sources}, Lifecycle = {Lifecycle}")]
     public sealed class SyncLatest14Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest14Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest14State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest14Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest14Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest14Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest14State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source14 = {Source14}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest14State: Source1 = {Source1}, Source14 = {Source14}")]
     public readonly record struct SyncLatest14State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest14State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>>
     {
         public SyncLatest14State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8, ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9, ReactiveUI.Primitives.Async.IObservableAsync<T10> Source10, ReactiveUI.Primitives.Async.IObservableAsync<T11> Source11, ReactiveUI.Primitives.Async.IObservableAsync<T12> Source12, ReactiveUI.Primitives.Async.IObservableAsync<T13> Source13, ReactiveUI.Primitives.Async.IObservableAsync<T14> Source14) { }
@@ -1249,19 +1249,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value15 = {Value15}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest15Coordinator: Value1 = {Value1}, Value15 = {Value15}")]
     public sealed class SyncLatest15Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest15Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest15State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest15Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest15Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest15Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest15State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source15 = {Source15}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest15State: Source1 = {Source1}, Source15 = {Source15}")]
     public readonly record struct SyncLatest15State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest15State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>>
     {
         public SyncLatest15State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8, ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9, ReactiveUI.Primitives.Async.IObservableAsync<T10> Source10, ReactiveUI.Primitives.Async.IObservableAsync<T11> Source11, ReactiveUI.Primitives.Async.IObservableAsync<T12> Source12, ReactiveUI.Primitives.Async.IObservableAsync<T13> Source13, ReactiveUI.Primitives.Async.IObservableAsync<T14> Source14, ReactiveUI.Primitives.Async.IObservableAsync<T15> Source15) { }
@@ -1281,19 +1281,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value16 = {Value16}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest16Coordinator: Value1 = {Value1}, Value16 = {Value16}")]
     public sealed class SyncLatest16Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest16Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest16State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest16Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest16Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest16Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest16State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source16 = {Source16}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest16State: Source1 = {Source1}, Source16 = {Source16}")]
     public readonly record struct SyncLatest16State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest16State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>>
     {
         public SyncLatest16State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8, ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9, ReactiveUI.Primitives.Async.IObservableAsync<T10> Source10, ReactiveUI.Primitives.Async.IObservableAsync<T11> Source11, ReactiveUI.Primitives.Async.IObservableAsync<T12> Source12, ReactiveUI.Primitives.Async.IObservableAsync<T13> Source13, ReactiveUI.Primitives.Async.IObservableAsync<T14> Source14, ReactiveUI.Primitives.Async.IObservableAsync<T15> Source15, ReactiveUI.Primitives.Async.IObservableAsync<T16> Source16) { }
@@ -1314,38 +1314,38 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest2Coordinator: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest2Coordinator<T1, T2, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest2Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest2State<T1, T2> sources, System.Func<T1, T2, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest2Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest2Signal<T1, T2, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest2Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest2State<T1, T2> sources, System.Func<T1, T2, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source2 = {Source2}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest2State: Source1 = {Source1}, Source2 = {Source2}")]
     public readonly record struct SyncLatest2State<T1, T2> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest2State<T1, T2>>
     {
         public SyncLatest2State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2) { }
         public ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value3 = {Value3}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest3Coordinator: Value1 = {Value1}, Value3 = {Value3}")]
     public sealed class SyncLatest3Coordinator<T1, T2, T3, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest3Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest3State<T1, T2, T3> sources, System.Func<T1, T2, T3, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest3Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest3Signal<T1, T2, T3, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest3Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest3State<T1, T2, T3> sources, System.Func<T1, T2, T3, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source2 = {Source2}, Source3 = {Source3}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest3State: Source1 = {Source1}, Source2 = {Source2}, Source3 = {Source3}")]
     public readonly record struct SyncLatest3State<T1, T2, T3> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest3State<T1, T2, T3>>
     {
         public SyncLatest3State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3) { }
@@ -1353,19 +1353,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value4 = {Value4}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest4Coordinator: Value1 = {Value1}, Value4 = {Value4}")]
     public sealed class SyncLatest4Coordinator<T1, T2, T3, T4, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest4Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest4State<T1, T2, T3, T4> sources, System.Func<T1, T2, T3, T4, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest4Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest4Signal<T1, T2, T3, T4, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest4Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest4State<T1, T2, T3, T4> sources, System.Func<T1, T2, T3, T4, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source2 = {Source2}, Source3 = {Source3}, Source4 = {Source4}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest4State: Source1 = {Source1}, Source2 = {Source2}, Source3 = {Source3}, Source4 = {Source4}")]
     public readonly record struct SyncLatest4State<T1, T2, T3, T4> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest4State<T1, T2, T3, T4>>
     {
         public SyncLatest4State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4) { }
@@ -1374,19 +1374,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value5 = {Value5}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest5Coordinator: Value1 = {Value1}, Value5 = {Value5}")]
     public sealed class SyncLatest5Coordinator<T1, T2, T3, T4, T5, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest5Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest5State<T1, T2, T3, T4, T5> sources, System.Func<T1, T2, T3, T4, T5, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest5Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest5Signal<T1, T2, T3, T4, T5, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest5Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest5State<T1, T2, T3, T4, T5> sources, System.Func<T1, T2, T3, T4, T5, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source5 = {Source5}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest5State: Source1 = {Source1}, Source5 = {Source5}")]
     public readonly record struct SyncLatest5State<T1, T2, T3, T4, T5> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest5State<T1, T2, T3, T4, T5>>
     {
         public SyncLatest5State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5) { }
@@ -1396,19 +1396,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value6 = {Value6}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest6Coordinator: Value1 = {Value1}, Value6 = {Value6}")]
     public sealed class SyncLatest6Coordinator<T1, T2, T3, T4, T5, T6, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest6Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest6State<T1, T2, T3, T4, T5, T6> sources, System.Func<T1, T2, T3, T4, T5, T6, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest6Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest6Signal<T1, T2, T3, T4, T5, T6, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest6Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest6State<T1, T2, T3, T4, T5, T6> sources, System.Func<T1, T2, T3, T4, T5, T6, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source6 = {Source6}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest6State: Source1 = {Source1}, Source6 = {Source6}")]
     public readonly record struct SyncLatest6State<T1, T2, T3, T4, T5, T6> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest6State<T1, T2, T3, T4, T5, T6>>
     {
         public SyncLatest6State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6) { }
@@ -1419,19 +1419,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest7Coordinator: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest7Coordinator<T1, T2, T3, T4, T5, T6, T7, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest7Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest7State<T1, T2, T3, T4, T5, T6, T7> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest7Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest7Signal<T1, T2, T3, T4, T5, T6, T7, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest7Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest7State<T1, T2, T3, T4, T5, T6, T7> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source7 = {Source7}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest7State: Source1 = {Source1}, Source7 = {Source7}")]
     public readonly record struct SyncLatest7State<T1, T2, T3, T4, T5, T6, T7> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest7State<T1, T2, T3, T4, T5, T6, T7>>
     {
         public SyncLatest7State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7) { }
@@ -1443,19 +1443,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest8Coordinator: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest8Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest8Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest8State<T1, T2, T3, T4, T5, T6, T7, T8> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest8Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest8Signal<T1, T2, T3, T4, T5, T6, T7, T8, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest8Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest8State<T1, T2, T3, T4, T5, T6, T7, T8> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source8 = {Source8}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest8State: Source1 = {Source1}, Source8 = {Source8}")]
     public readonly record struct SyncLatest8State<T1, T2, T3, T4, T5, T6, T7, T8> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest8State<T1, T2, T3, T4, T5, T6, T7, T8>>
     {
         public SyncLatest8State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8) { }
@@ -1468,19 +1468,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value9 = {Value9}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest9Coordinator: Value1 = {Value1}, Value9 = {Value9}")]
     public sealed class SyncLatest9Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest9Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest9State<T1, T2, T3, T4, T5, T6, T7, T8, T9> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest9Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest9Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest9Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest9State<T1, T2, T3, T4, T5, T6, T7, T8, T9> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source9 = {Source9}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest9State: Source1 = {Source1}, Source9 = {Source9}")]
     public readonly record struct SyncLatest9State<T1, T2, T3, T4, T5, T6, T7, T8, T9> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest9State<T1, T2, T3, T4, T5, T6, T7, T8, T9>>
     {
         public SyncLatest9State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8, ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9) { }
@@ -1494,7 +1494,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceCount = {Lifecycle.Subscriptions.Length}, HasDisposed = {Lifecycle.HasDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestCoordinatorBase: SourceCount = {Lifecycle.Subscriptions.Length}, HasDisposed = {Lifecycle.HasDisposed}")]
     public abstract class SyncLatestCoordinatorBase<TResult> : System.IAsyncDisposable
     {
         protected SyncLatestCoordinatorBase(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, int sourceCount) { }
@@ -1502,7 +1502,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected abstract System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.ValueTask SubscribeSourcesAsync(System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources.Length}, Completed = {_completedCount}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestEnumerableCoordinator: Sources = {Sources.Length}, Completed = {_completedCount}, Disposed = {_disposed}")]
     public sealed class SyncLatestEnumerableCoordinator<TSource, TResult> : System.IAsyncDisposable
     {
         public SyncLatestEnumerableCoordinator(ReactiveUI.Primitives.Async.IObservableAsync<TSource>[] sources, ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Func<System.Collections.Generic.IReadOnlyList<TSource>, TResult> resultSelector) { }
@@ -1510,13 +1510,13 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public System.Threading.Tasks.ValueTask DisposeAsync() { }
         public System.Threading.Tasks.ValueTask SubscribeSourcesAsync(System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceCount = {Sources.Length}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestEnumerableSignal: SourceCount = {Sources.Length}")]
     public sealed class SyncLatestEnumerableSignal<TSource, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatestEnumerableSignal(System.Collections.Generic.IEnumerable<ReactiveUI.Primitives.Async.IObservableAsync<TSource>> sources, System.Func<System.Collections.Generic.IReadOnlyList<TSource>, TResult> resultSelector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Index = {Index}, Parent = {Parent}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestEnumerableWitness: Index = {Index}, Parent = {Parent}")]
     public sealed class SyncLatestEnumerableWitness<TSource, TResult> : ReactiveUI.Primitives.Async.IObserverAsync<TSource>
     {
         public SyncLatestEnumerableWitness(ReactiveUI.Primitives.Async.Advanced.SyncLatestEnumerableCoordinator<TSource, TResult> parent, int index) { }
@@ -1536,7 +1536,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(TSource value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceCount = {Subscriptions.Length}, HasDisposed = {HasDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestLifecycle: SourceCount = {Subscriptions.Length}, HasDisposed = {HasDisposed}")]
     public sealed class SyncLatestLifecycle<TResult> : System.IAsyncDisposable
     {
         public SyncLatestLifecycle(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, int sourceCount) { }
@@ -1558,7 +1558,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(TSource value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, DisposeRequested = {DisposeToken.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("TakeUntilLifecycle: Observer = {_observer}, DisposeRequested = {DisposeToken.IsCancellationRequested}")]
     public sealed class TakeUntilLifecycle<T> : System.IAsyncDisposable
     {
         public TakeUntilLifecycle(ReactiveUI.Primitives.Async.IObserverAsync<T> observer) { }
@@ -1576,7 +1576,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(T value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsCompleted = {_taskSource.Task.IsCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("TaskResultCompletionSource: IsCompleted = {_taskSource.Task.IsCompleted}")]
     public sealed class TaskResultCompletionSource<T>
     {
         public TaskResultCompletionSource(System.Threading.CancellationToken cancellationToken) { }
@@ -1584,19 +1584,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public System.Threading.Tasks.ValueTask SetExceptionAndDisposeAsync(System.Exception exception, ReactiveUI.Primitives.Async.Advanced.IReentrantAsyncDisposable owner) { }
         public System.Threading.Tasks.ValueTask SetResultAndDisposeAsync(T value, ReactiveUI.Primitives.Async.Advanced.IReentrantAsyncDisposable owner) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskResultSignal: Task = {Task}")]
     public sealed class TaskResultSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public TaskResultSignal(System.Threading.Tasks.Task<T> task) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskResultSubscription: Task = {Task}")]
     public sealed class TaskResultSubscription<T> : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<T>
     {
         public TaskResultSubscription(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.Tasks.Task<T> task) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completion = {_completion}")]
+    [System.Diagnostics.DebuggerDisplay("TaskResultWitnessAsyncBase: Completion = {_completion}")]
     public abstract class TaskResultWitnessAsyncBase<T, TTaskValue> : ReactiveUI.Primitives.Async.WitnessAsync<T>
     {
         protected TaskResultWitnessAsyncBase(System.Threading.CancellationToken cancellationToken) { }
@@ -1611,7 +1611,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
     {
         public static ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<T> StartNew<T>(System.Func<ReactiveUI.Primitives.Async.IObserverAsync<T>, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> executeAsyncCore, ReactiveUI.Primitives.Async.IObserverAsync<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Disposed = {_disposed}, Completed = {_tcs.Task.IsCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("TaskSignalSubscription: Disposed = {_disposed}, Completed = {_tcs.Task.IsCompleted}")]
     public abstract class TaskSignalSubscription<T> : System.IAsyncDisposable
     {
         protected TaskSignalSubscription(ReactiveUI.Primitives.Async.IObserverAsync<T> observer) { }
@@ -1619,25 +1619,25 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected abstract System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
         public void Start() { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {DueTime}, Period = {Period}")]
+    [System.Diagnostics.DebuggerDisplay("TimerSignal: DueTime = {DueTime}, Period = {Period}")]
     public sealed class TimerSignal : ReactiveUI.Primitives.Async.IObservableAsync<long>
     {
         public TimerSignal(System.TimeSpan dueTime, System.TimeSpan? period, System.TimeProvider timeProvider) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<System.Int64>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<long> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {DueTime}, Period = {Period}")]
+    [System.Diagnostics.DebuggerDisplay("TimerSubscription: DueTime = {DueTime}, Period = {Period}")]
     public sealed class TimerSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<long>
     {
         public TimerSubscription(ReactiveUI.Primitives.Async.IObserverAsync<long> observer, System.TimeSpan dueTime, System.TimeSpan? period, System.TimeProvider timeProvider) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<long> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ResourceFactory = {ResourceFactory}, SignalFactory = {SignalFactory}")]
+    [System.Diagnostics.DebuggerDisplay("UsingSignal: ResourceFactory = {ResourceFactory}, SignalFactory = {SignalFactory}")]
     public sealed class UsingSignal<TResource, T> : ReactiveUI.Primitives.Async.IObservableAsync<T> where TResource : System.IAsyncDisposable
     {
         public UsingSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResource>> resourceFactory, System.Func<TResource, ReactiveUI.Primitives.Async.IObservableAsync<T>> signalFactory) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Resource = {Resource}")]
+    [System.Diagnostics.DebuggerDisplay("UsingWitness: Resource = {Resource}")]
     public sealed class UsingWitness<TResource, T> : ReactiveUI.Primitives.Async.Advanced.ForwardingWitnessAsync<T> where TResource : System.IAsyncDisposable
     {
         public UsingWitness(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, TResource resource) { }
@@ -1662,7 +1662,7 @@ namespace ReactiveUI.Primitives.Async.Disposables
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public static System.Threading.Tasks.ValueTask SwapAsync(ref System.IAsyncDisposable? slot, System.IAsyncDisposable? value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, IsDisposed = {_isDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("MultipleDisposableAsync: Count = {_count}, IsDisposed = {_isDisposed}")]
     public sealed class MultipleDisposableAsync : System.IAsyncDisposable
     {
         public MultipleDisposableAsync() { }
@@ -1679,7 +1679,7 @@ namespace ReactiveUI.Primitives.Async.Disposables
         public System.Collections.Generic.IEnumerator<System.IAsyncDisposable> GetEnumerator() { }
         public System.Threading.Tasks.ValueTask<bool> Remove(System.IAsyncDisposable item) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsDisposed = {IsDisposed}, Current = {_current}")]
+    [System.Diagnostics.DebuggerDisplay("SingleAssignmentDisposableAsync: IsDisposed = {IsDisposed}, Current = {_current}")]
     public sealed class SingleAssignmentDisposableAsync : System.IAsyncDisposable
     {
         public SingleAssignmentDisposableAsync() { }
@@ -1690,7 +1690,7 @@ namespace ReactiveUI.Primitives.Async.Disposables
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.Threading.Tasks.ValueTask SetDisposableAsync(System.IAsyncDisposable? value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Current = {_current}")]
+    [System.Diagnostics.DebuggerDisplay("SingleReplaceableDisposableAsync: Current = {_current}")]
     public class SingleReplaceableDisposableAsync : System.IAsyncDisposable
     {
         public SingleReplaceableDisposableAsync() { }
@@ -1716,7 +1716,7 @@ namespace ReactiveUI.Primitives.Async.Helpers
 }
 namespace ReactiveUI.Primitives.Async.Signals
 {
-    [System.Diagnostics.DebuggerDisplay("PublishingOption = {PublishingOption}, IsStateless = {IsStateless}")]
+    [System.Diagnostics.DebuggerDisplay("BehaviorSignalCreationOptions: PublishingOption = {PublishingOption}, IsStateless = {IsStateless}")]
     public record BehaviorSignalCreationOptions : System.IEquatable<ReactiveUI.Primitives.Async.Signals.BehaviorSignalCreationOptions>
     {
         public required bool IsStateless { get; init; }
@@ -1732,7 +1732,7 @@ namespace ReactiveUI.Primitives.Async.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public static System.Threading.Tasks.ValueTask ForwardOnNextConcurrently<T>(System.Collections.Immutable.ImmutableArray<ReactiveUI.Primitives.Async.IObserverAsync<T>> observers, T value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("LastValue = {_state.LastValue}, IsDisposed = {_state.IsDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ConcurrentReplayLatestSignalAsync: LastValue = {_state.LastValue}, IsDisposed = {_state.IsDisposed}")]
     public sealed class ConcurrentReplayLatestSignalAsync<T> : ReactiveUI.Primitives.Async.Signals.ISignalAsync<T>
     {
         public ConcurrentReplayLatestSignalAsync(ReactiveUI.Primitives.Optional<T> startValue) { }
@@ -1748,7 +1748,7 @@ namespace ReactiveUI.Primitives.Async.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_state.Observers.Length}, Result = {_state.Result}")]
+    [System.Diagnostics.DebuggerDisplay("ConcurrentSignalAsync: Observers = {_state.Observers.Length}, Result = {_state.Result}")]
     public sealed class ConcurrentSignalAsync<T> : ReactiveUI.Primitives.Async.Signals.ISignalAsync<T>
     {
         public ConcurrentSignalAsync() { }
@@ -1764,7 +1764,7 @@ namespace ReactiveUI.Primitives.Async.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_state.Value}, IsDisposed = {_state.IsDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ConcurrentStatelessReplayLatestSignalAsync: Value = {_state.Value}, IsDisposed = {_state.IsDisposed}")]
     public sealed class ConcurrentStatelessReplayLatestSignalAsync<T> : ReactiveUI.Primitives.Async.Signals.ISignalAsync<T>
     {
         public ConcurrentStatelessReplayLatestSignalAsync(ReactiveUI.Primitives.Optional<T> startValue) { }
@@ -1780,7 +1780,7 @@ namespace ReactiveUI.Primitives.Async.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_state.Observers.Length}")]
+    [System.Diagnostics.DebuggerDisplay("ConcurrentStatelessSignalAsync: Observers = {_state.Observers.Length}")]
     public sealed class ConcurrentStatelessSignalAsync<T> : ReactiveUI.Primitives.Async.Signals.ISignalAsync<T>
     {
         public ConcurrentStatelessSignalAsync() { }
@@ -1805,14 +1805,14 @@ namespace ReactiveUI.Primitives.Async.Signals
         Serial = 0,
         Concurrent = 1,
     }
-    [System.Diagnostics.DebuggerDisplay("PublishingOption = {PublishingOption}, IsStateless = {IsStateless}")]
+    [System.Diagnostics.DebuggerDisplay("ReplayLatestSignalCreationOptions: PublishingOption = {PublishingOption}, IsStateless = {IsStateless}")]
     public record ReplayLatestSignalCreationOptions : System.IEquatable<ReactiveUI.Primitives.Async.Signals.ReplayLatestSignalCreationOptions>
     {
         public required bool IsStateless { get; init; }
         public required ReactiveUI.Primitives.Async.Signals.PublishingOption PublishingOption { get; init; }
         public static ReactiveUI.Primitives.Async.Signals.ReplayLatestSignalCreationOptions Default { get; }
     }
-    [System.Diagnostics.DebuggerDisplay("LastValue = {_state.LastValue}, IsDisposed = {_state.IsDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("SerialReplayLatestSignalAsync: LastValue = {_state.LastValue}, IsDisposed = {_state.IsDisposed}")]
     public sealed class SerialReplayLatestSignalAsync<T> : ReactiveUI.Primitives.Async.Signals.ISignalAsync<T>
     {
         public SerialReplayLatestSignalAsync(ReactiveUI.Primitives.Optional<T> startValue) { }
@@ -1828,7 +1828,7 @@ namespace ReactiveUI.Primitives.Async.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_state.Observers.Length}, Result = {_state.Result}")]
+    [System.Diagnostics.DebuggerDisplay("SerialSignalAsync: Observers = {_state.Observers.Length}, Result = {_state.Result}")]
     public sealed class SerialSignalAsync<T> : ReactiveUI.Primitives.Async.Signals.ISignalAsync<T>
     {
         public SerialSignalAsync() { }
@@ -1844,7 +1844,7 @@ namespace ReactiveUI.Primitives.Async.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("State = {_state}")]
+    [System.Diagnostics.DebuggerDisplay("SerialStatelessReplayLatestSignalAsync: State = {_state}")]
     public sealed class SerialStatelessReplayLatestSignalAsync<T> : ReactiveUI.Primitives.Async.Signals.ISignalAsync<T>
     {
         public SerialStatelessReplayLatestSignalAsync(ReactiveUI.Primitives.Optional<T> startValue) { }
@@ -1860,7 +1860,7 @@ namespace ReactiveUI.Primitives.Async.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_state.Observers.Length}")]
+    [System.Diagnostics.DebuggerDisplay("SerialStatelessSignalAsync: Observers = {_state.Observers.Length}")]
     public sealed class SerialStatelessSignalAsync<T> : ReactiveUI.Primitives.Async.Signals.ISignalAsync<T>
     {
         public SerialStatelessSignalAsync() { }
@@ -1888,7 +1888,7 @@ namespace ReactiveUI.Primitives.Async.Signals
         public static ReactiveUI.Primitives.Async.Signals.ISignalAsync<T> CreateReplayLatest<T>() { }
         public static ReactiveUI.Primitives.Async.Signals.ISignalAsync<T> CreateReplayLatest<T>(ReactiveUI.Primitives.Async.Signals.ReplayLatestSignalCreationOptions? options) { }
     }
-    [System.Diagnostics.DebuggerDisplay("PublishingOption = {PublishingOption}, IsStateless = {IsStateless}")]
+    [System.Diagnostics.DebuggerDisplay("SignalCreationOptions: PublishingOption = {PublishingOption}, IsStateless = {IsStateless}")]
     public record SignalCreationOptions : System.IEquatable<ReactiveUI.Primitives.Async.Signals.SignalCreationOptions>
     {
         public required bool IsStateless { get; init; }

--- a/src/ReactiveUI.Primitives.Async.Core/PublicAPI/net48/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Async.Core/PublicAPI/net48/PublicAPI.txt
@@ -3,7 +3,7 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Primitives.Tests")]
 namespace ReactiveUI.Primitives.Async
 {
-    [System.Diagnostics.DebuggerDisplay("Signals = {_signals}")]
+    [System.Diagnostics.DebuggerDisplay("ChainEnumerableSignal: Signals = {_signals}")]
     public sealed class ChainEnumerableSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public ChainEnumerableSignal(System.Collections.Generic.IEnumerable<ReactiveUI.Primitives.Async.IObservableAsync<T>> signals) { }
@@ -23,7 +23,7 @@ namespace ReactiveUI.Primitives.Async
         protected ConcurrentWitnessCallsException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public ConcurrentWitnessCallsException(string message, System.Exception innerException) { }
     }
-    [System.Diagnostics.DebuggerDisplay("State = {State}")]
+    [System.Diagnostics.DebuggerDisplay("ConnectableSignalAsync: State = {State}")]
     public sealed class ConnectableSignalAsync<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>, System.IDisposable
     {
         public ConnectableSignalAsync(ReactiveUI.Primitives.Async.IObservableAsync<T> source, ReactiveUI.Primitives.Async.Signals.ISignalAsync<T> signal) { }
@@ -41,7 +41,7 @@ namespace ReactiveUI.Primitives.Async
             public System.IAsyncDisposable ToDisposableAsync() { }
         }
     }
-    [System.Diagnostics.DebuggerDisplay("Key = {Key}")]
+    [System.Diagnostics.DebuggerDisplay("GroupedAsyncSignal: Key = {Key}")]
     public sealed class GroupedAsyncSignal<TKey, TValue> : ReactiveUI.Primitives.Async.IObservableAsync<TValue>
     {
         public TKey Key { get; }
@@ -826,7 +826,7 @@ namespace ReactiveUI.Primitives.Async
         public SwitchToSignal(ReactiveUI.Primitives.Async.IObservableAsync<ReactiveUI.Primitives.Async.IObservableAsync<T>> source) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceFailsWhenOtherFails = {SourceFailsWhenOtherFails}")]
+    [System.Diagnostics.DebuggerDisplay("TakeUntilOptions: SourceFailsWhenOtherFails = {SourceFailsWhenOtherFails}")]
     public record TakeUntilOptions : System.IEquatable<ReactiveUI.Primitives.Async.TakeUntilOptions>
     {
         public bool SourceFailsWhenOtherFails { get; init; }
@@ -836,7 +836,7 @@ namespace ReactiveUI.Primitives.Async
     {
         public static void Register(System.Action<System.Exception> unhandledExceptionHandler) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Disposed = {_disposed}, CallState = {_callState}")]
+    [System.Diagnostics.DebuggerDisplay("WitnessAsync: Disposed = {_disposed}, CallState = {_callState}")]
     public abstract class WitnessAsync<T> : ReactiveUI.Primitives.Async.Advanced.IReentrantAsyncDisposable, ReactiveUI.Primitives.Async.IObserverAsync<T>
     {
         protected WitnessAsync() { }
@@ -860,19 +860,19 @@ namespace ReactiveUI.Primitives.Async
 }
 namespace ReactiveUI.Primitives.Async.Advanced
 {
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncEnumerableSignal: Source = {Source}")]
     public sealed class AsyncEnumerableSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public AsyncEnumerableSignal(System.Collections.Generic.IAsyncEnumerable<T> source) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncEnumerableSubscription: Source = {Source}")]
     public sealed class AsyncEnumerableSubscription<T> : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<T>
     {
         public AsyncEnumerableSubscription(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Collections.Generic.IAsyncEnumerable<T> source) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("OwnerThreadId = {_ownerThreadId}, Waiters = {_waiters}, RecursionDepth = {_recursionDepth}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncSerialGate: OwnerThreadId = {_ownerThreadId}, Waiters = {_waiters}, RecursionDepth = {_recursionDepth}")]
     public sealed class AsyncSerialGate : System.IDisposable
     {
         public AsyncSerialGate() { }
@@ -880,7 +880,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.Threading.Tasks.ValueTask<ReactiveUI.Primitives.Async.Advanced.AsyncSerialGate.Lease> EnterAsync() { }
         public System.Threading.Tasks.ValueTask<ReactiveUI.Primitives.Async.Advanced.AsyncSerialGate.Lease> EnterAsync(System.Threading.CancellationToken cancellationToken) { }
-        [System.Diagnostics.DebuggerDisplay("Parent = {_parent}")]
+        [System.Diagnostics.DebuggerDisplay("Lease: Parent = {_parent}")]
         public readonly record struct Lease : System.IDisposable, System.IEquatable<ReactiveUI.Primitives.Async.Advanced.AsyncSerialGate.Lease>
         {
             public Lease(ReactiveUI.Primitives.Async.Advanced.AsyncSerialGate parent) { }
@@ -888,13 +888,13 @@ namespace ReactiveUI.Primitives.Async.Advanced
             public readonly void Dispose() { }
         }
     }
-    [System.Diagnostics.DebuggerDisplay("StartSynchronously = {StartSynchronously}, TaskScheduler = {TaskScheduler}")]
+    [System.Diagnostics.DebuggerDisplay("BackgroundJobSignal: StartSynchronously = {StartSynchronously}, TaskScheduler = {TaskScheduler}")]
     public sealed class BackgroundJobSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public BackgroundJobSignal(System.Func<ReactiveUI.Primitives.Async.IObserverAsync<T>, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> job, bool startSynchronously, System.Threading.Tasks.TaskScheduler? taskScheduler) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasDisposed = {HasDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("CallbackWitnessAsync: HasDisposed = {HasDisposed}")]
     public sealed class CallbackWitnessAsync<T> : ReactiveUI.Primitives.Async.WitnessAsync<T>
     {
         public CallbackWitnessAsync(System.Func<T, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> onNextAsync, System.Func<System.Exception, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask>? onErrorResumeAsync = null, System.Func<ReactiveUI.Primitives.Result, System.Threading.Tasks.ValueTask>? onCompletedAsync = null) { }
@@ -902,31 +902,31 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(T value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Action = {Action}")]
+    [System.Diagnostics.DebuggerDisplay("DoOnSubscribeAsyncSignal: Source = {Source}, Action = {Action}")]
     public sealed class DoOnSubscribeAsyncSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public DoOnSubscribeAsyncSignal(ReactiveUI.Primitives.Async.IObservableAsync<T> source, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> action) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Action = {Action}")]
+    [System.Diagnostics.DebuggerDisplay("DoOnSubscribeSignal: Source = {Source}, Action = {Action}")]
     public sealed class DoOnSubscribeSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public DoOnSubscribeSignal(ReactiveUI.Primitives.Async.IObservableAsync<T> source, System.Action action) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("EnumerableSignal: Source = {Source}")]
     public sealed class EnumerableSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public EnumerableSignal(System.Collections.Generic.IEnumerable<T> source) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("EnumerableSubscription: Source = {Source}")]
     public sealed class EnumerableSubscription<T> : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<T>
     {
         public EnumerableSubscription(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Collections.Generic.IEnumerable<T> source) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ActiveInnerCount = {ActiveInnerCount}, OuterCompleted = {OuterCompleted}, Disposed = {Disposed}")]
+    [System.Diagnostics.DebuggerDisplay("FlatMapCoordinator: ActiveInnerCount = {ActiveInnerCount}, OuterCompleted = {OuterCompleted}, Disposed = {Disposed}")]
     public sealed class FlatMapCoordinator<TResult> : System.IAsyncDisposable
     {
         public FlatMapCoordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer) { }
@@ -942,14 +942,14 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public System.Threading.Tasks.ValueTask SetOuterObserverAsync(System.IAsyncDisposable observer) { }
         public System.Threading.Tasks.ValueTask SubscribeInnerAsync(ReactiveUI.Primitives.Async.IObservableAsync<TResult> inner) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, SyncSelector = {SyncSelector}, AsyncSelector = {AsyncSelector}")]
+    [System.Diagnostics.DebuggerDisplay("FlatMapSignal: Source = {Source}, SyncSelector = {SyncSelector}, AsyncSelector = {AsyncSelector}")]
     public sealed class FlatMapSignal<TSource, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public FlatMapSignal(ReactiveUI.Primitives.Async.IObservableAsync<TSource> source, System.Func<TSource, ReactiveUI.Primitives.Async.IObservableAsync<TResult>> selector) { }
         public FlatMapSignal(ReactiveUI.Primitives.Async.IObservableAsync<TSource> source, System.Func<TSource, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<ReactiveUI.Primitives.Async.IObservableAsync<TResult>>> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Coordinator = {Coordinator}")]
+    [System.Diagnostics.DebuggerDisplay("FlatMapWitness: Coordinator = {Coordinator}")]
     public sealed class FlatMapWitness<TResult> : ReactiveUI.Primitives.Async.WitnessAsync<TResult>
     {
         public FlatMapWitness(ReactiveUI.Primitives.Async.Advanced.FlatMapCoordinator<TResult> coordinator) { }
@@ -957,7 +957,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(TResult value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Coordinator = {Coordinator}, SyncSelector = {SyncSelector}, AsyncSelector = {AsyncSelector}")]
+    [System.Diagnostics.DebuggerDisplay("FlatMapWitness: Coordinator = {Coordinator}, SyncSelector = {SyncSelector}, AsyncSelector = {AsyncSelector}")]
     public sealed class FlatMapWitness<TSource, TResult> : ReactiveUI.Primitives.Async.WitnessAsync<TSource>
     {
         public FlatMapWitness(ReactiveUI.Primitives.Async.Advanced.FlatMapCoordinator<TResult> coordinator, System.Func<TSource, ReactiveUI.Primitives.Async.IObservableAsync<TResult>>? syncSelector, System.Func<TSource, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<ReactiveUI.Primitives.Async.IObservableAsync<TResult>>>? asyncSelector) { }
@@ -965,7 +965,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(TSource value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Downstream = {Downstream}")]
+    [System.Diagnostics.DebuggerDisplay("ForwardingWitnessAsync: Downstream = {Downstream}")]
     public class ForwardingWitnessAsync<T> : ReactiveUI.Primitives.Async.WitnessAsync<T>
     {
         protected ForwardingWitnessAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> downstream) { }
@@ -974,13 +974,13 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(T value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Factory = {Factory}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSignal: Factory = {Factory}")]
     public sealed class FromAsyncSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<T>> factory) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Factory = {Factory}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSubscription: Factory = {Factory}")]
     public sealed class FromAsyncSubscription<T> : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<T>
     {
         public FromAsyncSubscription(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<T>> factory) { }
@@ -990,39 +990,39 @@ namespace ReactiveUI.Primitives.Async.Advanced
     {
         System.Threading.Tasks.ValueTask DisposeFromNotificationAsync() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Period = {Period}, TimeProvider = {TimeProvider}")]
+    [System.Diagnostics.DebuggerDisplay("IntervalSignal: Period = {Period}, TimeProvider = {TimeProvider}")]
     public sealed class IntervalSignal : ReactiveUI.Primitives.Async.IObservableAsync<long>
     {
         public IntervalSignal(System.TimeSpan period, System.TimeProvider? timeProvider) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<System.Int64>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<long> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Period = {Period}, TimeProvider = {TimeProvider}")]
+    [System.Diagnostics.DebuggerDisplay("IntervalSubscription: Period = {Period}, TimeProvider = {TimeProvider}")]
     public sealed class IntervalSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<long>
     {
         public IntervalSubscription(ReactiveUI.Primitives.Async.IObserverAsync<long> observer, System.TimeSpan period, System.TimeProvider? timeProvider) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<long> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Values = {Values}")]
+    [System.Diagnostics.DebuggerDisplay("LeadSignal: Source = {Source}, Values = {Values}")]
     public sealed class LeadSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public LeadSignal(ReactiveUI.Primitives.Async.IObservableAsync<T> source, System.Collections.Generic.IEnumerable<T> values) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Disposed = {Disposed}, Pipeline = {Pipeline}")]
+    [System.Diagnostics.DebuggerDisplay("LeadSubscription: Disposed = {Disposed}, Pipeline = {Pipeline}")]
     public sealed class LeadSubscription<T> : System.IAsyncDisposable
     {
         public LeadSubscription(ReactiveUI.Primitives.Async.IObservableAsync<T> source, System.Collections.Generic.IEnumerable<T> values, ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken subscriptionToken) { }
         public System.Threading.Tasks.ValueTask DisposeAsync() { }
         public void Start() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Logger = {Logger}")]
+    [System.Diagnostics.DebuggerDisplay("LogErrorsSignal: Source = {Source}, Logger = {Logger}")]
     public sealed class LogErrorsSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public LogErrorsSignal(ReactiveUI.Primitives.Async.IObservableAsync<T> source, System.Action<System.Exception> logger) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Downstream = {Downstream}, Logger = {Logger}")]
+    [System.Diagnostics.DebuggerDisplay("LogErrorsWitness: Downstream = {Downstream}, Logger = {Logger}")]
     public sealed class LogErrorsWitness<T> : ReactiveUI.Primitives.Async.WitnessAsync<T>
     {
         public LogErrorsWitness(ReactiveUI.Primitives.Async.IObserverAsync<T> downstream, System.Action<System.Exception> logger) { }
@@ -1030,7 +1030,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(T value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {_completed}, Timer = {_timer}")]
+    [System.Diagnostics.DebuggerDisplay("PooledDelaySource: Completed = {_completed}, Timer = {_timer}")]
     public sealed class PooledDelaySource : System.Threading.Tasks.Sources.IValueTaskSource
     {
         public System.Threading.Tasks.ValueTask BeginAsync(System.TimeSpan delay, System.TimeProvider timeProvider, System.Threading.CancellationToken cancellationToken) { }
@@ -1041,13 +1041,13 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public void OnCompleted(System.Action<object?> continuation, object? state, short token, System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags flags) { }
         public static ReactiveUI.Primitives.Async.Advanced.PooledDelaySource Rent() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, RetryCount = {RetryCount}")]
+    [System.Diagnostics.DebuggerDisplay("ReattemptSignal: Source = {Source}, RetryCount = {RetryCount}")]
     public sealed class ReattemptSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public ReattemptSignal(ReactiveUI.Primitives.Async.IObservableAsync<T> source, int retryCount) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Remaining = {Remaining}")]
+    [System.Diagnostics.DebuggerDisplay("ReattemptSubscription: Source = {Source}, Remaining = {Remaining}")]
     public sealed class ReattemptSubscription<T> : System.IAsyncDisposable
     {
         public ReattemptSubscription(ReactiveUI.Primitives.Async.IObservableAsync<T> source, ReactiveUI.Primitives.Async.IObserverAsync<T> observer, int retryCount, System.Threading.CancellationToken cancellationToken) { }
@@ -1060,7 +1060,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public System.Threading.Tasks.ValueTask RelayNextAsync(T value, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.ValueTask SubscribeOnceAsync() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("ReattemptWitness: Subscription = {Subscription}")]
     public sealed class ReattemptWitness<T> : ReactiveUI.Primitives.Async.WitnessAsync<T>
     {
         public ReattemptWitness(ReactiveUI.Primitives.Async.Advanced.ReattemptSubscription<T> subscription) { }
@@ -1072,19 +1072,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
     {
         public RelayWitnessAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("StartValue = {StartValue}, Count = {Count}")]
+    [System.Diagnostics.DebuggerDisplay("SequenceSignal: StartValue = {StartValue}, Count = {Count}")]
     public sealed class SequenceSignal : ReactiveUI.Primitives.Async.IObservableAsync<int>
     {
         public SequenceSignal(int start, int count) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<System.Int32>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<int> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("StartValue = {StartValue}, Count = {Count}")]
+    [System.Diagnostics.DebuggerDisplay("SequenceSubscription: StartValue = {StartValue}, Count = {Count}")]
     public sealed class SequenceSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<int>
     {
         public SequenceSubscription(ReactiveUI.Primitives.Async.IObserverAsync<int> observer, int start, int count) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<int> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasValue = {_hasValue}, Value = {_value}")]
+    [System.Diagnostics.DebuggerDisplay("SingleElementWitness: HasValue = {_hasValue}, Value = {_value}")]
     public sealed class SingleElementWitness<T> : ReactiveUI.Primitives.Async.Advanced.TaskResultWitnessAsyncBase<T, T?>
     {
         public SingleElementWitness(System.Func<T, bool>? predicate, bool requireExactlyOne, T? defaultValue, System.Threading.CancellationToken cancellationToken) { }
@@ -1092,31 +1092,31 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(T value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Function = {Function}, TaskScheduler = {TaskScheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Function = {Function}, TaskScheduler = {TaskScheduler}")]
     public sealed class StartSignal<TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public StartSignal(System.Func<TResult> function, System.Threading.Tasks.TaskScheduler? taskScheduler) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Function = {Function}, TaskScheduler = {TaskScheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSubscription: Function = {Function}, TaskScheduler = {TaskScheduler}")]
     public sealed class StartSubscription<TResult> : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<TResult>
     {
         public StartSubscription(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Func<TResult> function, System.Threading.Tasks.TaskScheduler? taskScheduler) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceCount = {SourceCount}, Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest10Coordinator: SourceCount = {SourceCount}, Sources = {Sources}")]
     public sealed class SyncLatest10Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest10Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest10State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest10Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest10Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest10Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest10State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source10 = {Source10}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest10State: Source1 = {Source1}, Source10 = {Source10}")]
     public readonly record struct SyncLatest10State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest10State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>>
     {
         public SyncLatest10State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8, ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9, ReactiveUI.Primitives.Async.IObservableAsync<T10> Source10) { }
@@ -1131,19 +1131,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceCount = {SourceCount}, Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest11Coordinator: SourceCount = {SourceCount}, Sources = {Sources}")]
     public sealed class SyncLatest11Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest11Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest11State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest11Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest11Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest11Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest11State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source2 = {Source2}, Source11 = {Source11}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest11State: Source1 = {Source1}, Source2 = {Source2}, Source11 = {Source11}")]
     public readonly record struct SyncLatest11State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest11State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>>
     {
         public SyncLatest11State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8, ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9, ReactiveUI.Primitives.Async.IObservableAsync<T10> Source10, ReactiveUI.Primitives.Async.IObservableAsync<T11> Source11) { }
@@ -1159,19 +1159,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Lifecycle = {Lifecycle}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest12Coordinator: Sources = {Sources}, Lifecycle = {Lifecycle}")]
     public sealed class SyncLatest12Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest12Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest12State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest12Signal: Sources = {Sources}")]
     public sealed class SyncLatest12Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest12Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest12State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source12 = {Source12}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest12State: Source1 = {Source1}, Source12 = {Source12}")]
     public readonly record struct SyncLatest12State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest12State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>>
     {
         public SyncLatest12State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8, ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9, ReactiveUI.Primitives.Async.IObservableAsync<T10> Source10, ReactiveUI.Primitives.Async.IObservableAsync<T11> Source11, ReactiveUI.Primitives.Async.IObservableAsync<T12> Source12) { }
@@ -1188,19 +1188,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value13 = {Value13}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest13Coordinator: Value1 = {Value1}, Value13 = {Value13}")]
     public sealed class SyncLatest13Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest13Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest13State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest13Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest13Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest13Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest13State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source13 = {Source13}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest13State: Source1 = {Source1}, Source13 = {Source13}")]
     public readonly record struct SyncLatest13State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest13State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>>
     {
         public SyncLatest13State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8, ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9, ReactiveUI.Primitives.Async.IObservableAsync<T10> Source10, ReactiveUI.Primitives.Async.IObservableAsync<T11> Source11, ReactiveUI.Primitives.Async.IObservableAsync<T12> Source12, ReactiveUI.Primitives.Async.IObservableAsync<T13> Source13) { }
@@ -1218,19 +1218,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Lifecycle = {Lifecycle}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest14Coordinator: Sources = {Sources}, Lifecycle = {Lifecycle}")]
     public sealed class SyncLatest14Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest14Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest14State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest14Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest14Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest14Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest14State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source14 = {Source14}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest14State: Source1 = {Source1}, Source14 = {Source14}")]
     public readonly record struct SyncLatest14State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest14State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>>
     {
         public SyncLatest14State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8, ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9, ReactiveUI.Primitives.Async.IObservableAsync<T10> Source10, ReactiveUI.Primitives.Async.IObservableAsync<T11> Source11, ReactiveUI.Primitives.Async.IObservableAsync<T12> Source12, ReactiveUI.Primitives.Async.IObservableAsync<T13> Source13, ReactiveUI.Primitives.Async.IObservableAsync<T14> Source14) { }
@@ -1249,19 +1249,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value15 = {Value15}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest15Coordinator: Value1 = {Value1}, Value15 = {Value15}")]
     public sealed class SyncLatest15Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest15Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest15State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest15Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest15Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest15Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest15State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source15 = {Source15}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest15State: Source1 = {Source1}, Source15 = {Source15}")]
     public readonly record struct SyncLatest15State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest15State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>>
     {
         public SyncLatest15State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8, ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9, ReactiveUI.Primitives.Async.IObservableAsync<T10> Source10, ReactiveUI.Primitives.Async.IObservableAsync<T11> Source11, ReactiveUI.Primitives.Async.IObservableAsync<T12> Source12, ReactiveUI.Primitives.Async.IObservableAsync<T13> Source13, ReactiveUI.Primitives.Async.IObservableAsync<T14> Source14, ReactiveUI.Primitives.Async.IObservableAsync<T15> Source15) { }
@@ -1281,19 +1281,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value16 = {Value16}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest16Coordinator: Value1 = {Value1}, Value16 = {Value16}")]
     public sealed class SyncLatest16Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest16Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest16State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest16Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest16Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest16Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest16State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source16 = {Source16}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest16State: Source1 = {Source1}, Source16 = {Source16}")]
     public readonly record struct SyncLatest16State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest16State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>>
     {
         public SyncLatest16State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8, ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9, ReactiveUI.Primitives.Async.IObservableAsync<T10> Source10, ReactiveUI.Primitives.Async.IObservableAsync<T11> Source11, ReactiveUI.Primitives.Async.IObservableAsync<T12> Source12, ReactiveUI.Primitives.Async.IObservableAsync<T13> Source13, ReactiveUI.Primitives.Async.IObservableAsync<T14> Source14, ReactiveUI.Primitives.Async.IObservableAsync<T15> Source15, ReactiveUI.Primitives.Async.IObservableAsync<T16> Source16) { }
@@ -1314,38 +1314,38 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest2Coordinator: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest2Coordinator<T1, T2, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest2Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest2State<T1, T2> sources, System.Func<T1, T2, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest2Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest2Signal<T1, T2, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest2Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest2State<T1, T2> sources, System.Func<T1, T2, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source2 = {Source2}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest2State: Source1 = {Source1}, Source2 = {Source2}")]
     public readonly record struct SyncLatest2State<T1, T2> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest2State<T1, T2>>
     {
         public SyncLatest2State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2) { }
         public ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value3 = {Value3}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest3Coordinator: Value1 = {Value1}, Value3 = {Value3}")]
     public sealed class SyncLatest3Coordinator<T1, T2, T3, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest3Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest3State<T1, T2, T3> sources, System.Func<T1, T2, T3, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest3Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest3Signal<T1, T2, T3, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest3Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest3State<T1, T2, T3> sources, System.Func<T1, T2, T3, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source2 = {Source2}, Source3 = {Source3}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest3State: Source1 = {Source1}, Source2 = {Source2}, Source3 = {Source3}")]
     public readonly record struct SyncLatest3State<T1, T2, T3> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest3State<T1, T2, T3>>
     {
         public SyncLatest3State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3) { }
@@ -1353,19 +1353,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value4 = {Value4}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest4Coordinator: Value1 = {Value1}, Value4 = {Value4}")]
     public sealed class SyncLatest4Coordinator<T1, T2, T3, T4, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest4Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest4State<T1, T2, T3, T4> sources, System.Func<T1, T2, T3, T4, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest4Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest4Signal<T1, T2, T3, T4, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest4Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest4State<T1, T2, T3, T4> sources, System.Func<T1, T2, T3, T4, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source2 = {Source2}, Source3 = {Source3}, Source4 = {Source4}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest4State: Source1 = {Source1}, Source2 = {Source2}, Source3 = {Source3}, Source4 = {Source4}")]
     public readonly record struct SyncLatest4State<T1, T2, T3, T4> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest4State<T1, T2, T3, T4>>
     {
         public SyncLatest4State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4) { }
@@ -1374,19 +1374,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value5 = {Value5}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest5Coordinator: Value1 = {Value1}, Value5 = {Value5}")]
     public sealed class SyncLatest5Coordinator<T1, T2, T3, T4, T5, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest5Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest5State<T1, T2, T3, T4, T5> sources, System.Func<T1, T2, T3, T4, T5, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest5Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest5Signal<T1, T2, T3, T4, T5, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest5Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest5State<T1, T2, T3, T4, T5> sources, System.Func<T1, T2, T3, T4, T5, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source5 = {Source5}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest5State: Source1 = {Source1}, Source5 = {Source5}")]
     public readonly record struct SyncLatest5State<T1, T2, T3, T4, T5> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest5State<T1, T2, T3, T4, T5>>
     {
         public SyncLatest5State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5) { }
@@ -1396,19 +1396,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value6 = {Value6}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest6Coordinator: Value1 = {Value1}, Value6 = {Value6}")]
     public sealed class SyncLatest6Coordinator<T1, T2, T3, T4, T5, T6, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest6Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest6State<T1, T2, T3, T4, T5, T6> sources, System.Func<T1, T2, T3, T4, T5, T6, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest6Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest6Signal<T1, T2, T3, T4, T5, T6, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest6Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest6State<T1, T2, T3, T4, T5, T6> sources, System.Func<T1, T2, T3, T4, T5, T6, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source6 = {Source6}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest6State: Source1 = {Source1}, Source6 = {Source6}")]
     public readonly record struct SyncLatest6State<T1, T2, T3, T4, T5, T6> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest6State<T1, T2, T3, T4, T5, T6>>
     {
         public SyncLatest6State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6) { }
@@ -1419,19 +1419,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest7Coordinator: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest7Coordinator<T1, T2, T3, T4, T5, T6, T7, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest7Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest7State<T1, T2, T3, T4, T5, T6, T7> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest7Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest7Signal<T1, T2, T3, T4, T5, T6, T7, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest7Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest7State<T1, T2, T3, T4, T5, T6, T7> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source7 = {Source7}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest7State: Source1 = {Source1}, Source7 = {Source7}")]
     public readonly record struct SyncLatest7State<T1, T2, T3, T4, T5, T6, T7> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest7State<T1, T2, T3, T4, T5, T6, T7>>
     {
         public SyncLatest7State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7) { }
@@ -1443,19 +1443,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest8Coordinator: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest8Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest8Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest8State<T1, T2, T3, T4, T5, T6, T7, T8> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest8Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest8Signal<T1, T2, T3, T4, T5, T6, T7, T8, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest8Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest8State<T1, T2, T3, T4, T5, T6, T7, T8> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source8 = {Source8}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest8State: Source1 = {Source1}, Source8 = {Source8}")]
     public readonly record struct SyncLatest8State<T1, T2, T3, T4, T5, T6, T7, T8> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest8State<T1, T2, T3, T4, T5, T6, T7, T8>>
     {
         public SyncLatest8State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8) { }
@@ -1468,19 +1468,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value9 = {Value9}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest9Coordinator: Value1 = {Value1}, Value9 = {Value9}")]
     public sealed class SyncLatest9Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest9Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest9State<T1, T2, T3, T4, T5, T6, T7, T8, T9> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest9Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest9Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest9Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest9State<T1, T2, T3, T4, T5, T6, T7, T8, T9> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source9 = {Source9}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest9State: Source1 = {Source1}, Source9 = {Source9}")]
     public readonly record struct SyncLatest9State<T1, T2, T3, T4, T5, T6, T7, T8, T9> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest9State<T1, T2, T3, T4, T5, T6, T7, T8, T9>>
     {
         public SyncLatest9State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8, ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9) { }
@@ -1494,7 +1494,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceCount = {Lifecycle.Subscriptions.Length}, HasDisposed = {Lifecycle.HasDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestCoordinatorBase: SourceCount = {Lifecycle.Subscriptions.Length}, HasDisposed = {Lifecycle.HasDisposed}")]
     public abstract class SyncLatestCoordinatorBase<TResult> : System.IAsyncDisposable
     {
         protected SyncLatestCoordinatorBase(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, int sourceCount) { }
@@ -1502,7 +1502,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected abstract System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.ValueTask SubscribeSourcesAsync(System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources.Length}, Completed = {_completedCount}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestEnumerableCoordinator: Sources = {Sources.Length}, Completed = {_completedCount}, Disposed = {_disposed}")]
     public sealed class SyncLatestEnumerableCoordinator<TSource, TResult> : System.IAsyncDisposable
     {
         public SyncLatestEnumerableCoordinator(ReactiveUI.Primitives.Async.IObservableAsync<TSource>[] sources, ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Func<System.Collections.Generic.IReadOnlyList<TSource>, TResult> resultSelector) { }
@@ -1510,13 +1510,13 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public System.Threading.Tasks.ValueTask DisposeAsync() { }
         public System.Threading.Tasks.ValueTask SubscribeSourcesAsync(System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceCount = {Sources.Length}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestEnumerableSignal: SourceCount = {Sources.Length}")]
     public sealed class SyncLatestEnumerableSignal<TSource, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatestEnumerableSignal(System.Collections.Generic.IEnumerable<ReactiveUI.Primitives.Async.IObservableAsync<TSource>> sources, System.Func<System.Collections.Generic.IReadOnlyList<TSource>, TResult> resultSelector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Index = {Index}, Parent = {Parent}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestEnumerableWitness: Index = {Index}, Parent = {Parent}")]
     public sealed class SyncLatestEnumerableWitness<TSource, TResult> : ReactiveUI.Primitives.Async.IObserverAsync<TSource>
     {
         public SyncLatestEnumerableWitness(ReactiveUI.Primitives.Async.Advanced.SyncLatestEnumerableCoordinator<TSource, TResult> parent, int index) { }
@@ -1536,7 +1536,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(TSource value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceCount = {Subscriptions.Length}, HasDisposed = {HasDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestLifecycle: SourceCount = {Subscriptions.Length}, HasDisposed = {HasDisposed}")]
     public sealed class SyncLatestLifecycle<TResult> : System.IAsyncDisposable
     {
         public SyncLatestLifecycle(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, int sourceCount) { }
@@ -1558,7 +1558,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(TSource value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, DisposeRequested = {DisposeToken.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("TakeUntilLifecycle: Observer = {_observer}, DisposeRequested = {DisposeToken.IsCancellationRequested}")]
     public sealed class TakeUntilLifecycle<T> : System.IAsyncDisposable
     {
         public TakeUntilLifecycle(ReactiveUI.Primitives.Async.IObserverAsync<T> observer) { }
@@ -1576,7 +1576,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(T value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsCompleted = {_taskSource.Task.IsCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("TaskResultCompletionSource: IsCompleted = {_taskSource.Task.IsCompleted}")]
     public sealed class TaskResultCompletionSource<T>
     {
         public TaskResultCompletionSource(System.Threading.CancellationToken cancellationToken) { }
@@ -1584,19 +1584,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public System.Threading.Tasks.ValueTask SetExceptionAndDisposeAsync(System.Exception exception, ReactiveUI.Primitives.Async.Advanced.IReentrantAsyncDisposable owner) { }
         public System.Threading.Tasks.ValueTask SetResultAndDisposeAsync(T value, ReactiveUI.Primitives.Async.Advanced.IReentrantAsyncDisposable owner) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskResultSignal: Task = {Task}")]
     public sealed class TaskResultSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public TaskResultSignal(System.Threading.Tasks.Task<T> task) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskResultSubscription: Task = {Task}")]
     public sealed class TaskResultSubscription<T> : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<T>
     {
         public TaskResultSubscription(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.Tasks.Task<T> task) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completion = {_completion}")]
+    [System.Diagnostics.DebuggerDisplay("TaskResultWitnessAsyncBase: Completion = {_completion}")]
     public abstract class TaskResultWitnessAsyncBase<T, TTaskValue> : ReactiveUI.Primitives.Async.WitnessAsync<T>
     {
         protected TaskResultWitnessAsyncBase(System.Threading.CancellationToken cancellationToken) { }
@@ -1611,7 +1611,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
     {
         public static ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<T> StartNew<T>(System.Func<ReactiveUI.Primitives.Async.IObserverAsync<T>, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> executeAsyncCore, ReactiveUI.Primitives.Async.IObserverAsync<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Disposed = {_disposed}, Completed = {_tcs.Task.IsCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("TaskSignalSubscription: Disposed = {_disposed}, Completed = {_tcs.Task.IsCompleted}")]
     public abstract class TaskSignalSubscription<T> : System.IAsyncDisposable
     {
         protected TaskSignalSubscription(ReactiveUI.Primitives.Async.IObserverAsync<T> observer) { }
@@ -1619,25 +1619,25 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected abstract System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
         public void Start() { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {DueTime}, Period = {Period}")]
+    [System.Diagnostics.DebuggerDisplay("TimerSignal: DueTime = {DueTime}, Period = {Period}")]
     public sealed class TimerSignal : ReactiveUI.Primitives.Async.IObservableAsync<long>
     {
         public TimerSignal(System.TimeSpan dueTime, System.TimeSpan? period, System.TimeProvider timeProvider) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<System.Int64>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<long> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {DueTime}, Period = {Period}")]
+    [System.Diagnostics.DebuggerDisplay("TimerSubscription: DueTime = {DueTime}, Period = {Period}")]
     public sealed class TimerSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<long>
     {
         public TimerSubscription(ReactiveUI.Primitives.Async.IObserverAsync<long> observer, System.TimeSpan dueTime, System.TimeSpan? period, System.TimeProvider timeProvider) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<long> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ResourceFactory = {ResourceFactory}, SignalFactory = {SignalFactory}")]
+    [System.Diagnostics.DebuggerDisplay("UsingSignal: ResourceFactory = {ResourceFactory}, SignalFactory = {SignalFactory}")]
     public sealed class UsingSignal<TResource, T> : ReactiveUI.Primitives.Async.IObservableAsync<T> where TResource : System.IAsyncDisposable
     {
         public UsingSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResource>> resourceFactory, System.Func<TResource, ReactiveUI.Primitives.Async.IObservableAsync<T>> signalFactory) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Resource = {Resource}")]
+    [System.Diagnostics.DebuggerDisplay("UsingWitness: Resource = {Resource}")]
     public sealed class UsingWitness<TResource, T> : ReactiveUI.Primitives.Async.Advanced.ForwardingWitnessAsync<T> where TResource : System.IAsyncDisposable
     {
         public UsingWitness(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, TResource resource) { }
@@ -1662,7 +1662,7 @@ namespace ReactiveUI.Primitives.Async.Disposables
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public static System.Threading.Tasks.ValueTask SwapAsync(ref System.IAsyncDisposable? slot, System.IAsyncDisposable? value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, IsDisposed = {_isDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("MultipleDisposableAsync: Count = {_count}, IsDisposed = {_isDisposed}")]
     public sealed class MultipleDisposableAsync : System.IAsyncDisposable
     {
         public MultipleDisposableAsync() { }
@@ -1679,7 +1679,7 @@ namespace ReactiveUI.Primitives.Async.Disposables
         public System.Collections.Generic.IEnumerator<System.IAsyncDisposable> GetEnumerator() { }
         public System.Threading.Tasks.ValueTask<bool> Remove(System.IAsyncDisposable item) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsDisposed = {IsDisposed}, Current = {_current}")]
+    [System.Diagnostics.DebuggerDisplay("SingleAssignmentDisposableAsync: IsDisposed = {IsDisposed}, Current = {_current}")]
     public sealed class SingleAssignmentDisposableAsync : System.IAsyncDisposable
     {
         public SingleAssignmentDisposableAsync() { }
@@ -1690,7 +1690,7 @@ namespace ReactiveUI.Primitives.Async.Disposables
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.Threading.Tasks.ValueTask SetDisposableAsync(System.IAsyncDisposable? value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Current = {_current}")]
+    [System.Diagnostics.DebuggerDisplay("SingleReplaceableDisposableAsync: Current = {_current}")]
     public class SingleReplaceableDisposableAsync : System.IAsyncDisposable
     {
         public SingleReplaceableDisposableAsync() { }
@@ -1716,7 +1716,7 @@ namespace ReactiveUI.Primitives.Async.Helpers
 }
 namespace ReactiveUI.Primitives.Async.Signals
 {
-    [System.Diagnostics.DebuggerDisplay("PublishingOption = {PublishingOption}, IsStateless = {IsStateless}")]
+    [System.Diagnostics.DebuggerDisplay("BehaviorSignalCreationOptions: PublishingOption = {PublishingOption}, IsStateless = {IsStateless}")]
     public record BehaviorSignalCreationOptions : System.IEquatable<ReactiveUI.Primitives.Async.Signals.BehaviorSignalCreationOptions>
     {
         public required bool IsStateless { get; init; }
@@ -1732,7 +1732,7 @@ namespace ReactiveUI.Primitives.Async.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public static System.Threading.Tasks.ValueTask ForwardOnNextConcurrently<T>(System.Collections.Immutable.ImmutableArray<ReactiveUI.Primitives.Async.IObserverAsync<T>> observers, T value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("LastValue = {_state.LastValue}, IsDisposed = {_state.IsDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ConcurrentReplayLatestSignalAsync: LastValue = {_state.LastValue}, IsDisposed = {_state.IsDisposed}")]
     public sealed class ConcurrentReplayLatestSignalAsync<T> : ReactiveUI.Primitives.Async.Signals.ISignalAsync<T>
     {
         public ConcurrentReplayLatestSignalAsync(ReactiveUI.Primitives.Optional<T> startValue) { }
@@ -1748,7 +1748,7 @@ namespace ReactiveUI.Primitives.Async.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_state.Observers.Length}, Result = {_state.Result}")]
+    [System.Diagnostics.DebuggerDisplay("ConcurrentSignalAsync: Observers = {_state.Observers.Length}, Result = {_state.Result}")]
     public sealed class ConcurrentSignalAsync<T> : ReactiveUI.Primitives.Async.Signals.ISignalAsync<T>
     {
         public ConcurrentSignalAsync() { }
@@ -1764,7 +1764,7 @@ namespace ReactiveUI.Primitives.Async.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_state.Value}, IsDisposed = {_state.IsDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ConcurrentStatelessReplayLatestSignalAsync: Value = {_state.Value}, IsDisposed = {_state.IsDisposed}")]
     public sealed class ConcurrentStatelessReplayLatestSignalAsync<T> : ReactiveUI.Primitives.Async.Signals.ISignalAsync<T>
     {
         public ConcurrentStatelessReplayLatestSignalAsync(ReactiveUI.Primitives.Optional<T> startValue) { }
@@ -1780,7 +1780,7 @@ namespace ReactiveUI.Primitives.Async.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_state.Observers.Length}")]
+    [System.Diagnostics.DebuggerDisplay("ConcurrentStatelessSignalAsync: Observers = {_state.Observers.Length}")]
     public sealed class ConcurrentStatelessSignalAsync<T> : ReactiveUI.Primitives.Async.Signals.ISignalAsync<T>
     {
         public ConcurrentStatelessSignalAsync() { }
@@ -1805,14 +1805,14 @@ namespace ReactiveUI.Primitives.Async.Signals
         Serial = 0,
         Concurrent = 1,
     }
-    [System.Diagnostics.DebuggerDisplay("PublishingOption = {PublishingOption}, IsStateless = {IsStateless}")]
+    [System.Diagnostics.DebuggerDisplay("ReplayLatestSignalCreationOptions: PublishingOption = {PublishingOption}, IsStateless = {IsStateless}")]
     public record ReplayLatestSignalCreationOptions : System.IEquatable<ReactiveUI.Primitives.Async.Signals.ReplayLatestSignalCreationOptions>
     {
         public required bool IsStateless { get; init; }
         public required ReactiveUI.Primitives.Async.Signals.PublishingOption PublishingOption { get; init; }
         public static ReactiveUI.Primitives.Async.Signals.ReplayLatestSignalCreationOptions Default { get; }
     }
-    [System.Diagnostics.DebuggerDisplay("LastValue = {_state.LastValue}, IsDisposed = {_state.IsDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("SerialReplayLatestSignalAsync: LastValue = {_state.LastValue}, IsDisposed = {_state.IsDisposed}")]
     public sealed class SerialReplayLatestSignalAsync<T> : ReactiveUI.Primitives.Async.Signals.ISignalAsync<T>
     {
         public SerialReplayLatestSignalAsync(ReactiveUI.Primitives.Optional<T> startValue) { }
@@ -1828,7 +1828,7 @@ namespace ReactiveUI.Primitives.Async.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_state.Observers.Length}, Result = {_state.Result}")]
+    [System.Diagnostics.DebuggerDisplay("SerialSignalAsync: Observers = {_state.Observers.Length}, Result = {_state.Result}")]
     public sealed class SerialSignalAsync<T> : ReactiveUI.Primitives.Async.Signals.ISignalAsync<T>
     {
         public SerialSignalAsync() { }
@@ -1844,7 +1844,7 @@ namespace ReactiveUI.Primitives.Async.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("State = {_state}")]
+    [System.Diagnostics.DebuggerDisplay("SerialStatelessReplayLatestSignalAsync: State = {_state}")]
     public sealed class SerialStatelessReplayLatestSignalAsync<T> : ReactiveUI.Primitives.Async.Signals.ISignalAsync<T>
     {
         public SerialStatelessReplayLatestSignalAsync(ReactiveUI.Primitives.Optional<T> startValue) { }
@@ -1860,7 +1860,7 @@ namespace ReactiveUI.Primitives.Async.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_state.Observers.Length}")]
+    [System.Diagnostics.DebuggerDisplay("SerialStatelessSignalAsync: Observers = {_state.Observers.Length}")]
     public sealed class SerialStatelessSignalAsync<T> : ReactiveUI.Primitives.Async.Signals.ISignalAsync<T>
     {
         public SerialStatelessSignalAsync() { }
@@ -1888,7 +1888,7 @@ namespace ReactiveUI.Primitives.Async.Signals
         public static ReactiveUI.Primitives.Async.Signals.ISignalAsync<T> CreateReplayLatest<T>() { }
         public static ReactiveUI.Primitives.Async.Signals.ISignalAsync<T> CreateReplayLatest<T>(ReactiveUI.Primitives.Async.Signals.ReplayLatestSignalCreationOptions? options) { }
     }
-    [System.Diagnostics.DebuggerDisplay("PublishingOption = {PublishingOption}, IsStateless = {IsStateless}")]
+    [System.Diagnostics.DebuggerDisplay("SignalCreationOptions: PublishingOption = {PublishingOption}, IsStateless = {IsStateless}")]
     public record SignalCreationOptions : System.IEquatable<ReactiveUI.Primitives.Async.Signals.SignalCreationOptions>
     {
         public required bool IsStateless { get; init; }

--- a/src/ReactiveUI.Primitives.Async.Core/PublicAPI/net481/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Async.Core/PublicAPI/net481/PublicAPI.txt
@@ -3,7 +3,7 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Primitives.Tests")]
 namespace ReactiveUI.Primitives.Async
 {
-    [System.Diagnostics.DebuggerDisplay("Signals = {_signals}")]
+    [System.Diagnostics.DebuggerDisplay("ChainEnumerableSignal: Signals = {_signals}")]
     public sealed class ChainEnumerableSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public ChainEnumerableSignal(System.Collections.Generic.IEnumerable<ReactiveUI.Primitives.Async.IObservableAsync<T>> signals) { }
@@ -23,7 +23,7 @@ namespace ReactiveUI.Primitives.Async
         protected ConcurrentWitnessCallsException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public ConcurrentWitnessCallsException(string message, System.Exception innerException) { }
     }
-    [System.Diagnostics.DebuggerDisplay("State = {State}")]
+    [System.Diagnostics.DebuggerDisplay("ConnectableSignalAsync: State = {State}")]
     public sealed class ConnectableSignalAsync<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>, System.IDisposable
     {
         public ConnectableSignalAsync(ReactiveUI.Primitives.Async.IObservableAsync<T> source, ReactiveUI.Primitives.Async.Signals.ISignalAsync<T> signal) { }
@@ -41,7 +41,7 @@ namespace ReactiveUI.Primitives.Async
             public System.IAsyncDisposable ToDisposableAsync() { }
         }
     }
-    [System.Diagnostics.DebuggerDisplay("Key = {Key}")]
+    [System.Diagnostics.DebuggerDisplay("GroupedAsyncSignal: Key = {Key}")]
     public sealed class GroupedAsyncSignal<TKey, TValue> : ReactiveUI.Primitives.Async.IObservableAsync<TValue>
     {
         public TKey Key { get; }
@@ -826,7 +826,7 @@ namespace ReactiveUI.Primitives.Async
         public SwitchToSignal(ReactiveUI.Primitives.Async.IObservableAsync<ReactiveUI.Primitives.Async.IObservableAsync<T>> source) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceFailsWhenOtherFails = {SourceFailsWhenOtherFails}")]
+    [System.Diagnostics.DebuggerDisplay("TakeUntilOptions: SourceFailsWhenOtherFails = {SourceFailsWhenOtherFails}")]
     public record TakeUntilOptions : System.IEquatable<ReactiveUI.Primitives.Async.TakeUntilOptions>
     {
         public bool SourceFailsWhenOtherFails { get; init; }
@@ -836,7 +836,7 @@ namespace ReactiveUI.Primitives.Async
     {
         public static void Register(System.Action<System.Exception> unhandledExceptionHandler) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Disposed = {_disposed}, CallState = {_callState}")]
+    [System.Diagnostics.DebuggerDisplay("WitnessAsync: Disposed = {_disposed}, CallState = {_callState}")]
     public abstract class WitnessAsync<T> : ReactiveUI.Primitives.Async.Advanced.IReentrantAsyncDisposable, ReactiveUI.Primitives.Async.IObserverAsync<T>
     {
         protected WitnessAsync() { }
@@ -860,19 +860,19 @@ namespace ReactiveUI.Primitives.Async
 }
 namespace ReactiveUI.Primitives.Async.Advanced
 {
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncEnumerableSignal: Source = {Source}")]
     public sealed class AsyncEnumerableSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public AsyncEnumerableSignal(System.Collections.Generic.IAsyncEnumerable<T> source) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncEnumerableSubscription: Source = {Source}")]
     public sealed class AsyncEnumerableSubscription<T> : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<T>
     {
         public AsyncEnumerableSubscription(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Collections.Generic.IAsyncEnumerable<T> source) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("OwnerThreadId = {_ownerThreadId}, Waiters = {_waiters}, RecursionDepth = {_recursionDepth}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncSerialGate: OwnerThreadId = {_ownerThreadId}, Waiters = {_waiters}, RecursionDepth = {_recursionDepth}")]
     public sealed class AsyncSerialGate : System.IDisposable
     {
         public AsyncSerialGate() { }
@@ -880,7 +880,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.Threading.Tasks.ValueTask<ReactiveUI.Primitives.Async.Advanced.AsyncSerialGate.Lease> EnterAsync() { }
         public System.Threading.Tasks.ValueTask<ReactiveUI.Primitives.Async.Advanced.AsyncSerialGate.Lease> EnterAsync(System.Threading.CancellationToken cancellationToken) { }
-        [System.Diagnostics.DebuggerDisplay("Parent = {_parent}")]
+        [System.Diagnostics.DebuggerDisplay("Lease: Parent = {_parent}")]
         public readonly record struct Lease : System.IDisposable, System.IEquatable<ReactiveUI.Primitives.Async.Advanced.AsyncSerialGate.Lease>
         {
             public Lease(ReactiveUI.Primitives.Async.Advanced.AsyncSerialGate parent) { }
@@ -888,13 +888,13 @@ namespace ReactiveUI.Primitives.Async.Advanced
             public readonly void Dispose() { }
         }
     }
-    [System.Diagnostics.DebuggerDisplay("StartSynchronously = {StartSynchronously}, TaskScheduler = {TaskScheduler}")]
+    [System.Diagnostics.DebuggerDisplay("BackgroundJobSignal: StartSynchronously = {StartSynchronously}, TaskScheduler = {TaskScheduler}")]
     public sealed class BackgroundJobSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public BackgroundJobSignal(System.Func<ReactiveUI.Primitives.Async.IObserverAsync<T>, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> job, bool startSynchronously, System.Threading.Tasks.TaskScheduler? taskScheduler) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasDisposed = {HasDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("CallbackWitnessAsync: HasDisposed = {HasDisposed}")]
     public sealed class CallbackWitnessAsync<T> : ReactiveUI.Primitives.Async.WitnessAsync<T>
     {
         public CallbackWitnessAsync(System.Func<T, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> onNextAsync, System.Func<System.Exception, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask>? onErrorResumeAsync = null, System.Func<ReactiveUI.Primitives.Result, System.Threading.Tasks.ValueTask>? onCompletedAsync = null) { }
@@ -902,31 +902,31 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(T value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Action = {Action}")]
+    [System.Diagnostics.DebuggerDisplay("DoOnSubscribeAsyncSignal: Source = {Source}, Action = {Action}")]
     public sealed class DoOnSubscribeAsyncSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public DoOnSubscribeAsyncSignal(ReactiveUI.Primitives.Async.IObservableAsync<T> source, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> action) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Action = {Action}")]
+    [System.Diagnostics.DebuggerDisplay("DoOnSubscribeSignal: Source = {Source}, Action = {Action}")]
     public sealed class DoOnSubscribeSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public DoOnSubscribeSignal(ReactiveUI.Primitives.Async.IObservableAsync<T> source, System.Action action) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("EnumerableSignal: Source = {Source}")]
     public sealed class EnumerableSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public EnumerableSignal(System.Collections.Generic.IEnumerable<T> source) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("EnumerableSubscription: Source = {Source}")]
     public sealed class EnumerableSubscription<T> : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<T>
     {
         public EnumerableSubscription(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Collections.Generic.IEnumerable<T> source) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ActiveInnerCount = {ActiveInnerCount}, OuterCompleted = {OuterCompleted}, Disposed = {Disposed}")]
+    [System.Diagnostics.DebuggerDisplay("FlatMapCoordinator: ActiveInnerCount = {ActiveInnerCount}, OuterCompleted = {OuterCompleted}, Disposed = {Disposed}")]
     public sealed class FlatMapCoordinator<TResult> : System.IAsyncDisposable
     {
         public FlatMapCoordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer) { }
@@ -942,14 +942,14 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public System.Threading.Tasks.ValueTask SetOuterObserverAsync(System.IAsyncDisposable observer) { }
         public System.Threading.Tasks.ValueTask SubscribeInnerAsync(ReactiveUI.Primitives.Async.IObservableAsync<TResult> inner) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, SyncSelector = {SyncSelector}, AsyncSelector = {AsyncSelector}")]
+    [System.Diagnostics.DebuggerDisplay("FlatMapSignal: Source = {Source}, SyncSelector = {SyncSelector}, AsyncSelector = {AsyncSelector}")]
     public sealed class FlatMapSignal<TSource, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public FlatMapSignal(ReactiveUI.Primitives.Async.IObservableAsync<TSource> source, System.Func<TSource, ReactiveUI.Primitives.Async.IObservableAsync<TResult>> selector) { }
         public FlatMapSignal(ReactiveUI.Primitives.Async.IObservableAsync<TSource> source, System.Func<TSource, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<ReactiveUI.Primitives.Async.IObservableAsync<TResult>>> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Coordinator = {Coordinator}")]
+    [System.Diagnostics.DebuggerDisplay("FlatMapWitness: Coordinator = {Coordinator}")]
     public sealed class FlatMapWitness<TResult> : ReactiveUI.Primitives.Async.WitnessAsync<TResult>
     {
         public FlatMapWitness(ReactiveUI.Primitives.Async.Advanced.FlatMapCoordinator<TResult> coordinator) { }
@@ -957,7 +957,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(TResult value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Coordinator = {Coordinator}, SyncSelector = {SyncSelector}, AsyncSelector = {AsyncSelector}")]
+    [System.Diagnostics.DebuggerDisplay("FlatMapWitness: Coordinator = {Coordinator}, SyncSelector = {SyncSelector}, AsyncSelector = {AsyncSelector}")]
     public sealed class FlatMapWitness<TSource, TResult> : ReactiveUI.Primitives.Async.WitnessAsync<TSource>
     {
         public FlatMapWitness(ReactiveUI.Primitives.Async.Advanced.FlatMapCoordinator<TResult> coordinator, System.Func<TSource, ReactiveUI.Primitives.Async.IObservableAsync<TResult>>? syncSelector, System.Func<TSource, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<ReactiveUI.Primitives.Async.IObservableAsync<TResult>>>? asyncSelector) { }
@@ -965,7 +965,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(TSource value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Downstream = {Downstream}")]
+    [System.Diagnostics.DebuggerDisplay("ForwardingWitnessAsync: Downstream = {Downstream}")]
     public class ForwardingWitnessAsync<T> : ReactiveUI.Primitives.Async.WitnessAsync<T>
     {
         protected ForwardingWitnessAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> downstream) { }
@@ -974,13 +974,13 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(T value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Factory = {Factory}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSignal: Factory = {Factory}")]
     public sealed class FromAsyncSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<T>> factory) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Factory = {Factory}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSubscription: Factory = {Factory}")]
     public sealed class FromAsyncSubscription<T> : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<T>
     {
         public FromAsyncSubscription(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<T>> factory) { }
@@ -990,39 +990,39 @@ namespace ReactiveUI.Primitives.Async.Advanced
     {
         System.Threading.Tasks.ValueTask DisposeFromNotificationAsync() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Period = {Period}, TimeProvider = {TimeProvider}")]
+    [System.Diagnostics.DebuggerDisplay("IntervalSignal: Period = {Period}, TimeProvider = {TimeProvider}")]
     public sealed class IntervalSignal : ReactiveUI.Primitives.Async.IObservableAsync<long>
     {
         public IntervalSignal(System.TimeSpan period, System.TimeProvider? timeProvider) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<System.Int64>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<long> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Period = {Period}, TimeProvider = {TimeProvider}")]
+    [System.Diagnostics.DebuggerDisplay("IntervalSubscription: Period = {Period}, TimeProvider = {TimeProvider}")]
     public sealed class IntervalSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<long>
     {
         public IntervalSubscription(ReactiveUI.Primitives.Async.IObserverAsync<long> observer, System.TimeSpan period, System.TimeProvider? timeProvider) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<long> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Values = {Values}")]
+    [System.Diagnostics.DebuggerDisplay("LeadSignal: Source = {Source}, Values = {Values}")]
     public sealed class LeadSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public LeadSignal(ReactiveUI.Primitives.Async.IObservableAsync<T> source, System.Collections.Generic.IEnumerable<T> values) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Disposed = {Disposed}, Pipeline = {Pipeline}")]
+    [System.Diagnostics.DebuggerDisplay("LeadSubscription: Disposed = {Disposed}, Pipeline = {Pipeline}")]
     public sealed class LeadSubscription<T> : System.IAsyncDisposable
     {
         public LeadSubscription(ReactiveUI.Primitives.Async.IObservableAsync<T> source, System.Collections.Generic.IEnumerable<T> values, ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken subscriptionToken) { }
         public System.Threading.Tasks.ValueTask DisposeAsync() { }
         public void Start() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Logger = {Logger}")]
+    [System.Diagnostics.DebuggerDisplay("LogErrorsSignal: Source = {Source}, Logger = {Logger}")]
     public sealed class LogErrorsSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public LogErrorsSignal(ReactiveUI.Primitives.Async.IObservableAsync<T> source, System.Action<System.Exception> logger) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Downstream = {Downstream}, Logger = {Logger}")]
+    [System.Diagnostics.DebuggerDisplay("LogErrorsWitness: Downstream = {Downstream}, Logger = {Logger}")]
     public sealed class LogErrorsWitness<T> : ReactiveUI.Primitives.Async.WitnessAsync<T>
     {
         public LogErrorsWitness(ReactiveUI.Primitives.Async.IObserverAsync<T> downstream, System.Action<System.Exception> logger) { }
@@ -1030,7 +1030,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(T value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {_completed}, Timer = {_timer}")]
+    [System.Diagnostics.DebuggerDisplay("PooledDelaySource: Completed = {_completed}, Timer = {_timer}")]
     public sealed class PooledDelaySource : System.Threading.Tasks.Sources.IValueTaskSource
     {
         public System.Threading.Tasks.ValueTask BeginAsync(System.TimeSpan delay, System.TimeProvider timeProvider, System.Threading.CancellationToken cancellationToken) { }
@@ -1041,13 +1041,13 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public void OnCompleted(System.Action<object?> continuation, object? state, short token, System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags flags) { }
         public static ReactiveUI.Primitives.Async.Advanced.PooledDelaySource Rent() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, RetryCount = {RetryCount}")]
+    [System.Diagnostics.DebuggerDisplay("ReattemptSignal: Source = {Source}, RetryCount = {RetryCount}")]
     public sealed class ReattemptSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public ReattemptSignal(ReactiveUI.Primitives.Async.IObservableAsync<T> source, int retryCount) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Remaining = {Remaining}")]
+    [System.Diagnostics.DebuggerDisplay("ReattemptSubscription: Source = {Source}, Remaining = {Remaining}")]
     public sealed class ReattemptSubscription<T> : System.IAsyncDisposable
     {
         public ReattemptSubscription(ReactiveUI.Primitives.Async.IObservableAsync<T> source, ReactiveUI.Primitives.Async.IObserverAsync<T> observer, int retryCount, System.Threading.CancellationToken cancellationToken) { }
@@ -1060,7 +1060,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public System.Threading.Tasks.ValueTask RelayNextAsync(T value, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.ValueTask SubscribeOnceAsync() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("ReattemptWitness: Subscription = {Subscription}")]
     public sealed class ReattemptWitness<T> : ReactiveUI.Primitives.Async.WitnessAsync<T>
     {
         public ReattemptWitness(ReactiveUI.Primitives.Async.Advanced.ReattemptSubscription<T> subscription) { }
@@ -1072,19 +1072,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
     {
         public RelayWitnessAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("StartValue = {StartValue}, Count = {Count}")]
+    [System.Diagnostics.DebuggerDisplay("SequenceSignal: StartValue = {StartValue}, Count = {Count}")]
     public sealed class SequenceSignal : ReactiveUI.Primitives.Async.IObservableAsync<int>
     {
         public SequenceSignal(int start, int count) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<System.Int32>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<int> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("StartValue = {StartValue}, Count = {Count}")]
+    [System.Diagnostics.DebuggerDisplay("SequenceSubscription: StartValue = {StartValue}, Count = {Count}")]
     public sealed class SequenceSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<int>
     {
         public SequenceSubscription(ReactiveUI.Primitives.Async.IObserverAsync<int> observer, int start, int count) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<int> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasValue = {_hasValue}, Value = {_value}")]
+    [System.Diagnostics.DebuggerDisplay("SingleElementWitness: HasValue = {_hasValue}, Value = {_value}")]
     public sealed class SingleElementWitness<T> : ReactiveUI.Primitives.Async.Advanced.TaskResultWitnessAsyncBase<T, T?>
     {
         public SingleElementWitness(System.Func<T, bool>? predicate, bool requireExactlyOne, T? defaultValue, System.Threading.CancellationToken cancellationToken) { }
@@ -1092,31 +1092,31 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(T value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Function = {Function}, TaskScheduler = {TaskScheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Function = {Function}, TaskScheduler = {TaskScheduler}")]
     public sealed class StartSignal<TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public StartSignal(System.Func<TResult> function, System.Threading.Tasks.TaskScheduler? taskScheduler) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Function = {Function}, TaskScheduler = {TaskScheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSubscription: Function = {Function}, TaskScheduler = {TaskScheduler}")]
     public sealed class StartSubscription<TResult> : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<TResult>
     {
         public StartSubscription(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Func<TResult> function, System.Threading.Tasks.TaskScheduler? taskScheduler) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceCount = {SourceCount}, Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest10Coordinator: SourceCount = {SourceCount}, Sources = {Sources}")]
     public sealed class SyncLatest10Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest10Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest10State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest10Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest10Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest10Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest10State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source10 = {Source10}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest10State: Source1 = {Source1}, Source10 = {Source10}")]
     public readonly record struct SyncLatest10State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest10State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>>
     {
         public SyncLatest10State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8, ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9, ReactiveUI.Primitives.Async.IObservableAsync<T10> Source10) { }
@@ -1131,19 +1131,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceCount = {SourceCount}, Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest11Coordinator: SourceCount = {SourceCount}, Sources = {Sources}")]
     public sealed class SyncLatest11Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest11Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest11State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest11Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest11Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest11Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest11State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source2 = {Source2}, Source11 = {Source11}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest11State: Source1 = {Source1}, Source2 = {Source2}, Source11 = {Source11}")]
     public readonly record struct SyncLatest11State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest11State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>>
     {
         public SyncLatest11State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8, ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9, ReactiveUI.Primitives.Async.IObservableAsync<T10> Source10, ReactiveUI.Primitives.Async.IObservableAsync<T11> Source11) { }
@@ -1159,19 +1159,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Lifecycle = {Lifecycle}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest12Coordinator: Sources = {Sources}, Lifecycle = {Lifecycle}")]
     public sealed class SyncLatest12Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest12Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest12State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest12Signal: Sources = {Sources}")]
     public sealed class SyncLatest12Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest12Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest12State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source12 = {Source12}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest12State: Source1 = {Source1}, Source12 = {Source12}")]
     public readonly record struct SyncLatest12State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest12State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>>
     {
         public SyncLatest12State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8, ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9, ReactiveUI.Primitives.Async.IObservableAsync<T10> Source10, ReactiveUI.Primitives.Async.IObservableAsync<T11> Source11, ReactiveUI.Primitives.Async.IObservableAsync<T12> Source12) { }
@@ -1188,19 +1188,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value13 = {Value13}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest13Coordinator: Value1 = {Value1}, Value13 = {Value13}")]
     public sealed class SyncLatest13Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest13Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest13State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest13Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest13Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest13Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest13State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source13 = {Source13}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest13State: Source1 = {Source1}, Source13 = {Source13}")]
     public readonly record struct SyncLatest13State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest13State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>>
     {
         public SyncLatest13State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8, ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9, ReactiveUI.Primitives.Async.IObservableAsync<T10> Source10, ReactiveUI.Primitives.Async.IObservableAsync<T11> Source11, ReactiveUI.Primitives.Async.IObservableAsync<T12> Source12, ReactiveUI.Primitives.Async.IObservableAsync<T13> Source13) { }
@@ -1218,19 +1218,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Lifecycle = {Lifecycle}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest14Coordinator: Sources = {Sources}, Lifecycle = {Lifecycle}")]
     public sealed class SyncLatest14Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest14Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest14State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest14Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest14Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest14Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest14State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source14 = {Source14}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest14State: Source1 = {Source1}, Source14 = {Source14}")]
     public readonly record struct SyncLatest14State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest14State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>>
     {
         public SyncLatest14State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8, ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9, ReactiveUI.Primitives.Async.IObservableAsync<T10> Source10, ReactiveUI.Primitives.Async.IObservableAsync<T11> Source11, ReactiveUI.Primitives.Async.IObservableAsync<T12> Source12, ReactiveUI.Primitives.Async.IObservableAsync<T13> Source13, ReactiveUI.Primitives.Async.IObservableAsync<T14> Source14) { }
@@ -1249,19 +1249,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value15 = {Value15}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest15Coordinator: Value1 = {Value1}, Value15 = {Value15}")]
     public sealed class SyncLatest15Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest15Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest15State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest15Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest15Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest15Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest15State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source15 = {Source15}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest15State: Source1 = {Source1}, Source15 = {Source15}")]
     public readonly record struct SyncLatest15State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest15State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>>
     {
         public SyncLatest15State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8, ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9, ReactiveUI.Primitives.Async.IObservableAsync<T10> Source10, ReactiveUI.Primitives.Async.IObservableAsync<T11> Source11, ReactiveUI.Primitives.Async.IObservableAsync<T12> Source12, ReactiveUI.Primitives.Async.IObservableAsync<T13> Source13, ReactiveUI.Primitives.Async.IObservableAsync<T14> Source14, ReactiveUI.Primitives.Async.IObservableAsync<T15> Source15) { }
@@ -1281,19 +1281,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value16 = {Value16}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest16Coordinator: Value1 = {Value1}, Value16 = {Value16}")]
     public sealed class SyncLatest16Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest16Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest16State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest16Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest16Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest16Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest16State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source16 = {Source16}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest16State: Source1 = {Source1}, Source16 = {Source16}")]
     public readonly record struct SyncLatest16State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest16State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>>
     {
         public SyncLatest16State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8, ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9, ReactiveUI.Primitives.Async.IObservableAsync<T10> Source10, ReactiveUI.Primitives.Async.IObservableAsync<T11> Source11, ReactiveUI.Primitives.Async.IObservableAsync<T12> Source12, ReactiveUI.Primitives.Async.IObservableAsync<T13> Source13, ReactiveUI.Primitives.Async.IObservableAsync<T14> Source14, ReactiveUI.Primitives.Async.IObservableAsync<T15> Source15, ReactiveUI.Primitives.Async.IObservableAsync<T16> Source16) { }
@@ -1314,38 +1314,38 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest2Coordinator: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest2Coordinator<T1, T2, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest2Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest2State<T1, T2> sources, System.Func<T1, T2, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest2Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest2Signal<T1, T2, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest2Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest2State<T1, T2> sources, System.Func<T1, T2, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source2 = {Source2}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest2State: Source1 = {Source1}, Source2 = {Source2}")]
     public readonly record struct SyncLatest2State<T1, T2> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest2State<T1, T2>>
     {
         public SyncLatest2State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2) { }
         public ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value3 = {Value3}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest3Coordinator: Value1 = {Value1}, Value3 = {Value3}")]
     public sealed class SyncLatest3Coordinator<T1, T2, T3, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest3Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest3State<T1, T2, T3> sources, System.Func<T1, T2, T3, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest3Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest3Signal<T1, T2, T3, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest3Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest3State<T1, T2, T3> sources, System.Func<T1, T2, T3, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source2 = {Source2}, Source3 = {Source3}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest3State: Source1 = {Source1}, Source2 = {Source2}, Source3 = {Source3}")]
     public readonly record struct SyncLatest3State<T1, T2, T3> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest3State<T1, T2, T3>>
     {
         public SyncLatest3State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3) { }
@@ -1353,19 +1353,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value4 = {Value4}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest4Coordinator: Value1 = {Value1}, Value4 = {Value4}")]
     public sealed class SyncLatest4Coordinator<T1, T2, T3, T4, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest4Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest4State<T1, T2, T3, T4> sources, System.Func<T1, T2, T3, T4, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest4Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest4Signal<T1, T2, T3, T4, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest4Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest4State<T1, T2, T3, T4> sources, System.Func<T1, T2, T3, T4, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source2 = {Source2}, Source3 = {Source3}, Source4 = {Source4}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest4State: Source1 = {Source1}, Source2 = {Source2}, Source3 = {Source3}, Source4 = {Source4}")]
     public readonly record struct SyncLatest4State<T1, T2, T3, T4> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest4State<T1, T2, T3, T4>>
     {
         public SyncLatest4State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4) { }
@@ -1374,19 +1374,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value5 = {Value5}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest5Coordinator: Value1 = {Value1}, Value5 = {Value5}")]
     public sealed class SyncLatest5Coordinator<T1, T2, T3, T4, T5, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest5Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest5State<T1, T2, T3, T4, T5> sources, System.Func<T1, T2, T3, T4, T5, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest5Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest5Signal<T1, T2, T3, T4, T5, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest5Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest5State<T1, T2, T3, T4, T5> sources, System.Func<T1, T2, T3, T4, T5, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source5 = {Source5}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest5State: Source1 = {Source1}, Source5 = {Source5}")]
     public readonly record struct SyncLatest5State<T1, T2, T3, T4, T5> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest5State<T1, T2, T3, T4, T5>>
     {
         public SyncLatest5State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5) { }
@@ -1396,19 +1396,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value6 = {Value6}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest6Coordinator: Value1 = {Value1}, Value6 = {Value6}")]
     public sealed class SyncLatest6Coordinator<T1, T2, T3, T4, T5, T6, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest6Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest6State<T1, T2, T3, T4, T5, T6> sources, System.Func<T1, T2, T3, T4, T5, T6, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest6Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest6Signal<T1, T2, T3, T4, T5, T6, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest6Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest6State<T1, T2, T3, T4, T5, T6> sources, System.Func<T1, T2, T3, T4, T5, T6, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source6 = {Source6}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest6State: Source1 = {Source1}, Source6 = {Source6}")]
     public readonly record struct SyncLatest6State<T1, T2, T3, T4, T5, T6> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest6State<T1, T2, T3, T4, T5, T6>>
     {
         public SyncLatest6State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6) { }
@@ -1419,19 +1419,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest7Coordinator: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest7Coordinator<T1, T2, T3, T4, T5, T6, T7, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest7Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest7State<T1, T2, T3, T4, T5, T6, T7> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest7Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest7Signal<T1, T2, T3, T4, T5, T6, T7, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest7Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest7State<T1, T2, T3, T4, T5, T6, T7> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source7 = {Source7}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest7State: Source1 = {Source1}, Source7 = {Source7}")]
     public readonly record struct SyncLatest7State<T1, T2, T3, T4, T5, T6, T7> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest7State<T1, T2, T3, T4, T5, T6, T7>>
     {
         public SyncLatest7State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7) { }
@@ -1443,19 +1443,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest8Coordinator: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest8Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest8Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest8State<T1, T2, T3, T4, T5, T6, T7, T8> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest8Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest8Signal<T1, T2, T3, T4, T5, T6, T7, T8, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest8Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest8State<T1, T2, T3, T4, T5, T6, T7, T8> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source8 = {Source8}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest8State: Source1 = {Source1}, Source8 = {Source8}")]
     public readonly record struct SyncLatest8State<T1, T2, T3, T4, T5, T6, T7, T8> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest8State<T1, T2, T3, T4, T5, T6, T7, T8>>
     {
         public SyncLatest8State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8) { }
@@ -1468,19 +1468,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value9 = {Value9}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest9Coordinator: Value1 = {Value1}, Value9 = {Value9}")]
     public sealed class SyncLatest9Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest9Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest9State<T1, T2, T3, T4, T5, T6, T7, T8, T9> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest9Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest9Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest9Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest9State<T1, T2, T3, T4, T5, T6, T7, T8, T9> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source9 = {Source9}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest9State: Source1 = {Source1}, Source9 = {Source9}")]
     public readonly record struct SyncLatest9State<T1, T2, T3, T4, T5, T6, T7, T8, T9> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest9State<T1, T2, T3, T4, T5, T6, T7, T8, T9>>
     {
         public SyncLatest9State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8, ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9) { }
@@ -1494,7 +1494,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceCount = {Lifecycle.Subscriptions.Length}, HasDisposed = {Lifecycle.HasDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestCoordinatorBase: SourceCount = {Lifecycle.Subscriptions.Length}, HasDisposed = {Lifecycle.HasDisposed}")]
     public abstract class SyncLatestCoordinatorBase<TResult> : System.IAsyncDisposable
     {
         protected SyncLatestCoordinatorBase(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, int sourceCount) { }
@@ -1502,7 +1502,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected abstract System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.ValueTask SubscribeSourcesAsync(System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources.Length}, Completed = {_completedCount}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestEnumerableCoordinator: Sources = {Sources.Length}, Completed = {_completedCount}, Disposed = {_disposed}")]
     public sealed class SyncLatestEnumerableCoordinator<TSource, TResult> : System.IAsyncDisposable
     {
         public SyncLatestEnumerableCoordinator(ReactiveUI.Primitives.Async.IObservableAsync<TSource>[] sources, ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Func<System.Collections.Generic.IReadOnlyList<TSource>, TResult> resultSelector) { }
@@ -1510,13 +1510,13 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public System.Threading.Tasks.ValueTask DisposeAsync() { }
         public System.Threading.Tasks.ValueTask SubscribeSourcesAsync(System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceCount = {Sources.Length}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestEnumerableSignal: SourceCount = {Sources.Length}")]
     public sealed class SyncLatestEnumerableSignal<TSource, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatestEnumerableSignal(System.Collections.Generic.IEnumerable<ReactiveUI.Primitives.Async.IObservableAsync<TSource>> sources, System.Func<System.Collections.Generic.IReadOnlyList<TSource>, TResult> resultSelector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Index = {Index}, Parent = {Parent}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestEnumerableWitness: Index = {Index}, Parent = {Parent}")]
     public sealed class SyncLatestEnumerableWitness<TSource, TResult> : ReactiveUI.Primitives.Async.IObserverAsync<TSource>
     {
         public SyncLatestEnumerableWitness(ReactiveUI.Primitives.Async.Advanced.SyncLatestEnumerableCoordinator<TSource, TResult> parent, int index) { }
@@ -1536,7 +1536,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(TSource value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceCount = {Subscriptions.Length}, HasDisposed = {HasDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestLifecycle: SourceCount = {Subscriptions.Length}, HasDisposed = {HasDisposed}")]
     public sealed class SyncLatestLifecycle<TResult> : System.IAsyncDisposable
     {
         public SyncLatestLifecycle(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, int sourceCount) { }
@@ -1558,7 +1558,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(TSource value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, DisposeRequested = {DisposeToken.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("TakeUntilLifecycle: Observer = {_observer}, DisposeRequested = {DisposeToken.IsCancellationRequested}")]
     public sealed class TakeUntilLifecycle<T> : System.IAsyncDisposable
     {
         public TakeUntilLifecycle(ReactiveUI.Primitives.Async.IObserverAsync<T> observer) { }
@@ -1576,7 +1576,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(T value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsCompleted = {_taskSource.Task.IsCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("TaskResultCompletionSource: IsCompleted = {_taskSource.Task.IsCompleted}")]
     public sealed class TaskResultCompletionSource<T>
     {
         public TaskResultCompletionSource(System.Threading.CancellationToken cancellationToken) { }
@@ -1584,19 +1584,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public System.Threading.Tasks.ValueTask SetExceptionAndDisposeAsync(System.Exception exception, ReactiveUI.Primitives.Async.Advanced.IReentrantAsyncDisposable owner) { }
         public System.Threading.Tasks.ValueTask SetResultAndDisposeAsync(T value, ReactiveUI.Primitives.Async.Advanced.IReentrantAsyncDisposable owner) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskResultSignal: Task = {Task}")]
     public sealed class TaskResultSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public TaskResultSignal(System.Threading.Tasks.Task<T> task) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskResultSubscription: Task = {Task}")]
     public sealed class TaskResultSubscription<T> : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<T>
     {
         public TaskResultSubscription(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.Tasks.Task<T> task) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completion = {_completion}")]
+    [System.Diagnostics.DebuggerDisplay("TaskResultWitnessAsyncBase: Completion = {_completion}")]
     public abstract class TaskResultWitnessAsyncBase<T, TTaskValue> : ReactiveUI.Primitives.Async.WitnessAsync<T>
     {
         protected TaskResultWitnessAsyncBase(System.Threading.CancellationToken cancellationToken) { }
@@ -1611,7 +1611,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
     {
         public static ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<T> StartNew<T>(System.Func<ReactiveUI.Primitives.Async.IObserverAsync<T>, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> executeAsyncCore, ReactiveUI.Primitives.Async.IObserverAsync<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Disposed = {_disposed}, Completed = {_tcs.Task.IsCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("TaskSignalSubscription: Disposed = {_disposed}, Completed = {_tcs.Task.IsCompleted}")]
     public abstract class TaskSignalSubscription<T> : System.IAsyncDisposable
     {
         protected TaskSignalSubscription(ReactiveUI.Primitives.Async.IObserverAsync<T> observer) { }
@@ -1619,25 +1619,25 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected abstract System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
         public void Start() { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {DueTime}, Period = {Period}")]
+    [System.Diagnostics.DebuggerDisplay("TimerSignal: DueTime = {DueTime}, Period = {Period}")]
     public sealed class TimerSignal : ReactiveUI.Primitives.Async.IObservableAsync<long>
     {
         public TimerSignal(System.TimeSpan dueTime, System.TimeSpan? period, System.TimeProvider timeProvider) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<System.Int64>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<long> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {DueTime}, Period = {Period}")]
+    [System.Diagnostics.DebuggerDisplay("TimerSubscription: DueTime = {DueTime}, Period = {Period}")]
     public sealed class TimerSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<long>
     {
         public TimerSubscription(ReactiveUI.Primitives.Async.IObserverAsync<long> observer, System.TimeSpan dueTime, System.TimeSpan? period, System.TimeProvider timeProvider) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<long> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ResourceFactory = {ResourceFactory}, SignalFactory = {SignalFactory}")]
+    [System.Diagnostics.DebuggerDisplay("UsingSignal: ResourceFactory = {ResourceFactory}, SignalFactory = {SignalFactory}")]
     public sealed class UsingSignal<TResource, T> : ReactiveUI.Primitives.Async.IObservableAsync<T> where TResource : System.IAsyncDisposable
     {
         public UsingSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResource>> resourceFactory, System.Func<TResource, ReactiveUI.Primitives.Async.IObservableAsync<T>> signalFactory) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Resource = {Resource}")]
+    [System.Diagnostics.DebuggerDisplay("UsingWitness: Resource = {Resource}")]
     public sealed class UsingWitness<TResource, T> : ReactiveUI.Primitives.Async.Advanced.ForwardingWitnessAsync<T> where TResource : System.IAsyncDisposable
     {
         public UsingWitness(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, TResource resource) { }
@@ -1662,7 +1662,7 @@ namespace ReactiveUI.Primitives.Async.Disposables
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public static System.Threading.Tasks.ValueTask SwapAsync(ref System.IAsyncDisposable? slot, System.IAsyncDisposable? value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, IsDisposed = {_isDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("MultipleDisposableAsync: Count = {_count}, IsDisposed = {_isDisposed}")]
     public sealed class MultipleDisposableAsync : System.IAsyncDisposable
     {
         public MultipleDisposableAsync() { }
@@ -1679,7 +1679,7 @@ namespace ReactiveUI.Primitives.Async.Disposables
         public System.Collections.Generic.IEnumerator<System.IAsyncDisposable> GetEnumerator() { }
         public System.Threading.Tasks.ValueTask<bool> Remove(System.IAsyncDisposable item) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsDisposed = {IsDisposed}, Current = {_current}")]
+    [System.Diagnostics.DebuggerDisplay("SingleAssignmentDisposableAsync: IsDisposed = {IsDisposed}, Current = {_current}")]
     public sealed class SingleAssignmentDisposableAsync : System.IAsyncDisposable
     {
         public SingleAssignmentDisposableAsync() { }
@@ -1690,7 +1690,7 @@ namespace ReactiveUI.Primitives.Async.Disposables
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.Threading.Tasks.ValueTask SetDisposableAsync(System.IAsyncDisposable? value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Current = {_current}")]
+    [System.Diagnostics.DebuggerDisplay("SingleReplaceableDisposableAsync: Current = {_current}")]
     public class SingleReplaceableDisposableAsync : System.IAsyncDisposable
     {
         public SingleReplaceableDisposableAsync() { }
@@ -1716,7 +1716,7 @@ namespace ReactiveUI.Primitives.Async.Helpers
 }
 namespace ReactiveUI.Primitives.Async.Signals
 {
-    [System.Diagnostics.DebuggerDisplay("PublishingOption = {PublishingOption}, IsStateless = {IsStateless}")]
+    [System.Diagnostics.DebuggerDisplay("BehaviorSignalCreationOptions: PublishingOption = {PublishingOption}, IsStateless = {IsStateless}")]
     public record BehaviorSignalCreationOptions : System.IEquatable<ReactiveUI.Primitives.Async.Signals.BehaviorSignalCreationOptions>
     {
         public required bool IsStateless { get; init; }
@@ -1732,7 +1732,7 @@ namespace ReactiveUI.Primitives.Async.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public static System.Threading.Tasks.ValueTask ForwardOnNextConcurrently<T>(System.Collections.Immutable.ImmutableArray<ReactiveUI.Primitives.Async.IObserverAsync<T>> observers, T value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("LastValue = {_state.LastValue}, IsDisposed = {_state.IsDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ConcurrentReplayLatestSignalAsync: LastValue = {_state.LastValue}, IsDisposed = {_state.IsDisposed}")]
     public sealed class ConcurrentReplayLatestSignalAsync<T> : ReactiveUI.Primitives.Async.Signals.ISignalAsync<T>
     {
         public ConcurrentReplayLatestSignalAsync(ReactiveUI.Primitives.Optional<T> startValue) { }
@@ -1748,7 +1748,7 @@ namespace ReactiveUI.Primitives.Async.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_state.Observers.Length}, Result = {_state.Result}")]
+    [System.Diagnostics.DebuggerDisplay("ConcurrentSignalAsync: Observers = {_state.Observers.Length}, Result = {_state.Result}")]
     public sealed class ConcurrentSignalAsync<T> : ReactiveUI.Primitives.Async.Signals.ISignalAsync<T>
     {
         public ConcurrentSignalAsync() { }
@@ -1764,7 +1764,7 @@ namespace ReactiveUI.Primitives.Async.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_state.Value}, IsDisposed = {_state.IsDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ConcurrentStatelessReplayLatestSignalAsync: Value = {_state.Value}, IsDisposed = {_state.IsDisposed}")]
     public sealed class ConcurrentStatelessReplayLatestSignalAsync<T> : ReactiveUI.Primitives.Async.Signals.ISignalAsync<T>
     {
         public ConcurrentStatelessReplayLatestSignalAsync(ReactiveUI.Primitives.Optional<T> startValue) { }
@@ -1780,7 +1780,7 @@ namespace ReactiveUI.Primitives.Async.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_state.Observers.Length}")]
+    [System.Diagnostics.DebuggerDisplay("ConcurrentStatelessSignalAsync: Observers = {_state.Observers.Length}")]
     public sealed class ConcurrentStatelessSignalAsync<T> : ReactiveUI.Primitives.Async.Signals.ISignalAsync<T>
     {
         public ConcurrentStatelessSignalAsync() { }
@@ -1805,14 +1805,14 @@ namespace ReactiveUI.Primitives.Async.Signals
         Serial = 0,
         Concurrent = 1,
     }
-    [System.Diagnostics.DebuggerDisplay("PublishingOption = {PublishingOption}, IsStateless = {IsStateless}")]
+    [System.Diagnostics.DebuggerDisplay("ReplayLatestSignalCreationOptions: PublishingOption = {PublishingOption}, IsStateless = {IsStateless}")]
     public record ReplayLatestSignalCreationOptions : System.IEquatable<ReactiveUI.Primitives.Async.Signals.ReplayLatestSignalCreationOptions>
     {
         public required bool IsStateless { get; init; }
         public required ReactiveUI.Primitives.Async.Signals.PublishingOption PublishingOption { get; init; }
         public static ReactiveUI.Primitives.Async.Signals.ReplayLatestSignalCreationOptions Default { get; }
     }
-    [System.Diagnostics.DebuggerDisplay("LastValue = {_state.LastValue}, IsDisposed = {_state.IsDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("SerialReplayLatestSignalAsync: LastValue = {_state.LastValue}, IsDisposed = {_state.IsDisposed}")]
     public sealed class SerialReplayLatestSignalAsync<T> : ReactiveUI.Primitives.Async.Signals.ISignalAsync<T>
     {
         public SerialReplayLatestSignalAsync(ReactiveUI.Primitives.Optional<T> startValue) { }
@@ -1828,7 +1828,7 @@ namespace ReactiveUI.Primitives.Async.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_state.Observers.Length}, Result = {_state.Result}")]
+    [System.Diagnostics.DebuggerDisplay("SerialSignalAsync: Observers = {_state.Observers.Length}, Result = {_state.Result}")]
     public sealed class SerialSignalAsync<T> : ReactiveUI.Primitives.Async.Signals.ISignalAsync<T>
     {
         public SerialSignalAsync() { }
@@ -1844,7 +1844,7 @@ namespace ReactiveUI.Primitives.Async.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("State = {_state}")]
+    [System.Diagnostics.DebuggerDisplay("SerialStatelessReplayLatestSignalAsync: State = {_state}")]
     public sealed class SerialStatelessReplayLatestSignalAsync<T> : ReactiveUI.Primitives.Async.Signals.ISignalAsync<T>
     {
         public SerialStatelessReplayLatestSignalAsync(ReactiveUI.Primitives.Optional<T> startValue) { }
@@ -1860,7 +1860,7 @@ namespace ReactiveUI.Primitives.Async.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_state.Observers.Length}")]
+    [System.Diagnostics.DebuggerDisplay("SerialStatelessSignalAsync: Observers = {_state.Observers.Length}")]
     public sealed class SerialStatelessSignalAsync<T> : ReactiveUI.Primitives.Async.Signals.ISignalAsync<T>
     {
         public SerialStatelessSignalAsync() { }
@@ -1888,7 +1888,7 @@ namespace ReactiveUI.Primitives.Async.Signals
         public static ReactiveUI.Primitives.Async.Signals.ISignalAsync<T> CreateReplayLatest<T>() { }
         public static ReactiveUI.Primitives.Async.Signals.ISignalAsync<T> CreateReplayLatest<T>(ReactiveUI.Primitives.Async.Signals.ReplayLatestSignalCreationOptions? options) { }
     }
-    [System.Diagnostics.DebuggerDisplay("PublishingOption = {PublishingOption}, IsStateless = {IsStateless}")]
+    [System.Diagnostics.DebuggerDisplay("SignalCreationOptions: PublishingOption = {PublishingOption}, IsStateless = {IsStateless}")]
     public record SignalCreationOptions : System.IEquatable<ReactiveUI.Primitives.Async.Signals.SignalCreationOptions>
     {
         public required bool IsStateless { get; init; }

--- a/src/ReactiveUI.Primitives.Async.Core/PublicAPI/net8.0/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Async.Core/PublicAPI/net8.0/PublicAPI.txt
@@ -3,7 +3,7 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Primitives.Tests")]
 namespace ReactiveUI.Primitives.Async
 {
-    [System.Diagnostics.DebuggerDisplay("Signals = {_signals}")]
+    [System.Diagnostics.DebuggerDisplay("ChainEnumerableSignal: Signals = {_signals}")]
     public sealed class ChainEnumerableSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public ChainEnumerableSignal(System.Collections.Generic.IEnumerable<ReactiveUI.Primitives.Async.IObservableAsync<T>> signals) { }
@@ -22,7 +22,7 @@ namespace ReactiveUI.Primitives.Async
         public ConcurrentWitnessCallsException(string message) { }
         public ConcurrentWitnessCallsException(string message, System.Exception innerException) { }
     }
-    [System.Diagnostics.DebuggerDisplay("State = {State}")]
+    [System.Diagnostics.DebuggerDisplay("ConnectableSignalAsync: State = {State}")]
     public sealed class ConnectableSignalAsync<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>, System.IDisposable
     {
         public ConnectableSignalAsync(ReactiveUI.Primitives.Async.IObservableAsync<T> source, ReactiveUI.Primitives.Async.Signals.ISignalAsync<T> signal) { }
@@ -40,7 +40,7 @@ namespace ReactiveUI.Primitives.Async
             public System.IAsyncDisposable ToDisposableAsync() { }
         }
     }
-    [System.Diagnostics.DebuggerDisplay("Key = {Key}")]
+    [System.Diagnostics.DebuggerDisplay("GroupedAsyncSignal: Key = {Key}")]
     public sealed class GroupedAsyncSignal<TKey, TValue> : ReactiveUI.Primitives.Async.IObservableAsync<TValue>
     {
         public TKey Key { get; }
@@ -825,7 +825,7 @@ namespace ReactiveUI.Primitives.Async
         public SwitchToSignal(ReactiveUI.Primitives.Async.IObservableAsync<ReactiveUI.Primitives.Async.IObservableAsync<T>> source) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceFailsWhenOtherFails = {SourceFailsWhenOtherFails}")]
+    [System.Diagnostics.DebuggerDisplay("TakeUntilOptions: SourceFailsWhenOtherFails = {SourceFailsWhenOtherFails}")]
     public record TakeUntilOptions : System.IEquatable<ReactiveUI.Primitives.Async.TakeUntilOptions>
     {
         public bool SourceFailsWhenOtherFails { get; init; }
@@ -835,7 +835,7 @@ namespace ReactiveUI.Primitives.Async
     {
         public static void Register(System.Action<System.Exception> unhandledExceptionHandler) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Disposed = {_disposed}, CallState = {_callState}")]
+    [System.Diagnostics.DebuggerDisplay("WitnessAsync: Disposed = {_disposed}, CallState = {_callState}")]
     public abstract class WitnessAsync<T> : ReactiveUI.Primitives.Async.Advanced.IReentrantAsyncDisposable, ReactiveUI.Primitives.Async.IObserverAsync<T>
     {
         protected WitnessAsync() { }
@@ -859,19 +859,19 @@ namespace ReactiveUI.Primitives.Async
 }
 namespace ReactiveUI.Primitives.Async.Advanced
 {
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncEnumerableSignal: Source = {Source}")]
     public sealed class AsyncEnumerableSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public AsyncEnumerableSignal(System.Collections.Generic.IAsyncEnumerable<T> source) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncEnumerableSubscription: Source = {Source}")]
     public sealed class AsyncEnumerableSubscription<T> : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<T>
     {
         public AsyncEnumerableSubscription(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Collections.Generic.IAsyncEnumerable<T> source) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("OwnerThreadId = {_ownerThreadId}, Waiters = {_waiters}, RecursionDepth = {_recursionDepth}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncSerialGate: OwnerThreadId = {_ownerThreadId}, Waiters = {_waiters}, RecursionDepth = {_recursionDepth}")]
     public sealed class AsyncSerialGate : System.IDisposable
     {
         public AsyncSerialGate() { }
@@ -879,7 +879,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.Threading.Tasks.ValueTask<ReactiveUI.Primitives.Async.Advanced.AsyncSerialGate.Lease> EnterAsync() { }
         public System.Threading.Tasks.ValueTask<ReactiveUI.Primitives.Async.Advanced.AsyncSerialGate.Lease> EnterAsync(System.Threading.CancellationToken cancellationToken) { }
-        [System.Diagnostics.DebuggerDisplay("Parent = {_parent}")]
+        [System.Diagnostics.DebuggerDisplay("Lease: Parent = {_parent}")]
         public readonly record struct Lease : System.IDisposable, System.IEquatable<ReactiveUI.Primitives.Async.Advanced.AsyncSerialGate.Lease>
         {
             public Lease(ReactiveUI.Primitives.Async.Advanced.AsyncSerialGate parent) { }
@@ -887,13 +887,13 @@ namespace ReactiveUI.Primitives.Async.Advanced
             public readonly void Dispose() { }
         }
     }
-    [System.Diagnostics.DebuggerDisplay("StartSynchronously = {StartSynchronously}, TaskScheduler = {TaskScheduler}")]
+    [System.Diagnostics.DebuggerDisplay("BackgroundJobSignal: StartSynchronously = {StartSynchronously}, TaskScheduler = {TaskScheduler}")]
     public sealed class BackgroundJobSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public BackgroundJobSignal(System.Func<ReactiveUI.Primitives.Async.IObserverAsync<T>, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> job, bool startSynchronously, System.Threading.Tasks.TaskScheduler? taskScheduler) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasDisposed = {HasDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("CallbackWitnessAsync: HasDisposed = {HasDisposed}")]
     public sealed class CallbackWitnessAsync<T> : ReactiveUI.Primitives.Async.WitnessAsync<T>
     {
         public CallbackWitnessAsync(System.Func<T, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> onNextAsync, System.Func<System.Exception, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask>? onErrorResumeAsync = null, System.Func<ReactiveUI.Primitives.Result, System.Threading.Tasks.ValueTask>? onCompletedAsync = null) { }
@@ -901,31 +901,31 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(T value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Action = {Action}")]
+    [System.Diagnostics.DebuggerDisplay("DoOnSubscribeAsyncSignal: Source = {Source}, Action = {Action}")]
     public sealed class DoOnSubscribeAsyncSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public DoOnSubscribeAsyncSignal(ReactiveUI.Primitives.Async.IObservableAsync<T> source, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> action) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Action = {Action}")]
+    [System.Diagnostics.DebuggerDisplay("DoOnSubscribeSignal: Source = {Source}, Action = {Action}")]
     public sealed class DoOnSubscribeSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public DoOnSubscribeSignal(ReactiveUI.Primitives.Async.IObservableAsync<T> source, System.Action action) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("EnumerableSignal: Source = {Source}")]
     public sealed class EnumerableSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public EnumerableSignal(System.Collections.Generic.IEnumerable<T> source) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("EnumerableSubscription: Source = {Source}")]
     public sealed class EnumerableSubscription<T> : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<T>
     {
         public EnumerableSubscription(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Collections.Generic.IEnumerable<T> source) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ActiveInnerCount = {ActiveInnerCount}, OuterCompleted = {OuterCompleted}, Disposed = {Disposed}")]
+    [System.Diagnostics.DebuggerDisplay("FlatMapCoordinator: ActiveInnerCount = {ActiveInnerCount}, OuterCompleted = {OuterCompleted}, Disposed = {Disposed}")]
     public sealed class FlatMapCoordinator<TResult> : System.IAsyncDisposable
     {
         public FlatMapCoordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer) { }
@@ -941,14 +941,14 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public System.Threading.Tasks.ValueTask SetOuterObserverAsync(System.IAsyncDisposable observer) { }
         public System.Threading.Tasks.ValueTask SubscribeInnerAsync(ReactiveUI.Primitives.Async.IObservableAsync<TResult> inner) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, SyncSelector = {SyncSelector}, AsyncSelector = {AsyncSelector}")]
+    [System.Diagnostics.DebuggerDisplay("FlatMapSignal: Source = {Source}, SyncSelector = {SyncSelector}, AsyncSelector = {AsyncSelector}")]
     public sealed class FlatMapSignal<TSource, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public FlatMapSignal(ReactiveUI.Primitives.Async.IObservableAsync<TSource> source, System.Func<TSource, ReactiveUI.Primitives.Async.IObservableAsync<TResult>> selector) { }
         public FlatMapSignal(ReactiveUI.Primitives.Async.IObservableAsync<TSource> source, System.Func<TSource, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<ReactiveUI.Primitives.Async.IObservableAsync<TResult>>> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Coordinator = {Coordinator}")]
+    [System.Diagnostics.DebuggerDisplay("FlatMapWitness: Coordinator = {Coordinator}")]
     public sealed class FlatMapWitness<TResult> : ReactiveUI.Primitives.Async.WitnessAsync<TResult>
     {
         public FlatMapWitness(ReactiveUI.Primitives.Async.Advanced.FlatMapCoordinator<TResult> coordinator) { }
@@ -956,7 +956,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(TResult value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Coordinator = {Coordinator}, SyncSelector = {SyncSelector}, AsyncSelector = {AsyncSelector}")]
+    [System.Diagnostics.DebuggerDisplay("FlatMapWitness: Coordinator = {Coordinator}, SyncSelector = {SyncSelector}, AsyncSelector = {AsyncSelector}")]
     public sealed class FlatMapWitness<TSource, TResult> : ReactiveUI.Primitives.Async.WitnessAsync<TSource>
     {
         public FlatMapWitness(ReactiveUI.Primitives.Async.Advanced.FlatMapCoordinator<TResult> coordinator, System.Func<TSource, ReactiveUI.Primitives.Async.IObservableAsync<TResult>>? syncSelector, System.Func<TSource, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<ReactiveUI.Primitives.Async.IObservableAsync<TResult>>>? asyncSelector) { }
@@ -964,7 +964,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(TSource value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Downstream = {Downstream}")]
+    [System.Diagnostics.DebuggerDisplay("ForwardingWitnessAsync: Downstream = {Downstream}")]
     public class ForwardingWitnessAsync<T> : ReactiveUI.Primitives.Async.WitnessAsync<T>
     {
         protected ForwardingWitnessAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> downstream) { }
@@ -973,13 +973,13 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(T value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Factory = {Factory}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSignal: Factory = {Factory}")]
     public sealed class FromAsyncSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<T>> factory) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Factory = {Factory}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSubscription: Factory = {Factory}")]
     public sealed class FromAsyncSubscription<T> : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<T>
     {
         public FromAsyncSubscription(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<T>> factory) { }
@@ -989,39 +989,39 @@ namespace ReactiveUI.Primitives.Async.Advanced
     {
         System.Threading.Tasks.ValueTask DisposeFromNotificationAsync() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Period = {Period}, TimeProvider = {TimeProvider}")]
+    [System.Diagnostics.DebuggerDisplay("IntervalSignal: Period = {Period}, TimeProvider = {TimeProvider}")]
     public sealed class IntervalSignal : ReactiveUI.Primitives.Async.IObservableAsync<long>
     {
         public IntervalSignal(System.TimeSpan period, System.TimeProvider? timeProvider) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<System.Int64>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<long> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Period = {Period}, TimeProvider = {TimeProvider}")]
+    [System.Diagnostics.DebuggerDisplay("IntervalSubscription: Period = {Period}, TimeProvider = {TimeProvider}")]
     public sealed class IntervalSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<long>
     {
         public IntervalSubscription(ReactiveUI.Primitives.Async.IObserverAsync<long> observer, System.TimeSpan period, System.TimeProvider? timeProvider) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<long> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Values = {Values}")]
+    [System.Diagnostics.DebuggerDisplay("LeadSignal: Source = {Source}, Values = {Values}")]
     public sealed class LeadSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public LeadSignal(ReactiveUI.Primitives.Async.IObservableAsync<T> source, System.Collections.Generic.IEnumerable<T> values) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Disposed = {Disposed}, Pipeline = {Pipeline}")]
+    [System.Diagnostics.DebuggerDisplay("LeadSubscription: Disposed = {Disposed}, Pipeline = {Pipeline}")]
     public sealed class LeadSubscription<T> : System.IAsyncDisposable
     {
         public LeadSubscription(ReactiveUI.Primitives.Async.IObservableAsync<T> source, System.Collections.Generic.IEnumerable<T> values, ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken subscriptionToken) { }
         public System.Threading.Tasks.ValueTask DisposeAsync() { }
         public void Start() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Logger = {Logger}")]
+    [System.Diagnostics.DebuggerDisplay("LogErrorsSignal: Source = {Source}, Logger = {Logger}")]
     public sealed class LogErrorsSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public LogErrorsSignal(ReactiveUI.Primitives.Async.IObservableAsync<T> source, System.Action<System.Exception> logger) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Downstream = {Downstream}, Logger = {Logger}")]
+    [System.Diagnostics.DebuggerDisplay("LogErrorsWitness: Downstream = {Downstream}, Logger = {Logger}")]
     public sealed class LogErrorsWitness<T> : ReactiveUI.Primitives.Async.WitnessAsync<T>
     {
         public LogErrorsWitness(ReactiveUI.Primitives.Async.IObserverAsync<T> downstream, System.Action<System.Exception> logger) { }
@@ -1029,7 +1029,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(T value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {_completed}, Timer = {_timer}")]
+    [System.Diagnostics.DebuggerDisplay("PooledDelaySource: Completed = {_completed}, Timer = {_timer}")]
     public sealed class PooledDelaySource : System.Threading.Tasks.Sources.IValueTaskSource
     {
         public System.Threading.Tasks.ValueTask BeginAsync(System.TimeSpan delay, System.TimeProvider timeProvider, System.Threading.CancellationToken cancellationToken) { }
@@ -1040,13 +1040,13 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public void OnCompleted(System.Action<object?> continuation, object? state, short token, System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags flags) { }
         public static ReactiveUI.Primitives.Async.Advanced.PooledDelaySource Rent() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, RetryCount = {RetryCount}")]
+    [System.Diagnostics.DebuggerDisplay("ReattemptSignal: Source = {Source}, RetryCount = {RetryCount}")]
     public sealed class ReattemptSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public ReattemptSignal(ReactiveUI.Primitives.Async.IObservableAsync<T> source, int retryCount) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Remaining = {Remaining}")]
+    [System.Diagnostics.DebuggerDisplay("ReattemptSubscription: Source = {Source}, Remaining = {Remaining}")]
     public sealed class ReattemptSubscription<T> : System.IAsyncDisposable
     {
         public ReattemptSubscription(ReactiveUI.Primitives.Async.IObservableAsync<T> source, ReactiveUI.Primitives.Async.IObserverAsync<T> observer, int retryCount, System.Threading.CancellationToken cancellationToken) { }
@@ -1059,7 +1059,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public System.Threading.Tasks.ValueTask RelayNextAsync(T value, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.ValueTask SubscribeOnceAsync() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("ReattemptWitness: Subscription = {Subscription}")]
     public sealed class ReattemptWitness<T> : ReactiveUI.Primitives.Async.WitnessAsync<T>
     {
         public ReattemptWitness(ReactiveUI.Primitives.Async.Advanced.ReattemptSubscription<T> subscription) { }
@@ -1071,19 +1071,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
     {
         public RelayWitnessAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("StartValue = {StartValue}, Count = {Count}")]
+    [System.Diagnostics.DebuggerDisplay("SequenceSignal: StartValue = {StartValue}, Count = {Count}")]
     public sealed class SequenceSignal : ReactiveUI.Primitives.Async.IObservableAsync<int>
     {
         public SequenceSignal(int start, int count) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<System.Int32>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<int> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("StartValue = {StartValue}, Count = {Count}")]
+    [System.Diagnostics.DebuggerDisplay("SequenceSubscription: StartValue = {StartValue}, Count = {Count}")]
     public sealed class SequenceSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<int>
     {
         public SequenceSubscription(ReactiveUI.Primitives.Async.IObserverAsync<int> observer, int start, int count) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<int> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasValue = {_hasValue}, Value = {_value}")]
+    [System.Diagnostics.DebuggerDisplay("SingleElementWitness: HasValue = {_hasValue}, Value = {_value}")]
     public sealed class SingleElementWitness<T> : ReactiveUI.Primitives.Async.Advanced.TaskResultWitnessAsyncBase<T, T?>
     {
         public SingleElementWitness(System.Func<T, bool>? predicate, bool requireExactlyOne, T? defaultValue, System.Threading.CancellationToken cancellationToken) { }
@@ -1091,31 +1091,31 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(T value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Function = {Function}, TaskScheduler = {TaskScheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Function = {Function}, TaskScheduler = {TaskScheduler}")]
     public sealed class StartSignal<TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public StartSignal(System.Func<TResult> function, System.Threading.Tasks.TaskScheduler? taskScheduler) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Function = {Function}, TaskScheduler = {TaskScheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSubscription: Function = {Function}, TaskScheduler = {TaskScheduler}")]
     public sealed class StartSubscription<TResult> : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<TResult>
     {
         public StartSubscription(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Func<TResult> function, System.Threading.Tasks.TaskScheduler? taskScheduler) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceCount = {SourceCount}, Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest10Coordinator: SourceCount = {SourceCount}, Sources = {Sources}")]
     public sealed class SyncLatest10Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest10Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest10State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest10Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest10Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest10Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest10State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source10 = {Source10}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest10State: Source1 = {Source1}, Source10 = {Source10}")]
     public readonly record struct SyncLatest10State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest10State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>>
     {
         public SyncLatest10State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8, ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9, ReactiveUI.Primitives.Async.IObservableAsync<T10> Source10) { }
@@ -1130,19 +1130,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceCount = {SourceCount}, Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest11Coordinator: SourceCount = {SourceCount}, Sources = {Sources}")]
     public sealed class SyncLatest11Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest11Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest11State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest11Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest11Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest11Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest11State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source2 = {Source2}, Source11 = {Source11}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest11State: Source1 = {Source1}, Source2 = {Source2}, Source11 = {Source11}")]
     public readonly record struct SyncLatest11State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest11State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>>
     {
         public SyncLatest11State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8, ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9, ReactiveUI.Primitives.Async.IObservableAsync<T10> Source10, ReactiveUI.Primitives.Async.IObservableAsync<T11> Source11) { }
@@ -1158,19 +1158,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Lifecycle = {Lifecycle}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest12Coordinator: Sources = {Sources}, Lifecycle = {Lifecycle}")]
     public sealed class SyncLatest12Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest12Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest12State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest12Signal: Sources = {Sources}")]
     public sealed class SyncLatest12Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest12Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest12State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source12 = {Source12}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest12State: Source1 = {Source1}, Source12 = {Source12}")]
     public readonly record struct SyncLatest12State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest12State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>>
     {
         public SyncLatest12State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8, ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9, ReactiveUI.Primitives.Async.IObservableAsync<T10> Source10, ReactiveUI.Primitives.Async.IObservableAsync<T11> Source11, ReactiveUI.Primitives.Async.IObservableAsync<T12> Source12) { }
@@ -1187,19 +1187,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value13 = {Value13}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest13Coordinator: Value1 = {Value1}, Value13 = {Value13}")]
     public sealed class SyncLatest13Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest13Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest13State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest13Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest13Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest13Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest13State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source13 = {Source13}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest13State: Source1 = {Source1}, Source13 = {Source13}")]
     public readonly record struct SyncLatest13State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest13State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>>
     {
         public SyncLatest13State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8, ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9, ReactiveUI.Primitives.Async.IObservableAsync<T10> Source10, ReactiveUI.Primitives.Async.IObservableAsync<T11> Source11, ReactiveUI.Primitives.Async.IObservableAsync<T12> Source12, ReactiveUI.Primitives.Async.IObservableAsync<T13> Source13) { }
@@ -1217,19 +1217,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Lifecycle = {Lifecycle}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest14Coordinator: Sources = {Sources}, Lifecycle = {Lifecycle}")]
     public sealed class SyncLatest14Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest14Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest14State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest14Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest14Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest14Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest14State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source14 = {Source14}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest14State: Source1 = {Source1}, Source14 = {Source14}")]
     public readonly record struct SyncLatest14State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest14State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>>
     {
         public SyncLatest14State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8, ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9, ReactiveUI.Primitives.Async.IObservableAsync<T10> Source10, ReactiveUI.Primitives.Async.IObservableAsync<T11> Source11, ReactiveUI.Primitives.Async.IObservableAsync<T12> Source12, ReactiveUI.Primitives.Async.IObservableAsync<T13> Source13, ReactiveUI.Primitives.Async.IObservableAsync<T14> Source14) { }
@@ -1248,19 +1248,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value15 = {Value15}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest15Coordinator: Value1 = {Value1}, Value15 = {Value15}")]
     public sealed class SyncLatest15Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest15Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest15State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest15Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest15Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest15Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest15State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source15 = {Source15}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest15State: Source1 = {Source1}, Source15 = {Source15}")]
     public readonly record struct SyncLatest15State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest15State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>>
     {
         public SyncLatest15State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8, ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9, ReactiveUI.Primitives.Async.IObservableAsync<T10> Source10, ReactiveUI.Primitives.Async.IObservableAsync<T11> Source11, ReactiveUI.Primitives.Async.IObservableAsync<T12> Source12, ReactiveUI.Primitives.Async.IObservableAsync<T13> Source13, ReactiveUI.Primitives.Async.IObservableAsync<T14> Source14, ReactiveUI.Primitives.Async.IObservableAsync<T15> Source15) { }
@@ -1280,19 +1280,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value16 = {Value16}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest16Coordinator: Value1 = {Value1}, Value16 = {Value16}")]
     public sealed class SyncLatest16Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest16Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest16State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest16Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest16Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest16Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest16State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source16 = {Source16}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest16State: Source1 = {Source1}, Source16 = {Source16}")]
     public readonly record struct SyncLatest16State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest16State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>>
     {
         public SyncLatest16State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8, ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9, ReactiveUI.Primitives.Async.IObservableAsync<T10> Source10, ReactiveUI.Primitives.Async.IObservableAsync<T11> Source11, ReactiveUI.Primitives.Async.IObservableAsync<T12> Source12, ReactiveUI.Primitives.Async.IObservableAsync<T13> Source13, ReactiveUI.Primitives.Async.IObservableAsync<T14> Source14, ReactiveUI.Primitives.Async.IObservableAsync<T15> Source15, ReactiveUI.Primitives.Async.IObservableAsync<T16> Source16) { }
@@ -1313,38 +1313,38 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest2Coordinator: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest2Coordinator<T1, T2, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest2Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest2State<T1, T2> sources, System.Func<T1, T2, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest2Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest2Signal<T1, T2, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest2Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest2State<T1, T2> sources, System.Func<T1, T2, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source2 = {Source2}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest2State: Source1 = {Source1}, Source2 = {Source2}")]
     public readonly record struct SyncLatest2State<T1, T2> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest2State<T1, T2>>
     {
         public SyncLatest2State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2) { }
         public ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value3 = {Value3}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest3Coordinator: Value1 = {Value1}, Value3 = {Value3}")]
     public sealed class SyncLatest3Coordinator<T1, T2, T3, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest3Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest3State<T1, T2, T3> sources, System.Func<T1, T2, T3, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest3Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest3Signal<T1, T2, T3, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest3Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest3State<T1, T2, T3> sources, System.Func<T1, T2, T3, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source2 = {Source2}, Source3 = {Source3}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest3State: Source1 = {Source1}, Source2 = {Source2}, Source3 = {Source3}")]
     public readonly record struct SyncLatest3State<T1, T2, T3> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest3State<T1, T2, T3>>
     {
         public SyncLatest3State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3) { }
@@ -1352,19 +1352,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value4 = {Value4}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest4Coordinator: Value1 = {Value1}, Value4 = {Value4}")]
     public sealed class SyncLatest4Coordinator<T1, T2, T3, T4, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest4Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest4State<T1, T2, T3, T4> sources, System.Func<T1, T2, T3, T4, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest4Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest4Signal<T1, T2, T3, T4, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest4Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest4State<T1, T2, T3, T4> sources, System.Func<T1, T2, T3, T4, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source2 = {Source2}, Source3 = {Source3}, Source4 = {Source4}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest4State: Source1 = {Source1}, Source2 = {Source2}, Source3 = {Source3}, Source4 = {Source4}")]
     public readonly record struct SyncLatest4State<T1, T2, T3, T4> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest4State<T1, T2, T3, T4>>
     {
         public SyncLatest4State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4) { }
@@ -1373,19 +1373,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value5 = {Value5}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest5Coordinator: Value1 = {Value1}, Value5 = {Value5}")]
     public sealed class SyncLatest5Coordinator<T1, T2, T3, T4, T5, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest5Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest5State<T1, T2, T3, T4, T5> sources, System.Func<T1, T2, T3, T4, T5, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest5Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest5Signal<T1, T2, T3, T4, T5, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest5Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest5State<T1, T2, T3, T4, T5> sources, System.Func<T1, T2, T3, T4, T5, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source5 = {Source5}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest5State: Source1 = {Source1}, Source5 = {Source5}")]
     public readonly record struct SyncLatest5State<T1, T2, T3, T4, T5> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest5State<T1, T2, T3, T4, T5>>
     {
         public SyncLatest5State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5) { }
@@ -1395,19 +1395,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value6 = {Value6}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest6Coordinator: Value1 = {Value1}, Value6 = {Value6}")]
     public sealed class SyncLatest6Coordinator<T1, T2, T3, T4, T5, T6, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest6Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest6State<T1, T2, T3, T4, T5, T6> sources, System.Func<T1, T2, T3, T4, T5, T6, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest6Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest6Signal<T1, T2, T3, T4, T5, T6, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest6Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest6State<T1, T2, T3, T4, T5, T6> sources, System.Func<T1, T2, T3, T4, T5, T6, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source6 = {Source6}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest6State: Source1 = {Source1}, Source6 = {Source6}")]
     public readonly record struct SyncLatest6State<T1, T2, T3, T4, T5, T6> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest6State<T1, T2, T3, T4, T5, T6>>
     {
         public SyncLatest6State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6) { }
@@ -1418,19 +1418,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest7Coordinator: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest7Coordinator<T1, T2, T3, T4, T5, T6, T7, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest7Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest7State<T1, T2, T3, T4, T5, T6, T7> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest7Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest7Signal<T1, T2, T3, T4, T5, T6, T7, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest7Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest7State<T1, T2, T3, T4, T5, T6, T7> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source7 = {Source7}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest7State: Source1 = {Source1}, Source7 = {Source7}")]
     public readonly record struct SyncLatest7State<T1, T2, T3, T4, T5, T6, T7> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest7State<T1, T2, T3, T4, T5, T6, T7>>
     {
         public SyncLatest7State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7) { }
@@ -1442,19 +1442,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest8Coordinator: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest8Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest8Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest8State<T1, T2, T3, T4, T5, T6, T7, T8> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest8Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest8Signal<T1, T2, T3, T4, T5, T6, T7, T8, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest8Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest8State<T1, T2, T3, T4, T5, T6, T7, T8> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source8 = {Source8}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest8State: Source1 = {Source1}, Source8 = {Source8}")]
     public readonly record struct SyncLatest8State<T1, T2, T3, T4, T5, T6, T7, T8> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest8State<T1, T2, T3, T4, T5, T6, T7, T8>>
     {
         public SyncLatest8State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8) { }
@@ -1467,19 +1467,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value9 = {Value9}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest9Coordinator: Value1 = {Value1}, Value9 = {Value9}")]
     public sealed class SyncLatest9Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest9Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest9State<T1, T2, T3, T4, T5, T6, T7, T8, T9> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest9Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest9Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest9Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest9State<T1, T2, T3, T4, T5, T6, T7, T8, T9> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source9 = {Source9}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest9State: Source1 = {Source1}, Source9 = {Source9}")]
     public readonly record struct SyncLatest9State<T1, T2, T3, T4, T5, T6, T7, T8, T9> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest9State<T1, T2, T3, T4, T5, T6, T7, T8, T9>>
     {
         public SyncLatest9State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8, ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9) { }
@@ -1493,7 +1493,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceCount = {Lifecycle.Subscriptions.Length}, HasDisposed = {Lifecycle.HasDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestCoordinatorBase: SourceCount = {Lifecycle.Subscriptions.Length}, HasDisposed = {Lifecycle.HasDisposed}")]
     public abstract class SyncLatestCoordinatorBase<TResult> : System.IAsyncDisposable
     {
         protected SyncLatestCoordinatorBase(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, int sourceCount) { }
@@ -1501,7 +1501,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected abstract System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.ValueTask SubscribeSourcesAsync(System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources.Length}, Completed = {_completedCount}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestEnumerableCoordinator: Sources = {Sources.Length}, Completed = {_completedCount}, Disposed = {_disposed}")]
     public sealed class SyncLatestEnumerableCoordinator<TSource, TResult> : System.IAsyncDisposable
     {
         public SyncLatestEnumerableCoordinator(ReactiveUI.Primitives.Async.IObservableAsync<TSource>[] sources, ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Func<System.Collections.Generic.IReadOnlyList<TSource>, TResult> resultSelector) { }
@@ -1509,13 +1509,13 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public System.Threading.Tasks.ValueTask DisposeAsync() { }
         public System.Threading.Tasks.ValueTask SubscribeSourcesAsync(System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceCount = {Sources.Length}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestEnumerableSignal: SourceCount = {Sources.Length}")]
     public sealed class SyncLatestEnumerableSignal<TSource, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatestEnumerableSignal(System.Collections.Generic.IEnumerable<ReactiveUI.Primitives.Async.IObservableAsync<TSource>> sources, System.Func<System.Collections.Generic.IReadOnlyList<TSource>, TResult> resultSelector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Index = {Index}, Parent = {Parent}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestEnumerableWitness: Index = {Index}, Parent = {Parent}")]
     public sealed class SyncLatestEnumerableWitness<TSource, TResult> : ReactiveUI.Primitives.Async.IObserverAsync<TSource>
     {
         public SyncLatestEnumerableWitness(ReactiveUI.Primitives.Async.Advanced.SyncLatestEnumerableCoordinator<TSource, TResult> parent, int index) { }
@@ -1535,7 +1535,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(TSource value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceCount = {Subscriptions.Length}, HasDisposed = {HasDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestLifecycle: SourceCount = {Subscriptions.Length}, HasDisposed = {HasDisposed}")]
     public sealed class SyncLatestLifecycle<TResult> : System.IAsyncDisposable
     {
         public SyncLatestLifecycle(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, int sourceCount) { }
@@ -1557,7 +1557,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(TSource value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, DisposeRequested = {DisposeToken.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("TakeUntilLifecycle: Observer = {_observer}, DisposeRequested = {DisposeToken.IsCancellationRequested}")]
     public sealed class TakeUntilLifecycle<T> : System.IAsyncDisposable
     {
         public TakeUntilLifecycle(ReactiveUI.Primitives.Async.IObserverAsync<T> observer) { }
@@ -1575,7 +1575,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(T value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsCompleted = {_taskSource.Task.IsCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("TaskResultCompletionSource: IsCompleted = {_taskSource.Task.IsCompleted}")]
     public sealed class TaskResultCompletionSource<T>
     {
         public TaskResultCompletionSource(System.Threading.CancellationToken cancellationToken) { }
@@ -1583,19 +1583,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public System.Threading.Tasks.ValueTask SetExceptionAndDisposeAsync(System.Exception exception, ReactiveUI.Primitives.Async.Advanced.IReentrantAsyncDisposable owner) { }
         public System.Threading.Tasks.ValueTask SetResultAndDisposeAsync(T value, ReactiveUI.Primitives.Async.Advanced.IReentrantAsyncDisposable owner) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskResultSignal: Task = {Task}")]
     public sealed class TaskResultSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public TaskResultSignal(System.Threading.Tasks.Task<T> task) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskResultSubscription: Task = {Task}")]
     public sealed class TaskResultSubscription<T> : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<T>
     {
         public TaskResultSubscription(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.Tasks.Task<T> task) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completion = {_completion}")]
+    [System.Diagnostics.DebuggerDisplay("TaskResultWitnessAsyncBase: Completion = {_completion}")]
     public abstract class TaskResultWitnessAsyncBase<T, TTaskValue> : ReactiveUI.Primitives.Async.WitnessAsync<T>
     {
         protected TaskResultWitnessAsyncBase(System.Threading.CancellationToken cancellationToken) { }
@@ -1610,7 +1610,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
     {
         public static ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<T> StartNew<T>(System.Func<ReactiveUI.Primitives.Async.IObserverAsync<T>, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> executeAsyncCore, ReactiveUI.Primitives.Async.IObserverAsync<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Disposed = {_disposed}, Completed = {_tcs.Task.IsCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("TaskSignalSubscription: Disposed = {_disposed}, Completed = {_tcs.Task.IsCompleted}")]
     public abstract class TaskSignalSubscription<T> : System.IAsyncDisposable
     {
         protected TaskSignalSubscription(ReactiveUI.Primitives.Async.IObserverAsync<T> observer) { }
@@ -1618,25 +1618,25 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected abstract System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
         public void Start() { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {DueTime}, Period = {Period}")]
+    [System.Diagnostics.DebuggerDisplay("TimerSignal: DueTime = {DueTime}, Period = {Period}")]
     public sealed class TimerSignal : ReactiveUI.Primitives.Async.IObservableAsync<long>
     {
         public TimerSignal(System.TimeSpan dueTime, System.TimeSpan? period, System.TimeProvider timeProvider) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<System.Int64>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<long> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {DueTime}, Period = {Period}")]
+    [System.Diagnostics.DebuggerDisplay("TimerSubscription: DueTime = {DueTime}, Period = {Period}")]
     public sealed class TimerSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<long>
     {
         public TimerSubscription(ReactiveUI.Primitives.Async.IObserverAsync<long> observer, System.TimeSpan dueTime, System.TimeSpan? period, System.TimeProvider timeProvider) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<long> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ResourceFactory = {ResourceFactory}, SignalFactory = {SignalFactory}")]
+    [System.Diagnostics.DebuggerDisplay("UsingSignal: ResourceFactory = {ResourceFactory}, SignalFactory = {SignalFactory}")]
     public sealed class UsingSignal<TResource, T> : ReactiveUI.Primitives.Async.IObservableAsync<T> where TResource : System.IAsyncDisposable
     {
         public UsingSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResource>> resourceFactory, System.Func<TResource, ReactiveUI.Primitives.Async.IObservableAsync<T>> signalFactory) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Resource = {Resource}")]
+    [System.Diagnostics.DebuggerDisplay("UsingWitness: Resource = {Resource}")]
     public sealed class UsingWitness<TResource, T> : ReactiveUI.Primitives.Async.Advanced.ForwardingWitnessAsync<T> where TResource : System.IAsyncDisposable
     {
         public UsingWitness(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, TResource resource) { }
@@ -1661,7 +1661,7 @@ namespace ReactiveUI.Primitives.Async.Disposables
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public static System.Threading.Tasks.ValueTask SwapAsync(ref System.IAsyncDisposable? slot, System.IAsyncDisposable? value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, IsDisposed = {_isDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("MultipleDisposableAsync: Count = {_count}, IsDisposed = {_isDisposed}")]
     public sealed class MultipleDisposableAsync : System.IAsyncDisposable
     {
         public MultipleDisposableAsync() { }
@@ -1678,7 +1678,7 @@ namespace ReactiveUI.Primitives.Async.Disposables
         public System.Collections.Generic.IEnumerator<System.IAsyncDisposable> GetEnumerator() { }
         public System.Threading.Tasks.ValueTask<bool> Remove(System.IAsyncDisposable item) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsDisposed = {IsDisposed}, Current = {_current}")]
+    [System.Diagnostics.DebuggerDisplay("SingleAssignmentDisposableAsync: IsDisposed = {IsDisposed}, Current = {_current}")]
     public sealed class SingleAssignmentDisposableAsync : System.IAsyncDisposable
     {
         public SingleAssignmentDisposableAsync() { }
@@ -1689,7 +1689,7 @@ namespace ReactiveUI.Primitives.Async.Disposables
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.Threading.Tasks.ValueTask SetDisposableAsync(System.IAsyncDisposable? value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Current = {_current}")]
+    [System.Diagnostics.DebuggerDisplay("SingleReplaceableDisposableAsync: Current = {_current}")]
     public class SingleReplaceableDisposableAsync : System.IAsyncDisposable
     {
         public SingleReplaceableDisposableAsync() { }
@@ -1715,7 +1715,7 @@ namespace ReactiveUI.Primitives.Async.Helpers
 }
 namespace ReactiveUI.Primitives.Async.Signals
 {
-    [System.Diagnostics.DebuggerDisplay("PublishingOption = {PublishingOption}, IsStateless = {IsStateless}")]
+    [System.Diagnostics.DebuggerDisplay("BehaviorSignalCreationOptions: PublishingOption = {PublishingOption}, IsStateless = {IsStateless}")]
     public record BehaviorSignalCreationOptions : System.IEquatable<ReactiveUI.Primitives.Async.Signals.BehaviorSignalCreationOptions>
     {
         public required bool IsStateless { get; init; }
@@ -1731,7 +1731,7 @@ namespace ReactiveUI.Primitives.Async.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public static System.Threading.Tasks.ValueTask ForwardOnNextConcurrently<T>(System.Collections.Immutable.ImmutableArray<ReactiveUI.Primitives.Async.IObserverAsync<T>> observers, T value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("LastValue = {_state.LastValue}, IsDisposed = {_state.IsDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ConcurrentReplayLatestSignalAsync: LastValue = {_state.LastValue}, IsDisposed = {_state.IsDisposed}")]
     public sealed class ConcurrentReplayLatestSignalAsync<T> : ReactiveUI.Primitives.Async.Signals.ISignalAsync<T>
     {
         public ConcurrentReplayLatestSignalAsync(ReactiveUI.Primitives.Optional<T> startValue) { }
@@ -1747,7 +1747,7 @@ namespace ReactiveUI.Primitives.Async.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_state.Observers.Length}, Result = {_state.Result}")]
+    [System.Diagnostics.DebuggerDisplay("ConcurrentSignalAsync: Observers = {_state.Observers.Length}, Result = {_state.Result}")]
     public sealed class ConcurrentSignalAsync<T> : ReactiveUI.Primitives.Async.Signals.ISignalAsync<T>
     {
         public ConcurrentSignalAsync() { }
@@ -1763,7 +1763,7 @@ namespace ReactiveUI.Primitives.Async.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_state.Value}, IsDisposed = {_state.IsDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ConcurrentStatelessReplayLatestSignalAsync: Value = {_state.Value}, IsDisposed = {_state.IsDisposed}")]
     public sealed class ConcurrentStatelessReplayLatestSignalAsync<T> : ReactiveUI.Primitives.Async.Signals.ISignalAsync<T>
     {
         public ConcurrentStatelessReplayLatestSignalAsync(ReactiveUI.Primitives.Optional<T> startValue) { }
@@ -1779,7 +1779,7 @@ namespace ReactiveUI.Primitives.Async.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_state.Observers.Length}")]
+    [System.Diagnostics.DebuggerDisplay("ConcurrentStatelessSignalAsync: Observers = {_state.Observers.Length}")]
     public sealed class ConcurrentStatelessSignalAsync<T> : ReactiveUI.Primitives.Async.Signals.ISignalAsync<T>
     {
         public ConcurrentStatelessSignalAsync() { }
@@ -1804,14 +1804,14 @@ namespace ReactiveUI.Primitives.Async.Signals
         Serial = 0,
         Concurrent = 1,
     }
-    [System.Diagnostics.DebuggerDisplay("PublishingOption = {PublishingOption}, IsStateless = {IsStateless}")]
+    [System.Diagnostics.DebuggerDisplay("ReplayLatestSignalCreationOptions: PublishingOption = {PublishingOption}, IsStateless = {IsStateless}")]
     public record ReplayLatestSignalCreationOptions : System.IEquatable<ReactiveUI.Primitives.Async.Signals.ReplayLatestSignalCreationOptions>
     {
         public required bool IsStateless { get; init; }
         public required ReactiveUI.Primitives.Async.Signals.PublishingOption PublishingOption { get; init; }
         public static ReactiveUI.Primitives.Async.Signals.ReplayLatestSignalCreationOptions Default { get; }
     }
-    [System.Diagnostics.DebuggerDisplay("LastValue = {_state.LastValue}, IsDisposed = {_state.IsDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("SerialReplayLatestSignalAsync: LastValue = {_state.LastValue}, IsDisposed = {_state.IsDisposed}")]
     public sealed class SerialReplayLatestSignalAsync<T> : ReactiveUI.Primitives.Async.Signals.ISignalAsync<T>
     {
         public SerialReplayLatestSignalAsync(ReactiveUI.Primitives.Optional<T> startValue) { }
@@ -1827,7 +1827,7 @@ namespace ReactiveUI.Primitives.Async.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_state.Observers.Length}, Result = {_state.Result}")]
+    [System.Diagnostics.DebuggerDisplay("SerialSignalAsync: Observers = {_state.Observers.Length}, Result = {_state.Result}")]
     public sealed class SerialSignalAsync<T> : ReactiveUI.Primitives.Async.Signals.ISignalAsync<T>
     {
         public SerialSignalAsync() { }
@@ -1843,7 +1843,7 @@ namespace ReactiveUI.Primitives.Async.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("State = {_state}")]
+    [System.Diagnostics.DebuggerDisplay("SerialStatelessReplayLatestSignalAsync: State = {_state}")]
     public sealed class SerialStatelessReplayLatestSignalAsync<T> : ReactiveUI.Primitives.Async.Signals.ISignalAsync<T>
     {
         public SerialStatelessReplayLatestSignalAsync(ReactiveUI.Primitives.Optional<T> startValue) { }
@@ -1859,7 +1859,7 @@ namespace ReactiveUI.Primitives.Async.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_state.Observers.Length}")]
+    [System.Diagnostics.DebuggerDisplay("SerialStatelessSignalAsync: Observers = {_state.Observers.Length}")]
     public sealed class SerialStatelessSignalAsync<T> : ReactiveUI.Primitives.Async.Signals.ISignalAsync<T>
     {
         public SerialStatelessSignalAsync() { }
@@ -1887,7 +1887,7 @@ namespace ReactiveUI.Primitives.Async.Signals
         public static ReactiveUI.Primitives.Async.Signals.ISignalAsync<T> CreateReplayLatest<T>() { }
         public static ReactiveUI.Primitives.Async.Signals.ISignalAsync<T> CreateReplayLatest<T>(ReactiveUI.Primitives.Async.Signals.ReplayLatestSignalCreationOptions? options) { }
     }
-    [System.Diagnostics.DebuggerDisplay("PublishingOption = {PublishingOption}, IsStateless = {IsStateless}")]
+    [System.Diagnostics.DebuggerDisplay("SignalCreationOptions: PublishingOption = {PublishingOption}, IsStateless = {IsStateless}")]
     public record SignalCreationOptions : System.IEquatable<ReactiveUI.Primitives.Async.Signals.SignalCreationOptions>
     {
         public required bool IsStateless { get; init; }

--- a/src/ReactiveUI.Primitives.Async.Core/PublicAPI/net9.0/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Async.Core/PublicAPI/net9.0/PublicAPI.txt
@@ -3,7 +3,7 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Primitives.Tests")]
 namespace ReactiveUI.Primitives.Async
 {
-    [System.Diagnostics.DebuggerDisplay("Signals = {_signals}")]
+    [System.Diagnostics.DebuggerDisplay("ChainEnumerableSignal: Signals = {_signals}")]
     public sealed class ChainEnumerableSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public ChainEnumerableSignal(System.Collections.Generic.IEnumerable<ReactiveUI.Primitives.Async.IObservableAsync<T>> signals) { }
@@ -22,7 +22,7 @@ namespace ReactiveUI.Primitives.Async
         public ConcurrentWitnessCallsException(string message) { }
         public ConcurrentWitnessCallsException(string message, System.Exception innerException) { }
     }
-    [System.Diagnostics.DebuggerDisplay("State = {State}")]
+    [System.Diagnostics.DebuggerDisplay("ConnectableSignalAsync: State = {State}")]
     public sealed class ConnectableSignalAsync<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>, System.IDisposable
     {
         public ConnectableSignalAsync(ReactiveUI.Primitives.Async.IObservableAsync<T> source, ReactiveUI.Primitives.Async.Signals.ISignalAsync<T> signal) { }
@@ -40,7 +40,7 @@ namespace ReactiveUI.Primitives.Async
             public System.IAsyncDisposable ToDisposableAsync() { }
         }
     }
-    [System.Diagnostics.DebuggerDisplay("Key = {Key}")]
+    [System.Diagnostics.DebuggerDisplay("GroupedAsyncSignal: Key = {Key}")]
     public sealed class GroupedAsyncSignal<TKey, TValue> : ReactiveUI.Primitives.Async.IObservableAsync<TValue>
     {
         public TKey Key { get; }
@@ -825,7 +825,7 @@ namespace ReactiveUI.Primitives.Async
         public SwitchToSignal(ReactiveUI.Primitives.Async.IObservableAsync<ReactiveUI.Primitives.Async.IObservableAsync<T>> source) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceFailsWhenOtherFails = {SourceFailsWhenOtherFails}")]
+    [System.Diagnostics.DebuggerDisplay("TakeUntilOptions: SourceFailsWhenOtherFails = {SourceFailsWhenOtherFails}")]
     public record TakeUntilOptions : System.IEquatable<ReactiveUI.Primitives.Async.TakeUntilOptions>
     {
         public bool SourceFailsWhenOtherFails { get; init; }
@@ -835,7 +835,7 @@ namespace ReactiveUI.Primitives.Async
     {
         public static void Register(System.Action<System.Exception> unhandledExceptionHandler) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Disposed = {_disposed}, CallState = {_callState}")]
+    [System.Diagnostics.DebuggerDisplay("WitnessAsync: Disposed = {_disposed}, CallState = {_callState}")]
     public abstract class WitnessAsync<T> : ReactiveUI.Primitives.Async.Advanced.IReentrantAsyncDisposable, ReactiveUI.Primitives.Async.IObserverAsync<T>
     {
         protected WitnessAsync() { }
@@ -859,19 +859,19 @@ namespace ReactiveUI.Primitives.Async
 }
 namespace ReactiveUI.Primitives.Async.Advanced
 {
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncEnumerableSignal: Source = {Source}")]
     public sealed class AsyncEnumerableSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public AsyncEnumerableSignal(System.Collections.Generic.IAsyncEnumerable<T> source) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncEnumerableSubscription: Source = {Source}")]
     public sealed class AsyncEnumerableSubscription<T> : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<T>
     {
         public AsyncEnumerableSubscription(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Collections.Generic.IAsyncEnumerable<T> source) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("OwnerThreadId = {_ownerThreadId}, Waiters = {_waiters}, RecursionDepth = {_recursionDepth}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncSerialGate: OwnerThreadId = {_ownerThreadId}, Waiters = {_waiters}, RecursionDepth = {_recursionDepth}")]
     public sealed class AsyncSerialGate : System.IDisposable
     {
         public AsyncSerialGate() { }
@@ -879,7 +879,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.Threading.Tasks.ValueTask<ReactiveUI.Primitives.Async.Advanced.AsyncSerialGate.Lease> EnterAsync() { }
         public System.Threading.Tasks.ValueTask<ReactiveUI.Primitives.Async.Advanced.AsyncSerialGate.Lease> EnterAsync(System.Threading.CancellationToken cancellationToken) { }
-        [System.Diagnostics.DebuggerDisplay("Parent = {_parent}")]
+        [System.Diagnostics.DebuggerDisplay("Lease: Parent = {_parent}")]
         public readonly record struct Lease : System.IDisposable, System.IEquatable<ReactiveUI.Primitives.Async.Advanced.AsyncSerialGate.Lease>
         {
             public Lease(ReactiveUI.Primitives.Async.Advanced.AsyncSerialGate parent) { }
@@ -887,13 +887,13 @@ namespace ReactiveUI.Primitives.Async.Advanced
             public readonly void Dispose() { }
         }
     }
-    [System.Diagnostics.DebuggerDisplay("StartSynchronously = {StartSynchronously}, TaskScheduler = {TaskScheduler}")]
+    [System.Diagnostics.DebuggerDisplay("BackgroundJobSignal: StartSynchronously = {StartSynchronously}, TaskScheduler = {TaskScheduler}")]
     public sealed class BackgroundJobSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public BackgroundJobSignal(System.Func<ReactiveUI.Primitives.Async.IObserverAsync<T>, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> job, bool startSynchronously, System.Threading.Tasks.TaskScheduler? taskScheduler) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasDisposed = {HasDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("CallbackWitnessAsync: HasDisposed = {HasDisposed}")]
     public sealed class CallbackWitnessAsync<T> : ReactiveUI.Primitives.Async.WitnessAsync<T>
     {
         public CallbackWitnessAsync(System.Func<T, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> onNextAsync, System.Func<System.Exception, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask>? onErrorResumeAsync = null, System.Func<ReactiveUI.Primitives.Result, System.Threading.Tasks.ValueTask>? onCompletedAsync = null) { }
@@ -901,31 +901,31 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(T value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Action = {Action}")]
+    [System.Diagnostics.DebuggerDisplay("DoOnSubscribeAsyncSignal: Source = {Source}, Action = {Action}")]
     public sealed class DoOnSubscribeAsyncSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public DoOnSubscribeAsyncSignal(ReactiveUI.Primitives.Async.IObservableAsync<T> source, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> action) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Action = {Action}")]
+    [System.Diagnostics.DebuggerDisplay("DoOnSubscribeSignal: Source = {Source}, Action = {Action}")]
     public sealed class DoOnSubscribeSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public DoOnSubscribeSignal(ReactiveUI.Primitives.Async.IObservableAsync<T> source, System.Action action) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("EnumerableSignal: Source = {Source}")]
     public sealed class EnumerableSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public EnumerableSignal(System.Collections.Generic.IEnumerable<T> source) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("EnumerableSubscription: Source = {Source}")]
     public sealed class EnumerableSubscription<T> : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<T>
     {
         public EnumerableSubscription(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Collections.Generic.IEnumerable<T> source) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ActiveInnerCount = {ActiveInnerCount}, OuterCompleted = {OuterCompleted}, Disposed = {Disposed}")]
+    [System.Diagnostics.DebuggerDisplay("FlatMapCoordinator: ActiveInnerCount = {ActiveInnerCount}, OuterCompleted = {OuterCompleted}, Disposed = {Disposed}")]
     public sealed class FlatMapCoordinator<TResult> : System.IAsyncDisposable
     {
         public FlatMapCoordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer) { }
@@ -941,14 +941,14 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public System.Threading.Tasks.ValueTask SetOuterObserverAsync(System.IAsyncDisposable observer) { }
         public System.Threading.Tasks.ValueTask SubscribeInnerAsync(ReactiveUI.Primitives.Async.IObservableAsync<TResult> inner) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, SyncSelector = {SyncSelector}, AsyncSelector = {AsyncSelector}")]
+    [System.Diagnostics.DebuggerDisplay("FlatMapSignal: Source = {Source}, SyncSelector = {SyncSelector}, AsyncSelector = {AsyncSelector}")]
     public sealed class FlatMapSignal<TSource, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public FlatMapSignal(ReactiveUI.Primitives.Async.IObservableAsync<TSource> source, System.Func<TSource, ReactiveUI.Primitives.Async.IObservableAsync<TResult>> selector) { }
         public FlatMapSignal(ReactiveUI.Primitives.Async.IObservableAsync<TSource> source, System.Func<TSource, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<ReactiveUI.Primitives.Async.IObservableAsync<TResult>>> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Coordinator = {Coordinator}")]
+    [System.Diagnostics.DebuggerDisplay("FlatMapWitness: Coordinator = {Coordinator}")]
     public sealed class FlatMapWitness<TResult> : ReactiveUI.Primitives.Async.WitnessAsync<TResult>
     {
         public FlatMapWitness(ReactiveUI.Primitives.Async.Advanced.FlatMapCoordinator<TResult> coordinator) { }
@@ -956,7 +956,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(TResult value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Coordinator = {Coordinator}, SyncSelector = {SyncSelector}, AsyncSelector = {AsyncSelector}")]
+    [System.Diagnostics.DebuggerDisplay("FlatMapWitness: Coordinator = {Coordinator}, SyncSelector = {SyncSelector}, AsyncSelector = {AsyncSelector}")]
     public sealed class FlatMapWitness<TSource, TResult> : ReactiveUI.Primitives.Async.WitnessAsync<TSource>
     {
         public FlatMapWitness(ReactiveUI.Primitives.Async.Advanced.FlatMapCoordinator<TResult> coordinator, System.Func<TSource, ReactiveUI.Primitives.Async.IObservableAsync<TResult>>? syncSelector, System.Func<TSource, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<ReactiveUI.Primitives.Async.IObservableAsync<TResult>>>? asyncSelector) { }
@@ -964,7 +964,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(TSource value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Downstream = {Downstream}")]
+    [System.Diagnostics.DebuggerDisplay("ForwardingWitnessAsync: Downstream = {Downstream}")]
     public class ForwardingWitnessAsync<T> : ReactiveUI.Primitives.Async.WitnessAsync<T>
     {
         protected ForwardingWitnessAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> downstream) { }
@@ -973,13 +973,13 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(T value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Factory = {Factory}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSignal: Factory = {Factory}")]
     public sealed class FromAsyncSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<T>> factory) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Factory = {Factory}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSubscription: Factory = {Factory}")]
     public sealed class FromAsyncSubscription<T> : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<T>
     {
         public FromAsyncSubscription(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<T>> factory) { }
@@ -989,39 +989,39 @@ namespace ReactiveUI.Primitives.Async.Advanced
     {
         System.Threading.Tasks.ValueTask DisposeFromNotificationAsync() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Period = {Period}, TimeProvider = {TimeProvider}")]
+    [System.Diagnostics.DebuggerDisplay("IntervalSignal: Period = {Period}, TimeProvider = {TimeProvider}")]
     public sealed class IntervalSignal : ReactiveUI.Primitives.Async.IObservableAsync<long>
     {
         public IntervalSignal(System.TimeSpan period, System.TimeProvider? timeProvider) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<System.Int64>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<long> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Period = {Period}, TimeProvider = {TimeProvider}")]
+    [System.Diagnostics.DebuggerDisplay("IntervalSubscription: Period = {Period}, TimeProvider = {TimeProvider}")]
     public sealed class IntervalSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<long>
     {
         public IntervalSubscription(ReactiveUI.Primitives.Async.IObserverAsync<long> observer, System.TimeSpan period, System.TimeProvider? timeProvider) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<long> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Values = {Values}")]
+    [System.Diagnostics.DebuggerDisplay("LeadSignal: Source = {Source}, Values = {Values}")]
     public sealed class LeadSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public LeadSignal(ReactiveUI.Primitives.Async.IObservableAsync<T> source, System.Collections.Generic.IEnumerable<T> values) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Disposed = {Disposed}, Pipeline = {Pipeline}")]
+    [System.Diagnostics.DebuggerDisplay("LeadSubscription: Disposed = {Disposed}, Pipeline = {Pipeline}")]
     public sealed class LeadSubscription<T> : System.IAsyncDisposable
     {
         public LeadSubscription(ReactiveUI.Primitives.Async.IObservableAsync<T> source, System.Collections.Generic.IEnumerable<T> values, ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken subscriptionToken) { }
         public System.Threading.Tasks.ValueTask DisposeAsync() { }
         public void Start() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Logger = {Logger}")]
+    [System.Diagnostics.DebuggerDisplay("LogErrorsSignal: Source = {Source}, Logger = {Logger}")]
     public sealed class LogErrorsSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public LogErrorsSignal(ReactiveUI.Primitives.Async.IObservableAsync<T> source, System.Action<System.Exception> logger) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Downstream = {Downstream}, Logger = {Logger}")]
+    [System.Diagnostics.DebuggerDisplay("LogErrorsWitness: Downstream = {Downstream}, Logger = {Logger}")]
     public sealed class LogErrorsWitness<T> : ReactiveUI.Primitives.Async.WitnessAsync<T>
     {
         public LogErrorsWitness(ReactiveUI.Primitives.Async.IObserverAsync<T> downstream, System.Action<System.Exception> logger) { }
@@ -1029,7 +1029,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(T value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {_completed}, Timer = {_timer}")]
+    [System.Diagnostics.DebuggerDisplay("PooledDelaySource: Completed = {_completed}, Timer = {_timer}")]
     public sealed class PooledDelaySource : System.Threading.Tasks.Sources.IValueTaskSource
     {
         public System.Threading.Tasks.ValueTask BeginAsync(System.TimeSpan delay, System.TimeProvider timeProvider, System.Threading.CancellationToken cancellationToken) { }
@@ -1040,13 +1040,13 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public void OnCompleted(System.Action<object?> continuation, object? state, short token, System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags flags) { }
         public static ReactiveUI.Primitives.Async.Advanced.PooledDelaySource Rent() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, RetryCount = {RetryCount}")]
+    [System.Diagnostics.DebuggerDisplay("ReattemptSignal: Source = {Source}, RetryCount = {RetryCount}")]
     public sealed class ReattemptSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public ReattemptSignal(ReactiveUI.Primitives.Async.IObservableAsync<T> source, int retryCount) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Remaining = {Remaining}")]
+    [System.Diagnostics.DebuggerDisplay("ReattemptSubscription: Source = {Source}, Remaining = {Remaining}")]
     public sealed class ReattemptSubscription<T> : System.IAsyncDisposable
     {
         public ReattemptSubscription(ReactiveUI.Primitives.Async.IObservableAsync<T> source, ReactiveUI.Primitives.Async.IObserverAsync<T> observer, int retryCount, System.Threading.CancellationToken cancellationToken) { }
@@ -1059,7 +1059,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public System.Threading.Tasks.ValueTask RelayNextAsync(T value, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.ValueTask SubscribeOnceAsync() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("ReattemptWitness: Subscription = {Subscription}")]
     public sealed class ReattemptWitness<T> : ReactiveUI.Primitives.Async.WitnessAsync<T>
     {
         public ReattemptWitness(ReactiveUI.Primitives.Async.Advanced.ReattemptSubscription<T> subscription) { }
@@ -1071,19 +1071,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
     {
         public RelayWitnessAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("StartValue = {StartValue}, Count = {Count}")]
+    [System.Diagnostics.DebuggerDisplay("SequenceSignal: StartValue = {StartValue}, Count = {Count}")]
     public sealed class SequenceSignal : ReactiveUI.Primitives.Async.IObservableAsync<int>
     {
         public SequenceSignal(int start, int count) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<System.Int32>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<int> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("StartValue = {StartValue}, Count = {Count}")]
+    [System.Diagnostics.DebuggerDisplay("SequenceSubscription: StartValue = {StartValue}, Count = {Count}")]
     public sealed class SequenceSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<int>
     {
         public SequenceSubscription(ReactiveUI.Primitives.Async.IObserverAsync<int> observer, int start, int count) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<int> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasValue = {_hasValue}, Value = {_value}")]
+    [System.Diagnostics.DebuggerDisplay("SingleElementWitness: HasValue = {_hasValue}, Value = {_value}")]
     public sealed class SingleElementWitness<T> : ReactiveUI.Primitives.Async.Advanced.TaskResultWitnessAsyncBase<T, T?>
     {
         public SingleElementWitness(System.Func<T, bool>? predicate, bool requireExactlyOne, T? defaultValue, System.Threading.CancellationToken cancellationToken) { }
@@ -1091,31 +1091,31 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(T value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Function = {Function}, TaskScheduler = {TaskScheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Function = {Function}, TaskScheduler = {TaskScheduler}")]
     public sealed class StartSignal<TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public StartSignal(System.Func<TResult> function, System.Threading.Tasks.TaskScheduler? taskScheduler) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Function = {Function}, TaskScheduler = {TaskScheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSubscription: Function = {Function}, TaskScheduler = {TaskScheduler}")]
     public sealed class StartSubscription<TResult> : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<TResult>
     {
         public StartSubscription(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Func<TResult> function, System.Threading.Tasks.TaskScheduler? taskScheduler) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceCount = {SourceCount}, Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest10Coordinator: SourceCount = {SourceCount}, Sources = {Sources}")]
     public sealed class SyncLatest10Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest10Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest10State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest10Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest10Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest10Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest10State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source10 = {Source10}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest10State: Source1 = {Source1}, Source10 = {Source10}")]
     public readonly record struct SyncLatest10State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest10State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>>
     {
         public SyncLatest10State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8, ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9, ReactiveUI.Primitives.Async.IObservableAsync<T10> Source10) { }
@@ -1130,19 +1130,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceCount = {SourceCount}, Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest11Coordinator: SourceCount = {SourceCount}, Sources = {Sources}")]
     public sealed class SyncLatest11Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest11Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest11State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest11Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest11Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest11Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest11State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source2 = {Source2}, Source11 = {Source11}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest11State: Source1 = {Source1}, Source2 = {Source2}, Source11 = {Source11}")]
     public readonly record struct SyncLatest11State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest11State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>>
     {
         public SyncLatest11State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8, ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9, ReactiveUI.Primitives.Async.IObservableAsync<T10> Source10, ReactiveUI.Primitives.Async.IObservableAsync<T11> Source11) { }
@@ -1158,19 +1158,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Lifecycle = {Lifecycle}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest12Coordinator: Sources = {Sources}, Lifecycle = {Lifecycle}")]
     public sealed class SyncLatest12Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest12Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest12State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest12Signal: Sources = {Sources}")]
     public sealed class SyncLatest12Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest12Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest12State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source12 = {Source12}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest12State: Source1 = {Source1}, Source12 = {Source12}")]
     public readonly record struct SyncLatest12State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest12State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>>
     {
         public SyncLatest12State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8, ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9, ReactiveUI.Primitives.Async.IObservableAsync<T10> Source10, ReactiveUI.Primitives.Async.IObservableAsync<T11> Source11, ReactiveUI.Primitives.Async.IObservableAsync<T12> Source12) { }
@@ -1187,19 +1187,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value13 = {Value13}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest13Coordinator: Value1 = {Value1}, Value13 = {Value13}")]
     public sealed class SyncLatest13Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest13Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest13State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest13Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest13Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest13Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest13State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source13 = {Source13}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest13State: Source1 = {Source1}, Source13 = {Source13}")]
     public readonly record struct SyncLatest13State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest13State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>>
     {
         public SyncLatest13State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8, ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9, ReactiveUI.Primitives.Async.IObservableAsync<T10> Source10, ReactiveUI.Primitives.Async.IObservableAsync<T11> Source11, ReactiveUI.Primitives.Async.IObservableAsync<T12> Source12, ReactiveUI.Primitives.Async.IObservableAsync<T13> Source13) { }
@@ -1217,19 +1217,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Lifecycle = {Lifecycle}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest14Coordinator: Sources = {Sources}, Lifecycle = {Lifecycle}")]
     public sealed class SyncLatest14Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest14Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest14State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest14Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest14Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest14Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest14State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source14 = {Source14}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest14State: Source1 = {Source1}, Source14 = {Source14}")]
     public readonly record struct SyncLatest14State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest14State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>>
     {
         public SyncLatest14State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8, ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9, ReactiveUI.Primitives.Async.IObservableAsync<T10> Source10, ReactiveUI.Primitives.Async.IObservableAsync<T11> Source11, ReactiveUI.Primitives.Async.IObservableAsync<T12> Source12, ReactiveUI.Primitives.Async.IObservableAsync<T13> Source13, ReactiveUI.Primitives.Async.IObservableAsync<T14> Source14) { }
@@ -1248,19 +1248,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value15 = {Value15}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest15Coordinator: Value1 = {Value1}, Value15 = {Value15}")]
     public sealed class SyncLatest15Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest15Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest15State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest15Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest15Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest15Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest15State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source15 = {Source15}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest15State: Source1 = {Source1}, Source15 = {Source15}")]
     public readonly record struct SyncLatest15State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest15State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>>
     {
         public SyncLatest15State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8, ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9, ReactiveUI.Primitives.Async.IObservableAsync<T10> Source10, ReactiveUI.Primitives.Async.IObservableAsync<T11> Source11, ReactiveUI.Primitives.Async.IObservableAsync<T12> Source12, ReactiveUI.Primitives.Async.IObservableAsync<T13> Source13, ReactiveUI.Primitives.Async.IObservableAsync<T14> Source14, ReactiveUI.Primitives.Async.IObservableAsync<T15> Source15) { }
@@ -1280,19 +1280,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value16 = {Value16}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest16Coordinator: Value1 = {Value1}, Value16 = {Value16}")]
     public sealed class SyncLatest16Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest16Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest16State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest16Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest16Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest16Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest16State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source16 = {Source16}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest16State: Source1 = {Source1}, Source16 = {Source16}")]
     public readonly record struct SyncLatest16State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest16State<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>>
     {
         public SyncLatest16State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8, ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9, ReactiveUI.Primitives.Async.IObservableAsync<T10> Source10, ReactiveUI.Primitives.Async.IObservableAsync<T11> Source11, ReactiveUI.Primitives.Async.IObservableAsync<T12> Source12, ReactiveUI.Primitives.Async.IObservableAsync<T13> Source13, ReactiveUI.Primitives.Async.IObservableAsync<T14> Source14, ReactiveUI.Primitives.Async.IObservableAsync<T15> Source15, ReactiveUI.Primitives.Async.IObservableAsync<T16> Source16) { }
@@ -1313,38 +1313,38 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest2Coordinator: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest2Coordinator<T1, T2, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest2Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest2State<T1, T2> sources, System.Func<T1, T2, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest2Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest2Signal<T1, T2, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest2Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest2State<T1, T2> sources, System.Func<T1, T2, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source2 = {Source2}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest2State: Source1 = {Source1}, Source2 = {Source2}")]
     public readonly record struct SyncLatest2State<T1, T2> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest2State<T1, T2>>
     {
         public SyncLatest2State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2) { }
         public ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value3 = {Value3}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest3Coordinator: Value1 = {Value1}, Value3 = {Value3}")]
     public sealed class SyncLatest3Coordinator<T1, T2, T3, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest3Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest3State<T1, T2, T3> sources, System.Func<T1, T2, T3, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest3Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest3Signal<T1, T2, T3, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest3Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest3State<T1, T2, T3> sources, System.Func<T1, T2, T3, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source2 = {Source2}, Source3 = {Source3}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest3State: Source1 = {Source1}, Source2 = {Source2}, Source3 = {Source3}")]
     public readonly record struct SyncLatest3State<T1, T2, T3> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest3State<T1, T2, T3>>
     {
         public SyncLatest3State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3) { }
@@ -1352,19 +1352,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value4 = {Value4}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest4Coordinator: Value1 = {Value1}, Value4 = {Value4}")]
     public sealed class SyncLatest4Coordinator<T1, T2, T3, T4, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest4Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest4State<T1, T2, T3, T4> sources, System.Func<T1, T2, T3, T4, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest4Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest4Signal<T1, T2, T3, T4, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest4Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest4State<T1, T2, T3, T4> sources, System.Func<T1, T2, T3, T4, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source2 = {Source2}, Source3 = {Source3}, Source4 = {Source4}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest4State: Source1 = {Source1}, Source2 = {Source2}, Source3 = {Source3}, Source4 = {Source4}")]
     public readonly record struct SyncLatest4State<T1, T2, T3, T4> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest4State<T1, T2, T3, T4>>
     {
         public SyncLatest4State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4) { }
@@ -1373,19 +1373,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value5 = {Value5}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest5Coordinator: Value1 = {Value1}, Value5 = {Value5}")]
     public sealed class SyncLatest5Coordinator<T1, T2, T3, T4, T5, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest5Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest5State<T1, T2, T3, T4, T5> sources, System.Func<T1, T2, T3, T4, T5, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest5Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest5Signal<T1, T2, T3, T4, T5, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest5Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest5State<T1, T2, T3, T4, T5> sources, System.Func<T1, T2, T3, T4, T5, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source5 = {Source5}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest5State: Source1 = {Source1}, Source5 = {Source5}")]
     public readonly record struct SyncLatest5State<T1, T2, T3, T4, T5> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest5State<T1, T2, T3, T4, T5>>
     {
         public SyncLatest5State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5) { }
@@ -1395,19 +1395,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value6 = {Value6}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest6Coordinator: Value1 = {Value1}, Value6 = {Value6}")]
     public sealed class SyncLatest6Coordinator<T1, T2, T3, T4, T5, T6, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest6Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest6State<T1, T2, T3, T4, T5, T6> sources, System.Func<T1, T2, T3, T4, T5, T6, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest6Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest6Signal<T1, T2, T3, T4, T5, T6, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest6Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest6State<T1, T2, T3, T4, T5, T6> sources, System.Func<T1, T2, T3, T4, T5, T6, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source6 = {Source6}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest6State: Source1 = {Source1}, Source6 = {Source6}")]
     public readonly record struct SyncLatest6State<T1, T2, T3, T4, T5, T6> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest6State<T1, T2, T3, T4, T5, T6>>
     {
         public SyncLatest6State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6) { }
@@ -1418,19 +1418,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest7Coordinator: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest7Coordinator<T1, T2, T3, T4, T5, T6, T7, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest7Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest7State<T1, T2, T3, T4, T5, T6, T7> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest7Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest7Signal<T1, T2, T3, T4, T5, T6, T7, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest7Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest7State<T1, T2, T3, T4, T5, T6, T7> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source7 = {Source7}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest7State: Source1 = {Source1}, Source7 = {Source7}")]
     public readonly record struct SyncLatest7State<T1, T2, T3, T4, T5, T6, T7> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest7State<T1, T2, T3, T4, T5, T6, T7>>
     {
         public SyncLatest7State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7) { }
@@ -1442,19 +1442,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest8Coordinator: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest8Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest8Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest8State<T1, T2, T3, T4, T5, T6, T7, T8> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest8Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest8Signal<T1, T2, T3, T4, T5, T6, T7, T8, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest8Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest8State<T1, T2, T3, T4, T5, T6, T7, T8> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source8 = {Source8}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest8State: Source1 = {Source1}, Source8 = {Source8}")]
     public readonly record struct SyncLatest8State<T1, T2, T3, T4, T5, T6, T7, T8> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest8State<T1, T2, T3, T4, T5, T6, T7, T8>>
     {
         public SyncLatest8State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8) { }
@@ -1467,19 +1467,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("Value1 = {Value1}, Value9 = {Value9}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest9Coordinator: Value1 = {Value1}, Value9 = {Value9}")]
     public sealed class SyncLatest9Coordinator<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> : ReactiveUI.Primitives.Async.Advanced.SyncLatestCoordinatorBase<TResult>
     {
         public SyncLatest9Coordinator(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, ReactiveUI.Primitives.Async.Advanced.SyncLatest9State<T1, T2, T3, T4, T5, T6, T7, T8, T9> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> selector) { }
         protected override System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest9Signal: Sources = {Sources}, Selector = {Selector}")]
     public sealed class SyncLatest9Signal<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatest9Signal(ReactiveUI.Primitives.Async.Advanced.SyncLatest9State<T1, T2, T3, T4, T5, T6, T7, T8, T9> sources, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> selector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source1 = {Source1}, Source9 = {Source9}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatest9State: Source1 = {Source1}, Source9 = {Source9}")]
     public readonly record struct SyncLatest9State<T1, T2, T3, T4, T5, T6, T7, T8, T9> : System.IEquatable<ReactiveUI.Primitives.Async.Advanced.SyncLatest9State<T1, T2, T3, T4, T5, T6, T7, T8, T9>>
     {
         public SyncLatest9State(ReactiveUI.Primitives.Async.IObservableAsync<T1> Source1, ReactiveUI.Primitives.Async.IObservableAsync<T2> Source2, ReactiveUI.Primitives.Async.IObservableAsync<T3> Source3, ReactiveUI.Primitives.Async.IObservableAsync<T4> Source4, ReactiveUI.Primitives.Async.IObservableAsync<T5> Source5, ReactiveUI.Primitives.Async.IObservableAsync<T6> Source6, ReactiveUI.Primitives.Async.IObservableAsync<T7> Source7, ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8, ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9) { }
@@ -1493,7 +1493,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public ReactiveUI.Primitives.Async.IObservableAsync<T8> Source8 { get; init; }
         public ReactiveUI.Primitives.Async.IObservableAsync<T9> Source9 { get; init; }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceCount = {Lifecycle.Subscriptions.Length}, HasDisposed = {Lifecycle.HasDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestCoordinatorBase: SourceCount = {Lifecycle.Subscriptions.Length}, HasDisposed = {Lifecycle.HasDisposed}")]
     public abstract class SyncLatestCoordinatorBase<TResult> : System.IAsyncDisposable
     {
         protected SyncLatestCoordinatorBase(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, int sourceCount) { }
@@ -1501,7 +1501,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected abstract System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAtAsync(int index, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.ValueTask SubscribeSourcesAsync(System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources.Length}, Completed = {_completedCount}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestEnumerableCoordinator: Sources = {Sources.Length}, Completed = {_completedCount}, Disposed = {_disposed}")]
     public sealed class SyncLatestEnumerableCoordinator<TSource, TResult> : System.IAsyncDisposable
     {
         public SyncLatestEnumerableCoordinator(ReactiveUI.Primitives.Async.IObservableAsync<TSource>[] sources, ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Func<System.Collections.Generic.IReadOnlyList<TSource>, TResult> resultSelector) { }
@@ -1509,13 +1509,13 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public System.Threading.Tasks.ValueTask DisposeAsync() { }
         public System.Threading.Tasks.ValueTask SubscribeSourcesAsync(System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceCount = {Sources.Length}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestEnumerableSignal: SourceCount = {Sources.Length}")]
     public sealed class SyncLatestEnumerableSignal<TSource, TResult> : ReactiveUI.Primitives.Async.IObservableAsync<TResult>
     {
         public SyncLatestEnumerableSignal(System.Collections.Generic.IEnumerable<ReactiveUI.Primitives.Async.IObservableAsync<TSource>> sources, System.Func<System.Collections.Generic.IReadOnlyList<TSource>, TResult> resultSelector) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<TResult>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Index = {Index}, Parent = {Parent}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestEnumerableWitness: Index = {Index}, Parent = {Parent}")]
     public sealed class SyncLatestEnumerableWitness<TSource, TResult> : ReactiveUI.Primitives.Async.IObserverAsync<TSource>
     {
         public SyncLatestEnumerableWitness(ReactiveUI.Primitives.Async.Advanced.SyncLatestEnumerableCoordinator<TSource, TResult> parent, int index) { }
@@ -1535,7 +1535,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(TSource value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceCount = {Subscriptions.Length}, HasDisposed = {HasDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestLifecycle: SourceCount = {Subscriptions.Length}, HasDisposed = {HasDisposed}")]
     public sealed class SyncLatestLifecycle<TResult> : System.IAsyncDisposable
     {
         public SyncLatestLifecycle(ReactiveUI.Primitives.Async.IObserverAsync<TResult> observer, int sourceCount) { }
@@ -1557,7 +1557,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(TSource value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, DisposeRequested = {DisposeToken.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("TakeUntilLifecycle: Observer = {_observer}, DisposeRequested = {DisposeToken.IsCancellationRequested}")]
     public sealed class TakeUntilLifecycle<T> : System.IAsyncDisposable
     {
         public TakeUntilLifecycle(ReactiveUI.Primitives.Async.IObserverAsync<T> observer) { }
@@ -1575,7 +1575,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected override System.Threading.Tasks.ValueTask OnErrorResumeAsyncCore(System.Exception error, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.ValueTask OnNextAsyncCore(T value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsCompleted = {_taskSource.Task.IsCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("TaskResultCompletionSource: IsCompleted = {_taskSource.Task.IsCompleted}")]
     public sealed class TaskResultCompletionSource<T>
     {
         public TaskResultCompletionSource(System.Threading.CancellationToken cancellationToken) { }
@@ -1583,19 +1583,19 @@ namespace ReactiveUI.Primitives.Async.Advanced
         public System.Threading.Tasks.ValueTask SetExceptionAndDisposeAsync(System.Exception exception, ReactiveUI.Primitives.Async.Advanced.IReentrantAsyncDisposable owner) { }
         public System.Threading.Tasks.ValueTask SetResultAndDisposeAsync(T value, ReactiveUI.Primitives.Async.Advanced.IReentrantAsyncDisposable owner) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskResultSignal: Task = {Task}")]
     public sealed class TaskResultSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public TaskResultSignal(System.Threading.Tasks.Task<T> task) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskResultSubscription: Task = {Task}")]
     public sealed class TaskResultSubscription<T> : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<T>
     {
         public TaskResultSubscription(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.Tasks.Task<T> task) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completion = {_completion}")]
+    [System.Diagnostics.DebuggerDisplay("TaskResultWitnessAsyncBase: Completion = {_completion}")]
     public abstract class TaskResultWitnessAsyncBase<T, TTaskValue> : ReactiveUI.Primitives.Async.WitnessAsync<T>
     {
         protected TaskResultWitnessAsyncBase(System.Threading.CancellationToken cancellationToken) { }
@@ -1610,7 +1610,7 @@ namespace ReactiveUI.Primitives.Async.Advanced
     {
         public static ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<T> StartNew<T>(System.Func<ReactiveUI.Primitives.Async.IObserverAsync<T>, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> executeAsyncCore, ReactiveUI.Primitives.Async.IObserverAsync<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Disposed = {_disposed}, Completed = {_tcs.Task.IsCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("TaskSignalSubscription: Disposed = {_disposed}, Completed = {_tcs.Task.IsCompleted}")]
     public abstract class TaskSignalSubscription<T> : System.IAsyncDisposable
     {
         protected TaskSignalSubscription(ReactiveUI.Primitives.Async.IObserverAsync<T> observer) { }
@@ -1618,25 +1618,25 @@ namespace ReactiveUI.Primitives.Async.Advanced
         protected abstract System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
         public void Start() { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {DueTime}, Period = {Period}")]
+    [System.Diagnostics.DebuggerDisplay("TimerSignal: DueTime = {DueTime}, Period = {Period}")]
     public sealed class TimerSignal : ReactiveUI.Primitives.Async.IObservableAsync<long>
     {
         public TimerSignal(System.TimeSpan dueTime, System.TimeSpan? period, System.TimeProvider timeProvider) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<System.Int64>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<long> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {DueTime}, Period = {Period}")]
+    [System.Diagnostics.DebuggerDisplay("TimerSubscription: DueTime = {DueTime}, Period = {Period}")]
     public sealed class TimerSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<long>
     {
         public TimerSubscription(ReactiveUI.Primitives.Async.IObserverAsync<long> observer, System.TimeSpan dueTime, System.TimeSpan? period, System.TimeProvider timeProvider) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<long> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ResourceFactory = {ResourceFactory}, SignalFactory = {SignalFactory}")]
+    [System.Diagnostics.DebuggerDisplay("UsingSignal: ResourceFactory = {ResourceFactory}, SignalFactory = {SignalFactory}")]
     public sealed class UsingSignal<TResource, T> : ReactiveUI.Primitives.Async.IObservableAsync<T> where TResource : System.IAsyncDisposable
     {
         public UsingSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResource>> resourceFactory, System.Func<TResource, ReactiveUI.Primitives.Async.IObservableAsync<T>> signalFactory) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Resource = {Resource}")]
+    [System.Diagnostics.DebuggerDisplay("UsingWitness: Resource = {Resource}")]
     public sealed class UsingWitness<TResource, T> : ReactiveUI.Primitives.Async.Advanced.ForwardingWitnessAsync<T> where TResource : System.IAsyncDisposable
     {
         public UsingWitness(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, TResource resource) { }
@@ -1661,7 +1661,7 @@ namespace ReactiveUI.Primitives.Async.Disposables
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public static System.Threading.Tasks.ValueTask SwapAsync(ref System.IAsyncDisposable? slot, System.IAsyncDisposable? value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, IsDisposed = {_isDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("MultipleDisposableAsync: Count = {_count}, IsDisposed = {_isDisposed}")]
     public sealed class MultipleDisposableAsync : System.IAsyncDisposable
     {
         public MultipleDisposableAsync() { }
@@ -1678,7 +1678,7 @@ namespace ReactiveUI.Primitives.Async.Disposables
         public System.Collections.Generic.IEnumerator<System.IAsyncDisposable> GetEnumerator() { }
         public System.Threading.Tasks.ValueTask<bool> Remove(System.IAsyncDisposable item) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsDisposed = {IsDisposed}, Current = {_current}")]
+    [System.Diagnostics.DebuggerDisplay("SingleAssignmentDisposableAsync: IsDisposed = {IsDisposed}, Current = {_current}")]
     public sealed class SingleAssignmentDisposableAsync : System.IAsyncDisposable
     {
         public SingleAssignmentDisposableAsync() { }
@@ -1689,7 +1689,7 @@ namespace ReactiveUI.Primitives.Async.Disposables
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.Threading.Tasks.ValueTask SetDisposableAsync(System.IAsyncDisposable? value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Current = {_current}")]
+    [System.Diagnostics.DebuggerDisplay("SingleReplaceableDisposableAsync: Current = {_current}")]
     public class SingleReplaceableDisposableAsync : System.IAsyncDisposable
     {
         public SingleReplaceableDisposableAsync() { }
@@ -1715,7 +1715,7 @@ namespace ReactiveUI.Primitives.Async.Helpers
 }
 namespace ReactiveUI.Primitives.Async.Signals
 {
-    [System.Diagnostics.DebuggerDisplay("PublishingOption = {PublishingOption}, IsStateless = {IsStateless}")]
+    [System.Diagnostics.DebuggerDisplay("BehaviorSignalCreationOptions: PublishingOption = {PublishingOption}, IsStateless = {IsStateless}")]
     public record BehaviorSignalCreationOptions : System.IEquatable<ReactiveUI.Primitives.Async.Signals.BehaviorSignalCreationOptions>
     {
         public required bool IsStateless { get; init; }
@@ -1731,7 +1731,7 @@ namespace ReactiveUI.Primitives.Async.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public static System.Threading.Tasks.ValueTask ForwardOnNextConcurrently<T>(System.Collections.Immutable.ImmutableArray<ReactiveUI.Primitives.Async.IObserverAsync<T>> observers, T value, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("LastValue = {_state.LastValue}, IsDisposed = {_state.IsDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ConcurrentReplayLatestSignalAsync: LastValue = {_state.LastValue}, IsDisposed = {_state.IsDisposed}")]
     public sealed class ConcurrentReplayLatestSignalAsync<T> : ReactiveUI.Primitives.Async.Signals.ISignalAsync<T>
     {
         public ConcurrentReplayLatestSignalAsync(ReactiveUI.Primitives.Optional<T> startValue) { }
@@ -1747,7 +1747,7 @@ namespace ReactiveUI.Primitives.Async.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_state.Observers.Length}, Result = {_state.Result}")]
+    [System.Diagnostics.DebuggerDisplay("ConcurrentSignalAsync: Observers = {_state.Observers.Length}, Result = {_state.Result}")]
     public sealed class ConcurrentSignalAsync<T> : ReactiveUI.Primitives.Async.Signals.ISignalAsync<T>
     {
         public ConcurrentSignalAsync() { }
@@ -1763,7 +1763,7 @@ namespace ReactiveUI.Primitives.Async.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_state.Value}, IsDisposed = {_state.IsDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ConcurrentStatelessReplayLatestSignalAsync: Value = {_state.Value}, IsDisposed = {_state.IsDisposed}")]
     public sealed class ConcurrentStatelessReplayLatestSignalAsync<T> : ReactiveUI.Primitives.Async.Signals.ISignalAsync<T>
     {
         public ConcurrentStatelessReplayLatestSignalAsync(ReactiveUI.Primitives.Optional<T> startValue) { }
@@ -1779,7 +1779,7 @@ namespace ReactiveUI.Primitives.Async.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_state.Observers.Length}")]
+    [System.Diagnostics.DebuggerDisplay("ConcurrentStatelessSignalAsync: Observers = {_state.Observers.Length}")]
     public sealed class ConcurrentStatelessSignalAsync<T> : ReactiveUI.Primitives.Async.Signals.ISignalAsync<T>
     {
         public ConcurrentStatelessSignalAsync() { }
@@ -1804,14 +1804,14 @@ namespace ReactiveUI.Primitives.Async.Signals
         Serial = 0,
         Concurrent = 1,
     }
-    [System.Diagnostics.DebuggerDisplay("PublishingOption = {PublishingOption}, IsStateless = {IsStateless}")]
+    [System.Diagnostics.DebuggerDisplay("ReplayLatestSignalCreationOptions: PublishingOption = {PublishingOption}, IsStateless = {IsStateless}")]
     public record ReplayLatestSignalCreationOptions : System.IEquatable<ReactiveUI.Primitives.Async.Signals.ReplayLatestSignalCreationOptions>
     {
         public required bool IsStateless { get; init; }
         public required ReactiveUI.Primitives.Async.Signals.PublishingOption PublishingOption { get; init; }
         public static ReactiveUI.Primitives.Async.Signals.ReplayLatestSignalCreationOptions Default { get; }
     }
-    [System.Diagnostics.DebuggerDisplay("LastValue = {_state.LastValue}, IsDisposed = {_state.IsDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("SerialReplayLatestSignalAsync: LastValue = {_state.LastValue}, IsDisposed = {_state.IsDisposed}")]
     public sealed class SerialReplayLatestSignalAsync<T> : ReactiveUI.Primitives.Async.Signals.ISignalAsync<T>
     {
         public SerialReplayLatestSignalAsync(ReactiveUI.Primitives.Optional<T> startValue) { }
@@ -1827,7 +1827,7 @@ namespace ReactiveUI.Primitives.Async.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_state.Observers.Length}, Result = {_state.Result}")]
+    [System.Diagnostics.DebuggerDisplay("SerialSignalAsync: Observers = {_state.Observers.Length}, Result = {_state.Result}")]
     public sealed class SerialSignalAsync<T> : ReactiveUI.Primitives.Async.Signals.ISignalAsync<T>
     {
         public SerialSignalAsync() { }
@@ -1843,7 +1843,7 @@ namespace ReactiveUI.Primitives.Async.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("State = {_state}")]
+    [System.Diagnostics.DebuggerDisplay("SerialStatelessReplayLatestSignalAsync: State = {_state}")]
     public sealed class SerialStatelessReplayLatestSignalAsync<T> : ReactiveUI.Primitives.Async.Signals.ISignalAsync<T>
     {
         public SerialStatelessReplayLatestSignalAsync(ReactiveUI.Primitives.Optional<T> startValue) { }
@@ -1859,7 +1859,7 @@ namespace ReactiveUI.Primitives.Async.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.Threading.Tasks.ValueTask<System.IAsyncDisposable> SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_state.Observers.Length}")]
+    [System.Diagnostics.DebuggerDisplay("SerialStatelessSignalAsync: Observers = {_state.Observers.Length}")]
     public sealed class SerialStatelessSignalAsync<T> : ReactiveUI.Primitives.Async.Signals.ISignalAsync<T>
     {
         public SerialStatelessSignalAsync() { }
@@ -1887,7 +1887,7 @@ namespace ReactiveUI.Primitives.Async.Signals
         public static ReactiveUI.Primitives.Async.Signals.ISignalAsync<T> CreateReplayLatest<T>() { }
         public static ReactiveUI.Primitives.Async.Signals.ISignalAsync<T> CreateReplayLatest<T>(ReactiveUI.Primitives.Async.Signals.ReplayLatestSignalCreationOptions? options) { }
     }
-    [System.Diagnostics.DebuggerDisplay("PublishingOption = {PublishingOption}, IsStateless = {IsStateless}")]
+    [System.Diagnostics.DebuggerDisplay("SignalCreationOptions: PublishingOption = {PublishingOption}, IsStateless = {IsStateless}")]
     public record SignalCreationOptions : System.IEquatable<ReactiveUI.Primitives.Async.Signals.SignalCreationOptions>
     {
         public required bool IsStateless { get; init; }

--- a/src/ReactiveUI.Primitives.Async.Core/Signals/ConcurrentReplayLatestSignalAsync.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Signals/ConcurrentReplayLatestSignalAsync.cs
@@ -15,7 +15,7 @@ namespace ReactiveUI.Primitives.Async.Signals;
 /// <remarks>This Signal notifies all observers concurrently, which can improve throughput in scenarios with
 /// multiple observers. The order in which observers receive notifications is not guaranteed. This type is thread-safe
 /// and suitable for use in asynchronous and concurrent environments.</remarks>
-[System.Diagnostics.DebuggerDisplay("LastValue = {_state.LastValue}, IsDisposed = {_state.IsDisposed}")]
+[System.Diagnostics.DebuggerDisplay("ConcurrentReplayLatestSignalAsync: LastValue = {_state.LastValue}, IsDisposed = {_state.IsDisposed}")]
 public sealed class ConcurrentReplayLatestSignalAsync<T>(Optional<T> startValue) : ISignalAsync<T>
 {
     /// <inheritdoc/>

--- a/src/ReactiveUI.Primitives.Async.Core/Signals/ConcurrentSignalAsync.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Signals/ConcurrentSignalAsync.cs
@@ -11,7 +11,7 @@ namespace ReactiveUI.Primitives.Async.Signals;
 /// <remarks>Observers are notified in parallel for each event. This class is suitable for scenarios where high
 /// throughput and concurrent notification of multiple observers are required. Thread safety is ensured for observer
 /// notification operations. Cancellation tokens can be used to cancel ongoing notification tasks.</remarks>
-[System.Diagnostics.DebuggerDisplay("Observers = {_state.Observers.Length}, Result = {_state.Result}")]
+[System.Diagnostics.DebuggerDisplay("ConcurrentSignalAsync: Observers = {_state.Observers.Length}, Result = {_state.Result}")]
 public sealed class ConcurrentSignalAsync<T> : ISignalAsync<T>
 {
     /// <inheritdoc/>

--- a/src/ReactiveUI.Primitives.Async.Core/Signals/ConcurrentStatelessReplayLatestSignalAsync.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Signals/ConcurrentStatelessReplayLatestSignalAsync.cs
@@ -17,7 +17,7 @@ namespace ReactiveUI.Primitives.Async.Signals;
 /// delivered in parallel. It does not buffer or store a sequence of values, but only replays the most recent value (if
 /// any) to new subscribers. Thread safety is ensured for concurrent observer notifications. If a notification operation
 /// is canceled, not all observers may receive the notification.</remarks>
-[System.Diagnostics.DebuggerDisplay("Value = {_state.Value}, IsDisposed = {_state.IsDisposed}")]
+[System.Diagnostics.DebuggerDisplay("ConcurrentStatelessReplayLatestSignalAsync: Value = {_state.Value}, IsDisposed = {_state.IsDisposed}")]
 public sealed class ConcurrentStatelessReplayLatestSignalAsync<T>(Optional<T> startValue) : ISignalAsync<T>
 {
     /// <inheritdoc/>

--- a/src/ReactiveUI.Primitives.Async.Core/Signals/ConcurrentStatelessSignalAsync.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Signals/ConcurrentStatelessSignalAsync.cs
@@ -12,7 +12,7 @@ namespace ReactiveUI.Primitives.Async.Signals;
 /// throughput in scenarios where observer processing can occur independently. Use this type when observer notification
 /// order is not important and concurrent delivery is desired. Thread safety is ensured for concurrent observer
 /// notifications.</remarks>
-[System.Diagnostics.DebuggerDisplay("Observers = {_state.Observers.Length}")]
+[System.Diagnostics.DebuggerDisplay("ConcurrentStatelessSignalAsync: Observers = {_state.Observers.Length}")]
 public sealed class ConcurrentStatelessSignalAsync<T> : ISignalAsync<T>
 {
     /// <inheritdoc/>

--- a/src/ReactiveUI.Primitives.Async.Core/Signals/Options/BehaviorSignalCreationOptions.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Signals/Options/BehaviorSignalCreationOptions.cs
@@ -5,7 +5,7 @@
 namespace ReactiveUI.Primitives.Async.Signals;
 
 /// <summary>Represents configuration options for creating a behavior Signal, including publishing behavior and statefulness.</summary>
-[System.Diagnostics.DebuggerDisplay("PublishingOption = {PublishingOption}, IsStateless = {IsStateless}")]
+[System.Diagnostics.DebuggerDisplay("BehaviorSignalCreationOptions: PublishingOption = {PublishingOption}, IsStateless = {IsStateless}")]
 public sealed record BehaviorSignalCreationOptions
 {
     /// <summary>Gets the default configuration options for creating a new BehaviorSignal instance.</summary>

--- a/src/ReactiveUI.Primitives.Async.Core/Signals/Options/ReplayLatestSignalCreationOptions.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Signals/Options/ReplayLatestSignalCreationOptions.cs
@@ -12,7 +12,7 @@ namespace ReactiveUI.Primitives.Async.Signals;
 /// maintains state. The options provided affect how subscribers receive messages and whether the Signal retains the
 /// latest value. This type is immutable and can be used to configure Signal creation in a thread-safe
 /// manner.</remarks>
-[System.Diagnostics.DebuggerDisplay("PublishingOption = {PublishingOption}, IsStateless = {IsStateless}")]
+[System.Diagnostics.DebuggerDisplay("ReplayLatestSignalCreationOptions: PublishingOption = {PublishingOption}, IsStateless = {IsStateless}")]
 public sealed record ReplayLatestSignalCreationOptions
 {
     /// <summary>Gets the default configuration options for creating a ReplayLatestSignal instance.</summary>

--- a/src/ReactiveUI.Primitives.Async.Core/Signals/Options/SignalCreationOptions.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Signals/Options/SignalCreationOptions.cs
@@ -11,7 +11,7 @@ namespace ReactiveUI.Primitives.Async.Signals;
 /// <remarks>Use this type to configure how a Signal is created, specifying whether it should be stateless and
 /// which publishing option to apply. The options provided affect the Signal's behavior and lifecycle. This record is
 /// immutable and can be used to ensure consistent Signal creation across different parts of an application.</remarks>
-[System.Diagnostics.DebuggerDisplay("PublishingOption = {PublishingOption}, IsStateless = {IsStateless}")]
+[System.Diagnostics.DebuggerDisplay("SignalCreationOptions: PublishingOption = {PublishingOption}, IsStateless = {IsStateless}")]
 public sealed record SignalCreationOptions
 {
     /// <summary>Gets the default configuration for Signal creation options.</summary>

--- a/src/ReactiveUI.Primitives.Async.Core/Signals/SerialReplayLatestSignalAsync.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Signals/SerialReplayLatestSignalAsync.cs
@@ -17,7 +17,7 @@ namespace ReactiveUI.Primitives.Async.Signals;
 /// notifications. All observer notifications are performed asynchronously and in a serial order, ensuring thread
 /// safety. This type is suitable for use cases where replaying only the latest value is desired, such as event streams
 /// or state broadcasts.</remarks>
-[System.Diagnostics.DebuggerDisplay("LastValue = {_state.LastValue}, IsDisposed = {_state.IsDisposed}")]
+[System.Diagnostics.DebuggerDisplay("SerialReplayLatestSignalAsync: LastValue = {_state.LastValue}, IsDisposed = {_state.IsDisposed}")]
 public sealed class SerialReplayLatestSignalAsync<T>(Optional<T> startValue) : ISignalAsync<T>
 {
     /// <inheritdoc/>

--- a/src/ReactiveUI.Primitives.Async.Core/Signals/SerialSignalAsync.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Signals/SerialSignalAsync.cs
@@ -14,7 +14,7 @@ namespace ReactiveUI.Primitives.Async.Signals;
 /// <remarks>SerialSignalAsync{T} is designed for scenarios where observers must be notified sequentially rather
 /// than concurrently. This can be useful when observer operations are not thread-safe or when order of notification is
 /// important. Notifications to observers are performed asynchronously and in sequence.</remarks>
-[System.Diagnostics.DebuggerDisplay("Observers = {_state.Observers.Length}, Result = {_state.Result}")]
+[System.Diagnostics.DebuggerDisplay("SerialSignalAsync: Observers = {_state.Observers.Length}, Result = {_state.Result}")]
 public sealed class SerialSignalAsync<T> : ISignalAsync<T>
 {
     /// <inheritdoc/>

--- a/src/ReactiveUI.Primitives.Async.Core/Signals/SerialStatelessReplayLatestSignalAsync.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Signals/SerialStatelessReplayLatestSignalAsync.cs
@@ -17,7 +17,7 @@ namespace ReactiveUI.Primitives.Async.Signals;
 /// does not maintain any state beyond the most recent value, and only the last value (if any) is replayed to new
 /// subscribers. All observer notifications are dispatched asynchronously and serially, ensuring that each observer
 /// receives notifications in the correct order.</remarks>
-[System.Diagnostics.DebuggerDisplay("State = {_state}")]
+[System.Diagnostics.DebuggerDisplay("SerialStatelessReplayLatestSignalAsync: State = {_state}")]
 public sealed class SerialStatelessReplayLatestSignalAsync<T>(Optional<T> startValue) : ISignalAsync<T>
 {
     /// <inheritdoc/>

--- a/src/ReactiveUI.Primitives.Async.Core/Signals/SerialStatelessSignalAsync.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/Signals/SerialStatelessSignalAsync.cs
@@ -11,7 +11,7 @@ namespace ReactiveUI.Primitives.Async.Signals;
 /// <remarks>Observers are notified one at a time in the order they are registered. Each observer receives the
 /// event only after the previous observer has completed processing. This class is suitable for scenarios where event
 /// delivery order and sequential processing are required. Thread safety and ordering are managed internally.</remarks>
-[System.Diagnostics.DebuggerDisplay("Observers = {_state.Observers.Length}")]
+[System.Diagnostics.DebuggerDisplay("SerialStatelessSignalAsync: Observers = {_state.Observers.Length}")]
 public sealed class SerialStatelessSignalAsync<T> : ISignalAsync<T>
 {
     /// <inheritdoc/>

--- a/src/ReactiveUI.Primitives.Async.Core/WitnessAsync.cs
+++ b/src/ReactiveUI.Primitives.Async.Core/WitnessAsync.cs
@@ -16,7 +16,7 @@ namespace ReactiveUI.Primitives.Async;
 /// handling new data, errors, and completion signals, and supports proper resource cleanup via asynchronous disposal.
 /// Instances are not thread-safe for concurrent notification handling; notifications are processed sequentially, and
 /// reentrant calls are detected and reported as unhandled exceptions.</remarks>
-[System.Diagnostics.DebuggerDisplay("Disposed = {_disposed}, CallState = {_callState}")]
+[System.Diagnostics.DebuggerDisplay("WitnessAsync: Disposed = {_disposed}, CallState = {_callState}")]
 public abstract class WitnessAsync<T> : IObserverAsync<T>, IReentrantAsyncDisposable
 {
     /// <summary>Lazily-created CTS that signals disposal to in-flight operations. Stays

--- a/src/ReactiveUI.Primitives.Async.Reactive/PublicAPI/net10.0/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Async.Reactive/PublicAPI/net10.0/PublicAPI.txt
@@ -1,7 +1,7 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Primitives.Async.Reactive.Tests")]
 namespace ReactiveUI.Primitives.Async.Reactive
 {
-    [System.Diagnostics.DebuggerDisplay("SynchronizationContext = {SynchronizationContext}, TaskScheduler = {TaskScheduler}, Sequencer = {Sequencer}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncContext: SynchronizationContext = {SynchronizationContext}, TaskScheduler = {TaskScheduler}, Sequencer = {Sequencer}")]
     public record AsyncContext : System.IEquatable<ReactiveUI.Primitives.Async.Reactive.AsyncContext>
     {
         public System.Reactive.Concurrency.IScheduler? Sequencer { get; init; }
@@ -14,7 +14,7 @@ namespace ReactiveUI.Primitives.Async.Reactive
         public static ReactiveUI.Primitives.Async.Reactive.AsyncContext From(System.Threading.Tasks.TaskScheduler taskScheduler) { }
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public static ReactiveUI.Primitives.Async.Reactive.AsyncContext GetCurrent() { }
-        [System.Diagnostics.DebuggerDisplay("IsCompleted = {IsCompleted}, ForceYielding = {ForceYielding}")]
+        [System.Diagnostics.DebuggerDisplay("AsyncContextSwitcherAwaitable: IsCompleted = {IsCompleted}, ForceYielding = {ForceYielding}")]
         public readonly record struct AsyncContextSwitcherAwaitable : System.IEquatable<ReactiveUI.Primitives.Async.Reactive.AsyncContext.AsyncContextSwitcherAwaitable>, System.Runtime.CompilerServices.INotifyCompletion
         {
             public AsyncContextSwitcherAwaitable(ReactiveUI.Primitives.Async.Reactive.AsyncContext AsyncContext, bool ForceYielding, System.Threading.CancellationToken CancellationToken) { }
@@ -94,49 +94,49 @@ namespace ReactiveUI.Primitives.Async.Reactive
 }
 namespace ReactiveUI.Primitives.Async.Reactive.Advanced
 {
-    [System.Diagnostics.DebuggerDisplay("Factory = {Factory}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSignal: Factory = {Factory}")]
     public sealed class FromAsyncSignal : ReactiveUI.Primitives.Async.IObservableAsync<System.Reactive.Unit>
     {
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> factory) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<System.Reactive.Unit>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Factory = {Factory}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSubscription: Factory = {Factory}")]
     public sealed class FromAsyncSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<System.Reactive.Unit>
     {
         public FromAsyncSubscription(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> factory) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Action = {Action}, TaskScheduler = {TaskScheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Action = {Action}, TaskScheduler = {TaskScheduler}")]
     public sealed class StartSignal : ReactiveUI.Primitives.Async.IObservableAsync<System.Reactive.Unit>
     {
         public StartSignal(System.Action action, System.Threading.Tasks.TaskScheduler? taskScheduler) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<System.Reactive.Unit>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Action = {Action}, TaskScheduler = {TaskScheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSubscription: Action = {Action}, TaskScheduler = {TaskScheduler}")]
     public sealed class StartSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<System.Reactive.Unit>
     {
         public StartSubscription(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Action action, System.Threading.Tasks.TaskScheduler? taskScheduler) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceTask = {SourceTask}")]
+    [System.Diagnostics.DebuggerDisplay("TaskToAsyncSignal: SourceTask = {SourceTask}")]
     public sealed class TaskToAsyncSignal : ReactiveUI.Primitives.Async.IObservableAsync<System.Reactive.Unit>
     {
         public TaskToAsyncSignal(System.Threading.Tasks.Task task) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<System.Reactive.Unit>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceTask = {SourceTask}, Completed = {SourceTask.IsCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("ToAsyncSignalSubscription: SourceTask = {SourceTask}, Completed = {SourceTask.IsCompleted}")]
     public sealed class ToAsyncSignalSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<System.Reactive.Unit>
     {
         public ToAsyncSignalSubscription(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Threading.Tasks.Task task) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, ForceYielding = {ForceYielding}")]
+    [System.Diagnostics.DebuggerDisplay("WitnessOnSignal: Source = {Source}, ForceYielding = {ForceYielding}")]
     public sealed class WitnessOnSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public WitnessOnSignal(ReactiveUI.Primitives.Async.IObservableAsync<T> source, ReactiveUI.Primitives.Async.Reactive.AsyncContext asyncContext, bool forceYielding) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("AsyncContext = {AsyncContext}, ForceYielding = {ForceYielding}")]
+    [System.Diagnostics.DebuggerDisplay("WitnessOnWitness: AsyncContext = {AsyncContext}, ForceYielding = {ForceYielding}")]
     public sealed class WitnessOnWitness<T> : ReactiveUI.Primitives.Async.WitnessAsync<T>
     {
         public WitnessOnWitness(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, ReactiveUI.Primitives.Async.Reactive.AsyncContext asyncContext, bool forceYielding) { }

--- a/src/ReactiveUI.Primitives.Async.Reactive/PublicAPI/net11.0/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Async.Reactive/PublicAPI/net11.0/PublicAPI.txt
@@ -1,7 +1,7 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Primitives.Async.Reactive.Tests")]
 namespace ReactiveUI.Primitives.Async.Reactive
 {
-    [System.Diagnostics.DebuggerDisplay("SynchronizationContext = {SynchronizationContext}, TaskScheduler = {TaskScheduler}, Sequencer = {Sequencer}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncContext: SynchronizationContext = {SynchronizationContext}, TaskScheduler = {TaskScheduler}, Sequencer = {Sequencer}")]
     public record AsyncContext : System.IEquatable<ReactiveUI.Primitives.Async.Reactive.AsyncContext>
     {
         public System.Reactive.Concurrency.IScheduler? Sequencer { get; init; }
@@ -14,7 +14,7 @@ namespace ReactiveUI.Primitives.Async.Reactive
         public static ReactiveUI.Primitives.Async.Reactive.AsyncContext From(System.Threading.Tasks.TaskScheduler taskScheduler) { }
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public static ReactiveUI.Primitives.Async.Reactive.AsyncContext GetCurrent() { }
-        [System.Diagnostics.DebuggerDisplay("IsCompleted = {IsCompleted}, ForceYielding = {ForceYielding}")]
+        [System.Diagnostics.DebuggerDisplay("AsyncContextSwitcherAwaitable: IsCompleted = {IsCompleted}, ForceYielding = {ForceYielding}")]
         public readonly record struct AsyncContextSwitcherAwaitable : System.IEquatable<ReactiveUI.Primitives.Async.Reactive.AsyncContext.AsyncContextSwitcherAwaitable>, System.Runtime.CompilerServices.INotifyCompletion
         {
             public AsyncContextSwitcherAwaitable(ReactiveUI.Primitives.Async.Reactive.AsyncContext AsyncContext, bool ForceYielding, System.Threading.CancellationToken CancellationToken) { }
@@ -94,49 +94,49 @@ namespace ReactiveUI.Primitives.Async.Reactive
 }
 namespace ReactiveUI.Primitives.Async.Reactive.Advanced
 {
-    [System.Diagnostics.DebuggerDisplay("Factory = {Factory}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSignal: Factory = {Factory}")]
     public sealed class FromAsyncSignal : ReactiveUI.Primitives.Async.IObservableAsync<System.Reactive.Unit>
     {
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> factory) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<System.Reactive.Unit>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Factory = {Factory}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSubscription: Factory = {Factory}")]
     public sealed class FromAsyncSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<System.Reactive.Unit>
     {
         public FromAsyncSubscription(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> factory) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Action = {Action}, TaskScheduler = {TaskScheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Action = {Action}, TaskScheduler = {TaskScheduler}")]
     public sealed class StartSignal : ReactiveUI.Primitives.Async.IObservableAsync<System.Reactive.Unit>
     {
         public StartSignal(System.Action action, System.Threading.Tasks.TaskScheduler? taskScheduler) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<System.Reactive.Unit>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Action = {Action}, TaskScheduler = {TaskScheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSubscription: Action = {Action}, TaskScheduler = {TaskScheduler}")]
     public sealed class StartSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<System.Reactive.Unit>
     {
         public StartSubscription(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Action action, System.Threading.Tasks.TaskScheduler? taskScheduler) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceTask = {SourceTask}")]
+    [System.Diagnostics.DebuggerDisplay("TaskToAsyncSignal: SourceTask = {SourceTask}")]
     public sealed class TaskToAsyncSignal : ReactiveUI.Primitives.Async.IObservableAsync<System.Reactive.Unit>
     {
         public TaskToAsyncSignal(System.Threading.Tasks.Task task) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<System.Reactive.Unit>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceTask = {SourceTask}, Completed = {SourceTask.IsCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("ToAsyncSignalSubscription: SourceTask = {SourceTask}, Completed = {SourceTask.IsCompleted}")]
     public sealed class ToAsyncSignalSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<System.Reactive.Unit>
     {
         public ToAsyncSignalSubscription(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Threading.Tasks.Task task) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, ForceYielding = {ForceYielding}")]
+    [System.Diagnostics.DebuggerDisplay("WitnessOnSignal: Source = {Source}, ForceYielding = {ForceYielding}")]
     public sealed class WitnessOnSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public WitnessOnSignal(ReactiveUI.Primitives.Async.IObservableAsync<T> source, ReactiveUI.Primitives.Async.Reactive.AsyncContext asyncContext, bool forceYielding) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("AsyncContext = {AsyncContext}, ForceYielding = {ForceYielding}")]
+    [System.Diagnostics.DebuggerDisplay("WitnessOnWitness: AsyncContext = {AsyncContext}, ForceYielding = {ForceYielding}")]
     public sealed class WitnessOnWitness<T> : ReactiveUI.Primitives.Async.WitnessAsync<T>
     {
         public WitnessOnWitness(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, ReactiveUI.Primitives.Async.Reactive.AsyncContext asyncContext, bool forceYielding) { }

--- a/src/ReactiveUI.Primitives.Async.Reactive/PublicAPI/net462/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Async.Reactive/PublicAPI/net462/PublicAPI.txt
@@ -1,7 +1,7 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Primitives.Async.Reactive.Tests")]
 namespace ReactiveUI.Primitives.Async.Reactive
 {
-    [System.Diagnostics.DebuggerDisplay("SynchronizationContext = {SynchronizationContext}, TaskScheduler = {TaskScheduler}, Sequencer = {Sequencer}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncContext: SynchronizationContext = {SynchronizationContext}, TaskScheduler = {TaskScheduler}, Sequencer = {Sequencer}")]
     public record AsyncContext : System.IEquatable<ReactiveUI.Primitives.Async.Reactive.AsyncContext>
     {
         public System.Reactive.Concurrency.IScheduler? Sequencer { get; init; }
@@ -14,7 +14,7 @@ namespace ReactiveUI.Primitives.Async.Reactive
         public static ReactiveUI.Primitives.Async.Reactive.AsyncContext From(System.Threading.Tasks.TaskScheduler taskScheduler) { }
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public static ReactiveUI.Primitives.Async.Reactive.AsyncContext GetCurrent() { }
-        [System.Diagnostics.DebuggerDisplay("IsCompleted = {IsCompleted}, ForceYielding = {ForceYielding}")]
+        [System.Diagnostics.DebuggerDisplay("AsyncContextSwitcherAwaitable: IsCompleted = {IsCompleted}, ForceYielding = {ForceYielding}")]
         public readonly record struct AsyncContextSwitcherAwaitable : System.IEquatable<ReactiveUI.Primitives.Async.Reactive.AsyncContext.AsyncContextSwitcherAwaitable>, System.Runtime.CompilerServices.INotifyCompletion
         {
             public AsyncContextSwitcherAwaitable(ReactiveUI.Primitives.Async.Reactive.AsyncContext AsyncContext, bool ForceYielding, System.Threading.CancellationToken CancellationToken) { }
@@ -94,49 +94,49 @@ namespace ReactiveUI.Primitives.Async.Reactive
 }
 namespace ReactiveUI.Primitives.Async.Reactive.Advanced
 {
-    [System.Diagnostics.DebuggerDisplay("Factory = {Factory}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSignal: Factory = {Factory}")]
     public sealed class FromAsyncSignal : ReactiveUI.Primitives.Async.IObservableAsync<System.Reactive.Unit>
     {
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> factory) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<System.Reactive.Unit>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Factory = {Factory}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSubscription: Factory = {Factory}")]
     public sealed class FromAsyncSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<System.Reactive.Unit>
     {
         public FromAsyncSubscription(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> factory) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Action = {Action}, TaskScheduler = {TaskScheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Action = {Action}, TaskScheduler = {TaskScheduler}")]
     public sealed class StartSignal : ReactiveUI.Primitives.Async.IObservableAsync<System.Reactive.Unit>
     {
         public StartSignal(System.Action action, System.Threading.Tasks.TaskScheduler? taskScheduler) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<System.Reactive.Unit>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Action = {Action}, TaskScheduler = {TaskScheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSubscription: Action = {Action}, TaskScheduler = {TaskScheduler}")]
     public sealed class StartSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<System.Reactive.Unit>
     {
         public StartSubscription(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Action action, System.Threading.Tasks.TaskScheduler? taskScheduler) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceTask = {SourceTask}")]
+    [System.Diagnostics.DebuggerDisplay("TaskToAsyncSignal: SourceTask = {SourceTask}")]
     public sealed class TaskToAsyncSignal : ReactiveUI.Primitives.Async.IObservableAsync<System.Reactive.Unit>
     {
         public TaskToAsyncSignal(System.Threading.Tasks.Task task) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<System.Reactive.Unit>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceTask = {SourceTask}, Completed = {SourceTask.IsCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("ToAsyncSignalSubscription: SourceTask = {SourceTask}, Completed = {SourceTask.IsCompleted}")]
     public sealed class ToAsyncSignalSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<System.Reactive.Unit>
     {
         public ToAsyncSignalSubscription(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Threading.Tasks.Task task) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, ForceYielding = {ForceYielding}")]
+    [System.Diagnostics.DebuggerDisplay("WitnessOnSignal: Source = {Source}, ForceYielding = {ForceYielding}")]
     public sealed class WitnessOnSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public WitnessOnSignal(ReactiveUI.Primitives.Async.IObservableAsync<T> source, ReactiveUI.Primitives.Async.Reactive.AsyncContext asyncContext, bool forceYielding) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("AsyncContext = {AsyncContext}, ForceYielding = {ForceYielding}")]
+    [System.Diagnostics.DebuggerDisplay("WitnessOnWitness: AsyncContext = {AsyncContext}, ForceYielding = {ForceYielding}")]
     public sealed class WitnessOnWitness<T> : ReactiveUI.Primitives.Async.WitnessAsync<T>
     {
         public WitnessOnWitness(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, ReactiveUI.Primitives.Async.Reactive.AsyncContext asyncContext, bool forceYielding) { }

--- a/src/ReactiveUI.Primitives.Async.Reactive/PublicAPI/net472/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Async.Reactive/PublicAPI/net472/PublicAPI.txt
@@ -1,7 +1,7 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Primitives.Async.Reactive.Tests")]
 namespace ReactiveUI.Primitives.Async.Reactive
 {
-    [System.Diagnostics.DebuggerDisplay("SynchronizationContext = {SynchronizationContext}, TaskScheduler = {TaskScheduler}, Sequencer = {Sequencer}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncContext: SynchronizationContext = {SynchronizationContext}, TaskScheduler = {TaskScheduler}, Sequencer = {Sequencer}")]
     public record AsyncContext : System.IEquatable<ReactiveUI.Primitives.Async.Reactive.AsyncContext>
     {
         public System.Reactive.Concurrency.IScheduler? Sequencer { get; init; }
@@ -14,7 +14,7 @@ namespace ReactiveUI.Primitives.Async.Reactive
         public static ReactiveUI.Primitives.Async.Reactive.AsyncContext From(System.Threading.Tasks.TaskScheduler taskScheduler) { }
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public static ReactiveUI.Primitives.Async.Reactive.AsyncContext GetCurrent() { }
-        [System.Diagnostics.DebuggerDisplay("IsCompleted = {IsCompleted}, ForceYielding = {ForceYielding}")]
+        [System.Diagnostics.DebuggerDisplay("AsyncContextSwitcherAwaitable: IsCompleted = {IsCompleted}, ForceYielding = {ForceYielding}")]
         public readonly record struct AsyncContextSwitcherAwaitable : System.IEquatable<ReactiveUI.Primitives.Async.Reactive.AsyncContext.AsyncContextSwitcherAwaitable>, System.Runtime.CompilerServices.INotifyCompletion
         {
             public AsyncContextSwitcherAwaitable(ReactiveUI.Primitives.Async.Reactive.AsyncContext AsyncContext, bool ForceYielding, System.Threading.CancellationToken CancellationToken) { }
@@ -94,49 +94,49 @@ namespace ReactiveUI.Primitives.Async.Reactive
 }
 namespace ReactiveUI.Primitives.Async.Reactive.Advanced
 {
-    [System.Diagnostics.DebuggerDisplay("Factory = {Factory}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSignal: Factory = {Factory}")]
     public sealed class FromAsyncSignal : ReactiveUI.Primitives.Async.IObservableAsync<System.Reactive.Unit>
     {
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> factory) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<System.Reactive.Unit>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Factory = {Factory}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSubscription: Factory = {Factory}")]
     public sealed class FromAsyncSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<System.Reactive.Unit>
     {
         public FromAsyncSubscription(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> factory) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Action = {Action}, TaskScheduler = {TaskScheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Action = {Action}, TaskScheduler = {TaskScheduler}")]
     public sealed class StartSignal : ReactiveUI.Primitives.Async.IObservableAsync<System.Reactive.Unit>
     {
         public StartSignal(System.Action action, System.Threading.Tasks.TaskScheduler? taskScheduler) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<System.Reactive.Unit>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Action = {Action}, TaskScheduler = {TaskScheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSubscription: Action = {Action}, TaskScheduler = {TaskScheduler}")]
     public sealed class StartSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<System.Reactive.Unit>
     {
         public StartSubscription(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Action action, System.Threading.Tasks.TaskScheduler? taskScheduler) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceTask = {SourceTask}")]
+    [System.Diagnostics.DebuggerDisplay("TaskToAsyncSignal: SourceTask = {SourceTask}")]
     public sealed class TaskToAsyncSignal : ReactiveUI.Primitives.Async.IObservableAsync<System.Reactive.Unit>
     {
         public TaskToAsyncSignal(System.Threading.Tasks.Task task) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<System.Reactive.Unit>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceTask = {SourceTask}, Completed = {SourceTask.IsCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("ToAsyncSignalSubscription: SourceTask = {SourceTask}, Completed = {SourceTask.IsCompleted}")]
     public sealed class ToAsyncSignalSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<System.Reactive.Unit>
     {
         public ToAsyncSignalSubscription(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Threading.Tasks.Task task) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, ForceYielding = {ForceYielding}")]
+    [System.Diagnostics.DebuggerDisplay("WitnessOnSignal: Source = {Source}, ForceYielding = {ForceYielding}")]
     public sealed class WitnessOnSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public WitnessOnSignal(ReactiveUI.Primitives.Async.IObservableAsync<T> source, ReactiveUI.Primitives.Async.Reactive.AsyncContext asyncContext, bool forceYielding) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("AsyncContext = {AsyncContext}, ForceYielding = {ForceYielding}")]
+    [System.Diagnostics.DebuggerDisplay("WitnessOnWitness: AsyncContext = {AsyncContext}, ForceYielding = {ForceYielding}")]
     public sealed class WitnessOnWitness<T> : ReactiveUI.Primitives.Async.WitnessAsync<T>
     {
         public WitnessOnWitness(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, ReactiveUI.Primitives.Async.Reactive.AsyncContext asyncContext, bool forceYielding) { }

--- a/src/ReactiveUI.Primitives.Async.Reactive/PublicAPI/net48/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Async.Reactive/PublicAPI/net48/PublicAPI.txt
@@ -1,7 +1,7 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Primitives.Async.Reactive.Tests")]
 namespace ReactiveUI.Primitives.Async.Reactive
 {
-    [System.Diagnostics.DebuggerDisplay("SynchronizationContext = {SynchronizationContext}, TaskScheduler = {TaskScheduler}, Sequencer = {Sequencer}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncContext: SynchronizationContext = {SynchronizationContext}, TaskScheduler = {TaskScheduler}, Sequencer = {Sequencer}")]
     public record AsyncContext : System.IEquatable<ReactiveUI.Primitives.Async.Reactive.AsyncContext>
     {
         public System.Reactive.Concurrency.IScheduler? Sequencer { get; init; }
@@ -14,7 +14,7 @@ namespace ReactiveUI.Primitives.Async.Reactive
         public static ReactiveUI.Primitives.Async.Reactive.AsyncContext From(System.Threading.Tasks.TaskScheduler taskScheduler) { }
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public static ReactiveUI.Primitives.Async.Reactive.AsyncContext GetCurrent() { }
-        [System.Diagnostics.DebuggerDisplay("IsCompleted = {IsCompleted}, ForceYielding = {ForceYielding}")]
+        [System.Diagnostics.DebuggerDisplay("AsyncContextSwitcherAwaitable: IsCompleted = {IsCompleted}, ForceYielding = {ForceYielding}")]
         public readonly record struct AsyncContextSwitcherAwaitable : System.IEquatable<ReactiveUI.Primitives.Async.Reactive.AsyncContext.AsyncContextSwitcherAwaitable>, System.Runtime.CompilerServices.INotifyCompletion
         {
             public AsyncContextSwitcherAwaitable(ReactiveUI.Primitives.Async.Reactive.AsyncContext AsyncContext, bool ForceYielding, System.Threading.CancellationToken CancellationToken) { }
@@ -94,49 +94,49 @@ namespace ReactiveUI.Primitives.Async.Reactive
 }
 namespace ReactiveUI.Primitives.Async.Reactive.Advanced
 {
-    [System.Diagnostics.DebuggerDisplay("Factory = {Factory}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSignal: Factory = {Factory}")]
     public sealed class FromAsyncSignal : ReactiveUI.Primitives.Async.IObservableAsync<System.Reactive.Unit>
     {
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> factory) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<System.Reactive.Unit>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Factory = {Factory}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSubscription: Factory = {Factory}")]
     public sealed class FromAsyncSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<System.Reactive.Unit>
     {
         public FromAsyncSubscription(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> factory) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Action = {Action}, TaskScheduler = {TaskScheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Action = {Action}, TaskScheduler = {TaskScheduler}")]
     public sealed class StartSignal : ReactiveUI.Primitives.Async.IObservableAsync<System.Reactive.Unit>
     {
         public StartSignal(System.Action action, System.Threading.Tasks.TaskScheduler? taskScheduler) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<System.Reactive.Unit>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Action = {Action}, TaskScheduler = {TaskScheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSubscription: Action = {Action}, TaskScheduler = {TaskScheduler}")]
     public sealed class StartSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<System.Reactive.Unit>
     {
         public StartSubscription(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Action action, System.Threading.Tasks.TaskScheduler? taskScheduler) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceTask = {SourceTask}")]
+    [System.Diagnostics.DebuggerDisplay("TaskToAsyncSignal: SourceTask = {SourceTask}")]
     public sealed class TaskToAsyncSignal : ReactiveUI.Primitives.Async.IObservableAsync<System.Reactive.Unit>
     {
         public TaskToAsyncSignal(System.Threading.Tasks.Task task) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<System.Reactive.Unit>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceTask = {SourceTask}, Completed = {SourceTask.IsCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("ToAsyncSignalSubscription: SourceTask = {SourceTask}, Completed = {SourceTask.IsCompleted}")]
     public sealed class ToAsyncSignalSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<System.Reactive.Unit>
     {
         public ToAsyncSignalSubscription(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Threading.Tasks.Task task) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, ForceYielding = {ForceYielding}")]
+    [System.Diagnostics.DebuggerDisplay("WitnessOnSignal: Source = {Source}, ForceYielding = {ForceYielding}")]
     public sealed class WitnessOnSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public WitnessOnSignal(ReactiveUI.Primitives.Async.IObservableAsync<T> source, ReactiveUI.Primitives.Async.Reactive.AsyncContext asyncContext, bool forceYielding) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("AsyncContext = {AsyncContext}, ForceYielding = {ForceYielding}")]
+    [System.Diagnostics.DebuggerDisplay("WitnessOnWitness: AsyncContext = {AsyncContext}, ForceYielding = {ForceYielding}")]
     public sealed class WitnessOnWitness<T> : ReactiveUI.Primitives.Async.WitnessAsync<T>
     {
         public WitnessOnWitness(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, ReactiveUI.Primitives.Async.Reactive.AsyncContext asyncContext, bool forceYielding) { }

--- a/src/ReactiveUI.Primitives.Async.Reactive/PublicAPI/net481/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Async.Reactive/PublicAPI/net481/PublicAPI.txt
@@ -1,7 +1,7 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Primitives.Async.Reactive.Tests")]
 namespace ReactiveUI.Primitives.Async.Reactive
 {
-    [System.Diagnostics.DebuggerDisplay("SynchronizationContext = {SynchronizationContext}, TaskScheduler = {TaskScheduler}, Sequencer = {Sequencer}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncContext: SynchronizationContext = {SynchronizationContext}, TaskScheduler = {TaskScheduler}, Sequencer = {Sequencer}")]
     public record AsyncContext : System.IEquatable<ReactiveUI.Primitives.Async.Reactive.AsyncContext>
     {
         public System.Reactive.Concurrency.IScheduler? Sequencer { get; init; }
@@ -14,7 +14,7 @@ namespace ReactiveUI.Primitives.Async.Reactive
         public static ReactiveUI.Primitives.Async.Reactive.AsyncContext From(System.Threading.Tasks.TaskScheduler taskScheduler) { }
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public static ReactiveUI.Primitives.Async.Reactive.AsyncContext GetCurrent() { }
-        [System.Diagnostics.DebuggerDisplay("IsCompleted = {IsCompleted}, ForceYielding = {ForceYielding}")]
+        [System.Diagnostics.DebuggerDisplay("AsyncContextSwitcherAwaitable: IsCompleted = {IsCompleted}, ForceYielding = {ForceYielding}")]
         public readonly record struct AsyncContextSwitcherAwaitable : System.IEquatable<ReactiveUI.Primitives.Async.Reactive.AsyncContext.AsyncContextSwitcherAwaitable>, System.Runtime.CompilerServices.INotifyCompletion
         {
             public AsyncContextSwitcherAwaitable(ReactiveUI.Primitives.Async.Reactive.AsyncContext AsyncContext, bool ForceYielding, System.Threading.CancellationToken CancellationToken) { }
@@ -94,49 +94,49 @@ namespace ReactiveUI.Primitives.Async.Reactive
 }
 namespace ReactiveUI.Primitives.Async.Reactive.Advanced
 {
-    [System.Diagnostics.DebuggerDisplay("Factory = {Factory}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSignal: Factory = {Factory}")]
     public sealed class FromAsyncSignal : ReactiveUI.Primitives.Async.IObservableAsync<System.Reactive.Unit>
     {
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> factory) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<System.Reactive.Unit>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Factory = {Factory}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSubscription: Factory = {Factory}")]
     public sealed class FromAsyncSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<System.Reactive.Unit>
     {
         public FromAsyncSubscription(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> factory) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Action = {Action}, TaskScheduler = {TaskScheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Action = {Action}, TaskScheduler = {TaskScheduler}")]
     public sealed class StartSignal : ReactiveUI.Primitives.Async.IObservableAsync<System.Reactive.Unit>
     {
         public StartSignal(System.Action action, System.Threading.Tasks.TaskScheduler? taskScheduler) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<System.Reactive.Unit>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Action = {Action}, TaskScheduler = {TaskScheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSubscription: Action = {Action}, TaskScheduler = {TaskScheduler}")]
     public sealed class StartSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<System.Reactive.Unit>
     {
         public StartSubscription(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Action action, System.Threading.Tasks.TaskScheduler? taskScheduler) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceTask = {SourceTask}")]
+    [System.Diagnostics.DebuggerDisplay("TaskToAsyncSignal: SourceTask = {SourceTask}")]
     public sealed class TaskToAsyncSignal : ReactiveUI.Primitives.Async.IObservableAsync<System.Reactive.Unit>
     {
         public TaskToAsyncSignal(System.Threading.Tasks.Task task) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<System.Reactive.Unit>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceTask = {SourceTask}, Completed = {SourceTask.IsCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("ToAsyncSignalSubscription: SourceTask = {SourceTask}, Completed = {SourceTask.IsCompleted}")]
     public sealed class ToAsyncSignalSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<System.Reactive.Unit>
     {
         public ToAsyncSignalSubscription(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Threading.Tasks.Task task) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, ForceYielding = {ForceYielding}")]
+    [System.Diagnostics.DebuggerDisplay("WitnessOnSignal: Source = {Source}, ForceYielding = {ForceYielding}")]
     public sealed class WitnessOnSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public WitnessOnSignal(ReactiveUI.Primitives.Async.IObservableAsync<T> source, ReactiveUI.Primitives.Async.Reactive.AsyncContext asyncContext, bool forceYielding) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("AsyncContext = {AsyncContext}, ForceYielding = {ForceYielding}")]
+    [System.Diagnostics.DebuggerDisplay("WitnessOnWitness: AsyncContext = {AsyncContext}, ForceYielding = {ForceYielding}")]
     public sealed class WitnessOnWitness<T> : ReactiveUI.Primitives.Async.WitnessAsync<T>
     {
         public WitnessOnWitness(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, ReactiveUI.Primitives.Async.Reactive.AsyncContext asyncContext, bool forceYielding) { }

--- a/src/ReactiveUI.Primitives.Async.Reactive/PublicAPI/net8.0/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Async.Reactive/PublicAPI/net8.0/PublicAPI.txt
@@ -1,7 +1,7 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Primitives.Async.Reactive.Tests")]
 namespace ReactiveUI.Primitives.Async.Reactive
 {
-    [System.Diagnostics.DebuggerDisplay("SynchronizationContext = {SynchronizationContext}, TaskScheduler = {TaskScheduler}, Sequencer = {Sequencer}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncContext: SynchronizationContext = {SynchronizationContext}, TaskScheduler = {TaskScheduler}, Sequencer = {Sequencer}")]
     public record AsyncContext : System.IEquatable<ReactiveUI.Primitives.Async.Reactive.AsyncContext>
     {
         public System.Reactive.Concurrency.IScheduler? Sequencer { get; init; }
@@ -14,7 +14,7 @@ namespace ReactiveUI.Primitives.Async.Reactive
         public static ReactiveUI.Primitives.Async.Reactive.AsyncContext From(System.Threading.Tasks.TaskScheduler taskScheduler) { }
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public static ReactiveUI.Primitives.Async.Reactive.AsyncContext GetCurrent() { }
-        [System.Diagnostics.DebuggerDisplay("IsCompleted = {IsCompleted}, ForceYielding = {ForceYielding}")]
+        [System.Diagnostics.DebuggerDisplay("AsyncContextSwitcherAwaitable: IsCompleted = {IsCompleted}, ForceYielding = {ForceYielding}")]
         public readonly record struct AsyncContextSwitcherAwaitable : System.IEquatable<ReactiveUI.Primitives.Async.Reactive.AsyncContext.AsyncContextSwitcherAwaitable>, System.Runtime.CompilerServices.INotifyCompletion
         {
             public AsyncContextSwitcherAwaitable(ReactiveUI.Primitives.Async.Reactive.AsyncContext AsyncContext, bool ForceYielding, System.Threading.CancellationToken CancellationToken) { }
@@ -94,49 +94,49 @@ namespace ReactiveUI.Primitives.Async.Reactive
 }
 namespace ReactiveUI.Primitives.Async.Reactive.Advanced
 {
-    [System.Diagnostics.DebuggerDisplay("Factory = {Factory}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSignal: Factory = {Factory}")]
     public sealed class FromAsyncSignal : ReactiveUI.Primitives.Async.IObservableAsync<System.Reactive.Unit>
     {
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> factory) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<System.Reactive.Unit>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Factory = {Factory}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSubscription: Factory = {Factory}")]
     public sealed class FromAsyncSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<System.Reactive.Unit>
     {
         public FromAsyncSubscription(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> factory) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Action = {Action}, TaskScheduler = {TaskScheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Action = {Action}, TaskScheduler = {TaskScheduler}")]
     public sealed class StartSignal : ReactiveUI.Primitives.Async.IObservableAsync<System.Reactive.Unit>
     {
         public StartSignal(System.Action action, System.Threading.Tasks.TaskScheduler? taskScheduler) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<System.Reactive.Unit>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Action = {Action}, TaskScheduler = {TaskScheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSubscription: Action = {Action}, TaskScheduler = {TaskScheduler}")]
     public sealed class StartSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<System.Reactive.Unit>
     {
         public StartSubscription(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Action action, System.Threading.Tasks.TaskScheduler? taskScheduler) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceTask = {SourceTask}")]
+    [System.Diagnostics.DebuggerDisplay("TaskToAsyncSignal: SourceTask = {SourceTask}")]
     public sealed class TaskToAsyncSignal : ReactiveUI.Primitives.Async.IObservableAsync<System.Reactive.Unit>
     {
         public TaskToAsyncSignal(System.Threading.Tasks.Task task) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<System.Reactive.Unit>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceTask = {SourceTask}, Completed = {SourceTask.IsCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("ToAsyncSignalSubscription: SourceTask = {SourceTask}, Completed = {SourceTask.IsCompleted}")]
     public sealed class ToAsyncSignalSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<System.Reactive.Unit>
     {
         public ToAsyncSignalSubscription(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Threading.Tasks.Task task) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, ForceYielding = {ForceYielding}")]
+    [System.Diagnostics.DebuggerDisplay("WitnessOnSignal: Source = {Source}, ForceYielding = {ForceYielding}")]
     public sealed class WitnessOnSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public WitnessOnSignal(ReactiveUI.Primitives.Async.IObservableAsync<T> source, ReactiveUI.Primitives.Async.Reactive.AsyncContext asyncContext, bool forceYielding) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("AsyncContext = {AsyncContext}, ForceYielding = {ForceYielding}")]
+    [System.Diagnostics.DebuggerDisplay("WitnessOnWitness: AsyncContext = {AsyncContext}, ForceYielding = {ForceYielding}")]
     public sealed class WitnessOnWitness<T> : ReactiveUI.Primitives.Async.WitnessAsync<T>
     {
         public WitnessOnWitness(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, ReactiveUI.Primitives.Async.Reactive.AsyncContext asyncContext, bool forceYielding) { }

--- a/src/ReactiveUI.Primitives.Async.Reactive/PublicAPI/net9.0/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Async.Reactive/PublicAPI/net9.0/PublicAPI.txt
@@ -1,7 +1,7 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Primitives.Async.Reactive.Tests")]
 namespace ReactiveUI.Primitives.Async.Reactive
 {
-    [System.Diagnostics.DebuggerDisplay("SynchronizationContext = {SynchronizationContext}, TaskScheduler = {TaskScheduler}, Sequencer = {Sequencer}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncContext: SynchronizationContext = {SynchronizationContext}, TaskScheduler = {TaskScheduler}, Sequencer = {Sequencer}")]
     public record AsyncContext : System.IEquatable<ReactiveUI.Primitives.Async.Reactive.AsyncContext>
     {
         public System.Reactive.Concurrency.IScheduler? Sequencer { get; init; }
@@ -14,7 +14,7 @@ namespace ReactiveUI.Primitives.Async.Reactive
         public static ReactiveUI.Primitives.Async.Reactive.AsyncContext From(System.Threading.Tasks.TaskScheduler taskScheduler) { }
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public static ReactiveUI.Primitives.Async.Reactive.AsyncContext GetCurrent() { }
-        [System.Diagnostics.DebuggerDisplay("IsCompleted = {IsCompleted}, ForceYielding = {ForceYielding}")]
+        [System.Diagnostics.DebuggerDisplay("AsyncContextSwitcherAwaitable: IsCompleted = {IsCompleted}, ForceYielding = {ForceYielding}")]
         public readonly record struct AsyncContextSwitcherAwaitable : System.IEquatable<ReactiveUI.Primitives.Async.Reactive.AsyncContext.AsyncContextSwitcherAwaitable>, System.Runtime.CompilerServices.INotifyCompletion
         {
             public AsyncContextSwitcherAwaitable(ReactiveUI.Primitives.Async.Reactive.AsyncContext AsyncContext, bool ForceYielding, System.Threading.CancellationToken CancellationToken) { }
@@ -94,49 +94,49 @@ namespace ReactiveUI.Primitives.Async.Reactive
 }
 namespace ReactiveUI.Primitives.Async.Reactive.Advanced
 {
-    [System.Diagnostics.DebuggerDisplay("Factory = {Factory}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSignal: Factory = {Factory}")]
     public sealed class FromAsyncSignal : ReactiveUI.Primitives.Async.IObservableAsync<System.Reactive.Unit>
     {
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> factory) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<System.Reactive.Unit>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Factory = {Factory}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSubscription: Factory = {Factory}")]
     public sealed class FromAsyncSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<System.Reactive.Unit>
     {
         public FromAsyncSubscription(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> factory) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Action = {Action}, TaskScheduler = {TaskScheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Action = {Action}, TaskScheduler = {TaskScheduler}")]
     public sealed class StartSignal : ReactiveUI.Primitives.Async.IObservableAsync<System.Reactive.Unit>
     {
         public StartSignal(System.Action action, System.Threading.Tasks.TaskScheduler? taskScheduler) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<System.Reactive.Unit>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Action = {Action}, TaskScheduler = {TaskScheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSubscription: Action = {Action}, TaskScheduler = {TaskScheduler}")]
     public sealed class StartSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<System.Reactive.Unit>
     {
         public StartSubscription(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Action action, System.Threading.Tasks.TaskScheduler? taskScheduler) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceTask = {SourceTask}")]
+    [System.Diagnostics.DebuggerDisplay("TaskToAsyncSignal: SourceTask = {SourceTask}")]
     public sealed class TaskToAsyncSignal : ReactiveUI.Primitives.Async.IObservableAsync<System.Reactive.Unit>
     {
         public TaskToAsyncSignal(System.Threading.Tasks.Task task) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<System.Reactive.Unit>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceTask = {SourceTask}, Completed = {SourceTask.IsCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("ToAsyncSignalSubscription: SourceTask = {SourceTask}, Completed = {SourceTask.IsCompleted}")]
     public sealed class ToAsyncSignalSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<System.Reactive.Unit>
     {
         public ToAsyncSignalSubscription(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Threading.Tasks.Task task) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<System.Reactive.Unit> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, ForceYielding = {ForceYielding}")]
+    [System.Diagnostics.DebuggerDisplay("WitnessOnSignal: Source = {Source}, ForceYielding = {ForceYielding}")]
     public sealed class WitnessOnSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public WitnessOnSignal(ReactiveUI.Primitives.Async.IObservableAsync<T> source, ReactiveUI.Primitives.Async.Reactive.AsyncContext asyncContext, bool forceYielding) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("AsyncContext = {AsyncContext}, ForceYielding = {ForceYielding}")]
+    [System.Diagnostics.DebuggerDisplay("WitnessOnWitness: AsyncContext = {AsyncContext}, ForceYielding = {ForceYielding}")]
     public sealed class WitnessOnWitness<T> : ReactiveUI.Primitives.Async.WitnessAsync<T>
     {
         public WitnessOnWitness(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, ReactiveUI.Primitives.Async.Reactive.AsyncContext asyncContext, bool forceYielding) { }

--- a/src/ReactiveUI.Primitives.Async/PublicAPI/net10.0/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Async/PublicAPI/net10.0/PublicAPI.txt
@@ -2,7 +2,7 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Primitives.Tests")]
 namespace ReactiveUI.Primitives.Async
 {
-    [System.Diagnostics.DebuggerDisplay("SynchronizationContext = {SynchronizationContext}, TaskScheduler = {TaskScheduler}, Sequencer = {Sequencer}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncContext: SynchronizationContext = {SynchronizationContext}, TaskScheduler = {TaskScheduler}, Sequencer = {Sequencer}")]
     public record AsyncContext : System.IEquatable<ReactiveUI.Primitives.Async.AsyncContext>
     {
         public ReactiveUI.Primitives.Concurrency.ISequencer? Sequencer { get; init; }
@@ -15,7 +15,7 @@ namespace ReactiveUI.Primitives.Async
         public static ReactiveUI.Primitives.Async.AsyncContext From(System.Threading.Tasks.TaskScheduler taskScheduler) { }
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public static ReactiveUI.Primitives.Async.AsyncContext GetCurrent() { }
-        [System.Diagnostics.DebuggerDisplay("IsCompleted = {IsCompleted}, ForceYielding = {ForceYielding}")]
+        [System.Diagnostics.DebuggerDisplay("AsyncContextSwitcherAwaitable: IsCompleted = {IsCompleted}, ForceYielding = {ForceYielding}")]
         public readonly record struct AsyncContextSwitcherAwaitable : System.IEquatable<ReactiveUI.Primitives.Async.AsyncContext.AsyncContextSwitcherAwaitable>, System.Runtime.CompilerServices.INotifyCompletion
         {
             public AsyncContextSwitcherAwaitable(ReactiveUI.Primitives.Async.AsyncContext AsyncContext, bool ForceYielding, System.Threading.CancellationToken CancellationToken) { }
@@ -95,49 +95,49 @@ namespace ReactiveUI.Primitives.Async
 }
 namespace ReactiveUI.Primitives.Async.Advanced
 {
-    [System.Diagnostics.DebuggerDisplay("Factory = {Factory}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSignal: Factory = {Factory}")]
     public sealed class FromAsyncSignal : ReactiveUI.Primitives.Async.IObservableAsync<ReactiveUI.Primitives.RxVoid>
     {
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> factory) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<ReactiveUI.Primitives.RxVoid>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Factory = {Factory}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSubscription: Factory = {Factory}")]
     public sealed class FromAsyncSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<ReactiveUI.Primitives.RxVoid>
     {
         public FromAsyncSubscription(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> factory) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Action = {Action}, TaskScheduler = {TaskScheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Action = {Action}, TaskScheduler = {TaskScheduler}")]
     public sealed class StartSignal : ReactiveUI.Primitives.Async.IObservableAsync<ReactiveUI.Primitives.RxVoid>
     {
         public StartSignal(System.Action action, System.Threading.Tasks.TaskScheduler? taskScheduler) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<ReactiveUI.Primitives.RxVoid>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Action = {Action}, TaskScheduler = {TaskScheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSubscription: Action = {Action}, TaskScheduler = {TaskScheduler}")]
     public sealed class StartSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<ReactiveUI.Primitives.RxVoid>
     {
         public StartSubscription(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Action action, System.Threading.Tasks.TaskScheduler? taskScheduler) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceTask = {SourceTask}")]
+    [System.Diagnostics.DebuggerDisplay("TaskToAsyncSignal: SourceTask = {SourceTask}")]
     public sealed class TaskToAsyncSignal : ReactiveUI.Primitives.Async.IObservableAsync<ReactiveUI.Primitives.RxVoid>
     {
         public TaskToAsyncSignal(System.Threading.Tasks.Task task) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<ReactiveUI.Primitives.RxVoid>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceTask = {SourceTask}, Completed = {SourceTask.IsCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("ToAsyncSignalSubscription: SourceTask = {SourceTask}, Completed = {SourceTask.IsCompleted}")]
     public sealed class ToAsyncSignalSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<ReactiveUI.Primitives.RxVoid>
     {
         public ToAsyncSignalSubscription(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Threading.Tasks.Task task) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, ForceYielding = {ForceYielding}")]
+    [System.Diagnostics.DebuggerDisplay("WitnessOnSignal: Source = {Source}, ForceYielding = {ForceYielding}")]
     public sealed class WitnessOnSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public WitnessOnSignal(ReactiveUI.Primitives.Async.IObservableAsync<T> source, ReactiveUI.Primitives.Async.AsyncContext asyncContext, bool forceYielding) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("AsyncContext = {AsyncContext}, ForceYielding = {ForceYielding}")]
+    [System.Diagnostics.DebuggerDisplay("WitnessOnWitness: AsyncContext = {AsyncContext}, ForceYielding = {ForceYielding}")]
     public sealed class WitnessOnWitness<T> : ReactiveUI.Primitives.Async.WitnessAsync<T>
     {
         public WitnessOnWitness(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, ReactiveUI.Primitives.Async.AsyncContext asyncContext, bool forceYielding) { }

--- a/src/ReactiveUI.Primitives.Async/PublicAPI/net11.0/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Async/PublicAPI/net11.0/PublicAPI.txt
@@ -2,7 +2,7 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Primitives.Tests")]
 namespace ReactiveUI.Primitives.Async
 {
-    [System.Diagnostics.DebuggerDisplay("SynchronizationContext = {SynchronizationContext}, TaskScheduler = {TaskScheduler}, Sequencer = {Sequencer}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncContext: SynchronizationContext = {SynchronizationContext}, TaskScheduler = {TaskScheduler}, Sequencer = {Sequencer}")]
     public record AsyncContext : System.IEquatable<ReactiveUI.Primitives.Async.AsyncContext>
     {
         public ReactiveUI.Primitives.Concurrency.ISequencer? Sequencer { get; init; }
@@ -15,7 +15,7 @@ namespace ReactiveUI.Primitives.Async
         public static ReactiveUI.Primitives.Async.AsyncContext From(System.Threading.Tasks.TaskScheduler taskScheduler) { }
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public static ReactiveUI.Primitives.Async.AsyncContext GetCurrent() { }
-        [System.Diagnostics.DebuggerDisplay("IsCompleted = {IsCompleted}, ForceYielding = {ForceYielding}")]
+        [System.Diagnostics.DebuggerDisplay("AsyncContextSwitcherAwaitable: IsCompleted = {IsCompleted}, ForceYielding = {ForceYielding}")]
         public readonly record struct AsyncContextSwitcherAwaitable : System.IEquatable<ReactiveUI.Primitives.Async.AsyncContext.AsyncContextSwitcherAwaitable>, System.Runtime.CompilerServices.INotifyCompletion
         {
             public AsyncContextSwitcherAwaitable(ReactiveUI.Primitives.Async.AsyncContext AsyncContext, bool ForceYielding, System.Threading.CancellationToken CancellationToken) { }
@@ -95,49 +95,49 @@ namespace ReactiveUI.Primitives.Async
 }
 namespace ReactiveUI.Primitives.Async.Advanced
 {
-    [System.Diagnostics.DebuggerDisplay("Factory = {Factory}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSignal: Factory = {Factory}")]
     public sealed class FromAsyncSignal : ReactiveUI.Primitives.Async.IObservableAsync<ReactiveUI.Primitives.RxVoid>
     {
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> factory) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<ReactiveUI.Primitives.RxVoid>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Factory = {Factory}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSubscription: Factory = {Factory}")]
     public sealed class FromAsyncSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<ReactiveUI.Primitives.RxVoid>
     {
         public FromAsyncSubscription(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> factory) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Action = {Action}, TaskScheduler = {TaskScheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Action = {Action}, TaskScheduler = {TaskScheduler}")]
     public sealed class StartSignal : ReactiveUI.Primitives.Async.IObservableAsync<ReactiveUI.Primitives.RxVoid>
     {
         public StartSignal(System.Action action, System.Threading.Tasks.TaskScheduler? taskScheduler) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<ReactiveUI.Primitives.RxVoid>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Action = {Action}, TaskScheduler = {TaskScheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSubscription: Action = {Action}, TaskScheduler = {TaskScheduler}")]
     public sealed class StartSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<ReactiveUI.Primitives.RxVoid>
     {
         public StartSubscription(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Action action, System.Threading.Tasks.TaskScheduler? taskScheduler) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceTask = {SourceTask}")]
+    [System.Diagnostics.DebuggerDisplay("TaskToAsyncSignal: SourceTask = {SourceTask}")]
     public sealed class TaskToAsyncSignal : ReactiveUI.Primitives.Async.IObservableAsync<ReactiveUI.Primitives.RxVoid>
     {
         public TaskToAsyncSignal(System.Threading.Tasks.Task task) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<ReactiveUI.Primitives.RxVoid>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceTask = {SourceTask}, Completed = {SourceTask.IsCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("ToAsyncSignalSubscription: SourceTask = {SourceTask}, Completed = {SourceTask.IsCompleted}")]
     public sealed class ToAsyncSignalSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<ReactiveUI.Primitives.RxVoid>
     {
         public ToAsyncSignalSubscription(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Threading.Tasks.Task task) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, ForceYielding = {ForceYielding}")]
+    [System.Diagnostics.DebuggerDisplay("WitnessOnSignal: Source = {Source}, ForceYielding = {ForceYielding}")]
     public sealed class WitnessOnSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public WitnessOnSignal(ReactiveUI.Primitives.Async.IObservableAsync<T> source, ReactiveUI.Primitives.Async.AsyncContext asyncContext, bool forceYielding) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("AsyncContext = {AsyncContext}, ForceYielding = {ForceYielding}")]
+    [System.Diagnostics.DebuggerDisplay("WitnessOnWitness: AsyncContext = {AsyncContext}, ForceYielding = {ForceYielding}")]
     public sealed class WitnessOnWitness<T> : ReactiveUI.Primitives.Async.WitnessAsync<T>
     {
         public WitnessOnWitness(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, ReactiveUI.Primitives.Async.AsyncContext asyncContext, bool forceYielding) { }

--- a/src/ReactiveUI.Primitives.Async/PublicAPI/net462/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Async/PublicAPI/net462/PublicAPI.txt
@@ -2,7 +2,7 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Primitives.Tests")]
 namespace ReactiveUI.Primitives.Async
 {
-    [System.Diagnostics.DebuggerDisplay("SynchronizationContext = {SynchronizationContext}, TaskScheduler = {TaskScheduler}, Sequencer = {Sequencer}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncContext: SynchronizationContext = {SynchronizationContext}, TaskScheduler = {TaskScheduler}, Sequencer = {Sequencer}")]
     public record AsyncContext : System.IEquatable<ReactiveUI.Primitives.Async.AsyncContext>
     {
         public ReactiveUI.Primitives.Concurrency.ISequencer? Sequencer { get; init; }
@@ -15,7 +15,7 @@ namespace ReactiveUI.Primitives.Async
         public static ReactiveUI.Primitives.Async.AsyncContext From(System.Threading.Tasks.TaskScheduler taskScheduler) { }
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public static ReactiveUI.Primitives.Async.AsyncContext GetCurrent() { }
-        [System.Diagnostics.DebuggerDisplay("IsCompleted = {IsCompleted}, ForceYielding = {ForceYielding}")]
+        [System.Diagnostics.DebuggerDisplay("AsyncContextSwitcherAwaitable: IsCompleted = {IsCompleted}, ForceYielding = {ForceYielding}")]
         public readonly record struct AsyncContextSwitcherAwaitable : System.IEquatable<ReactiveUI.Primitives.Async.AsyncContext.AsyncContextSwitcherAwaitable>, System.Runtime.CompilerServices.INotifyCompletion
         {
             public AsyncContextSwitcherAwaitable(ReactiveUI.Primitives.Async.AsyncContext AsyncContext, bool ForceYielding, System.Threading.CancellationToken CancellationToken) { }
@@ -95,49 +95,49 @@ namespace ReactiveUI.Primitives.Async
 }
 namespace ReactiveUI.Primitives.Async.Advanced
 {
-    [System.Diagnostics.DebuggerDisplay("Factory = {Factory}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSignal: Factory = {Factory}")]
     public sealed class FromAsyncSignal : ReactiveUI.Primitives.Async.IObservableAsync<ReactiveUI.Primitives.RxVoid>
     {
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> factory) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<ReactiveUI.Primitives.RxVoid>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Factory = {Factory}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSubscription: Factory = {Factory}")]
     public sealed class FromAsyncSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<ReactiveUI.Primitives.RxVoid>
     {
         public FromAsyncSubscription(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> factory) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Action = {Action}, TaskScheduler = {TaskScheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Action = {Action}, TaskScheduler = {TaskScheduler}")]
     public sealed class StartSignal : ReactiveUI.Primitives.Async.IObservableAsync<ReactiveUI.Primitives.RxVoid>
     {
         public StartSignal(System.Action action, System.Threading.Tasks.TaskScheduler? taskScheduler) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<ReactiveUI.Primitives.RxVoid>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Action = {Action}, TaskScheduler = {TaskScheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSubscription: Action = {Action}, TaskScheduler = {TaskScheduler}")]
     public sealed class StartSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<ReactiveUI.Primitives.RxVoid>
     {
         public StartSubscription(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Action action, System.Threading.Tasks.TaskScheduler? taskScheduler) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceTask = {SourceTask}")]
+    [System.Diagnostics.DebuggerDisplay("TaskToAsyncSignal: SourceTask = {SourceTask}")]
     public sealed class TaskToAsyncSignal : ReactiveUI.Primitives.Async.IObservableAsync<ReactiveUI.Primitives.RxVoid>
     {
         public TaskToAsyncSignal(System.Threading.Tasks.Task task) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<ReactiveUI.Primitives.RxVoid>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceTask = {SourceTask}, Completed = {SourceTask.IsCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("ToAsyncSignalSubscription: SourceTask = {SourceTask}, Completed = {SourceTask.IsCompleted}")]
     public sealed class ToAsyncSignalSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<ReactiveUI.Primitives.RxVoid>
     {
         public ToAsyncSignalSubscription(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Threading.Tasks.Task task) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, ForceYielding = {ForceYielding}")]
+    [System.Diagnostics.DebuggerDisplay("WitnessOnSignal: Source = {Source}, ForceYielding = {ForceYielding}")]
     public sealed class WitnessOnSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public WitnessOnSignal(ReactiveUI.Primitives.Async.IObservableAsync<T> source, ReactiveUI.Primitives.Async.AsyncContext asyncContext, bool forceYielding) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("AsyncContext = {AsyncContext}, ForceYielding = {ForceYielding}")]
+    [System.Diagnostics.DebuggerDisplay("WitnessOnWitness: AsyncContext = {AsyncContext}, ForceYielding = {ForceYielding}")]
     public sealed class WitnessOnWitness<T> : ReactiveUI.Primitives.Async.WitnessAsync<T>
     {
         public WitnessOnWitness(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, ReactiveUI.Primitives.Async.AsyncContext asyncContext, bool forceYielding) { }

--- a/src/ReactiveUI.Primitives.Async/PublicAPI/net472/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Async/PublicAPI/net472/PublicAPI.txt
@@ -2,7 +2,7 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Primitives.Tests")]
 namespace ReactiveUI.Primitives.Async
 {
-    [System.Diagnostics.DebuggerDisplay("SynchronizationContext = {SynchronizationContext}, TaskScheduler = {TaskScheduler}, Sequencer = {Sequencer}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncContext: SynchronizationContext = {SynchronizationContext}, TaskScheduler = {TaskScheduler}, Sequencer = {Sequencer}")]
     public record AsyncContext : System.IEquatable<ReactiveUI.Primitives.Async.AsyncContext>
     {
         public ReactiveUI.Primitives.Concurrency.ISequencer? Sequencer { get; init; }
@@ -15,7 +15,7 @@ namespace ReactiveUI.Primitives.Async
         public static ReactiveUI.Primitives.Async.AsyncContext From(System.Threading.Tasks.TaskScheduler taskScheduler) { }
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public static ReactiveUI.Primitives.Async.AsyncContext GetCurrent() { }
-        [System.Diagnostics.DebuggerDisplay("IsCompleted = {IsCompleted}, ForceYielding = {ForceYielding}")]
+        [System.Diagnostics.DebuggerDisplay("AsyncContextSwitcherAwaitable: IsCompleted = {IsCompleted}, ForceYielding = {ForceYielding}")]
         public readonly record struct AsyncContextSwitcherAwaitable : System.IEquatable<ReactiveUI.Primitives.Async.AsyncContext.AsyncContextSwitcherAwaitable>, System.Runtime.CompilerServices.INotifyCompletion
         {
             public AsyncContextSwitcherAwaitable(ReactiveUI.Primitives.Async.AsyncContext AsyncContext, bool ForceYielding, System.Threading.CancellationToken CancellationToken) { }
@@ -95,49 +95,49 @@ namespace ReactiveUI.Primitives.Async
 }
 namespace ReactiveUI.Primitives.Async.Advanced
 {
-    [System.Diagnostics.DebuggerDisplay("Factory = {Factory}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSignal: Factory = {Factory}")]
     public sealed class FromAsyncSignal : ReactiveUI.Primitives.Async.IObservableAsync<ReactiveUI.Primitives.RxVoid>
     {
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> factory) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<ReactiveUI.Primitives.RxVoid>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Factory = {Factory}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSubscription: Factory = {Factory}")]
     public sealed class FromAsyncSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<ReactiveUI.Primitives.RxVoid>
     {
         public FromAsyncSubscription(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> factory) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Action = {Action}, TaskScheduler = {TaskScheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Action = {Action}, TaskScheduler = {TaskScheduler}")]
     public sealed class StartSignal : ReactiveUI.Primitives.Async.IObservableAsync<ReactiveUI.Primitives.RxVoid>
     {
         public StartSignal(System.Action action, System.Threading.Tasks.TaskScheduler? taskScheduler) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<ReactiveUI.Primitives.RxVoid>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Action = {Action}, TaskScheduler = {TaskScheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSubscription: Action = {Action}, TaskScheduler = {TaskScheduler}")]
     public sealed class StartSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<ReactiveUI.Primitives.RxVoid>
     {
         public StartSubscription(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Action action, System.Threading.Tasks.TaskScheduler? taskScheduler) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceTask = {SourceTask}")]
+    [System.Diagnostics.DebuggerDisplay("TaskToAsyncSignal: SourceTask = {SourceTask}")]
     public sealed class TaskToAsyncSignal : ReactiveUI.Primitives.Async.IObservableAsync<ReactiveUI.Primitives.RxVoid>
     {
         public TaskToAsyncSignal(System.Threading.Tasks.Task task) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<ReactiveUI.Primitives.RxVoid>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceTask = {SourceTask}, Completed = {SourceTask.IsCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("ToAsyncSignalSubscription: SourceTask = {SourceTask}, Completed = {SourceTask.IsCompleted}")]
     public sealed class ToAsyncSignalSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<ReactiveUI.Primitives.RxVoid>
     {
         public ToAsyncSignalSubscription(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Threading.Tasks.Task task) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, ForceYielding = {ForceYielding}")]
+    [System.Diagnostics.DebuggerDisplay("WitnessOnSignal: Source = {Source}, ForceYielding = {ForceYielding}")]
     public sealed class WitnessOnSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public WitnessOnSignal(ReactiveUI.Primitives.Async.IObservableAsync<T> source, ReactiveUI.Primitives.Async.AsyncContext asyncContext, bool forceYielding) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("AsyncContext = {AsyncContext}, ForceYielding = {ForceYielding}")]
+    [System.Diagnostics.DebuggerDisplay("WitnessOnWitness: AsyncContext = {AsyncContext}, ForceYielding = {ForceYielding}")]
     public sealed class WitnessOnWitness<T> : ReactiveUI.Primitives.Async.WitnessAsync<T>
     {
         public WitnessOnWitness(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, ReactiveUI.Primitives.Async.AsyncContext asyncContext, bool forceYielding) { }

--- a/src/ReactiveUI.Primitives.Async/PublicAPI/net48/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Async/PublicAPI/net48/PublicAPI.txt
@@ -2,7 +2,7 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Primitives.Tests")]
 namespace ReactiveUI.Primitives.Async
 {
-    [System.Diagnostics.DebuggerDisplay("SynchronizationContext = {SynchronizationContext}, TaskScheduler = {TaskScheduler}, Sequencer = {Sequencer}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncContext: SynchronizationContext = {SynchronizationContext}, TaskScheduler = {TaskScheduler}, Sequencer = {Sequencer}")]
     public record AsyncContext : System.IEquatable<ReactiveUI.Primitives.Async.AsyncContext>
     {
         public ReactiveUI.Primitives.Concurrency.ISequencer? Sequencer { get; init; }
@@ -15,7 +15,7 @@ namespace ReactiveUI.Primitives.Async
         public static ReactiveUI.Primitives.Async.AsyncContext From(System.Threading.Tasks.TaskScheduler taskScheduler) { }
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public static ReactiveUI.Primitives.Async.AsyncContext GetCurrent() { }
-        [System.Diagnostics.DebuggerDisplay("IsCompleted = {IsCompleted}, ForceYielding = {ForceYielding}")]
+        [System.Diagnostics.DebuggerDisplay("AsyncContextSwitcherAwaitable: IsCompleted = {IsCompleted}, ForceYielding = {ForceYielding}")]
         public readonly record struct AsyncContextSwitcherAwaitable : System.IEquatable<ReactiveUI.Primitives.Async.AsyncContext.AsyncContextSwitcherAwaitable>, System.Runtime.CompilerServices.INotifyCompletion
         {
             public AsyncContextSwitcherAwaitable(ReactiveUI.Primitives.Async.AsyncContext AsyncContext, bool ForceYielding, System.Threading.CancellationToken CancellationToken) { }
@@ -95,49 +95,49 @@ namespace ReactiveUI.Primitives.Async
 }
 namespace ReactiveUI.Primitives.Async.Advanced
 {
-    [System.Diagnostics.DebuggerDisplay("Factory = {Factory}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSignal: Factory = {Factory}")]
     public sealed class FromAsyncSignal : ReactiveUI.Primitives.Async.IObservableAsync<ReactiveUI.Primitives.RxVoid>
     {
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> factory) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<ReactiveUI.Primitives.RxVoid>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Factory = {Factory}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSubscription: Factory = {Factory}")]
     public sealed class FromAsyncSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<ReactiveUI.Primitives.RxVoid>
     {
         public FromAsyncSubscription(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> factory) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Action = {Action}, TaskScheduler = {TaskScheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Action = {Action}, TaskScheduler = {TaskScheduler}")]
     public sealed class StartSignal : ReactiveUI.Primitives.Async.IObservableAsync<ReactiveUI.Primitives.RxVoid>
     {
         public StartSignal(System.Action action, System.Threading.Tasks.TaskScheduler? taskScheduler) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<ReactiveUI.Primitives.RxVoid>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Action = {Action}, TaskScheduler = {TaskScheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSubscription: Action = {Action}, TaskScheduler = {TaskScheduler}")]
     public sealed class StartSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<ReactiveUI.Primitives.RxVoid>
     {
         public StartSubscription(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Action action, System.Threading.Tasks.TaskScheduler? taskScheduler) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceTask = {SourceTask}")]
+    [System.Diagnostics.DebuggerDisplay("TaskToAsyncSignal: SourceTask = {SourceTask}")]
     public sealed class TaskToAsyncSignal : ReactiveUI.Primitives.Async.IObservableAsync<ReactiveUI.Primitives.RxVoid>
     {
         public TaskToAsyncSignal(System.Threading.Tasks.Task task) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<ReactiveUI.Primitives.RxVoid>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceTask = {SourceTask}, Completed = {SourceTask.IsCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("ToAsyncSignalSubscription: SourceTask = {SourceTask}, Completed = {SourceTask.IsCompleted}")]
     public sealed class ToAsyncSignalSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<ReactiveUI.Primitives.RxVoid>
     {
         public ToAsyncSignalSubscription(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Threading.Tasks.Task task) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, ForceYielding = {ForceYielding}")]
+    [System.Diagnostics.DebuggerDisplay("WitnessOnSignal: Source = {Source}, ForceYielding = {ForceYielding}")]
     public sealed class WitnessOnSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public WitnessOnSignal(ReactiveUI.Primitives.Async.IObservableAsync<T> source, ReactiveUI.Primitives.Async.AsyncContext asyncContext, bool forceYielding) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("AsyncContext = {AsyncContext}, ForceYielding = {ForceYielding}")]
+    [System.Diagnostics.DebuggerDisplay("WitnessOnWitness: AsyncContext = {AsyncContext}, ForceYielding = {ForceYielding}")]
     public sealed class WitnessOnWitness<T> : ReactiveUI.Primitives.Async.WitnessAsync<T>
     {
         public WitnessOnWitness(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, ReactiveUI.Primitives.Async.AsyncContext asyncContext, bool forceYielding) { }

--- a/src/ReactiveUI.Primitives.Async/PublicAPI/net481/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Async/PublicAPI/net481/PublicAPI.txt
@@ -2,7 +2,7 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Primitives.Tests")]
 namespace ReactiveUI.Primitives.Async
 {
-    [System.Diagnostics.DebuggerDisplay("SynchronizationContext = {SynchronizationContext}, TaskScheduler = {TaskScheduler}, Sequencer = {Sequencer}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncContext: SynchronizationContext = {SynchronizationContext}, TaskScheduler = {TaskScheduler}, Sequencer = {Sequencer}")]
     public record AsyncContext : System.IEquatable<ReactiveUI.Primitives.Async.AsyncContext>
     {
         public ReactiveUI.Primitives.Concurrency.ISequencer? Sequencer { get; init; }
@@ -15,7 +15,7 @@ namespace ReactiveUI.Primitives.Async
         public static ReactiveUI.Primitives.Async.AsyncContext From(System.Threading.Tasks.TaskScheduler taskScheduler) { }
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public static ReactiveUI.Primitives.Async.AsyncContext GetCurrent() { }
-        [System.Diagnostics.DebuggerDisplay("IsCompleted = {IsCompleted}, ForceYielding = {ForceYielding}")]
+        [System.Diagnostics.DebuggerDisplay("AsyncContextSwitcherAwaitable: IsCompleted = {IsCompleted}, ForceYielding = {ForceYielding}")]
         public readonly record struct AsyncContextSwitcherAwaitable : System.IEquatable<ReactiveUI.Primitives.Async.AsyncContext.AsyncContextSwitcherAwaitable>, System.Runtime.CompilerServices.INotifyCompletion
         {
             public AsyncContextSwitcherAwaitable(ReactiveUI.Primitives.Async.AsyncContext AsyncContext, bool ForceYielding, System.Threading.CancellationToken CancellationToken) { }
@@ -95,49 +95,49 @@ namespace ReactiveUI.Primitives.Async
 }
 namespace ReactiveUI.Primitives.Async.Advanced
 {
-    [System.Diagnostics.DebuggerDisplay("Factory = {Factory}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSignal: Factory = {Factory}")]
     public sealed class FromAsyncSignal : ReactiveUI.Primitives.Async.IObservableAsync<ReactiveUI.Primitives.RxVoid>
     {
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> factory) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<ReactiveUI.Primitives.RxVoid>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Factory = {Factory}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSubscription: Factory = {Factory}")]
     public sealed class FromAsyncSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<ReactiveUI.Primitives.RxVoid>
     {
         public FromAsyncSubscription(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> factory) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Action = {Action}, TaskScheduler = {TaskScheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Action = {Action}, TaskScheduler = {TaskScheduler}")]
     public sealed class StartSignal : ReactiveUI.Primitives.Async.IObservableAsync<ReactiveUI.Primitives.RxVoid>
     {
         public StartSignal(System.Action action, System.Threading.Tasks.TaskScheduler? taskScheduler) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<ReactiveUI.Primitives.RxVoid>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Action = {Action}, TaskScheduler = {TaskScheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSubscription: Action = {Action}, TaskScheduler = {TaskScheduler}")]
     public sealed class StartSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<ReactiveUI.Primitives.RxVoid>
     {
         public StartSubscription(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Action action, System.Threading.Tasks.TaskScheduler? taskScheduler) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceTask = {SourceTask}")]
+    [System.Diagnostics.DebuggerDisplay("TaskToAsyncSignal: SourceTask = {SourceTask}")]
     public sealed class TaskToAsyncSignal : ReactiveUI.Primitives.Async.IObservableAsync<ReactiveUI.Primitives.RxVoid>
     {
         public TaskToAsyncSignal(System.Threading.Tasks.Task task) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<ReactiveUI.Primitives.RxVoid>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceTask = {SourceTask}, Completed = {SourceTask.IsCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("ToAsyncSignalSubscription: SourceTask = {SourceTask}, Completed = {SourceTask.IsCompleted}")]
     public sealed class ToAsyncSignalSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<ReactiveUI.Primitives.RxVoid>
     {
         public ToAsyncSignalSubscription(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Threading.Tasks.Task task) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, ForceYielding = {ForceYielding}")]
+    [System.Diagnostics.DebuggerDisplay("WitnessOnSignal: Source = {Source}, ForceYielding = {ForceYielding}")]
     public sealed class WitnessOnSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public WitnessOnSignal(ReactiveUI.Primitives.Async.IObservableAsync<T> source, ReactiveUI.Primitives.Async.AsyncContext asyncContext, bool forceYielding) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("AsyncContext = {AsyncContext}, ForceYielding = {ForceYielding}")]
+    [System.Diagnostics.DebuggerDisplay("WitnessOnWitness: AsyncContext = {AsyncContext}, ForceYielding = {ForceYielding}")]
     public sealed class WitnessOnWitness<T> : ReactiveUI.Primitives.Async.WitnessAsync<T>
     {
         public WitnessOnWitness(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, ReactiveUI.Primitives.Async.AsyncContext asyncContext, bool forceYielding) { }

--- a/src/ReactiveUI.Primitives.Async/PublicAPI/net8.0/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Async/PublicAPI/net8.0/PublicAPI.txt
@@ -2,7 +2,7 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Primitives.Tests")]
 namespace ReactiveUI.Primitives.Async
 {
-    [System.Diagnostics.DebuggerDisplay("SynchronizationContext = {SynchronizationContext}, TaskScheduler = {TaskScheduler}, Sequencer = {Sequencer}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncContext: SynchronizationContext = {SynchronizationContext}, TaskScheduler = {TaskScheduler}, Sequencer = {Sequencer}")]
     public record AsyncContext : System.IEquatable<ReactiveUI.Primitives.Async.AsyncContext>
     {
         public ReactiveUI.Primitives.Concurrency.ISequencer? Sequencer { get; init; }
@@ -15,7 +15,7 @@ namespace ReactiveUI.Primitives.Async
         public static ReactiveUI.Primitives.Async.AsyncContext From(System.Threading.Tasks.TaskScheduler taskScheduler) { }
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public static ReactiveUI.Primitives.Async.AsyncContext GetCurrent() { }
-        [System.Diagnostics.DebuggerDisplay("IsCompleted = {IsCompleted}, ForceYielding = {ForceYielding}")]
+        [System.Diagnostics.DebuggerDisplay("AsyncContextSwitcherAwaitable: IsCompleted = {IsCompleted}, ForceYielding = {ForceYielding}")]
         public readonly record struct AsyncContextSwitcherAwaitable : System.IEquatable<ReactiveUI.Primitives.Async.AsyncContext.AsyncContextSwitcherAwaitable>, System.Runtime.CompilerServices.INotifyCompletion
         {
             public AsyncContextSwitcherAwaitable(ReactiveUI.Primitives.Async.AsyncContext AsyncContext, bool ForceYielding, System.Threading.CancellationToken CancellationToken) { }
@@ -95,49 +95,49 @@ namespace ReactiveUI.Primitives.Async
 }
 namespace ReactiveUI.Primitives.Async.Advanced
 {
-    [System.Diagnostics.DebuggerDisplay("Factory = {Factory}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSignal: Factory = {Factory}")]
     public sealed class FromAsyncSignal : ReactiveUI.Primitives.Async.IObservableAsync<ReactiveUI.Primitives.RxVoid>
     {
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> factory) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<ReactiveUI.Primitives.RxVoid>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Factory = {Factory}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSubscription: Factory = {Factory}")]
     public sealed class FromAsyncSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<ReactiveUI.Primitives.RxVoid>
     {
         public FromAsyncSubscription(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> factory) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Action = {Action}, TaskScheduler = {TaskScheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Action = {Action}, TaskScheduler = {TaskScheduler}")]
     public sealed class StartSignal : ReactiveUI.Primitives.Async.IObservableAsync<ReactiveUI.Primitives.RxVoid>
     {
         public StartSignal(System.Action action, System.Threading.Tasks.TaskScheduler? taskScheduler) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<ReactiveUI.Primitives.RxVoid>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Action = {Action}, TaskScheduler = {TaskScheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSubscription: Action = {Action}, TaskScheduler = {TaskScheduler}")]
     public sealed class StartSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<ReactiveUI.Primitives.RxVoid>
     {
         public StartSubscription(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Action action, System.Threading.Tasks.TaskScheduler? taskScheduler) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceTask = {SourceTask}")]
+    [System.Diagnostics.DebuggerDisplay("TaskToAsyncSignal: SourceTask = {SourceTask}")]
     public sealed class TaskToAsyncSignal : ReactiveUI.Primitives.Async.IObservableAsync<ReactiveUI.Primitives.RxVoid>
     {
         public TaskToAsyncSignal(System.Threading.Tasks.Task task) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<ReactiveUI.Primitives.RxVoid>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceTask = {SourceTask}, Completed = {SourceTask.IsCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("ToAsyncSignalSubscription: SourceTask = {SourceTask}, Completed = {SourceTask.IsCompleted}")]
     public sealed class ToAsyncSignalSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<ReactiveUI.Primitives.RxVoid>
     {
         public ToAsyncSignalSubscription(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Threading.Tasks.Task task) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, ForceYielding = {ForceYielding}")]
+    [System.Diagnostics.DebuggerDisplay("WitnessOnSignal: Source = {Source}, ForceYielding = {ForceYielding}")]
     public sealed class WitnessOnSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public WitnessOnSignal(ReactiveUI.Primitives.Async.IObservableAsync<T> source, ReactiveUI.Primitives.Async.AsyncContext asyncContext, bool forceYielding) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("AsyncContext = {AsyncContext}, ForceYielding = {ForceYielding}")]
+    [System.Diagnostics.DebuggerDisplay("WitnessOnWitness: AsyncContext = {AsyncContext}, ForceYielding = {ForceYielding}")]
     public sealed class WitnessOnWitness<T> : ReactiveUI.Primitives.Async.WitnessAsync<T>
     {
         public WitnessOnWitness(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, ReactiveUI.Primitives.Async.AsyncContext asyncContext, bool forceYielding) { }

--- a/src/ReactiveUI.Primitives.Async/PublicAPI/net9.0/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Async/PublicAPI/net9.0/PublicAPI.txt
@@ -2,7 +2,7 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Primitives.Tests")]
 namespace ReactiveUI.Primitives.Async
 {
-    [System.Diagnostics.DebuggerDisplay("SynchronizationContext = {SynchronizationContext}, TaskScheduler = {TaskScheduler}, Sequencer = {Sequencer}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncContext: SynchronizationContext = {SynchronizationContext}, TaskScheduler = {TaskScheduler}, Sequencer = {Sequencer}")]
     public record AsyncContext : System.IEquatable<ReactiveUI.Primitives.Async.AsyncContext>
     {
         public ReactiveUI.Primitives.Concurrency.ISequencer? Sequencer { get; init; }
@@ -15,7 +15,7 @@ namespace ReactiveUI.Primitives.Async
         public static ReactiveUI.Primitives.Async.AsyncContext From(System.Threading.Tasks.TaskScheduler taskScheduler) { }
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public static ReactiveUI.Primitives.Async.AsyncContext GetCurrent() { }
-        [System.Diagnostics.DebuggerDisplay("IsCompleted = {IsCompleted}, ForceYielding = {ForceYielding}")]
+        [System.Diagnostics.DebuggerDisplay("AsyncContextSwitcherAwaitable: IsCompleted = {IsCompleted}, ForceYielding = {ForceYielding}")]
         public readonly record struct AsyncContextSwitcherAwaitable : System.IEquatable<ReactiveUI.Primitives.Async.AsyncContext.AsyncContextSwitcherAwaitable>, System.Runtime.CompilerServices.INotifyCompletion
         {
             public AsyncContextSwitcherAwaitable(ReactiveUI.Primitives.Async.AsyncContext AsyncContext, bool ForceYielding, System.Threading.CancellationToken CancellationToken) { }
@@ -95,49 +95,49 @@ namespace ReactiveUI.Primitives.Async
 }
 namespace ReactiveUI.Primitives.Async.Advanced
 {
-    [System.Diagnostics.DebuggerDisplay("Factory = {Factory}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSignal: Factory = {Factory}")]
     public sealed class FromAsyncSignal : ReactiveUI.Primitives.Async.IObservableAsync<ReactiveUI.Primitives.RxVoid>
     {
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> factory) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<ReactiveUI.Primitives.RxVoid>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Factory = {Factory}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSubscription: Factory = {Factory}")]
     public sealed class FromAsyncSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<ReactiveUI.Primitives.RxVoid>
     {
         public FromAsyncSubscription(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> factory) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Action = {Action}, TaskScheduler = {TaskScheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Action = {Action}, TaskScheduler = {TaskScheduler}")]
     public sealed class StartSignal : ReactiveUI.Primitives.Async.IObservableAsync<ReactiveUI.Primitives.RxVoid>
     {
         public StartSignal(System.Action action, System.Threading.Tasks.TaskScheduler? taskScheduler) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<ReactiveUI.Primitives.RxVoid>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Action = {Action}, TaskScheduler = {TaskScheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSubscription: Action = {Action}, TaskScheduler = {TaskScheduler}")]
     public sealed class StartSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<ReactiveUI.Primitives.RxVoid>
     {
         public StartSubscription(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Action action, System.Threading.Tasks.TaskScheduler? taskScheduler) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceTask = {SourceTask}")]
+    [System.Diagnostics.DebuggerDisplay("TaskToAsyncSignal: SourceTask = {SourceTask}")]
     public sealed class TaskToAsyncSignal : ReactiveUI.Primitives.Async.IObservableAsync<ReactiveUI.Primitives.RxVoid>
     {
         public TaskToAsyncSignal(System.Threading.Tasks.Task task) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<ReactiveUI.Primitives.RxVoid>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SourceTask = {SourceTask}, Completed = {SourceTask.IsCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("ToAsyncSignalSubscription: SourceTask = {SourceTask}, Completed = {SourceTask.IsCompleted}")]
     public sealed class ToAsyncSignalSubscription : ReactiveUI.Primitives.Async.Advanced.TaskSignalSubscription<ReactiveUI.Primitives.RxVoid>
     {
         public ToAsyncSignalSubscription(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Threading.Tasks.Task task) { }
         protected override System.Threading.Tasks.ValueTask ExecuteAsyncCore(ReactiveUI.Primitives.Async.IObserverAsync<ReactiveUI.Primitives.RxVoid> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, ForceYielding = {ForceYielding}")]
+    [System.Diagnostics.DebuggerDisplay("WitnessOnSignal: Source = {Source}, ForceYielding = {ForceYielding}")]
     public sealed class WitnessOnSignal<T> : ReactiveUI.Primitives.Async.IObservableAsync<T>
     {
         public WitnessOnSignal(ReactiveUI.Primitives.Async.IObservableAsync<T> source, ReactiveUI.Primitives.Async.AsyncContext asyncContext, bool forceYielding) { }
         System.Threading.Tasks.ValueTask<System.IAsyncDisposable> ReactiveUI.Primitives.Async.IObservableAsync<T>.SubscribeAsync(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Diagnostics.DebuggerDisplay("AsyncContext = {AsyncContext}, ForceYielding = {ForceYielding}")]
+    [System.Diagnostics.DebuggerDisplay("WitnessOnWitness: AsyncContext = {AsyncContext}, ForceYielding = {ForceYielding}")]
     public sealed class WitnessOnWitness<T> : ReactiveUI.Primitives.Async.WitnessAsync<T>
     {
         public WitnessOnWitness(ReactiveUI.Primitives.Async.IObserverAsync<T> observer, ReactiveUI.Primitives.Async.AsyncContext asyncContext, bool forceYielding) { }

--- a/src/ReactiveUI.Primitives.Avalonia.Reactive/Concurrency/AvaloniaScheduler.cs
+++ b/src/ReactiveUI.Primitives.Avalonia.Reactive/Concurrency/AvaloniaScheduler.cs
@@ -9,7 +9,7 @@ namespace ReactiveUI.Primitives.Reactive.Concurrency;
 
 /// <summary>Avalonia UI-thread scheduler that coalesces scheduled work onto a dispatcher drain.</summary>
 /// <seealso cref="System.Reactive.Concurrency.IScheduler" />
-[System.Diagnostics.DebuggerDisplay("Dispatcher = {Dispatcher}, Priority = {Priority}")]
+[System.Diagnostics.DebuggerDisplay("AvaloniaScheduler: Dispatcher = {Dispatcher}, Priority = {Priority}")]
 public sealed class AvaloniaScheduler : CoalescingDispatchScheduler
 {
     /// <summary>Gets the shared scheduler for <see cref="Dispatcher.UIThread"/>.</summary>

--- a/src/ReactiveUI.Primitives.Avalonia.Reactive/PublicAPI/net10.0/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Avalonia.Reactive/PublicAPI/net10.0/PublicAPI.txt
@@ -1,7 +1,7 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Primitives.Avalonia.Reactive.Tests")]
 namespace ReactiveUI.Primitives.Reactive.Concurrency;
 
-[System.Diagnostics.DebuggerDisplay("Dispatcher = {Dispatcher}, Priority = {Priority}")]
+[System.Diagnostics.DebuggerDisplay("AvaloniaScheduler: Dispatcher = {Dispatcher}, Priority = {Priority}")]
 public sealed class AvaloniaScheduler : ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler
 {
     public AvaloniaScheduler(Avalonia.Threading.Dispatcher dispatcher) { }
@@ -12,7 +12,7 @@ public sealed class AvaloniaScheduler : ReactiveUI.Primitives.Reactive.Concurren
     protected override bool Post(System.Action drain) { }
     protected override System.IDisposable ScheduleOnDispatcher(System.Action work, System.TimeSpan dueTime) { }
 }
-[System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
+[System.Diagnostics.DebuggerDisplay("CoalescingDispatchScheduler: ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
 public abstract class CoalescingDispatchScheduler : System.Reactive.Concurrency.LocalScheduler
 {
     protected CoalescingDispatchScheduler() { }

--- a/src/ReactiveUI.Primitives.Avalonia.Reactive/PublicAPI/net11.0/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Avalonia.Reactive/PublicAPI/net11.0/PublicAPI.txt
@@ -1,7 +1,7 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Primitives.Avalonia.Reactive.Tests")]
 namespace ReactiveUI.Primitives.Reactive.Concurrency;
 
-[System.Diagnostics.DebuggerDisplay("Dispatcher = {Dispatcher}, Priority = {Priority}")]
+[System.Diagnostics.DebuggerDisplay("AvaloniaScheduler: Dispatcher = {Dispatcher}, Priority = {Priority}")]
 public sealed class AvaloniaScheduler : ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler
 {
     public AvaloniaScheduler(Avalonia.Threading.Dispatcher dispatcher) { }
@@ -12,7 +12,7 @@ public sealed class AvaloniaScheduler : ReactiveUI.Primitives.Reactive.Concurren
     protected override bool Post(System.Action drain) { }
     protected override System.IDisposable ScheduleOnDispatcher(System.Action work, System.TimeSpan dueTime) { }
 }
-[System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
+[System.Diagnostics.DebuggerDisplay("CoalescingDispatchScheduler: ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
 public abstract class CoalescingDispatchScheduler : System.Reactive.Concurrency.LocalScheduler
 {
     protected CoalescingDispatchScheduler() { }

--- a/src/ReactiveUI.Primitives.Avalonia.Reactive/PublicAPI/net8.0/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Avalonia.Reactive/PublicAPI/net8.0/PublicAPI.txt
@@ -1,7 +1,7 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Primitives.Avalonia.Reactive.Tests")]
 namespace ReactiveUI.Primitives.Reactive.Concurrency;
 
-[System.Diagnostics.DebuggerDisplay("Dispatcher = {Dispatcher}, Priority = {Priority}")]
+[System.Diagnostics.DebuggerDisplay("AvaloniaScheduler: Dispatcher = {Dispatcher}, Priority = {Priority}")]
 public sealed class AvaloniaScheduler : ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler
 {
     public AvaloniaScheduler(Avalonia.Threading.Dispatcher dispatcher) { }
@@ -12,7 +12,7 @@ public sealed class AvaloniaScheduler : ReactiveUI.Primitives.Reactive.Concurren
     protected override bool Post(System.Action drain) { }
     protected override System.IDisposable ScheduleOnDispatcher(System.Action work, System.TimeSpan dueTime) { }
 }
-[System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
+[System.Diagnostics.DebuggerDisplay("CoalescingDispatchScheduler: ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
 public abstract class CoalescingDispatchScheduler : System.Reactive.Concurrency.LocalScheduler
 {
     protected CoalescingDispatchScheduler() { }

--- a/src/ReactiveUI.Primitives.Avalonia.Reactive/PublicAPI/net9.0/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Avalonia.Reactive/PublicAPI/net9.0/PublicAPI.txt
@@ -1,7 +1,7 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Primitives.Avalonia.Reactive.Tests")]
 namespace ReactiveUI.Primitives.Reactive.Concurrency;
 
-[System.Diagnostics.DebuggerDisplay("Dispatcher = {Dispatcher}, Priority = {Priority}")]
+[System.Diagnostics.DebuggerDisplay("AvaloniaScheduler: Dispatcher = {Dispatcher}, Priority = {Priority}")]
 public sealed class AvaloniaScheduler : ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler
 {
     public AvaloniaScheduler(Avalonia.Threading.Dispatcher dispatcher) { }
@@ -12,7 +12,7 @@ public sealed class AvaloniaScheduler : ReactiveUI.Primitives.Reactive.Concurren
     protected override bool Post(System.Action drain) { }
     protected override System.IDisposable ScheduleOnDispatcher(System.Action work, System.TimeSpan dueTime) { }
 }
-[System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
+[System.Diagnostics.DebuggerDisplay("CoalescingDispatchScheduler: ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
 public abstract class CoalescingDispatchScheduler : System.Reactive.Concurrency.LocalScheduler
 {
     protected CoalescingDispatchScheduler() { }

--- a/src/ReactiveUI.Primitives.Blazor.Reactive/Concurrency/BlazorRendererSequencer.cs
+++ b/src/ReactiveUI.Primitives.Blazor.Reactive/Concurrency/BlazorRendererSequencer.cs
@@ -10,7 +10,7 @@ namespace ReactiveUI.Primitives.Blazor.Reactive.Concurrency;
 
 /// <summary>Scheduler that coalesces scheduled work through a Blazor renderer dispatcher delegate.</summary>
 /// <seealso cref="System.Reactive.Concurrency.IScheduler" />
-[System.Diagnostics.DebuggerDisplay("InvokeAsync = {_invokeAsync}, UnhandledExceptionHandler = {UnhandledExceptionHandler}")]
+[System.Diagnostics.DebuggerDisplay("BlazorRendererSequencer: InvokeAsync = {_invokeAsync}, UnhandledExceptionHandler = {UnhandledExceptionHandler}")]
 public sealed class BlazorRendererSequencer : CoalescingDispatchScheduler
 {
     /// <summary>Delegate used to marshal work through Blazor's renderer.</summary>

--- a/src/ReactiveUI.Primitives.Blazor.Reactive/PublicAPI/net10.0/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Blazor.Reactive/PublicAPI/net10.0/PublicAPI.txt
@@ -22,7 +22,7 @@ namespace ReactiveUI.Primitives.Blazor.Reactive.Components
 }
 namespace ReactiveUI.Primitives.Blazor.Reactive.Concurrency
 {
-    [System.Diagnostics.DebuggerDisplay("InvokeAsync = {_invokeAsync}, UnhandledExceptionHandler = {UnhandledExceptionHandler}")]
+    [System.Diagnostics.DebuggerDisplay("BlazorRendererSequencer: InvokeAsync = {_invokeAsync}, UnhandledExceptionHandler = {UnhandledExceptionHandler}")]
     public sealed class BlazorRendererSequencer : ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler
     {
         public BlazorRendererSequencer(Microsoft.AspNetCore.Components.Dispatcher dispatcher) { }
@@ -40,7 +40,7 @@ namespace ReactiveUI.Primitives.Blazor.Reactive.Concurrency
 }
 namespace ReactiveUI.Primitives.Reactive.Concurrency
 {
-    [System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
+    [System.Diagnostics.DebuggerDisplay("CoalescingDispatchScheduler: ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
     public abstract class CoalescingDispatchScheduler : System.Reactive.Concurrency.LocalScheduler
     {
         protected CoalescingDispatchScheduler() { }

--- a/src/ReactiveUI.Primitives.Blazor.Reactive/PublicAPI/net11.0/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Blazor.Reactive/PublicAPI/net11.0/PublicAPI.txt
@@ -22,7 +22,7 @@ namespace ReactiveUI.Primitives.Blazor.Reactive.Components
 }
 namespace ReactiveUI.Primitives.Blazor.Reactive.Concurrency
 {
-    [System.Diagnostics.DebuggerDisplay("InvokeAsync = {_invokeAsync}, UnhandledExceptionHandler = {UnhandledExceptionHandler}")]
+    [System.Diagnostics.DebuggerDisplay("BlazorRendererSequencer: InvokeAsync = {_invokeAsync}, UnhandledExceptionHandler = {UnhandledExceptionHandler}")]
     public sealed class BlazorRendererSequencer : ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler
     {
         public BlazorRendererSequencer(Microsoft.AspNetCore.Components.Dispatcher dispatcher) { }
@@ -40,7 +40,7 @@ namespace ReactiveUI.Primitives.Blazor.Reactive.Concurrency
 }
 namespace ReactiveUI.Primitives.Reactive.Concurrency
 {
-    [System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
+    [System.Diagnostics.DebuggerDisplay("CoalescingDispatchScheduler: ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
     public abstract class CoalescingDispatchScheduler : System.Reactive.Concurrency.LocalScheduler
     {
         protected CoalescingDispatchScheduler() { }

--- a/src/ReactiveUI.Primitives.Blazor.Reactive/PublicAPI/net8.0/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Blazor.Reactive/PublicAPI/net8.0/PublicAPI.txt
@@ -22,7 +22,7 @@ namespace ReactiveUI.Primitives.Blazor.Reactive.Components
 }
 namespace ReactiveUI.Primitives.Blazor.Reactive.Concurrency
 {
-    [System.Diagnostics.DebuggerDisplay("InvokeAsync = {_invokeAsync}, UnhandledExceptionHandler = {UnhandledExceptionHandler}")]
+    [System.Diagnostics.DebuggerDisplay("BlazorRendererSequencer: InvokeAsync = {_invokeAsync}, UnhandledExceptionHandler = {UnhandledExceptionHandler}")]
     public sealed class BlazorRendererSequencer : ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler
     {
         public BlazorRendererSequencer(Microsoft.AspNetCore.Components.Dispatcher dispatcher) { }
@@ -40,7 +40,7 @@ namespace ReactiveUI.Primitives.Blazor.Reactive.Concurrency
 }
 namespace ReactiveUI.Primitives.Reactive.Concurrency
 {
-    [System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
+    [System.Diagnostics.DebuggerDisplay("CoalescingDispatchScheduler: ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
     public abstract class CoalescingDispatchScheduler : System.Reactive.Concurrency.LocalScheduler
     {
         protected CoalescingDispatchScheduler() { }

--- a/src/ReactiveUI.Primitives.Blazor.Reactive/PublicAPI/net9.0/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Blazor.Reactive/PublicAPI/net9.0/PublicAPI.txt
@@ -22,7 +22,7 @@ namespace ReactiveUI.Primitives.Blazor.Reactive.Components
 }
 namespace ReactiveUI.Primitives.Blazor.Reactive.Concurrency
 {
-    [System.Diagnostics.DebuggerDisplay("InvokeAsync = {_invokeAsync}, UnhandledExceptionHandler = {UnhandledExceptionHandler}")]
+    [System.Diagnostics.DebuggerDisplay("BlazorRendererSequencer: InvokeAsync = {_invokeAsync}, UnhandledExceptionHandler = {UnhandledExceptionHandler}")]
     public sealed class BlazorRendererSequencer : ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler
     {
         public BlazorRendererSequencer(Microsoft.AspNetCore.Components.Dispatcher dispatcher) { }
@@ -40,7 +40,7 @@ namespace ReactiveUI.Primitives.Blazor.Reactive.Concurrency
 }
 namespace ReactiveUI.Primitives.Reactive.Concurrency
 {
-    [System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
+    [System.Diagnostics.DebuggerDisplay("CoalescingDispatchScheduler: ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
     public abstract class CoalescingDispatchScheduler : System.Reactive.Concurrency.LocalScheduler
     {
         protected CoalescingDispatchScheduler() { }

--- a/src/ReactiveUI.Primitives.Core/Advanced/AggregateWitness.cs
+++ b/src/ReactiveUI.Primitives.Core/Advanced/AggregateWitness.cs
@@ -17,7 +17,7 @@ namespace ReactiveUI.Primitives.Advanced;
 /// <typeparam name="TAggregator">The value-type accumulator that folds values and yields the result.</typeparam>
 /// <param name="observer">The downstream observer.</param>
 /// <param name="aggregator">The seed accumulator.</param>
-[System.Diagnostics.DebuggerDisplay("Done = {_done}, Aggregator = {_aggregator}")]
+[System.Diagnostics.DebuggerDisplay("AggregateWitness: Done = {_done}, Aggregator = {_aggregator}")]
 public sealed class AggregateWitness<T, TResult, TAggregator>(IObserver<TResult> observer, TAggregator aggregator) : IObserver<T>, IDisposable
     where TAggregator : struct, IAggregator<T, TResult, TAggregator>
 {

--- a/src/ReactiveUI.Primitives.Core/Advanced/AllPredicateWitness.cs
+++ b/src/ReactiveUI.Primitives.Core/Advanced/AllPredicateWitness.cs
@@ -10,7 +10,7 @@ namespace ReactiveUI.Primitives.Advanced;
 /// <typeparam name="T">The source value type.</typeparam>
 /// <param name="observer">The downstream observer.</param>
 /// <param name="predicate">The predicate.</param>
-[System.Diagnostics.DebuggerDisplay("Done = {_done}, Observer = {_observer}")]
+[System.Diagnostics.DebuggerDisplay("AllPredicateWitness: Done = {_done}, Observer = {_observer}")]
 public sealed class AllPredicateWitness<T>(IObserver<bool> observer, Func<T, bool> predicate) : IObserver<T>, IDisposable
 {
     /// <summary>The predicate.</summary>

--- a/src/ReactiveUI.Primitives.Core/Advanced/AnyPredicateWitness.cs
+++ b/src/ReactiveUI.Primitives.Core/Advanced/AnyPredicateWitness.cs
@@ -10,7 +10,7 @@ namespace ReactiveUI.Primitives.Advanced;
 /// <typeparam name="T">The source value type.</typeparam>
 /// <param name="observer">The downstream observer.</param>
 /// <param name="predicate">The predicate.</param>
-[System.Diagnostics.DebuggerDisplay("Done = {_done}, Observer = {_observer}")]
+[System.Diagnostics.DebuggerDisplay("AnyPredicateWitness: Done = {_done}, Observer = {_observer}")]
 public sealed class AnyPredicateWitness<T>(IObserver<bool> observer, Func<T, bool> predicate) : IObserver<T>, IDisposable
 {
     /// <summary>The downstream observer.</summary>

--- a/src/ReactiveUI.Primitives.Core/Advanced/AnyWitness.cs
+++ b/src/ReactiveUI.Primitives.Core/Advanced/AnyWitness.cs
@@ -8,7 +8,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Observer for detecting whether any value is present.</summary>
 /// <typeparam name="T">The source value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Done = {_done}, Observer = {_observer}")]
+[System.Diagnostics.DebuggerDisplay("AnyWitness: Done = {_done}, Observer = {_observer}")]
 public sealed class AnyWitness<T> : IObserver<T>, IDisposable
 {
     /// <summary>The downstream observer.</summary>

--- a/src/ReactiveUI.Primitives.Core/Advanced/AppendDelegateWitness.cs
+++ b/src/ReactiveUI.Primitives.Core/Advanced/AppendDelegateWitness.cs
@@ -12,7 +12,7 @@ namespace ReactiveUI.Primitives.Advanced;
 /// <param name="onError">The error callback.</param>
 /// <param name="onCompleted">The completion callback.</param>
 /// <param name="value">The appended value.</param>
-[System.Diagnostics.DebuggerDisplay("Value = {_value}, Subscription = {_subscription}")]
+[System.Diagnostics.DebuggerDisplay("AppendDelegateWitness: Value = {_value}, Subscription = {_subscription}")]
 public sealed class AppendDelegateWitness<T>(Action<T> onNext, Action<Exception> onError, Action onCompleted, T value) : IObserver<T>, IDisposable
 {
     /// <summary>The next callback.</summary>

--- a/src/ReactiveUI.Primitives.Core/Advanced/AppendWitness.cs
+++ b/src/ReactiveUI.Primitives.Core/Advanced/AppendWitness.cs
@@ -10,7 +10,7 @@ namespace ReactiveUI.Primitives.Advanced;
 /// <typeparam name="T">The source value type.</typeparam>
 /// <param name="observer">The downstream observer.</param>
 /// <param name="value">The appended value.</param>
-[System.Diagnostics.DebuggerDisplay("AppendedValue = {_value}, Observer = {_observer}")]
+[System.Diagnostics.DebuggerDisplay("AppendWitness: AppendedValue = {_value}, Observer = {_observer}")]
 public sealed class AppendWitness<T>(IObserver<T> observer, T value) : IObserver<T>, IDisposable
 {
     /// <summary>The downstream observer.</summary>

--- a/src/ReactiveUI.Primitives.Core/Advanced/BufferWitness.cs
+++ b/src/ReactiveUI.Primitives.Core/Advanced/BufferWitness.cs
@@ -11,7 +11,7 @@ namespace ReactiveUI.Primitives.Advanced;
 /// <param name="observer">The downstream observer.</param>
 /// <param name="count">The window size.</param>
 /// <param name="skip">The number of elements skipped between windows.</param>
-[System.Diagnostics.DebuggerDisplay("Count = {_count}, Skip = {_skip}, Index = {_index}, Done = {_done}")]
+[System.Diagnostics.DebuggerDisplay("BufferWitness: Count = {_count}, Skip = {_skip}, Index = {_index}, Done = {_done}")]
 public sealed class BufferWitness<T>(IObserver<IList<T>> observer, int count, int skip) : IObserver<T>, IDisposable
 {
     /// <summary>The downstream observer.</summary>

--- a/src/ReactiveUI.Primitives.Core/Advanced/CallbackWitness.cs
+++ b/src/ReactiveUI.Primitives.Core/Advanced/CallbackWitness.cs
@@ -9,7 +9,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Observer that forwards notifications to delegates.</summary>
 /// <typeparam name="T">The observed value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("OnNext = {_onNext}, OnError = {_onError}, OnCompleted = {_onCompleted}")]
+[System.Diagnostics.DebuggerDisplay("CallbackWitness: OnNext = {_onNext}, OnError = {_onError}, OnCompleted = {_onCompleted}")]
 public sealed class CallbackWitness<T> : IObserver<T>
 {
     /// <summary>Next notification callback.</summary>

--- a/src/ReactiveUI.Primitives.Core/Advanced/CollectArrayWitness.cs
+++ b/src/ReactiveUI.Primitives.Core/Advanced/CollectArrayWitness.cs
@@ -8,7 +8,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Sink that buffers values and emits them as an array on completion.</summary>
 /// <typeparam name="T">The value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Count = {_values.Count}, Subscription = {_subscription}")]
+[System.Diagnostics.DebuggerDisplay("CollectArrayWitness: Count = {_values.Count}, Subscription = {_subscription}")]
 public sealed class CollectArrayWitness<T> : IObserver<T>, IDisposable
 {
     /// <summary>The downstream observer.</summary>

--- a/src/ReactiveUI.Primitives.Core/Advanced/CollectListWitness.cs
+++ b/src/ReactiveUI.Primitives.Core/Advanced/CollectListWitness.cs
@@ -8,7 +8,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Sink that buffers values and emits them as a list on completion.</summary>
 /// <typeparam name="T">The value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Count = {_values.Count}, Subscription = {_subscription}")]
+[System.Diagnostics.DebuggerDisplay("CollectListWitness: Count = {_values.Count}, Subscription = {_subscription}")]
 public sealed class CollectListWitness<T> : IObserver<T>, IDisposable
 {
     /// <summary>The downstream observer.</summary>

--- a/src/ReactiveUI.Primitives.Core/Advanced/ContainsWitness.cs
+++ b/src/ReactiveUI.Primitives.Core/Advanced/ContainsWitness.cs
@@ -11,7 +11,7 @@ namespace ReactiveUI.Primitives.Advanced;
 /// <param name="observer">The downstream observer.</param>
 /// <param name="value">The value to locate.</param>
 /// <param name="comparer">The comparer used for equality checks.</param>
-[System.Diagnostics.DebuggerDisplay("SoughtValue = {_value}, Done = {_done}")]
+[System.Diagnostics.DebuggerDisplay("ContainsWitness: SoughtValue = {_value}, Done = {_done}")]
 public sealed class ContainsWitness<T>(IObserver<bool> observer, T value, IEqualityComparer<T> comparer) : IObserver<T>, IDisposable
 {
     /// <summary>The value to locate.</summary>

--- a/src/ReactiveUI.Primitives.Core/Advanced/CopyOnWriteList{T}.cs
+++ b/src/ReactiveUI.Primitives.Core/Advanced/CopyOnWriteList{T}.cs
@@ -6,7 +6,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Immutable array-backed list optimized for copy-on-write observer storage.</summary>
 /// <typeparam name="T">The item type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Count = {Items.Length}")]
+[System.Diagnostics.DebuggerDisplay("CopyOnWriteList: Count = {Items.Length}")]
 public sealed class CopyOnWriteList<T>
 {
     /// <summary>Gets the shared empty list.</summary>

--- a/src/ReactiveUI.Primitives.Core/Advanced/CountAggregator.cs
+++ b/src/ReactiveUI.Primitives.Core/Advanced/CountAggregator.cs
@@ -6,7 +6,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Immutable accumulator that counts every observed value as an <see cref="int"/>.</summary>
 /// <typeparam name="T">The observed value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Result = {Result}")]
+[System.Diagnostics.DebuggerDisplay("CountAggregator: Result = {Result}")]
 public readonly record struct CountAggregator<T> : IAggregator<T, int, CountAggregator<T>>
 {
     /// <summary>Initializes a new instance of the <see cref="CountAggregator{T}"/> struct.</summary>

--- a/src/ReactiveUI.Primitives.Core/Advanced/CountPredicateAggregator.cs
+++ b/src/ReactiveUI.Primitives.Core/Advanced/CountPredicateAggregator.cs
@@ -6,7 +6,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Immutable accumulator that counts the values matching a predicate as an <see cref="int"/>.</summary>
 /// <typeparam name="T">The observed value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Result = {Result}, Predicate = {_predicate}")]
+[System.Diagnostics.DebuggerDisplay("CountPredicateAggregator: Result = {Result}, Predicate = {_predicate}")]
 public readonly record struct CountPredicateAggregator<T> : IAggregator<T, int, CountPredicateAggregator<T>>
 {
     /// <summary>The predicate selecting which values to count.</summary>

--- a/src/ReactiveUI.Primitives.Core/Advanced/DefaultIfEmptyWitness.cs
+++ b/src/ReactiveUI.Primitives.Core/Advanced/DefaultIfEmptyWitness.cs
@@ -10,7 +10,7 @@ namespace ReactiveUI.Primitives.Advanced;
 /// <typeparam name="T">The source value type.</typeparam>
 /// <param name="observer">The downstream observer.</param>
 /// <param name="defaultValue">Value emitted for an empty source.</param>
-[System.Diagnostics.DebuggerDisplay("Seen = {_seen}, DefaultValue = {_defaultValue}")]
+[System.Diagnostics.DebuggerDisplay("DefaultIfEmptyWitness: Seen = {_seen}, DefaultValue = {_defaultValue}")]
 public sealed class DefaultIfEmptyWitness<T>(IObserver<T> observer, T defaultValue) : IObserver<T>, IDisposable
 {
     /// <summary>The downstream observer.</summary>

--- a/src/ReactiveUI.Primitives.Core/Advanced/DistinctByCountAggregator.cs
+++ b/src/ReactiveUI.Primitives.Core/Advanced/DistinctByCountAggregator.cs
@@ -7,7 +7,7 @@ namespace ReactiveUI.Primitives.Advanced;
 /// <summary>Immutable accumulator that counts distinct selected keys as an <see cref="int"/>.</summary>
 /// <typeparam name="T">The observed value type.</typeparam>
 /// <typeparam name="TKey">The key type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Result = {Result}, Seen = {_seen}")]
+[System.Diagnostics.DebuggerDisplay("DistinctByCountAggregator: Result = {Result}, Seen = {_seen}")]
 public readonly record struct
     DistinctByCountAggregator<T, TKey> : IAggregator<T, int, DistinctByCountAggregator<T, TKey>>
 {

--- a/src/ReactiveUI.Primitives.Core/Advanced/DistinctByLongCountAggregator.cs
+++ b/src/ReactiveUI.Primitives.Core/Advanced/DistinctByLongCountAggregator.cs
@@ -7,7 +7,7 @@ namespace ReactiveUI.Primitives.Advanced;
 /// <summary>Immutable accumulator that counts distinct selected keys as a <see cref="long"/>.</summary>
 /// <typeparam name="T">The observed value type.</typeparam>
 /// <typeparam name="TKey">The key type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Result = {Result}, Seen = {_seen}")]
+[System.Diagnostics.DebuggerDisplay("DistinctByLongCountAggregator: Result = {Result}, Seen = {_seen}")]
 public readonly record struct
     DistinctByLongCountAggregator<T, TKey> : IAggregator<T, long, DistinctByLongCountAggregator<T, TKey>>
 {

--- a/src/ReactiveUI.Primitives.Core/Advanced/DistinctByWitness.cs
+++ b/src/ReactiveUI.Primitives.Core/Advanced/DistinctByWitness.cs
@@ -9,7 +9,7 @@ namespace ReactiveUI.Primitives.Advanced;
 /// <summary>Observer for distinct-by.</summary>
 /// <typeparam name="T">The source value type.</typeparam>
 /// <typeparam name="TKey">The key type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Done = {_done}, SeenKeys = {_seen.Count}")]
+[System.Diagnostics.DebuggerDisplay("DistinctByWitness: Done = {_done}, SeenKeys = {_seen.Count}")]
 public sealed class DistinctByWitness<T, TKey> : IObserver<T>, IDisposable
 {
     /// <summary>The downstream observer.</summary>

--- a/src/ReactiveUI.Primitives.Core/Advanced/DistinctWitness.cs
+++ b/src/ReactiveUI.Primitives.Core/Advanced/DistinctWitness.cs
@@ -10,7 +10,7 @@ namespace ReactiveUI.Primitives.Advanced;
 /// <typeparam name="T">The value type.</typeparam>
 /// <param name="observer">The downstream observer.</param>
 /// <param name="seen">The set used to track already-observed values.</param>
-[System.Diagnostics.DebuggerDisplay("Seen = {_seen.Count}, Subscription = {_subscription}")]
+[System.Diagnostics.DebuggerDisplay("DistinctWitness: Seen = {_seen.Count}, Subscription = {_subscription}")]
 public sealed class DistinctWitness<T>(IObserver<T> observer, HashSet<T> seen) : IObserver<T>, IDisposable
 {
     /// <summary>The downstream observer.</summary>

--- a/src/ReactiveUI.Primitives.Core/Advanced/EmptyWitness{T}.cs
+++ b/src/ReactiveUI.Primitives.Core/Advanced/EmptyWitness{T}.cs
@@ -9,7 +9,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Delegate-backed observer that defaults missing handlers to no-op behavior.</summary>
 /// <typeparam name="T">The observed value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("OnNext = {_onNext}, OnError = {_onError}, OnCompleted = {_onCompleted}")]
+[System.Diagnostics.DebuggerDisplay("EmptyWitness: OnNext = {_onNext}, OnError = {_onError}, OnCompleted = {_onCompleted}")]
 public sealed class EmptyWitness<T> : IObserver<T>
 {
     /// <summary>Gets the shared no-op witness instance.</summary>

--- a/src/ReactiveUI.Primitives.Core/Advanced/FoldWitness.cs
+++ b/src/ReactiveUI.Primitives.Core/Advanced/FoldWitness.cs
@@ -12,7 +12,7 @@ namespace ReactiveUI.Primitives.Advanced;
 /// <param name="observer">The downstream observer.</param>
 /// <param name="seed">The initial accumulated value.</param>
 /// <param name="accumulator">The accumulator function.</param>
-[System.Diagnostics.DebuggerDisplay("Current = {_current}, Observer = {_observer}")]
+[System.Diagnostics.DebuggerDisplay("FoldWitness: Current = {_current}, Observer = {_observer}")]
 public sealed class FoldWitness<TSource, TAccumulate>(
     IObserver<TAccumulate> observer,
     TAccumulate seed,

--- a/src/ReactiveUI.Primitives.Core/Advanced/ForwardingWitness.cs
+++ b/src/ReactiveUI.Primitives.Core/Advanced/ForwardingWitness.cs
@@ -8,7 +8,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Observer that forwards notifications to a standard observer.</summary>
 /// <typeparam name="T">The observed value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Observer = {_observer}")]
+[System.Diagnostics.DebuggerDisplay("ForwardingWitness: Observer = {_observer}")]
 public sealed class ForwardingWitness<T> : IObserver<T>
 {
     /// <summary>Wrapped observer.</summary>

--- a/src/ReactiveUI.Primitives.Core/Advanced/FromEnumerableSignal{T}.cs
+++ b/src/ReactiveUI.Primitives.Core/Advanced/FromEnumerableSignal{T}.cs
@@ -9,7 +9,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Represents a finite signal backed by an enumerable sequence.</summary>
 /// <typeparam name="T">The value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Values = {_values}, CancellationToken = {_cancellationToken}")]
+[System.Diagnostics.DebuggerDisplay("FromEnumerableSignal: Values = {_values}, CancellationToken = {_cancellationToken}")]
 public sealed class FromEnumerableSignal<T> : IRequireCurrentThread<T>, IInlineSignal<T>
 {
     /// <summary>Stores the source values.</summary>

--- a/src/ReactiveUI.Primitives.Core/Advanced/IgnoreValuesWitness.cs
+++ b/src/ReactiveUI.Primitives.Core/Advanced/IgnoreValuesWitness.cs
@@ -8,7 +8,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Sink that drops values and forwards only terminal notifications.</summary>
 /// <typeparam name="T">The value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+[System.Diagnostics.DebuggerDisplay("IgnoreValuesWitness: Observer = {_observer}, Subscription = {_subscription}")]
 public sealed class IgnoreValuesWitness<T> : IObserver<T>, IDisposable
 {
     /// <summary>The downstream observer.</summary>

--- a/src/ReactiveUI.Primitives.Core/Advanced/ImmediateReturnSignal{T}.cs
+++ b/src/ReactiveUI.Primitives.Core/Advanced/ImmediateReturnSignal{T}.cs
@@ -9,7 +9,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Represents the ImmediateReturnSignal class.</summary>
 /// <typeparam name="T">The T type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Value = {_value}")]
+[System.Diagnostics.DebuggerDisplay("ImmediateReturnSignal: Value = {_value}")]
 public sealed class ImmediateReturnSignal<T> : IRequireCurrentThread<T>, IInlineSignal<T>
 {
     /// <summary>Stores state for the signal implementation.</summary>

--- a/src/ReactiveUI.Primitives.Core/Advanced/ImmediateThrowSignal{T}.cs
+++ b/src/ReactiveUI.Primitives.Core/Advanced/ImmediateThrowSignal{T}.cs
@@ -9,7 +9,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Represents the immediate Throw signal fast path.</summary>
 /// <typeparam name="T">The T type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Error = {_error}")]
+[System.Diagnostics.DebuggerDisplay("ImmediateThrowSignal: Error = {_error}")]
 public sealed class ImmediateThrowSignal<T> : IRequireCurrentThread<T>, IInlineSignal<T>
 {
     /// <summary>Stores the terminal error.</summary>

--- a/src/ReactiveUI.Primitives.Core/Advanced/ImmutableReturnInt32Signal.cs
+++ b/src/ReactiveUI.Primitives.Core/Advanced/ImmutableReturnInt32Signal.cs
@@ -8,7 +8,7 @@ using ReactiveUI.Primitives.Disposables;
 namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Represents the ImmutableReturnInt32Signal class.</summary>
-[System.Diagnostics.DebuggerDisplay("Value = {_x}")]
+[System.Diagnostics.DebuggerDisplay("ImmutableReturnInt32Signal: Value = {_x}")]
 public sealed class ImmutableReturnInt32Signal : IRequireCurrentThread<int>, IInlineSignal<int>
 {
     /// <summary>Stores state for the signal implementation.</summary>

--- a/src/ReactiveUI.Primitives.Core/Advanced/KeepNotNullWitness.cs
+++ b/src/ReactiveUI.Primitives.Core/Advanced/KeepNotNullWitness.cs
@@ -8,7 +8,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Sink that forwards only non-null values.</summary>
 /// <typeparam name="T">The value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+[System.Diagnostics.DebuggerDisplay("KeepNotNullWitness: Observer = {_observer}, Subscription = {_subscription}")]
 public sealed class KeepNotNullWitness<T> : IObserver<T?>, IDisposable
     where T : class
 {

--- a/src/ReactiveUI.Primitives.Core/Advanced/KeepTypeWitness.cs
+++ b/src/ReactiveUI.Primitives.Core/Advanced/KeepTypeWitness.cs
@@ -8,7 +8,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Sink that forwards only values assignable to <typeparamref name="TResult"/>.</summary>
 /// <typeparam name="TResult">The result value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+[System.Diagnostics.DebuggerDisplay("KeepTypeWitness: Observer = {_observer}, Subscription = {_subscription}")]
 public sealed class KeepTypeWitness<TResult> : IObserver<object?>, IDisposable
 {
     /// <summary>The downstream observer.</summary>

--- a/src/ReactiveUI.Primitives.Core/Advanced/ListWitness{T}.cs
+++ b/src/ReactiveUI.Primitives.Core/Advanced/ListWitness{T}.cs
@@ -8,7 +8,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Observer that forwards notifications to an immutable observer list.</summary>
 /// <typeparam name="T">The observed value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("HasObservers = {HasObservers}, Count = {_observers.Items.Length}")]
+[System.Diagnostics.DebuggerDisplay("ListWitness: HasObservers = {HasObservers}, Count = {_observers.Items.Length}")]
 public sealed class ListWitness<T> : IObserver<T>
 {
     /// <summary>Immutable observer snapshot.</summary>

--- a/src/ReactiveUI.Primitives.Core/Advanced/LongCountAggregator.cs
+++ b/src/ReactiveUI.Primitives.Core/Advanced/LongCountAggregator.cs
@@ -6,7 +6,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Immutable accumulator that counts every observed value as a <see cref="long"/>.</summary>
 /// <typeparam name="T">The observed value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Result = {Result}")]
+[System.Diagnostics.DebuggerDisplay("LongCountAggregator: Result = {Result}")]
 public readonly record struct LongCountAggregator<T> : IAggregator<T, long, LongCountAggregator<T>>
 {
     /// <summary>Initializes a new instance of the <see cref="LongCountAggregator{T}"/> struct.</summary>

--- a/src/ReactiveUI.Primitives.Core/Advanced/LongCountPredicateAggregator.cs
+++ b/src/ReactiveUI.Primitives.Core/Advanced/LongCountPredicateAggregator.cs
@@ -6,7 +6,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Immutable accumulator that counts the values matching a predicate as a <see cref="long"/>.</summary>
 /// <typeparam name="T">The observed value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Result = {Result}, Predicate = {_predicate}")]
+[System.Diagnostics.DebuggerDisplay("LongCountPredicateAggregator: Result = {Result}, Predicate = {_predicate}")]
 public readonly record struct LongCountPredicateAggregator<T> : IAggregator<T, long, LongCountPredicateAggregator<T>>
 {
     /// <summary>The predicate selecting which values to count.</summary>

--- a/src/ReactiveUI.Primitives.Core/Advanced/RangeConcatSignal.cs
+++ b/src/ReactiveUI.Primitives.Core/Advanced/RangeConcatSignal.cs
@@ -8,7 +8,7 @@ using ReactiveUI.Primitives.Disposables;
 namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Concatenates synchronous integer ranges without outer observable/coordinator overhead.</summary>
-[System.Diagnostics.DebuggerDisplay("Ranges = {_ranges.Length}")]
+[System.Diagnostics.DebuggerDisplay("RangeConcatSignal: Ranges = {_ranges.Length}")]
 public sealed class RangeConcatSignal : IRequireCurrentThread<int>, IInlineSignal<int>
 {
     /// <summary>Source ranges to emit in order.</summary>

--- a/src/ReactiveUI.Primitives.Core/Advanced/RangeSignal.cs
+++ b/src/ReactiveUI.Primitives.Core/Advanced/RangeSignal.cs
@@ -8,7 +8,7 @@ using ReactiveUI.Primitives.Disposables;
 namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Represents the RangeSignal class.</summary>
-[System.Diagnostics.DebuggerDisplay("Start = {Start}, Count = {Count}")]
+[System.Diagnostics.DebuggerDisplay("RangeSignal: Start = {Start}, Count = {Count}")]
 public sealed class RangeSignal : IRequireCurrentThread<int>, IInlineSignal<int>
 {
     /// <summary>Initializes a new instance of the <see cref="RangeSignal"/> class.</summary>

--- a/src/ReactiveUI.Primitives.Core/Advanced/RangeZipSignal{TResult}.cs
+++ b/src/ReactiveUI.Primitives.Core/Advanced/RangeZipSignal{TResult}.cs
@@ -9,7 +9,7 @@ namespace ReactiveUI.Primitives.Advanced;
 
 /// <summary>Zips two synchronous integer ranges without coordinator queues.</summary>
 /// <typeparam name="TResult">The result value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Count = {_count}, LeftStart = {_leftStart}, RightStart = {_rightStart}")]
+[System.Diagnostics.DebuggerDisplay("RangeZipSignal: Count = {_count}, LeftStart = {_leftStart}, RightStart = {_rightStart}")]
 public sealed class RangeZipSignal<TResult> : IRequireCurrentThread<TResult>, IInlineSignal<TResult>
 {
     /// <summary>Stores state for the signal implementation.</summary>

--- a/src/ReactiveUI.Primitives.Core/Advanced/ReduceWitness.cs
+++ b/src/ReactiveUI.Primitives.Core/Advanced/ReduceWitness.cs
@@ -12,7 +12,7 @@ namespace ReactiveUI.Primitives.Advanced;
 /// <param name="observer">The downstream observer.</param>
 /// <param name="seed">The initial accumulated value.</param>
 /// <param name="accumulator">The accumulator function.</param>
-[System.Diagnostics.DebuggerDisplay("Current = {_current}, Subscription = {_subscription}")]
+[System.Diagnostics.DebuggerDisplay("ReduceWitness: Current = {_current}, Subscription = {_subscription}")]
 public sealed class ReduceWitness<TSource, TAccumulate>(
     IObserver<TAccumulate> observer,
     TAccumulate seed,

--- a/src/ReactiveUI.Primitives.Core/Advanced/RepeatSignal{T}.cs
+++ b/src/ReactiveUI.Primitives.Core/Advanced/RepeatSignal{T}.cs
@@ -11,7 +11,7 @@ namespace ReactiveUI.Primitives.Advanced;
 /// <typeparam name="T">The T type.</typeparam>
 /// <param name="value">The value.</param>
 /// <param name="count">The count value.</param>
-[System.Diagnostics.DebuggerDisplay("Value = {_value}, Count = {_count}")]
+[System.Diagnostics.DebuggerDisplay("RepeatSignal: Value = {_value}, Count = {_count}")]
 public sealed class RepeatSignal<T>(T value, int count) : IRequireCurrentThread<T>, IInlineSignal<T>
 {
     /// <summary>Stores state for the signal implementation.</summary>

--- a/src/ReactiveUI.Primitives.Core/Advanced/SkipWhileWitness.cs
+++ b/src/ReactiveUI.Primitives.Core/Advanced/SkipWhileWitness.cs
@@ -10,7 +10,7 @@ namespace ReactiveUI.Primitives.Advanced;
 /// <typeparam name="T">The value type.</typeparam>
 /// <param name="observer">The downstream observer.</param>
 /// <param name="predicate">The predicate that determines whether to keep skipping values.</param>
-[System.Diagnostics.DebuggerDisplay("Skipping = {_skipping}, Subscription = {_subscription}")]
+[System.Diagnostics.DebuggerDisplay("SkipWhileWitness: Skipping = {_skipping}, Subscription = {_subscription}")]
 public sealed class SkipWhileWitness<T>(IObserver<T> observer, Func<T, bool> predicate) : IObserver<T>, IDisposable
 {
     /// <summary>The downstream observer.</summary>

--- a/src/ReactiveUI.Primitives.Core/Advanced/SkipWitness.cs
+++ b/src/ReactiveUI.Primitives.Core/Advanced/SkipWitness.cs
@@ -10,7 +10,7 @@ namespace ReactiveUI.Primitives.Advanced;
 /// <typeparam name="T">The value type.</typeparam>
 /// <param name="observer">The downstream observer.</param>
 /// <param name="count">The number of leading values to drop.</param>
-[System.Diagnostics.DebuggerDisplay("Remaining = {_remaining}, Observer = {_observer}")]
+[System.Diagnostics.DebuggerDisplay("SkipWitness: Remaining = {_remaining}, Observer = {_observer}")]
 public sealed class SkipWitness<T>(IObserver<T> observer, int count) : IObserver<T>, IDisposable
 {
     /// <summary>The downstream observer.</summary>

--- a/src/ReactiveUI.Primitives.Core/Advanced/StatefulWitness.cs
+++ b/src/ReactiveUI.Primitives.Core/Advanced/StatefulWitness.cs
@@ -10,7 +10,7 @@ namespace ReactiveUI.Primitives.Advanced;
 /// <summary>Observer that forwards notifications to stateful delegates.</summary>
 /// <typeparam name="T">The observed value type.</typeparam>
 /// <typeparam name="TState">The state type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("State = {_state}, OnError = {_onError}")]
+[System.Diagnostics.DebuggerDisplay("StatefulWitness: State = {_state}, OnError = {_onError}")]
 public sealed class StatefulWitness<T, TState> : IObserver<T>
 {
     /// <summary>Callback state.</summary>

--- a/src/ReactiveUI.Primitives.Core/Advanced/SynchronizeWitness.cs
+++ b/src/ReactiveUI.Primitives.Core/Advanced/SynchronizeWitness.cs
@@ -13,7 +13,7 @@ namespace ReactiveUI.Primitives.Advanced;
 /// grammar; placing one of these ahead of them is the supported way to consume a non-conformant source.
 /// </summary>
 /// <typeparam name="T">The value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+[System.Diagnostics.DebuggerDisplay("SynchronizeWitness: Observer = {_observer}, Subscription = {_subscription}")]
 public sealed class SynchronizeWitness<T> : IObserver<T>, IDisposable
 {
     /// <summary>The downstream observer.</summary>

--- a/src/ReactiveUI.Primitives.Core/Advanced/TakeWhileWitness.cs
+++ b/src/ReactiveUI.Primitives.Core/Advanced/TakeWhileWitness.cs
@@ -10,7 +10,7 @@ namespace ReactiveUI.Primitives.Advanced;
 /// <typeparam name="T">The value type.</typeparam>
 /// <param name="observer">The downstream observer.</param>
 /// <param name="predicate">The predicate that determines whether to keep taking values.</param>
-[System.Diagnostics.DebuggerDisplay("Completed = {_completed}, Subscription = {_subscription}")]
+[System.Diagnostics.DebuggerDisplay("TakeWhileWitness: Completed = {_completed}, Subscription = {_subscription}")]
 public sealed class TakeWhileWitness<T>(IObserver<T> observer, Func<T, bool> predicate) : IObserver<T>, IDisposable
 {
     /// <summary>The downstream observer.</summary>

--- a/src/ReactiveUI.Primitives.Core/Advanced/TakeWitness.cs
+++ b/src/ReactiveUI.Primitives.Core/Advanced/TakeWitness.cs
@@ -11,7 +11,7 @@ namespace ReactiveUI.Primitives.Advanced;
 /// <typeparam name="T">The value type.</typeparam>
 /// <param name="observer">Downstream observer.</param>
 /// <param name="count">Number of values to forward.</param>
-[System.Diagnostics.DebuggerDisplay("Remaining = {_remaining}, Stopped = {_stopped}")]
+[System.Diagnostics.DebuggerDisplay("TakeWitness: Remaining = {_remaining}, Stopped = {_stopped}")]
 public sealed class TakeWitness<T>(IObserver<T> observer, int count) : IObserver<T>, IDisposable
 {
     /// <summary>Downstream observer.</summary>

--- a/src/ReactiveUI.Primitives.Core/Advanced/TapWitness.cs
+++ b/src/ReactiveUI.Primitives.Core/Advanced/TapWitness.cs
@@ -12,7 +12,7 @@ namespace ReactiveUI.Primitives.Advanced;
 /// <param name="onNext">The value side-effect.</param>
 /// <param name="onError">The error side-effect.</param>
 /// <param name="onCompleted">The completion side-effect.</param>
-[System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+[System.Diagnostics.DebuggerDisplay("TapWitness: Observer = {_observer}, Subscription = {_subscription}")]
 public sealed class TapWitness<T>(
     IObserver<T> observer,
     Action<T> onNext,

--- a/src/ReactiveUI.Primitives.Core/Advanced/UnfoldSignal{TState,TResult}.cs
+++ b/src/ReactiveUI.Primitives.Core/Advanced/UnfoldSignal{TState,TResult}.cs
@@ -14,7 +14,7 @@ namespace ReactiveUI.Primitives.Advanced;
 /// <param name="condition">Loop condition.</param>
 /// <param name="iterate">State iterator.</param>
 /// <param name="resultSelector">Result selector.</param>
-[System.Diagnostics.DebuggerDisplay("InitialState = {_initialState}, Condition = {_condition}")]
+[System.Diagnostics.DebuggerDisplay("UnfoldSignal: InitialState = {_initialState}, Condition = {_condition}")]
 public sealed class UnfoldSignal<TState, TResult>(
     TState initialState,
     Func<TState, bool> condition,

--- a/src/ReactiveUI.Primitives.Core/Advanced/UniqueByWitness.cs
+++ b/src/ReactiveUI.Primitives.Core/Advanced/UniqueByWitness.cs
@@ -12,7 +12,7 @@ namespace ReactiveUI.Primitives.Advanced;
 /// <param name="observer">The downstream observer.</param>
 /// <param name="keySelector">The key projection.</param>
 /// <param name="comparer">The comparer used to compare adjacent keys.</param>
-[System.Diagnostics.DebuggerDisplay("HasLast = {_hasLast}, Last = {_last}")]
+[System.Diagnostics.DebuggerDisplay("UniqueByWitness: HasLast = {_hasLast}, Last = {_last}")]
 public sealed class UniqueByWitness<T, TKey>(
     IObserver<T> observer,
     Func<T, TKey> keySelector,

--- a/src/ReactiveUI.Primitives.Core/Advanced/UniqueWitness.cs
+++ b/src/ReactiveUI.Primitives.Core/Advanced/UniqueWitness.cs
@@ -10,7 +10,7 @@ namespace ReactiveUI.Primitives.Advanced;
 /// <typeparam name="T">The value type.</typeparam>
 /// <param name="observer">The downstream observer.</param>
 /// <param name="comparer">The comparer used to compare adjacent values.</param>
-[System.Diagnostics.DebuggerDisplay("HasLast = {_hasLast}, Last = {_last}")]
+[System.Diagnostics.DebuggerDisplay("UniqueWitness: HasLast = {_hasLast}, Last = {_last}")]
 public sealed class UniqueWitness<T>(IObserver<T> observer, IEqualityComparer<T> comparer) : IObserver<T>, IDisposable
 {
     /// <summary>The downstream observer.</summary>

--- a/src/ReactiveUI.Primitives.Core/Advanced/UseSignal{TResource,T}.cs
+++ b/src/ReactiveUI.Primitives.Core/Advanced/UseSignal{TResource,T}.cs
@@ -12,7 +12,7 @@ namespace ReactiveUI.Primitives.Advanced;
 /// <typeparam name="T">Value type.</typeparam>
 /// <param name="resourceFactory">Resource factory.</param>
 /// <param name="signalFactory">Signal factory.</param>
-[System.Diagnostics.DebuggerDisplay("ResourceFactory = {_resourceFactory}, SignalFactory = {_signalFactory}")]
+[System.Diagnostics.DebuggerDisplay("UseSignal: ResourceFactory = {_resourceFactory}, SignalFactory = {_signalFactory}")]
 public sealed class UseSignal<TResource, T>(
     Func<TResource> resourceFactory,
     Func<TResource, IObservable<T>> signalFactory) : IObservable<T>

--- a/src/ReactiveUI.Primitives.Core/Core/PriorityQueue.cs
+++ b/src/ReactiveUI.Primitives.Core/Core/PriorityQueue.cs
@@ -8,7 +8,7 @@ namespace ReactiveUI.Primitives.Core;
 
 /// <summary>Binary heap priority queue that preserves insertion order for equal-priority items.</summary>
 /// <typeparam name="T">The queued item type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Count = {Count}, Capacity = {_items.Length}")]
+[System.Diagnostics.DebuggerDisplay("PriorityQueue: Count = {Count}, Capacity = {_items.Length}")]
 public sealed class PriorityQueue<T>
     where T : IComparable<T>
 {

--- a/src/ReactiveUI.Primitives.Core/Optional.cs
+++ b/src/ReactiveUI.Primitives.Core/Optional.cs
@@ -14,7 +14,7 @@ namespace ReactiveUI.Primitives;
 /// contained value. If no value is present, HasValue is <see langword="false"/> and accessing Value throws an
 /// exception. This pattern is useful for APIs that need to distinguish between an explicit 'no value' state and a
 /// default value.</remarks>
-[System.Diagnostics.DebuggerDisplay("HasValue = {HasValue}, Value = {_value}")]
+[System.Diagnostics.DebuggerDisplay("Optional: HasValue = {HasValue}, Value = {_value}")]
 public readonly record struct Optional<T>
 {
     /// <summary>The underlying value, or <see langword="default"/> when no value is present.</summary>

--- a/src/ReactiveUI.Primitives.Core/PublicAPI/net10.0/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Core/PublicAPI/net10.0/PublicAPI.txt
@@ -6,7 +6,7 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Primitives.Tests")]
 namespace ReactiveUI.Primitives
 {
-    [System.Diagnostics.DebuggerDisplay("Subscribe = {_subscribe}")]
+    [System.Diagnostics.DebuggerDisplay("AnonymousSignal: Subscribe = {_subscribe}")]
     public sealed class AnonymousSignal<T> : System.IObservable<T>
     {
         public AnonymousSignal(System.Func<System.IObserver<T>, System.IDisposable> subscribe) { }
@@ -48,7 +48,7 @@ namespace ReactiveUI.Primitives
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public static ReactiveUI.Primitives.Optional<T> Some<T>(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasValue = {HasValue}, Value = {_value}")]
+    [System.Diagnostics.DebuggerDisplay("Optional: HasValue = {HasValue}, Value = {_value}")]
     public readonly record struct Optional<T> : System.IEquatable<ReactiveUI.Primitives.Optional<T>>
     {
         public Optional() { }
@@ -68,7 +68,7 @@ namespace ReactiveUI.Primitives
         public static explicit operator T?(in ReactiveUI.Primitives.Optional<T> value) { }
         public static implicit operator ReactiveUI.Primitives.Optional<T>(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsSuccess = {IsSuccess}, Exception = {Exception}")]
+    [System.Diagnostics.DebuggerDisplay("Result: IsSuccess = {IsSuccess}, Exception = {Exception}")]
     public readonly record struct Result : System.IEquatable<ReactiveUI.Primitives.Result>
     {
         public Result(System.Exception exception) { }
@@ -111,7 +111,7 @@ namespace ReactiveUI.Primitives
 }
 namespace ReactiveUI.Primitives.Advanced
 {
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, Aggregator = {_aggregator}")]
+    [System.Diagnostics.DebuggerDisplay("AggregateWitness: Done = {_done}, Aggregator = {_aggregator}")]
     public sealed class AggregateWitness<T, TResult, TAggregator> : System.IDisposable, System.IObserver<T> where TAggregator : struct, ReactiveUI.Primitives.Advanced.IAggregator<T, TResult, TAggregator>
     {
         public AggregateWitness(System.IObserver<TResult> observer, TAggregator aggregator) { }
@@ -125,7 +125,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("AllPredicateWitness: Done = {_done}, Observer = {_observer}")]
     public sealed class AllPredicateWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public AllPredicateWitness(System.IObserver<bool> observer, System.Func<T, bool> predicate) { }
@@ -139,7 +139,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("AnyPredicateWitness: Done = {_done}, Observer = {_observer}")]
     public sealed class AnyPredicateWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public AnyPredicateWitness(System.IObserver<bool> observer, System.Func<T, bool> predicate) { }
@@ -153,7 +153,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("AnyWitness: Done = {_done}, Observer = {_observer}")]
     public sealed class AnyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public AnyWitness(System.IObserver<bool> observer) { }
@@ -168,7 +168,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_value}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("AppendDelegateWitness: Value = {_value}, Subscription = {_subscription}")]
     public sealed class AppendDelegateWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public AppendDelegateWitness(System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted, T value) { }
@@ -180,7 +180,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("AppendedValue = {_value}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("AppendWitness: AppendedValue = {_value}, Observer = {_observer}")]
     public sealed class AppendWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public AppendWitness(System.IObserver<T> observer, T value) { }
@@ -202,7 +202,7 @@ namespace ReactiveUI.Primitives.Advanced
         public System.Collections.Generic.IAsyncEnumerable<T> Values { get; }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Skip = {_skip}, Index = {_index}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("BufferWitness: Count = {_count}, Skip = {_skip}, Index = {_index}, Done = {_done}")]
     public sealed class BufferWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public BufferWitness(System.IObserver<System.Collections.Generic.IList<T>> observer, int count, int skip) { }
@@ -213,7 +213,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("OnNext = {_onNext}, OnError = {_onError}, OnCompleted = {_onCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("CallbackWitness: OnNext = {_onNext}, OnError = {_onError}, OnCompleted = {_onCompleted}")]
     public sealed class CallbackWitness<T> : System.IObserver<T>
     {
         public CallbackWitness(System.Action<T> onNext, System.Action<System.Exception>? onError, System.Action<ReactiveUI.Primitives.Result>? onCompleted) { }
@@ -224,7 +224,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_values.Count}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("CollectArrayWitness: Count = {_values.Count}, Subscription = {_subscription}")]
     public sealed class CollectArrayWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CollectArrayWitness(System.IObserver<T[]> observer) { }
@@ -239,7 +239,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_values.Count}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("CollectListWitness: Count = {_values.Count}, Subscription = {_subscription}")]
     public sealed class CollectListWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CollectListWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -254,7 +254,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SoughtValue = {_value}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("ContainsWitness: SoughtValue = {_value}, Done = {_done}")]
     public sealed class ContainsWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public ContainsWitness(System.IObserver<bool> observer, T value, System.Collections.Generic.IEqualityComparer<T> comparer) { }
@@ -268,7 +268,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {Items.Length}")]
+    [System.Diagnostics.DebuggerDisplay("CopyOnWriteList: Count = {Items.Length}")]
     public sealed class CopyOnWriteList<T>
     {
         public CopyOnWriteList(T[] data) { }
@@ -278,20 +278,20 @@ namespace ReactiveUI.Primitives.Advanced
         public int IndexOf(T value) { }
         public ReactiveUI.Primitives.Advanced.CopyOnWriteList<T> Remove(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Result = {Result}")]
+    [System.Diagnostics.DebuggerDisplay("CountAggregator: Result = {Result}")]
     public readonly record struct CountAggregator<T> : ReactiveUI.Primitives.Advanced.IAggregator<T, int, ReactiveUI.Primitives.Advanced.CountAggregator<T>>, System.IEquatable<ReactiveUI.Primitives.Advanced.CountAggregator<T>>
     {
         public int Result { get; }
         public readonly ReactiveUI.Primitives.Advanced.CountAggregator<T> Add(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Result = {Result}, Predicate = {_predicate}")]
+    [System.Diagnostics.DebuggerDisplay("CountPredicateAggregator: Result = {Result}, Predicate = {_predicate}")]
     public readonly record struct CountPredicateAggregator<T> : ReactiveUI.Primitives.Advanced.IAggregator<T, int, ReactiveUI.Primitives.Advanced.CountPredicateAggregator<T>>, System.IEquatable<ReactiveUI.Primitives.Advanced.CountPredicateAggregator<T>>
     {
         public CountPredicateAggregator(System.Func<T, bool> predicate) { }
         public int Result { get; }
         public readonly ReactiveUI.Primitives.Advanced.CountPredicateAggregator<T> Add(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Seen = {_seen}, DefaultValue = {_defaultValue}")]
+    [System.Diagnostics.DebuggerDisplay("DefaultIfEmptyWitness: Seen = {_seen}, DefaultValue = {_defaultValue}")]
     public sealed class DefaultIfEmptyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public DefaultIfEmptyWitness(System.IObserver<T> observer, T defaultValue) { }
@@ -316,21 +316,21 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Result = {Result}, Seen = {_seen}")]
+    [System.Diagnostics.DebuggerDisplay("DistinctByCountAggregator: Result = {Result}, Seen = {_seen}")]
     public readonly record struct DistinctByCountAggregator<T, TKey> : ReactiveUI.Primitives.Advanced.IAggregator<T, int, ReactiveUI.Primitives.Advanced.DistinctByCountAggregator<T, TKey>>, System.IEquatable<ReactiveUI.Primitives.Advanced.DistinctByCountAggregator<T, TKey>>
     {
         public DistinctByCountAggregator(System.Func<T, TKey> keySelector, System.Collections.Generic.IEqualityComparer<TKey>? comparer) { }
         public int Result { get; }
         public readonly ReactiveUI.Primitives.Advanced.DistinctByCountAggregator<T, TKey> Add(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Result = {Result}, Seen = {_seen}")]
+    [System.Diagnostics.DebuggerDisplay("DistinctByLongCountAggregator: Result = {Result}, Seen = {_seen}")]
     public readonly record struct DistinctByLongCountAggregator<T, TKey> : ReactiveUI.Primitives.Advanced.IAggregator<T, long, ReactiveUI.Primitives.Advanced.DistinctByLongCountAggregator<T, TKey>>, System.IEquatable<ReactiveUI.Primitives.Advanced.DistinctByLongCountAggregator<T, TKey>>
     {
         public DistinctByLongCountAggregator(System.Func<T, TKey> keySelector, System.Collections.Generic.IEqualityComparer<TKey>? comparer) { }
         public long Result { get; }
         public readonly ReactiveUI.Primitives.Advanced.DistinctByLongCountAggregator<T, TKey> Add(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, SeenKeys = {_seen.Count}")]
+    [System.Diagnostics.DebuggerDisplay("DistinctByWitness: Done = {_done}, SeenKeys = {_seen.Count}")]
     public sealed class DistinctByWitness<T, TKey> : System.IDisposable, System.IObserver<T>
     {
         public DistinctByWitness(System.IObserver<T> observer, System.Func<T, TKey> keySelector, System.Collections.Generic.IEqualityComparer<TKey>? comparer) { }
@@ -344,7 +344,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Seen = {_seen.Count}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("DistinctWitness: Seen = {_seen.Count}, Subscription = {_subscription}")]
     public sealed class DistinctWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public DistinctWitness(System.IObserver<T> observer, System.Collections.Generic.HashSet<T> seen) { }
@@ -358,7 +358,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("OnNext = {_onNext}, OnError = {_onError}, OnCompleted = {_onCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("EmptyWitness: OnNext = {_onNext}, OnError = {_onError}, OnCompleted = {_onCompleted}")]
     public sealed class EmptyWitness<T> : System.IObserver<T>
     {
         public EmptyWitness(System.Action<T> onNext) { }
@@ -373,7 +373,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Current = {_current}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("FoldWitness: Current = {_current}, Observer = {_observer}")]
     public sealed class FoldWitness<TSource, TAccumulate> : System.IDisposable, System.IObserver<TSource>
     {
         public FoldWitness(System.IObserver<TAccumulate> observer, TAccumulate seed, System.Func<TAccumulate, TSource, TAccumulate> accumulator) { }
@@ -387,7 +387,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("ForwardingWitness: Observer = {_observer}")]
     public sealed class ForwardingWitness<T> : System.IObserver<T>
     {
         public ForwardingWitness(System.IObserver<T> observer) { }
@@ -398,7 +398,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Values = {_values}, CancellationToken = {_cancellationToken}")]
+    [System.Diagnostics.DebuggerDisplay("FromEnumerableSignal: Values = {_values}, CancellationToken = {_cancellationToken}")]
     public sealed class FromEnumerableSignal<T> : ReactiveUI.Primitives.Advanced.IInlineSignal<T>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public FromEnumerableSignal(System.Collections.Generic.IEnumerable<T> values) { }
@@ -427,7 +427,7 @@ namespace ReactiveUI.Primitives.Advanced
     {
         bool IsRequiredSubscribeOnCurrentThread() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("IgnoreValuesWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class IgnoreValuesWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public IgnoreValuesWitness(System.IObserver<T> observer) { }
@@ -441,7 +441,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_value}")]
+    [System.Diagnostics.DebuggerDisplay("ImmediateReturnSignal: Value = {_value}")]
     public sealed class ImmediateReturnSignal<T> : ReactiveUI.Primitives.Advanced.IInlineSignal<T>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ImmediateReturnSignal(T value) { }
@@ -450,7 +450,7 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
         public System.IDisposable Subscribe(System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Error = {_error}")]
+    [System.Diagnostics.DebuggerDisplay("ImmediateThrowSignal: Error = {_error}")]
     public sealed class ImmediateThrowSignal<T> : ReactiveUI.Primitives.Advanced.IInlineSignal<T>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ImmediateThrowSignal(System.Exception error) { }
@@ -484,7 +484,7 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<bool> observer) { }
         public System.IDisposable Subscribe(System.Action<bool> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_x}")]
+    [System.Diagnostics.DebuggerDisplay("ImmutableReturnInt32Signal: Value = {_x}")]
     public sealed class ImmutableReturnInt32Signal : ReactiveUI.Primitives.Advanced.IInlineSignal<int>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<int>
     {
         public ImmutableReturnInt32Signal(int x) { }
@@ -502,7 +502,7 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<bool> observer) { }
         public System.IDisposable Subscribe(System.Action<bool> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("KeepNotNullWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class KeepNotNullWitness<T> : System.IDisposable, System.IObserver<T?> where T : class
     {
         public KeepNotNullWitness(System.IObserver<T> observer) { }
@@ -516,7 +516,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("KeepTypeWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class KeepTypeWitness<TResult> : System.IDisposable, System.IObserver<object?>
     {
         public KeepTypeWitness(System.IObserver<TResult> observer) { }
@@ -530,7 +530,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasObservers = {HasObservers}, Count = {_observers.Items.Length}")]
+    [System.Diagnostics.DebuggerDisplay("ListWitness: HasObservers = {HasObservers}, Count = {_observers.Items.Length}")]
     public sealed class ListWitness<T> : System.IObserver<T>
     {
         public ListWitness(ReactiveUI.Primitives.Advanced.CopyOnWriteList<System.IObserver<T>> observers) { }
@@ -539,20 +539,20 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Result = {Result}")]
+    [System.Diagnostics.DebuggerDisplay("LongCountAggregator: Result = {Result}")]
     public readonly record struct LongCountAggregator<T> : ReactiveUI.Primitives.Advanced.IAggregator<T, long, ReactiveUI.Primitives.Advanced.LongCountAggregator<T>>, System.IEquatable<ReactiveUI.Primitives.Advanced.LongCountAggregator<T>>
     {
         public long Result { get; }
         public readonly ReactiveUI.Primitives.Advanced.LongCountAggregator<T> Add(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Result = {Result}, Predicate = {_predicate}")]
+    [System.Diagnostics.DebuggerDisplay("LongCountPredicateAggregator: Result = {Result}, Predicate = {_predicate}")]
     public readonly record struct LongCountPredicateAggregator<T> : ReactiveUI.Primitives.Advanced.IAggregator<T, long, ReactiveUI.Primitives.Advanced.LongCountPredicateAggregator<T>>, System.IEquatable<ReactiveUI.Primitives.Advanced.LongCountPredicateAggregator<T>>
     {
         public LongCountPredicateAggregator(System.Func<T, bool> predicate) { }
         public long Result { get; }
         public readonly ReactiveUI.Primitives.Advanced.LongCountPredicateAggregator<T> Add(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Ranges = {_ranges.Length}")]
+    [System.Diagnostics.DebuggerDisplay("RangeConcatSignal: Ranges = {_ranges.Length}")]
     public sealed class RangeConcatSignal : ReactiveUI.Primitives.Advanced.IInlineSignal<int>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<int>
     {
         public RangeConcatSignal(ReactiveUI.Primitives.Advanced.RangeSignal[] ranges) { }
@@ -561,7 +561,7 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<int> observer) { }
         public System.IDisposable Subscribe(System.Action<int> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Start = {Start}, Count = {Count}")]
+    [System.Diagnostics.DebuggerDisplay("RangeSignal: Start = {Start}, Count = {Count}")]
     public sealed class RangeSignal : ReactiveUI.Primitives.Advanced.IInlineSignal<int>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<int>
     {
         public RangeSignal(int start, int count) { }
@@ -572,7 +572,7 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<int> observer) { }
         public System.IDisposable Subscribe(System.Action<int> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, LeftStart = {_leftStart}, RightStart = {_rightStart}")]
+    [System.Diagnostics.DebuggerDisplay("RangeZipSignal: Count = {_count}, LeftStart = {_leftStart}, RightStart = {_rightStart}")]
     public sealed class RangeZipSignal<TResult> : ReactiveUI.Primitives.Advanced.IInlineSignal<TResult>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public RangeZipSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
@@ -581,7 +581,7 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
         public System.IDisposable Subscribe(System.Action<TResult> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Current = {_current}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("ReduceWitness: Current = {_current}, Subscription = {_subscription}")]
     public sealed class ReduceWitness<TSource, TAccumulate> : System.IDisposable, System.IObserver<TSource>
     {
         public ReduceWitness(System.IObserver<TAccumulate> observer, TAccumulate seed, System.Func<TAccumulate, TSource, TAccumulate> accumulator) { }
@@ -595,7 +595,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_value}, Count = {_count}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSignal: Value = {_value}, Count = {_count}")]
     public sealed class RepeatSignal<T> : ReactiveUI.Primitives.Advanced.IInlineSignal<T>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public RepeatSignal(T value, int count) { }
@@ -620,7 +620,7 @@ namespace ReactiveUI.Primitives.Advanced
         public static void Fault<TResult>(System.IObserver<TResult> observer, System.Exception error, System.IDisposable sink) { }
         public static void Fault<TResult>(System.IObserver<TResult> observer, System.Exception error, System.IDisposable sink, ref bool done) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Skipping = {_skipping}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SkipWhileWitness: Skipping = {_skipping}, Subscription = {_subscription}")]
     public sealed class SkipWhileWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SkipWhileWitness(System.IObserver<T> observer, System.Func<T, bool> predicate) { }
@@ -634,7 +634,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Remaining = {_remaining}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SkipWitness: Remaining = {_remaining}, Observer = {_observer}")]
     public sealed class SkipWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SkipWitness(System.IObserver<T> observer, int count) { }
@@ -648,7 +648,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("State = {_state}, OnError = {_onError}")]
+    [System.Diagnostics.DebuggerDisplay("StatefulWitness: State = {_state}, OnError = {_onError}")]
     public sealed class StatefulWitness<T, TState> : System.IObserver<T>
     {
         public StatefulWitness(TState state, System.Action<T, TState> onNext, System.Action<System.Exception, TState>? onError, System.Action<ReactiveUI.Primitives.Result, TState>? onCompleted) { }
@@ -665,7 +665,7 @@ namespace ReactiveUI.Primitives.Advanced
         public static void Assign(ref System.IDisposable? slot, System.IDisposable subscription) { }
         public static void Release(ref System.IDisposable? slot) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SynchronizeWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SynchronizeWitness(System.IObserver<T> observer) { }
@@ -678,7 +678,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {_completed}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("TakeWhileWitness: Completed = {_completed}, Subscription = {_subscription}")]
     public sealed class TakeWhileWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TakeWhileWitness(System.IObserver<T> observer, System.Func<T, bool> predicate) { }
@@ -691,7 +691,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Remaining = {_remaining}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TakeWitness: Remaining = {_remaining}, Stopped = {_stopped}")]
     public sealed class TakeWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TakeWitness(System.IObserver<T> observer, int count) { }
@@ -703,7 +703,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("TapWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class TapWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TapWitness(System.IObserver<T> observer, System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
@@ -723,7 +723,7 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("InitialState = {_initialState}, Condition = {_condition}")]
+    [System.Diagnostics.DebuggerDisplay("UnfoldSignal: InitialState = {_initialState}, Condition = {_condition}")]
     public sealed class UnfoldSignal<TState, TResult> : ReactiveUI.Primitives.Advanced.IInlineSignal<TResult>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public UnfoldSignal(TState initialState, System.Func<TState, bool> condition, System.Func<TState, TState> iterate, System.Func<TState, TResult> resultSelector) { }
@@ -732,7 +732,7 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
         public System.IDisposable Subscribe(System.Action<TResult> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLast = {_hasLast}, Last = {_last}")]
+    [System.Diagnostics.DebuggerDisplay("UniqueByWitness: HasLast = {_hasLast}, Last = {_last}")]
     public sealed class UniqueByWitness<T, TKey> : System.IDisposable, System.IObserver<T>
     {
         public UniqueByWitness(System.IObserver<T> observer, System.Func<T, TKey> keySelector, System.Collections.Generic.IEqualityComparer<TKey> comparer) { }
@@ -746,7 +746,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLast = {_hasLast}, Last = {_last}")]
+    [System.Diagnostics.DebuggerDisplay("UniqueWitness: HasLast = {_hasLast}, Last = {_last}")]
     public sealed class UniqueWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public UniqueWitness(System.IObserver<T> observer, System.Collections.Generic.IEqualityComparer<T> comparer) { }
@@ -760,7 +760,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ResourceFactory = {_resourceFactory}, SignalFactory = {_signalFactory}")]
+    [System.Diagnostics.DebuggerDisplay("UseSignal: ResourceFactory = {_resourceFactory}, SignalFactory = {_signalFactory}")]
     public sealed class UseSignal<TResource, T> : System.IObservable<T> where TResource : System.IDisposable
     {
         public UseSignal(System.Func<TResource> resourceFactory, System.Func<TResource, System.IObservable<T>> signalFactory) { }
@@ -891,7 +891,7 @@ namespace ReactiveUI.Primitives.Core
         public static bool operator ==(ReactiveUI.Primitives.Core.Moment<T> first, ReactiveUI.Primitives.Core.Moment<T> second) { }
         public static bool operator !=(ReactiveUI.Primitives.Core.Moment<T> first, ReactiveUI.Primitives.Core.Moment<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {Count}, Capacity = {_items.Length}")]
+    [System.Diagnostics.DebuggerDisplay("PriorityQueue: Count = {Count}, Capacity = {_items.Length}")]
     public sealed class PriorityQueue<T> where T : System.IComparable<T>
     {
         public PriorityQueue() { }
@@ -934,14 +934,14 @@ namespace ReactiveUI.Primitives.Core
 }
 namespace ReactiveUI.Primitives.Extensions
 {
-    [System.Diagnostics.DebuggerDisplay("Outstanding = {_outstanding}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("ConcurrencyLimiter: Outstanding = {_outstanding}, Disposed = {_disposed}")]
     public sealed class ConcurrencyLimiter<T> : System.IObservable<T>
     {
         public ConcurrencyLimiter(System.Collections.Generic.IEnumerable<System.Threading.Tasks.Task<T>> taskFunctions, int maxConcurrency) { }
         public System.IObservable<T> Observable { get; }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Locked = {_locked}, CompletedPhases = {CompletedPhases}")]
+    [System.Diagnostics.DebuggerDisplay("Continuation: Locked = {_locked}, CompletedPhases = {CompletedPhases}")]
     public class Continuation : System.IDisposable
     {
         public Continuation() { }
@@ -951,7 +951,7 @@ namespace ReactiveUI.Primitives.Extensions
         public System.Threading.Tasks.Task Lock<T>(T item, System.IObserver<(T Value, System.IDisposable Sync)>? observer) { }
         public System.Threading.Tasks.ValueTask LockValueTask<T>(T item, System.IObserver<(T Value, System.IDisposable Sync)>? observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_value}, Completed = {_completed}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("CurrentValueSubject: Value = {_value}, Completed = {_completed}, Disposed = {_disposed}")]
     public sealed class CurrentValueSubject<T> : System.IDisposable, System.IObservable<T>, System.IObserver<T>
     {
         public CurrentValueSubject(T initialValue) { }
@@ -978,7 +978,7 @@ namespace ReactiveUI.Primitives.Extensions
     {
         public static System.Threading.Tasks.ValueTask<T> FirstAsValueTask(System.IObservable<T> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsHeartbeat = {IsHeartbeat}, Update = {Update}")]
+    [System.Diagnostics.DebuggerDisplay("Heartbeat: IsHeartbeat = {IsHeartbeat}, Update = {Update}")]
     public readonly record struct Heartbeat<T> : ReactiveUI.Primitives.Extensions.IHeartbeat<T>, System.IEquatable<ReactiveUI.Primitives.Extensions.Heartbeat<T>>
     {
         public Heartbeat() { }
@@ -1027,7 +1027,7 @@ namespace ReactiveUI.Primitives.Extensions
         public SingleValueSignal(T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsStale = {IsStale}")]
+    [System.Diagnostics.DebuggerDisplay("Stale: IsStale = {IsStale}")]
     public readonly record struct Stale<T> : ReactiveUI.Primitives.Extensions.IStale<T>, System.IEquatable<ReactiveUI.Primitives.Extensions.Stale<T>>
     {
         public Stale() { }
@@ -1035,7 +1035,7 @@ namespace ReactiveUI.Primitives.Extensions
         public bool IsStale { get; }
         public T? Update { get; }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {Done}, Timer = {Timer}")]
+    [System.Diagnostics.DebuggerDisplay("TimerSinkState: Done = {Done}, Timer = {Timer}")]
     public sealed class TimerSinkState<T>
     {
         public TimerSinkState(System.IObserver<T> downstream) { }
@@ -1048,13 +1048,13 @@ namespace ReactiveUI.Primitives.Extensions
 }
 namespace ReactiveUI.Primitives.Extensions.Operators
 {
-    [System.Diagnostics.DebuggerDisplay("Left = {_left}, Right = {_right}")]
+    [System.Diagnostics.DebuggerDisplay("BinaryMinMaxObservable: Left = {_left}, Right = {_right}")]
     public sealed class BinaryMinMaxObservable<T> : System.IObservable<T> where T : struct, System.IComparable<T>
     {
         public BinaryMinMaxObservable(System.IObservable<T> left, System.IObservable<T> right, bool emitMaximum) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sourceList}")]
+    [System.Diagnostics.DebuggerDisplay("BooleanReduceObservable: Sources = {_sourceList}")]
     public sealed class BooleanReduceObservable : System.IObservable<bool>
     {
         public BooleanReduceObservable(System.Collections.Generic.IEnumerable<System.IObservable<bool>> sources, bool target) { }
@@ -1075,7 +1075,7 @@ namespace ReactiveUI.Primitives.Extensions.Operators
         public CatchIgnoreEmptyObservable(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, ErrorAction = {_errorAction}")]
+    [System.Diagnostics.DebuggerDisplay("CatchIgnoreObservable: Source = {_source}, ErrorAction = {_errorAction}")]
     public sealed class CatchIgnoreObservable<TSource, TException> : System.IObservable<TSource> where TException : System.Exception
     {
         public CatchIgnoreObservable(System.IObservable<TSource> source, System.Action<TException> errorAction) { }
@@ -1110,7 +1110,7 @@ namespace ReactiveUI.Primitives.Extensions.Operators
     {
         public FirstMatchFromCandidatesObservable(System.Collections.Generic.IReadOnlyList<TKey> candidates, System.Func<TKey, System.IObservable<TRaw>> project, System.Func<TRaw, TResult> transform, System.Func<TResult, bool> predicate, TResult fallback) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
-        [System.Diagnostics.DebuggerDisplay("Completed = {Completed}, HasValue = {HasValue}, Value = {Value}")]
+        [System.Diagnostics.DebuggerDisplay("SyncProbe: Completed = {Completed}, HasValue = {HasValue}, Value = {Value}")]
         public sealed class SyncProbe : System.IObserver<TRaw>
         {
             public SyncProbe() { }
@@ -1131,7 +1131,7 @@ namespace ReactiveUI.Primitives.Extensions.Operators
         public LogErrorsObservable(System.IObservable<T> source, System.Action<System.Exception> logger) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sourceList.Count}")]
+    [System.Diagnostics.DebuggerDisplay("MinMaxObservable: Sources = {_sourceList.Count}")]
     public sealed class MinMaxObservable<T> : System.IObservable<T> where T : struct, System.IComparable<T>
     {
         public MinMaxObservable(System.Collections.Generic.IReadOnlyList<System.IObservable<T>> sources, bool emitMaximum) { }
@@ -1147,7 +1147,7 @@ namespace ReactiveUI.Primitives.Extensions.Operators
         public PairwiseObservable(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<(T Previous, T Current)> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, Subscriptions = {_subscriptionCount}")]
+    [System.Diagnostics.DebuggerDisplay("PartitionObservable: Source = {_source}, Subscriptions = {_subscriptionCount}")]
     public sealed class PartitionObservable<T>
     {
         public PartitionObservable(System.IObservable<T> source, System.Func<T, bool> predicate) { }
@@ -1209,7 +1209,7 @@ namespace ReactiveUI.Primitives.Extensions.Operators
         public SkipWhileNullObservable(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Queued = {_queue.Count}, Processing = {_isProcessing}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("SubscribeAsyncObservable: Queued = {_queue.Count}, Processing = {_isProcessing}, Done = {_done}")]
     public sealed class SubscribeAsyncObservable<T> : System.IDisposable
     {
         public SubscribeAsyncObservable(System.IObservable<T> source, System.Func<T, System.Threading.Tasks.ValueTask> onNext, System.Action<System.Exception>? onError, System.Action? onCompleted) { }
@@ -1281,7 +1281,7 @@ namespace ReactiveUI.Primitives.Signals
         public void RemoveObserver(System.IObserver<T> observer) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Callback = {_callback}, Context = {_context}")]
+    [System.Diagnostics.DebuggerDisplay("AwaitWitness: Callback = {_callback}, Context = {_context}")]
     public sealed class AwaitWitness<T> : System.IObserver<T>
     {
         public AwaitWitness(System.Action callback, bool originalContext) { }
@@ -1313,7 +1313,7 @@ namespace ReactiveUI.Primitives.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public bool TryGetValue(out T? value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_observers}")]
+    [System.Diagnostics.DebuggerDisplay("Broadcaster: Observers = {_observers}")]
     public struct Broadcaster<T> : System.IEquatable<ReactiveUI.Primitives.Signals.Broadcaster<T>>
     {
         public bool HasObservers { get; }
@@ -1332,7 +1332,7 @@ namespace ReactiveUI.Primitives.Signals
         public static bool operator ==(ReactiveUI.Primitives.Signals.Broadcaster<T> left, ReactiveUI.Primitives.Signals.Broadcaster<T> right) { }
         public static bool operator !=(ReactiveUI.Primitives.Signals.Broadcaster<T> left, ReactiveUI.Primitives.Signals.Broadcaster<T> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Task = {_task}, Result = {_result}, Exception = {_exception}")]
+    [System.Diagnostics.DebuggerDisplay("CommandExecution: Task = {_task}, Result = {_result}, Exception = {_exception}")]
     public readonly record struct CommandExecution<TResult> : System.IEquatable<ReactiveUI.Primitives.Signals.CommandExecution<TResult>>
     {
         public CommandExecution(System.Exception exception) { }
@@ -1340,7 +1340,7 @@ namespace ReactiveUI.Primitives.Signals
         public CommandExecution(TResult result) { }
         public readonly ReactiveUI.Primitives.Signals.CommandExecution<TResult> ConfigureAwait(bool continueOnCapturedContext) { }
         public readonly ReactiveUI.Primitives.Signals.CommandExecution<TResult>.Awaiter GetAwaiter() { }
-        [System.Diagnostics.DebuggerDisplay("IsCompleted = {IsCompleted}, Result = {_result}, Exception = {_exception}")]
+        [System.Diagnostics.DebuggerDisplay("Awaiter: IsCompleted = {IsCompleted}, Result = {_result}, Exception = {_exception}")]
         public readonly record struct Awaiter : System.IEquatable<ReactiveUI.Primitives.Signals.CommandExecution<TResult>.Awaiter>, System.Runtime.CompilerServices.ICriticalNotifyCompletion
         {
             public Awaiter(System.Threading.Tasks.Task<TResult>? task, TResult? result, System.Exception? exception, bool continueOnCapturedContext) { }
@@ -1369,7 +1369,7 @@ namespace ReactiveUI.Primitives.Signals
         public ReactiveUI.Primitives.Signals.CommandExecution<TResult> ExecuteAsync(System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Buffer = {_buffer}")]
+    [System.Diagnostics.DebuggerDisplay("DelayableNotificationSignal: Stopped = {_stopped}, Buffer = {_buffer}")]
     public sealed class DelayableNotificationSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T>
     {
         public DelayableNotificationSignal(System.Func<bool> isDelayed, System.Func<System.Collections.Generic.IList<T>, System.Collections.Generic.IEnumerable<T>> flushDistinct) { }
@@ -1382,7 +1382,7 @@ namespace ReactiveUI.Primitives.Signals
         public void OnNext(T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("OnNext = {_onNext}")]
+    [System.Diagnostics.DebuggerDisplay("DelegateWitness: OnNext = {_onNext}")]
     public sealed class DelegateWitness<T> : System.IObserver<T>
     {
         public DelegateWitness(System.Action<T> onNext, System.Action<System.Exception>? onError = null, System.Action? onCompleted = null) { }
@@ -1413,41 +1413,41 @@ namespace ReactiveUI.Primitives.Signals
         System.IObservable<T>? Source { get; }
         void GetOperationCanceled(System.IObserver<System.Exception> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, Predicate = {_predicate}")]
+    [System.Diagnostics.DebuggerDisplay("KeepSignal: Source = {_source}, Predicate = {_predicate}")]
     public sealed class KeepSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public KeepSignal(System.IObservable<T> source, System.Func<T, bool> predicate) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, State = {_state}")]
+    [System.Diagnostics.DebuggerDisplay("KeepWithSignal: Source = {_source}, State = {_state}")]
     public sealed class KeepWithSignal<T, TState> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public KeepWithSignal(System.IObservable<T> source, TState state, System.Func<TState, T, bool> predicate) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, Selector = {_selector}")]
+    [System.Diagnostics.DebuggerDisplay("MapSignal: Source = {_source}, Selector = {_selector}")]
     public sealed class MapSignal<TSource, TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public MapSignal(System.IObservable<TSource> source, System.Func<TSource, TResult> selector) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, State = {_state}")]
+    [System.Diagnostics.DebuggerDisplay("MapWithSignal: Source = {_source}, State = {_state}")]
     public sealed class MapWithSignal<TSource, TState, TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public MapWithSignal(System.IObservable<TSource> source, TState state, System.Func<TState, TSource, TResult> selector) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Subject = {_subject}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("ObserverHandler: Subject = {_subject}, Observer = {_observer}")]
     public sealed class ObserverHandler<T> : System.IDisposable
     {
         public ObserverHandler(ReactiveUI.Primitives.Signals.AsyncSignal<T> subject, System.IObserver<T> observer) { }
         public void Dispose() { }
     }
-    [System.Diagnostics.DebuggerDisplay("{Value}")]
+    [System.Diagnostics.DebuggerDisplay("ProjectedReadOnlyState: {Value}")]
     public sealed class ProjectedReadOnlyState<TSource, TResult> : System.IDisposable, System.IObservable<TResult>, System.IObserver<TSource>
     {
         public System.IObservable<TResult> Changed { get; }
@@ -1509,7 +1509,7 @@ namespace ReactiveUI.Primitives.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public bool TryGetValue(out T? value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, State = {_state}")]
+    [System.Diagnostics.DebuggerDisplay("TapWithSignal: Source = {_source}, State = {_state}")]
     public sealed class TapWithSignal<T, TState> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public TapWithSignal(System.IObservable<T> source, TState state, System.Action<TState, T> onNext) { }

--- a/src/ReactiveUI.Primitives.Core/PublicAPI/net11.0/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Core/PublicAPI/net11.0/PublicAPI.txt
@@ -6,7 +6,7 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Primitives.Tests")]
 namespace ReactiveUI.Primitives
 {
-    [System.Diagnostics.DebuggerDisplay("Subscribe = {_subscribe}")]
+    [System.Diagnostics.DebuggerDisplay("AnonymousSignal: Subscribe = {_subscribe}")]
     public sealed class AnonymousSignal<T> : System.IObservable<T>
     {
         public AnonymousSignal(System.Func<System.IObserver<T>, System.IDisposable> subscribe) { }
@@ -48,7 +48,7 @@ namespace ReactiveUI.Primitives
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public static ReactiveUI.Primitives.Optional<T> Some<T>(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasValue = {HasValue}, Value = {_value}")]
+    [System.Diagnostics.DebuggerDisplay("Optional: HasValue = {HasValue}, Value = {_value}")]
     public readonly record struct Optional<T> : System.IEquatable<ReactiveUI.Primitives.Optional<T>>
     {
         public Optional() { }
@@ -68,7 +68,7 @@ namespace ReactiveUI.Primitives
         public static explicit operator T?(in ReactiveUI.Primitives.Optional<T> value) { }
         public static implicit operator ReactiveUI.Primitives.Optional<T>(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsSuccess = {IsSuccess}, Exception = {Exception}")]
+    [System.Diagnostics.DebuggerDisplay("Result: IsSuccess = {IsSuccess}, Exception = {Exception}")]
     public readonly record struct Result : System.IEquatable<ReactiveUI.Primitives.Result>
     {
         public Result(System.Exception exception) { }
@@ -111,7 +111,7 @@ namespace ReactiveUI.Primitives
 }
 namespace ReactiveUI.Primitives.Advanced
 {
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, Aggregator = {_aggregator}")]
+    [System.Diagnostics.DebuggerDisplay("AggregateWitness: Done = {_done}, Aggregator = {_aggregator}")]
     public sealed class AggregateWitness<T, TResult, TAggregator> : System.IDisposable, System.IObserver<T> where TAggregator : struct, ReactiveUI.Primitives.Advanced.IAggregator<T, TResult, TAggregator>
     {
         public AggregateWitness(System.IObserver<TResult> observer, TAggregator aggregator) { }
@@ -125,7 +125,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("AllPredicateWitness: Done = {_done}, Observer = {_observer}")]
     public sealed class AllPredicateWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public AllPredicateWitness(System.IObserver<bool> observer, System.Func<T, bool> predicate) { }
@@ -139,7 +139,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("AnyPredicateWitness: Done = {_done}, Observer = {_observer}")]
     public sealed class AnyPredicateWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public AnyPredicateWitness(System.IObserver<bool> observer, System.Func<T, bool> predicate) { }
@@ -153,7 +153,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("AnyWitness: Done = {_done}, Observer = {_observer}")]
     public sealed class AnyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public AnyWitness(System.IObserver<bool> observer) { }
@@ -168,7 +168,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_value}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("AppendDelegateWitness: Value = {_value}, Subscription = {_subscription}")]
     public sealed class AppendDelegateWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public AppendDelegateWitness(System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted, T value) { }
@@ -180,7 +180,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("AppendedValue = {_value}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("AppendWitness: AppendedValue = {_value}, Observer = {_observer}")]
     public sealed class AppendWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public AppendWitness(System.IObserver<T> observer, T value) { }
@@ -202,7 +202,7 @@ namespace ReactiveUI.Primitives.Advanced
         public System.Collections.Generic.IAsyncEnumerable<T> Values { get; }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Skip = {_skip}, Index = {_index}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("BufferWitness: Count = {_count}, Skip = {_skip}, Index = {_index}, Done = {_done}")]
     public sealed class BufferWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public BufferWitness(System.IObserver<System.Collections.Generic.IList<T>> observer, int count, int skip) { }
@@ -213,7 +213,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("OnNext = {_onNext}, OnError = {_onError}, OnCompleted = {_onCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("CallbackWitness: OnNext = {_onNext}, OnError = {_onError}, OnCompleted = {_onCompleted}")]
     public sealed class CallbackWitness<T> : System.IObserver<T>
     {
         public CallbackWitness(System.Action<T> onNext, System.Action<System.Exception>? onError, System.Action<ReactiveUI.Primitives.Result>? onCompleted) { }
@@ -224,7 +224,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_values.Count}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("CollectArrayWitness: Count = {_values.Count}, Subscription = {_subscription}")]
     public sealed class CollectArrayWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CollectArrayWitness(System.IObserver<T[]> observer) { }
@@ -239,7 +239,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_values.Count}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("CollectListWitness: Count = {_values.Count}, Subscription = {_subscription}")]
     public sealed class CollectListWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CollectListWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -254,7 +254,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SoughtValue = {_value}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("ContainsWitness: SoughtValue = {_value}, Done = {_done}")]
     public sealed class ContainsWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public ContainsWitness(System.IObserver<bool> observer, T value, System.Collections.Generic.IEqualityComparer<T> comparer) { }
@@ -268,7 +268,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {Items.Length}")]
+    [System.Diagnostics.DebuggerDisplay("CopyOnWriteList: Count = {Items.Length}")]
     public sealed class CopyOnWriteList<T>
     {
         public CopyOnWriteList(T[] data) { }
@@ -278,20 +278,20 @@ namespace ReactiveUI.Primitives.Advanced
         public int IndexOf(T value) { }
         public ReactiveUI.Primitives.Advanced.CopyOnWriteList<T> Remove(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Result = {Result}")]
+    [System.Diagnostics.DebuggerDisplay("CountAggregator: Result = {Result}")]
     public readonly record struct CountAggregator<T> : ReactiveUI.Primitives.Advanced.IAggregator<T, int, ReactiveUI.Primitives.Advanced.CountAggregator<T>>, System.IEquatable<ReactiveUI.Primitives.Advanced.CountAggregator<T>>
     {
         public int Result { get; }
         public readonly ReactiveUI.Primitives.Advanced.CountAggregator<T> Add(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Result = {Result}, Predicate = {_predicate}")]
+    [System.Diagnostics.DebuggerDisplay("CountPredicateAggregator: Result = {Result}, Predicate = {_predicate}")]
     public readonly record struct CountPredicateAggregator<T> : ReactiveUI.Primitives.Advanced.IAggregator<T, int, ReactiveUI.Primitives.Advanced.CountPredicateAggregator<T>>, System.IEquatable<ReactiveUI.Primitives.Advanced.CountPredicateAggregator<T>>
     {
         public CountPredicateAggregator(System.Func<T, bool> predicate) { }
         public int Result { get; }
         public readonly ReactiveUI.Primitives.Advanced.CountPredicateAggregator<T> Add(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Seen = {_seen}, DefaultValue = {_defaultValue}")]
+    [System.Diagnostics.DebuggerDisplay("DefaultIfEmptyWitness: Seen = {_seen}, DefaultValue = {_defaultValue}")]
     public sealed class DefaultIfEmptyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public DefaultIfEmptyWitness(System.IObserver<T> observer, T defaultValue) { }
@@ -316,21 +316,21 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Result = {Result}, Seen = {_seen}")]
+    [System.Diagnostics.DebuggerDisplay("DistinctByCountAggregator: Result = {Result}, Seen = {_seen}")]
     public readonly record struct DistinctByCountAggregator<T, TKey> : ReactiveUI.Primitives.Advanced.IAggregator<T, int, ReactiveUI.Primitives.Advanced.DistinctByCountAggregator<T, TKey>>, System.IEquatable<ReactiveUI.Primitives.Advanced.DistinctByCountAggregator<T, TKey>>
     {
         public DistinctByCountAggregator(System.Func<T, TKey> keySelector, System.Collections.Generic.IEqualityComparer<TKey>? comparer) { }
         public int Result { get; }
         public readonly ReactiveUI.Primitives.Advanced.DistinctByCountAggregator<T, TKey> Add(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Result = {Result}, Seen = {_seen}")]
+    [System.Diagnostics.DebuggerDisplay("DistinctByLongCountAggregator: Result = {Result}, Seen = {_seen}")]
     public readonly record struct DistinctByLongCountAggregator<T, TKey> : ReactiveUI.Primitives.Advanced.IAggregator<T, long, ReactiveUI.Primitives.Advanced.DistinctByLongCountAggregator<T, TKey>>, System.IEquatable<ReactiveUI.Primitives.Advanced.DistinctByLongCountAggregator<T, TKey>>
     {
         public DistinctByLongCountAggregator(System.Func<T, TKey> keySelector, System.Collections.Generic.IEqualityComparer<TKey>? comparer) { }
         public long Result { get; }
         public readonly ReactiveUI.Primitives.Advanced.DistinctByLongCountAggregator<T, TKey> Add(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, SeenKeys = {_seen.Count}")]
+    [System.Diagnostics.DebuggerDisplay("DistinctByWitness: Done = {_done}, SeenKeys = {_seen.Count}")]
     public sealed class DistinctByWitness<T, TKey> : System.IDisposable, System.IObserver<T>
     {
         public DistinctByWitness(System.IObserver<T> observer, System.Func<T, TKey> keySelector, System.Collections.Generic.IEqualityComparer<TKey>? comparer) { }
@@ -344,7 +344,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Seen = {_seen.Count}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("DistinctWitness: Seen = {_seen.Count}, Subscription = {_subscription}")]
     public sealed class DistinctWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public DistinctWitness(System.IObserver<T> observer, System.Collections.Generic.HashSet<T> seen) { }
@@ -358,7 +358,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("OnNext = {_onNext}, OnError = {_onError}, OnCompleted = {_onCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("EmptyWitness: OnNext = {_onNext}, OnError = {_onError}, OnCompleted = {_onCompleted}")]
     public sealed class EmptyWitness<T> : System.IObserver<T>
     {
         public EmptyWitness(System.Action<T> onNext) { }
@@ -373,7 +373,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Current = {_current}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("FoldWitness: Current = {_current}, Observer = {_observer}")]
     public sealed class FoldWitness<TSource, TAccumulate> : System.IDisposable, System.IObserver<TSource>
     {
         public FoldWitness(System.IObserver<TAccumulate> observer, TAccumulate seed, System.Func<TAccumulate, TSource, TAccumulate> accumulator) { }
@@ -387,7 +387,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("ForwardingWitness: Observer = {_observer}")]
     public sealed class ForwardingWitness<T> : System.IObserver<T>
     {
         public ForwardingWitness(System.IObserver<T> observer) { }
@@ -398,7 +398,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Values = {_values}, CancellationToken = {_cancellationToken}")]
+    [System.Diagnostics.DebuggerDisplay("FromEnumerableSignal: Values = {_values}, CancellationToken = {_cancellationToken}")]
     public sealed class FromEnumerableSignal<T> : ReactiveUI.Primitives.Advanced.IInlineSignal<T>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public FromEnumerableSignal(System.Collections.Generic.IEnumerable<T> values) { }
@@ -427,7 +427,7 @@ namespace ReactiveUI.Primitives.Advanced
     {
         bool IsRequiredSubscribeOnCurrentThread() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("IgnoreValuesWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class IgnoreValuesWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public IgnoreValuesWitness(System.IObserver<T> observer) { }
@@ -441,7 +441,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_value}")]
+    [System.Diagnostics.DebuggerDisplay("ImmediateReturnSignal: Value = {_value}")]
     public sealed class ImmediateReturnSignal<T> : ReactiveUI.Primitives.Advanced.IInlineSignal<T>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ImmediateReturnSignal(T value) { }
@@ -450,7 +450,7 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
         public System.IDisposable Subscribe(System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Error = {_error}")]
+    [System.Diagnostics.DebuggerDisplay("ImmediateThrowSignal: Error = {_error}")]
     public sealed class ImmediateThrowSignal<T> : ReactiveUI.Primitives.Advanced.IInlineSignal<T>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ImmediateThrowSignal(System.Exception error) { }
@@ -484,7 +484,7 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<bool> observer) { }
         public System.IDisposable Subscribe(System.Action<bool> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_x}")]
+    [System.Diagnostics.DebuggerDisplay("ImmutableReturnInt32Signal: Value = {_x}")]
     public sealed class ImmutableReturnInt32Signal : ReactiveUI.Primitives.Advanced.IInlineSignal<int>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<int>
     {
         public ImmutableReturnInt32Signal(int x) { }
@@ -502,7 +502,7 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<bool> observer) { }
         public System.IDisposable Subscribe(System.Action<bool> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("KeepNotNullWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class KeepNotNullWitness<T> : System.IDisposable, System.IObserver<T?> where T : class
     {
         public KeepNotNullWitness(System.IObserver<T> observer) { }
@@ -516,7 +516,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("KeepTypeWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class KeepTypeWitness<TResult> : System.IDisposable, System.IObserver<object?>
     {
         public KeepTypeWitness(System.IObserver<TResult> observer) { }
@@ -530,7 +530,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasObservers = {HasObservers}, Count = {_observers.Items.Length}")]
+    [System.Diagnostics.DebuggerDisplay("ListWitness: HasObservers = {HasObservers}, Count = {_observers.Items.Length}")]
     public sealed class ListWitness<T> : System.IObserver<T>
     {
         public ListWitness(ReactiveUI.Primitives.Advanced.CopyOnWriteList<System.IObserver<T>> observers) { }
@@ -539,20 +539,20 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Result = {Result}")]
+    [System.Diagnostics.DebuggerDisplay("LongCountAggregator: Result = {Result}")]
     public readonly record struct LongCountAggregator<T> : ReactiveUI.Primitives.Advanced.IAggregator<T, long, ReactiveUI.Primitives.Advanced.LongCountAggregator<T>>, System.IEquatable<ReactiveUI.Primitives.Advanced.LongCountAggregator<T>>
     {
         public long Result { get; }
         public readonly ReactiveUI.Primitives.Advanced.LongCountAggregator<T> Add(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Result = {Result}, Predicate = {_predicate}")]
+    [System.Diagnostics.DebuggerDisplay("LongCountPredicateAggregator: Result = {Result}, Predicate = {_predicate}")]
     public readonly record struct LongCountPredicateAggregator<T> : ReactiveUI.Primitives.Advanced.IAggregator<T, long, ReactiveUI.Primitives.Advanced.LongCountPredicateAggregator<T>>, System.IEquatable<ReactiveUI.Primitives.Advanced.LongCountPredicateAggregator<T>>
     {
         public LongCountPredicateAggregator(System.Func<T, bool> predicate) { }
         public long Result { get; }
         public readonly ReactiveUI.Primitives.Advanced.LongCountPredicateAggregator<T> Add(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Ranges = {_ranges.Length}")]
+    [System.Diagnostics.DebuggerDisplay("RangeConcatSignal: Ranges = {_ranges.Length}")]
     public sealed class RangeConcatSignal : ReactiveUI.Primitives.Advanced.IInlineSignal<int>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<int>
     {
         public RangeConcatSignal(ReactiveUI.Primitives.Advanced.RangeSignal[] ranges) { }
@@ -561,7 +561,7 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<int> observer) { }
         public System.IDisposable Subscribe(System.Action<int> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Start = {Start}, Count = {Count}")]
+    [System.Diagnostics.DebuggerDisplay("RangeSignal: Start = {Start}, Count = {Count}")]
     public sealed class RangeSignal : ReactiveUI.Primitives.Advanced.IInlineSignal<int>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<int>
     {
         public RangeSignal(int start, int count) { }
@@ -572,7 +572,7 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<int> observer) { }
         public System.IDisposable Subscribe(System.Action<int> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, LeftStart = {_leftStart}, RightStart = {_rightStart}")]
+    [System.Diagnostics.DebuggerDisplay("RangeZipSignal: Count = {_count}, LeftStart = {_leftStart}, RightStart = {_rightStart}")]
     public sealed class RangeZipSignal<TResult> : ReactiveUI.Primitives.Advanced.IInlineSignal<TResult>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public RangeZipSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
@@ -581,7 +581,7 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
         public System.IDisposable Subscribe(System.Action<TResult> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Current = {_current}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("ReduceWitness: Current = {_current}, Subscription = {_subscription}")]
     public sealed class ReduceWitness<TSource, TAccumulate> : System.IDisposable, System.IObserver<TSource>
     {
         public ReduceWitness(System.IObserver<TAccumulate> observer, TAccumulate seed, System.Func<TAccumulate, TSource, TAccumulate> accumulator) { }
@@ -595,7 +595,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_value}, Count = {_count}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSignal: Value = {_value}, Count = {_count}")]
     public sealed class RepeatSignal<T> : ReactiveUI.Primitives.Advanced.IInlineSignal<T>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public RepeatSignal(T value, int count) { }
@@ -620,7 +620,7 @@ namespace ReactiveUI.Primitives.Advanced
         public static void Fault<TResult>(System.IObserver<TResult> observer, System.Exception error, System.IDisposable sink) { }
         public static void Fault<TResult>(System.IObserver<TResult> observer, System.Exception error, System.IDisposable sink, ref bool done) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Skipping = {_skipping}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SkipWhileWitness: Skipping = {_skipping}, Subscription = {_subscription}")]
     public sealed class SkipWhileWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SkipWhileWitness(System.IObserver<T> observer, System.Func<T, bool> predicate) { }
@@ -634,7 +634,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Remaining = {_remaining}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SkipWitness: Remaining = {_remaining}, Observer = {_observer}")]
     public sealed class SkipWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SkipWitness(System.IObserver<T> observer, int count) { }
@@ -648,7 +648,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("State = {_state}, OnError = {_onError}")]
+    [System.Diagnostics.DebuggerDisplay("StatefulWitness: State = {_state}, OnError = {_onError}")]
     public sealed class StatefulWitness<T, TState> : System.IObserver<T>
     {
         public StatefulWitness(TState state, System.Action<T, TState> onNext, System.Action<System.Exception, TState>? onError, System.Action<ReactiveUI.Primitives.Result, TState>? onCompleted) { }
@@ -665,7 +665,7 @@ namespace ReactiveUI.Primitives.Advanced
         public static void Assign(ref System.IDisposable? slot, System.IDisposable subscription) { }
         public static void Release(ref System.IDisposable? slot) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SynchronizeWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SynchronizeWitness(System.IObserver<T> observer) { }
@@ -678,7 +678,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {_completed}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("TakeWhileWitness: Completed = {_completed}, Subscription = {_subscription}")]
     public sealed class TakeWhileWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TakeWhileWitness(System.IObserver<T> observer, System.Func<T, bool> predicate) { }
@@ -691,7 +691,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Remaining = {_remaining}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TakeWitness: Remaining = {_remaining}, Stopped = {_stopped}")]
     public sealed class TakeWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TakeWitness(System.IObserver<T> observer, int count) { }
@@ -703,7 +703,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("TapWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class TapWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TapWitness(System.IObserver<T> observer, System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
@@ -723,7 +723,7 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("InitialState = {_initialState}, Condition = {_condition}")]
+    [System.Diagnostics.DebuggerDisplay("UnfoldSignal: InitialState = {_initialState}, Condition = {_condition}")]
     public sealed class UnfoldSignal<TState, TResult> : ReactiveUI.Primitives.Advanced.IInlineSignal<TResult>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public UnfoldSignal(TState initialState, System.Func<TState, bool> condition, System.Func<TState, TState> iterate, System.Func<TState, TResult> resultSelector) { }
@@ -732,7 +732,7 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
         public System.IDisposable Subscribe(System.Action<TResult> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLast = {_hasLast}, Last = {_last}")]
+    [System.Diagnostics.DebuggerDisplay("UniqueByWitness: HasLast = {_hasLast}, Last = {_last}")]
     public sealed class UniqueByWitness<T, TKey> : System.IDisposable, System.IObserver<T>
     {
         public UniqueByWitness(System.IObserver<T> observer, System.Func<T, TKey> keySelector, System.Collections.Generic.IEqualityComparer<TKey> comparer) { }
@@ -746,7 +746,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLast = {_hasLast}, Last = {_last}")]
+    [System.Diagnostics.DebuggerDisplay("UniqueWitness: HasLast = {_hasLast}, Last = {_last}")]
     public sealed class UniqueWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public UniqueWitness(System.IObserver<T> observer, System.Collections.Generic.IEqualityComparer<T> comparer) { }
@@ -760,7 +760,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ResourceFactory = {_resourceFactory}, SignalFactory = {_signalFactory}")]
+    [System.Diagnostics.DebuggerDisplay("UseSignal: ResourceFactory = {_resourceFactory}, SignalFactory = {_signalFactory}")]
     public sealed class UseSignal<TResource, T> : System.IObservable<T> where TResource : System.IDisposable
     {
         public UseSignal(System.Func<TResource> resourceFactory, System.Func<TResource, System.IObservable<T>> signalFactory) { }
@@ -891,7 +891,7 @@ namespace ReactiveUI.Primitives.Core
         public static bool operator ==(ReactiveUI.Primitives.Core.Moment<T> first, ReactiveUI.Primitives.Core.Moment<T> second) { }
         public static bool operator !=(ReactiveUI.Primitives.Core.Moment<T> first, ReactiveUI.Primitives.Core.Moment<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {Count}, Capacity = {_items.Length}")]
+    [System.Diagnostics.DebuggerDisplay("PriorityQueue: Count = {Count}, Capacity = {_items.Length}")]
     public sealed class PriorityQueue<T> where T : System.IComparable<T>
     {
         public PriorityQueue() { }
@@ -934,14 +934,14 @@ namespace ReactiveUI.Primitives.Core
 }
 namespace ReactiveUI.Primitives.Extensions
 {
-    [System.Diagnostics.DebuggerDisplay("Outstanding = {_outstanding}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("ConcurrencyLimiter: Outstanding = {_outstanding}, Disposed = {_disposed}")]
     public sealed class ConcurrencyLimiter<T> : System.IObservable<T>
     {
         public ConcurrencyLimiter(System.Collections.Generic.IEnumerable<System.Threading.Tasks.Task<T>> taskFunctions, int maxConcurrency) { }
         public System.IObservable<T> Observable { get; }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Locked = {_locked}, CompletedPhases = {CompletedPhases}")]
+    [System.Diagnostics.DebuggerDisplay("Continuation: Locked = {_locked}, CompletedPhases = {CompletedPhases}")]
     public class Continuation : System.IDisposable
     {
         public Continuation() { }
@@ -951,7 +951,7 @@ namespace ReactiveUI.Primitives.Extensions
         public System.Threading.Tasks.Task Lock<T>(T item, System.IObserver<(T Value, System.IDisposable Sync)>? observer) { }
         public System.Threading.Tasks.ValueTask LockValueTask<T>(T item, System.IObserver<(T Value, System.IDisposable Sync)>? observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_value}, Completed = {_completed}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("CurrentValueSubject: Value = {_value}, Completed = {_completed}, Disposed = {_disposed}")]
     public sealed class CurrentValueSubject<T> : System.IDisposable, System.IObservable<T>, System.IObserver<T>
     {
         public CurrentValueSubject(T initialValue) { }
@@ -978,7 +978,7 @@ namespace ReactiveUI.Primitives.Extensions
     {
         public static System.Threading.Tasks.ValueTask<T> FirstAsValueTask(System.IObservable<T> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsHeartbeat = {IsHeartbeat}, Update = {Update}")]
+    [System.Diagnostics.DebuggerDisplay("Heartbeat: IsHeartbeat = {IsHeartbeat}, Update = {Update}")]
     public readonly record struct Heartbeat<T> : ReactiveUI.Primitives.Extensions.IHeartbeat<T>, System.IEquatable<ReactiveUI.Primitives.Extensions.Heartbeat<T>>
     {
         public Heartbeat() { }
@@ -1027,7 +1027,7 @@ namespace ReactiveUI.Primitives.Extensions
         public SingleValueSignal(T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsStale = {IsStale}")]
+    [System.Diagnostics.DebuggerDisplay("Stale: IsStale = {IsStale}")]
     public readonly record struct Stale<T> : ReactiveUI.Primitives.Extensions.IStale<T>, System.IEquatable<ReactiveUI.Primitives.Extensions.Stale<T>>
     {
         public Stale() { }
@@ -1035,7 +1035,7 @@ namespace ReactiveUI.Primitives.Extensions
         public bool IsStale { get; }
         public T? Update { get; }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {Done}, Timer = {Timer}")]
+    [System.Diagnostics.DebuggerDisplay("TimerSinkState: Done = {Done}, Timer = {Timer}")]
     public sealed class TimerSinkState<T>
     {
         public TimerSinkState(System.IObserver<T> downstream) { }
@@ -1048,13 +1048,13 @@ namespace ReactiveUI.Primitives.Extensions
 }
 namespace ReactiveUI.Primitives.Extensions.Operators
 {
-    [System.Diagnostics.DebuggerDisplay("Left = {_left}, Right = {_right}")]
+    [System.Diagnostics.DebuggerDisplay("BinaryMinMaxObservable: Left = {_left}, Right = {_right}")]
     public sealed class BinaryMinMaxObservable<T> : System.IObservable<T> where T : struct, System.IComparable<T>
     {
         public BinaryMinMaxObservable(System.IObservable<T> left, System.IObservable<T> right, bool emitMaximum) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sourceList}")]
+    [System.Diagnostics.DebuggerDisplay("BooleanReduceObservable: Sources = {_sourceList}")]
     public sealed class BooleanReduceObservable : System.IObservable<bool>
     {
         public BooleanReduceObservable(System.Collections.Generic.IEnumerable<System.IObservable<bool>> sources, bool target) { }
@@ -1075,7 +1075,7 @@ namespace ReactiveUI.Primitives.Extensions.Operators
         public CatchIgnoreEmptyObservable(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, ErrorAction = {_errorAction}")]
+    [System.Diagnostics.DebuggerDisplay("CatchIgnoreObservable: Source = {_source}, ErrorAction = {_errorAction}")]
     public sealed class CatchIgnoreObservable<TSource, TException> : System.IObservable<TSource> where TException : System.Exception
     {
         public CatchIgnoreObservable(System.IObservable<TSource> source, System.Action<TException> errorAction) { }
@@ -1110,7 +1110,7 @@ namespace ReactiveUI.Primitives.Extensions.Operators
     {
         public FirstMatchFromCandidatesObservable(System.Collections.Generic.IReadOnlyList<TKey> candidates, System.Func<TKey, System.IObservable<TRaw>> project, System.Func<TRaw, TResult> transform, System.Func<TResult, bool> predicate, TResult fallback) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
-        [System.Diagnostics.DebuggerDisplay("Completed = {Completed}, HasValue = {HasValue}, Value = {Value}")]
+        [System.Diagnostics.DebuggerDisplay("SyncProbe: Completed = {Completed}, HasValue = {HasValue}, Value = {Value}")]
         public sealed class SyncProbe : System.IObserver<TRaw>
         {
             public SyncProbe() { }
@@ -1131,7 +1131,7 @@ namespace ReactiveUI.Primitives.Extensions.Operators
         public LogErrorsObservable(System.IObservable<T> source, System.Action<System.Exception> logger) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sourceList.Count}")]
+    [System.Diagnostics.DebuggerDisplay("MinMaxObservable: Sources = {_sourceList.Count}")]
     public sealed class MinMaxObservable<T> : System.IObservable<T> where T : struct, System.IComparable<T>
     {
         public MinMaxObservable(System.Collections.Generic.IReadOnlyList<System.IObservable<T>> sources, bool emitMaximum) { }
@@ -1147,7 +1147,7 @@ namespace ReactiveUI.Primitives.Extensions.Operators
         public PairwiseObservable(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<(T Previous, T Current)> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, Subscriptions = {_subscriptionCount}")]
+    [System.Diagnostics.DebuggerDisplay("PartitionObservable: Source = {_source}, Subscriptions = {_subscriptionCount}")]
     public sealed class PartitionObservable<T>
     {
         public PartitionObservable(System.IObservable<T> source, System.Func<T, bool> predicate) { }
@@ -1209,7 +1209,7 @@ namespace ReactiveUI.Primitives.Extensions.Operators
         public SkipWhileNullObservable(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Queued = {_queue.Count}, Processing = {_isProcessing}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("SubscribeAsyncObservable: Queued = {_queue.Count}, Processing = {_isProcessing}, Done = {_done}")]
     public sealed class SubscribeAsyncObservable<T> : System.IDisposable
     {
         public SubscribeAsyncObservable(System.IObservable<T> source, System.Func<T, System.Threading.Tasks.ValueTask> onNext, System.Action<System.Exception>? onError, System.Action? onCompleted) { }
@@ -1281,7 +1281,7 @@ namespace ReactiveUI.Primitives.Signals
         public void RemoveObserver(System.IObserver<T> observer) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Callback = {_callback}, Context = {_context}")]
+    [System.Diagnostics.DebuggerDisplay("AwaitWitness: Callback = {_callback}, Context = {_context}")]
     public sealed class AwaitWitness<T> : System.IObserver<T>
     {
         public AwaitWitness(System.Action callback, bool originalContext) { }
@@ -1313,7 +1313,7 @@ namespace ReactiveUI.Primitives.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public bool TryGetValue(out T? value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_observers}")]
+    [System.Diagnostics.DebuggerDisplay("Broadcaster: Observers = {_observers}")]
     public struct Broadcaster<T> : System.IEquatable<ReactiveUI.Primitives.Signals.Broadcaster<T>>
     {
         public bool HasObservers { get; }
@@ -1332,7 +1332,7 @@ namespace ReactiveUI.Primitives.Signals
         public static bool operator ==(ReactiveUI.Primitives.Signals.Broadcaster<T> left, ReactiveUI.Primitives.Signals.Broadcaster<T> right) { }
         public static bool operator !=(ReactiveUI.Primitives.Signals.Broadcaster<T> left, ReactiveUI.Primitives.Signals.Broadcaster<T> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Task = {_task}, Result = {_result}, Exception = {_exception}")]
+    [System.Diagnostics.DebuggerDisplay("CommandExecution: Task = {_task}, Result = {_result}, Exception = {_exception}")]
     public readonly record struct CommandExecution<TResult> : System.IEquatable<ReactiveUI.Primitives.Signals.CommandExecution<TResult>>
     {
         public CommandExecution(System.Exception exception) { }
@@ -1340,7 +1340,7 @@ namespace ReactiveUI.Primitives.Signals
         public CommandExecution(TResult result) { }
         public readonly ReactiveUI.Primitives.Signals.CommandExecution<TResult> ConfigureAwait(bool continueOnCapturedContext) { }
         public readonly ReactiveUI.Primitives.Signals.CommandExecution<TResult>.Awaiter GetAwaiter() { }
-        [System.Diagnostics.DebuggerDisplay("IsCompleted = {IsCompleted}, Result = {_result}, Exception = {_exception}")]
+        [System.Diagnostics.DebuggerDisplay("Awaiter: IsCompleted = {IsCompleted}, Result = {_result}, Exception = {_exception}")]
         public readonly record struct Awaiter : System.IEquatable<ReactiveUI.Primitives.Signals.CommandExecution<TResult>.Awaiter>, System.Runtime.CompilerServices.ICriticalNotifyCompletion
         {
             public Awaiter(System.Threading.Tasks.Task<TResult>? task, TResult? result, System.Exception? exception, bool continueOnCapturedContext) { }
@@ -1369,7 +1369,7 @@ namespace ReactiveUI.Primitives.Signals
         public ReactiveUI.Primitives.Signals.CommandExecution<TResult> ExecuteAsync(System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Buffer = {_buffer}")]
+    [System.Diagnostics.DebuggerDisplay("DelayableNotificationSignal: Stopped = {_stopped}, Buffer = {_buffer}")]
     public sealed class DelayableNotificationSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T>
     {
         public DelayableNotificationSignal(System.Func<bool> isDelayed, System.Func<System.Collections.Generic.IList<T>, System.Collections.Generic.IEnumerable<T>> flushDistinct) { }
@@ -1382,7 +1382,7 @@ namespace ReactiveUI.Primitives.Signals
         public void OnNext(T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("OnNext = {_onNext}")]
+    [System.Diagnostics.DebuggerDisplay("DelegateWitness: OnNext = {_onNext}")]
     public sealed class DelegateWitness<T> : System.IObserver<T>
     {
         public DelegateWitness(System.Action<T> onNext, System.Action<System.Exception>? onError = null, System.Action? onCompleted = null) { }
@@ -1413,41 +1413,41 @@ namespace ReactiveUI.Primitives.Signals
         System.IObservable<T>? Source { get; }
         void GetOperationCanceled(System.IObserver<System.Exception> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, Predicate = {_predicate}")]
+    [System.Diagnostics.DebuggerDisplay("KeepSignal: Source = {_source}, Predicate = {_predicate}")]
     public sealed class KeepSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public KeepSignal(System.IObservable<T> source, System.Func<T, bool> predicate) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, State = {_state}")]
+    [System.Diagnostics.DebuggerDisplay("KeepWithSignal: Source = {_source}, State = {_state}")]
     public sealed class KeepWithSignal<T, TState> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public KeepWithSignal(System.IObservable<T> source, TState state, System.Func<TState, T, bool> predicate) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, Selector = {_selector}")]
+    [System.Diagnostics.DebuggerDisplay("MapSignal: Source = {_source}, Selector = {_selector}")]
     public sealed class MapSignal<TSource, TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public MapSignal(System.IObservable<TSource> source, System.Func<TSource, TResult> selector) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, State = {_state}")]
+    [System.Diagnostics.DebuggerDisplay("MapWithSignal: Source = {_source}, State = {_state}")]
     public sealed class MapWithSignal<TSource, TState, TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public MapWithSignal(System.IObservable<TSource> source, TState state, System.Func<TState, TSource, TResult> selector) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Subject = {_subject}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("ObserverHandler: Subject = {_subject}, Observer = {_observer}")]
     public sealed class ObserverHandler<T> : System.IDisposable
     {
         public ObserverHandler(ReactiveUI.Primitives.Signals.AsyncSignal<T> subject, System.IObserver<T> observer) { }
         public void Dispose() { }
     }
-    [System.Diagnostics.DebuggerDisplay("{Value}")]
+    [System.Diagnostics.DebuggerDisplay("ProjectedReadOnlyState: {Value}")]
     public sealed class ProjectedReadOnlyState<TSource, TResult> : System.IDisposable, System.IObservable<TResult>, System.IObserver<TSource>
     {
         public System.IObservable<TResult> Changed { get; }
@@ -1509,7 +1509,7 @@ namespace ReactiveUI.Primitives.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public bool TryGetValue(out T? value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, State = {_state}")]
+    [System.Diagnostics.DebuggerDisplay("TapWithSignal: Source = {_source}, State = {_state}")]
     public sealed class TapWithSignal<T, TState> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public TapWithSignal(System.IObservable<T> source, TState state, System.Action<TState, T> onNext) { }

--- a/src/ReactiveUI.Primitives.Core/PublicAPI/net462/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Core/PublicAPI/net462/PublicAPI.txt
@@ -6,7 +6,7 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Primitives.Tests")]
 namespace ReactiveUI.Primitives
 {
-    [System.Diagnostics.DebuggerDisplay("Subscribe = {_subscribe}")]
+    [System.Diagnostics.DebuggerDisplay("AnonymousSignal: Subscribe = {_subscribe}")]
     public sealed class AnonymousSignal<T> : System.IObservable<T>
     {
         public AnonymousSignal(System.Func<System.IObserver<T>, System.IDisposable> subscribe) { }
@@ -48,7 +48,7 @@ namespace ReactiveUI.Primitives
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public static ReactiveUI.Primitives.Optional<T> Some<T>(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasValue = {HasValue}, Value = {_value}")]
+    [System.Diagnostics.DebuggerDisplay("Optional: HasValue = {HasValue}, Value = {_value}")]
     public readonly record struct Optional<T> : System.IEquatable<ReactiveUI.Primitives.Optional<T>>
     {
         public Optional() { }
@@ -67,7 +67,7 @@ namespace ReactiveUI.Primitives
         public static explicit operator T?(in ReactiveUI.Primitives.Optional<T> value) { }
         public static implicit operator ReactiveUI.Primitives.Optional<T>(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsSuccess = {IsSuccess}, Exception = {Exception}")]
+    [System.Diagnostics.DebuggerDisplay("Result: IsSuccess = {IsSuccess}, Exception = {Exception}")]
     public readonly record struct Result : System.IEquatable<ReactiveUI.Primitives.Result>
     {
         public Result(System.Exception exception) { }
@@ -108,7 +108,7 @@ namespace ReactiveUI.Primitives
 }
 namespace ReactiveUI.Primitives.Advanced
 {
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, Aggregator = {_aggregator}")]
+    [System.Diagnostics.DebuggerDisplay("AggregateWitness: Done = {_done}, Aggregator = {_aggregator}")]
     public sealed class AggregateWitness<T, TResult, TAggregator> : System.IDisposable, System.IObserver<T> where TAggregator : struct, ReactiveUI.Primitives.Advanced.IAggregator<T, TResult, TAggregator>
     {
         public AggregateWitness(System.IObserver<TResult> observer, TAggregator aggregator) { }
@@ -122,7 +122,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("AllPredicateWitness: Done = {_done}, Observer = {_observer}")]
     public sealed class AllPredicateWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public AllPredicateWitness(System.IObserver<bool> observer, System.Func<T, bool> predicate) { }
@@ -136,7 +136,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("AnyPredicateWitness: Done = {_done}, Observer = {_observer}")]
     public sealed class AnyPredicateWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public AnyPredicateWitness(System.IObserver<bool> observer, System.Func<T, bool> predicate) { }
@@ -150,7 +150,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("AnyWitness: Done = {_done}, Observer = {_observer}")]
     public sealed class AnyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public AnyWitness(System.IObserver<bool> observer) { }
@@ -165,7 +165,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_value}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("AppendDelegateWitness: Value = {_value}, Subscription = {_subscription}")]
     public sealed class AppendDelegateWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public AppendDelegateWitness(System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted, T value) { }
@@ -177,7 +177,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("AppendedValue = {_value}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("AppendWitness: AppendedValue = {_value}, Observer = {_observer}")]
     public sealed class AppendWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public AppendWitness(System.IObserver<T> observer, T value) { }
@@ -191,7 +191,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Skip = {_skip}, Index = {_index}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("BufferWitness: Count = {_count}, Skip = {_skip}, Index = {_index}, Done = {_done}")]
     public sealed class BufferWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public BufferWitness(System.IObserver<System.Collections.Generic.IList<T>> observer, int count, int skip) { }
@@ -202,7 +202,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("OnNext = {_onNext}, OnError = {_onError}, OnCompleted = {_onCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("CallbackWitness: OnNext = {_onNext}, OnError = {_onError}, OnCompleted = {_onCompleted}")]
     public sealed class CallbackWitness<T> : System.IObserver<T>
     {
         public CallbackWitness(System.Action<T> onNext, System.Action<System.Exception>? onError, System.Action<ReactiveUI.Primitives.Result>? onCompleted) { }
@@ -213,7 +213,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_values.Count}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("CollectArrayWitness: Count = {_values.Count}, Subscription = {_subscription}")]
     public sealed class CollectArrayWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CollectArrayWitness(System.IObserver<T[]> observer) { }
@@ -228,7 +228,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_values.Count}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("CollectListWitness: Count = {_values.Count}, Subscription = {_subscription}")]
     public sealed class CollectListWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CollectListWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -243,7 +243,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SoughtValue = {_value}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("ContainsWitness: SoughtValue = {_value}, Done = {_done}")]
     public sealed class ContainsWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public ContainsWitness(System.IObserver<bool> observer, T value, System.Collections.Generic.IEqualityComparer<T> comparer) { }
@@ -257,7 +257,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {Items.Length}")]
+    [System.Diagnostics.DebuggerDisplay("CopyOnWriteList: Count = {Items.Length}")]
     public sealed class CopyOnWriteList<T>
     {
         public CopyOnWriteList(T[] data) { }
@@ -267,20 +267,20 @@ namespace ReactiveUI.Primitives.Advanced
         public int IndexOf(T value) { }
         public ReactiveUI.Primitives.Advanced.CopyOnWriteList<T> Remove(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Result = {Result}")]
+    [System.Diagnostics.DebuggerDisplay("CountAggregator: Result = {Result}")]
     public readonly record struct CountAggregator<T> : ReactiveUI.Primitives.Advanced.IAggregator<T, int, ReactiveUI.Primitives.Advanced.CountAggregator<T>>, System.IEquatable<ReactiveUI.Primitives.Advanced.CountAggregator<T>>
     {
         public int Result { get; }
         public readonly ReactiveUI.Primitives.Advanced.CountAggregator<T> Add(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Result = {Result}, Predicate = {_predicate}")]
+    [System.Diagnostics.DebuggerDisplay("CountPredicateAggregator: Result = {Result}, Predicate = {_predicate}")]
     public readonly record struct CountPredicateAggregator<T> : ReactiveUI.Primitives.Advanced.IAggregator<T, int, ReactiveUI.Primitives.Advanced.CountPredicateAggregator<T>>, System.IEquatable<ReactiveUI.Primitives.Advanced.CountPredicateAggregator<T>>
     {
         public CountPredicateAggregator(System.Func<T, bool> predicate) { }
         public int Result { get; }
         public readonly ReactiveUI.Primitives.Advanced.CountPredicateAggregator<T> Add(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Seen = {_seen}, DefaultValue = {_defaultValue}")]
+    [System.Diagnostics.DebuggerDisplay("DefaultIfEmptyWitness: Seen = {_seen}, DefaultValue = {_defaultValue}")]
     public sealed class DefaultIfEmptyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public DefaultIfEmptyWitness(System.IObserver<T> observer, T defaultValue) { }
@@ -305,21 +305,21 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Result = {Result}, Seen = {_seen}")]
+    [System.Diagnostics.DebuggerDisplay("DistinctByCountAggregator: Result = {Result}, Seen = {_seen}")]
     public readonly record struct DistinctByCountAggregator<T, TKey> : ReactiveUI.Primitives.Advanced.IAggregator<T, int, ReactiveUI.Primitives.Advanced.DistinctByCountAggregator<T, TKey>>, System.IEquatable<ReactiveUI.Primitives.Advanced.DistinctByCountAggregator<T, TKey>>
     {
         public DistinctByCountAggregator(System.Func<T, TKey> keySelector, System.Collections.Generic.IEqualityComparer<TKey>? comparer) { }
         public int Result { get; }
         public readonly ReactiveUI.Primitives.Advanced.DistinctByCountAggregator<T, TKey> Add(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Result = {Result}, Seen = {_seen}")]
+    [System.Diagnostics.DebuggerDisplay("DistinctByLongCountAggregator: Result = {Result}, Seen = {_seen}")]
     public readonly record struct DistinctByLongCountAggregator<T, TKey> : ReactiveUI.Primitives.Advanced.IAggregator<T, long, ReactiveUI.Primitives.Advanced.DistinctByLongCountAggregator<T, TKey>>, System.IEquatable<ReactiveUI.Primitives.Advanced.DistinctByLongCountAggregator<T, TKey>>
     {
         public DistinctByLongCountAggregator(System.Func<T, TKey> keySelector, System.Collections.Generic.IEqualityComparer<TKey>? comparer) { }
         public long Result { get; }
         public readonly ReactiveUI.Primitives.Advanced.DistinctByLongCountAggregator<T, TKey> Add(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, SeenKeys = {_seen.Count}")]
+    [System.Diagnostics.DebuggerDisplay("DistinctByWitness: Done = {_done}, SeenKeys = {_seen.Count}")]
     public sealed class DistinctByWitness<T, TKey> : System.IDisposable, System.IObserver<T>
     {
         public DistinctByWitness(System.IObserver<T> observer, System.Func<T, TKey> keySelector, System.Collections.Generic.IEqualityComparer<TKey>? comparer) { }
@@ -333,7 +333,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Seen = {_seen.Count}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("DistinctWitness: Seen = {_seen.Count}, Subscription = {_subscription}")]
     public sealed class DistinctWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public DistinctWitness(System.IObserver<T> observer, System.Collections.Generic.HashSet<T> seen) { }
@@ -347,7 +347,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("OnNext = {_onNext}, OnError = {_onError}, OnCompleted = {_onCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("EmptyWitness: OnNext = {_onNext}, OnError = {_onError}, OnCompleted = {_onCompleted}")]
     public sealed class EmptyWitness<T> : System.IObserver<T>
     {
         public EmptyWitness(System.Action<T> onNext) { }
@@ -362,7 +362,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Current = {_current}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("FoldWitness: Current = {_current}, Observer = {_observer}")]
     public sealed class FoldWitness<TSource, TAccumulate> : System.IDisposable, System.IObserver<TSource>
     {
         public FoldWitness(System.IObserver<TAccumulate> observer, TAccumulate seed, System.Func<TAccumulate, TSource, TAccumulate> accumulator) { }
@@ -376,7 +376,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("ForwardingWitness: Observer = {_observer}")]
     public sealed class ForwardingWitness<T> : System.IObserver<T>
     {
         public ForwardingWitness(System.IObserver<T> observer) { }
@@ -387,7 +387,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Values = {_values}, CancellationToken = {_cancellationToken}")]
+    [System.Diagnostics.DebuggerDisplay("FromEnumerableSignal: Values = {_values}, CancellationToken = {_cancellationToken}")]
     public sealed class FromEnumerableSignal<T> : ReactiveUI.Primitives.Advanced.IInlineSignal<T>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public FromEnumerableSignal(System.Collections.Generic.IEnumerable<T> values) { }
@@ -411,7 +411,7 @@ namespace ReactiveUI.Primitives.Advanced
     {
         bool IsRequiredSubscribeOnCurrentThread() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("IgnoreValuesWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class IgnoreValuesWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public IgnoreValuesWitness(System.IObserver<T> observer) { }
@@ -425,7 +425,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_value}")]
+    [System.Diagnostics.DebuggerDisplay("ImmediateReturnSignal: Value = {_value}")]
     public sealed class ImmediateReturnSignal<T> : ReactiveUI.Primitives.Advanced.IInlineSignal<T>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ImmediateReturnSignal(T value) { }
@@ -434,7 +434,7 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
         public System.IDisposable Subscribe(System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Error = {_error}")]
+    [System.Diagnostics.DebuggerDisplay("ImmediateThrowSignal: Error = {_error}")]
     public sealed class ImmediateThrowSignal<T> : ReactiveUI.Primitives.Advanced.IInlineSignal<T>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ImmediateThrowSignal(System.Exception error) { }
@@ -468,7 +468,7 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<bool> observer) { }
         public System.IDisposable Subscribe(System.Action<bool> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_x}")]
+    [System.Diagnostics.DebuggerDisplay("ImmutableReturnInt32Signal: Value = {_x}")]
     public sealed class ImmutableReturnInt32Signal : ReactiveUI.Primitives.Advanced.IInlineSignal<int>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<int>
     {
         public ImmutableReturnInt32Signal(int x) { }
@@ -486,7 +486,7 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<bool> observer) { }
         public System.IDisposable Subscribe(System.Action<bool> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("KeepNotNullWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class KeepNotNullWitness<T> : System.IDisposable, System.IObserver<T?> where T : class
     {
         public KeepNotNullWitness(System.IObserver<T> observer) { }
@@ -500,7 +500,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("KeepTypeWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class KeepTypeWitness<TResult> : System.IDisposable, System.IObserver<object?>
     {
         public KeepTypeWitness(System.IObserver<TResult> observer) { }
@@ -514,7 +514,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasObservers = {HasObservers}, Count = {_observers.Items.Length}")]
+    [System.Diagnostics.DebuggerDisplay("ListWitness: HasObservers = {HasObservers}, Count = {_observers.Items.Length}")]
     public sealed class ListWitness<T> : System.IObserver<T>
     {
         public ListWitness(ReactiveUI.Primitives.Advanced.CopyOnWriteList<System.IObserver<T>> observers) { }
@@ -523,20 +523,20 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Result = {Result}")]
+    [System.Diagnostics.DebuggerDisplay("LongCountAggregator: Result = {Result}")]
     public readonly record struct LongCountAggregator<T> : ReactiveUI.Primitives.Advanced.IAggregator<T, long, ReactiveUI.Primitives.Advanced.LongCountAggregator<T>>, System.IEquatable<ReactiveUI.Primitives.Advanced.LongCountAggregator<T>>
     {
         public long Result { get; }
         public readonly ReactiveUI.Primitives.Advanced.LongCountAggregator<T> Add(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Result = {Result}, Predicate = {_predicate}")]
+    [System.Diagnostics.DebuggerDisplay("LongCountPredicateAggregator: Result = {Result}, Predicate = {_predicate}")]
     public readonly record struct LongCountPredicateAggregator<T> : ReactiveUI.Primitives.Advanced.IAggregator<T, long, ReactiveUI.Primitives.Advanced.LongCountPredicateAggregator<T>>, System.IEquatable<ReactiveUI.Primitives.Advanced.LongCountPredicateAggregator<T>>
     {
         public LongCountPredicateAggregator(System.Func<T, bool> predicate) { }
         public long Result { get; }
         public readonly ReactiveUI.Primitives.Advanced.LongCountPredicateAggregator<T> Add(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Ranges = {_ranges.Length}")]
+    [System.Diagnostics.DebuggerDisplay("RangeConcatSignal: Ranges = {_ranges.Length}")]
     public sealed class RangeConcatSignal : ReactiveUI.Primitives.Advanced.IInlineSignal<int>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<int>
     {
         public RangeConcatSignal(ReactiveUI.Primitives.Advanced.RangeSignal[] ranges) { }
@@ -545,7 +545,7 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<int> observer) { }
         public System.IDisposable Subscribe(System.Action<int> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Start = {Start}, Count = {Count}")]
+    [System.Diagnostics.DebuggerDisplay("RangeSignal: Start = {Start}, Count = {Count}")]
     public sealed class RangeSignal : ReactiveUI.Primitives.Advanced.IInlineSignal<int>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<int>
     {
         public RangeSignal(int start, int count) { }
@@ -556,7 +556,7 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<int> observer) { }
         public System.IDisposable Subscribe(System.Action<int> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, LeftStart = {_leftStart}, RightStart = {_rightStart}")]
+    [System.Diagnostics.DebuggerDisplay("RangeZipSignal: Count = {_count}, LeftStart = {_leftStart}, RightStart = {_rightStart}")]
     public sealed class RangeZipSignal<TResult> : ReactiveUI.Primitives.Advanced.IInlineSignal<TResult>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public RangeZipSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
@@ -565,7 +565,7 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
         public System.IDisposable Subscribe(System.Action<TResult> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Current = {_current}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("ReduceWitness: Current = {_current}, Subscription = {_subscription}")]
     public sealed class ReduceWitness<TSource, TAccumulate> : System.IDisposable, System.IObserver<TSource>
     {
         public ReduceWitness(System.IObserver<TAccumulate> observer, TAccumulate seed, System.Func<TAccumulate, TSource, TAccumulate> accumulator) { }
@@ -579,7 +579,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_value}, Count = {_count}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSignal: Value = {_value}, Count = {_count}")]
     public sealed class RepeatSignal<T> : ReactiveUI.Primitives.Advanced.IInlineSignal<T>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public RepeatSignal(T value, int count) { }
@@ -604,7 +604,7 @@ namespace ReactiveUI.Primitives.Advanced
         public static void Fault<TResult>(System.IObserver<TResult> observer, System.Exception error, System.IDisposable sink) { }
         public static void Fault<TResult>(System.IObserver<TResult> observer, System.Exception error, System.IDisposable sink, ref bool done) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Skipping = {_skipping}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SkipWhileWitness: Skipping = {_skipping}, Subscription = {_subscription}")]
     public sealed class SkipWhileWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SkipWhileWitness(System.IObserver<T> observer, System.Func<T, bool> predicate) { }
@@ -618,7 +618,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Remaining = {_remaining}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SkipWitness: Remaining = {_remaining}, Observer = {_observer}")]
     public sealed class SkipWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SkipWitness(System.IObserver<T> observer, int count) { }
@@ -632,7 +632,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("State = {_state}, OnError = {_onError}")]
+    [System.Diagnostics.DebuggerDisplay("StatefulWitness: State = {_state}, OnError = {_onError}")]
     public sealed class StatefulWitness<T, TState> : System.IObserver<T>
     {
         public StatefulWitness(TState state, System.Action<T, TState> onNext, System.Action<System.Exception, TState>? onError, System.Action<ReactiveUI.Primitives.Result, TState>? onCompleted) { }
@@ -649,7 +649,7 @@ namespace ReactiveUI.Primitives.Advanced
         public static void Assign(ref System.IDisposable? slot, System.IDisposable subscription) { }
         public static void Release(ref System.IDisposable? slot) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SynchronizeWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SynchronizeWitness(System.IObserver<T> observer) { }
@@ -662,7 +662,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {_completed}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("TakeWhileWitness: Completed = {_completed}, Subscription = {_subscription}")]
     public sealed class TakeWhileWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TakeWhileWitness(System.IObserver<T> observer, System.Func<T, bool> predicate) { }
@@ -675,7 +675,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Remaining = {_remaining}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TakeWitness: Remaining = {_remaining}, Stopped = {_stopped}")]
     public sealed class TakeWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TakeWitness(System.IObserver<T> observer, int count) { }
@@ -687,7 +687,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("TapWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class TapWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TapWitness(System.IObserver<T> observer, System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
@@ -707,7 +707,7 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("InitialState = {_initialState}, Condition = {_condition}")]
+    [System.Diagnostics.DebuggerDisplay("UnfoldSignal: InitialState = {_initialState}, Condition = {_condition}")]
     public sealed class UnfoldSignal<TState, TResult> : ReactiveUI.Primitives.Advanced.IInlineSignal<TResult>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public UnfoldSignal(TState initialState, System.Func<TState, bool> condition, System.Func<TState, TState> iterate, System.Func<TState, TResult> resultSelector) { }
@@ -716,7 +716,7 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
         public System.IDisposable Subscribe(System.Action<TResult> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLast = {_hasLast}, Last = {_last}")]
+    [System.Diagnostics.DebuggerDisplay("UniqueByWitness: HasLast = {_hasLast}, Last = {_last}")]
     public sealed class UniqueByWitness<T, TKey> : System.IDisposable, System.IObserver<T>
     {
         public UniqueByWitness(System.IObserver<T> observer, System.Func<T, TKey> keySelector, System.Collections.Generic.IEqualityComparer<TKey> comparer) { }
@@ -730,7 +730,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLast = {_hasLast}, Last = {_last}")]
+    [System.Diagnostics.DebuggerDisplay("UniqueWitness: HasLast = {_hasLast}, Last = {_last}")]
     public sealed class UniqueWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public UniqueWitness(System.IObserver<T> observer, System.Collections.Generic.IEqualityComparer<T> comparer) { }
@@ -744,7 +744,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ResourceFactory = {_resourceFactory}, SignalFactory = {_signalFactory}")]
+    [System.Diagnostics.DebuggerDisplay("UseSignal: ResourceFactory = {_resourceFactory}, SignalFactory = {_signalFactory}")]
     public sealed class UseSignal<TResource, T> : System.IObservable<T> where TResource : System.IDisposable
     {
         public UseSignal(System.Func<TResource> resourceFactory, System.Func<TResource, System.IObservable<T>> signalFactory) { }
@@ -875,7 +875,7 @@ namespace ReactiveUI.Primitives.Core
         public static bool operator ==(ReactiveUI.Primitives.Core.Moment<T> first, ReactiveUI.Primitives.Core.Moment<T> second) { }
         public static bool operator !=(ReactiveUI.Primitives.Core.Moment<T> first, ReactiveUI.Primitives.Core.Moment<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {Count}, Capacity = {_items.Length}")]
+    [System.Diagnostics.DebuggerDisplay("PriorityQueue: Count = {Count}, Capacity = {_items.Length}")]
     public sealed class PriorityQueue<T> where T : System.IComparable<T>
     {
         public PriorityQueue() { }
@@ -918,14 +918,14 @@ namespace ReactiveUI.Primitives.Core
 }
 namespace ReactiveUI.Primitives.Extensions
 {
-    [System.Diagnostics.DebuggerDisplay("Outstanding = {_outstanding}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("ConcurrencyLimiter: Outstanding = {_outstanding}, Disposed = {_disposed}")]
     public sealed class ConcurrencyLimiter<T> : System.IObservable<T>
     {
         public ConcurrencyLimiter(System.Collections.Generic.IEnumerable<System.Threading.Tasks.Task<T>> taskFunctions, int maxConcurrency) { }
         public System.IObservable<T> Observable { get; }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Locked = {_locked}, CompletedPhases = {CompletedPhases}")]
+    [System.Diagnostics.DebuggerDisplay("Continuation: Locked = {_locked}, CompletedPhases = {CompletedPhases}")]
     public class Continuation : System.IDisposable
     {
         public Continuation() { }
@@ -935,7 +935,7 @@ namespace ReactiveUI.Primitives.Extensions
         public System.Threading.Tasks.Task Lock<T>(T item, System.IObserver<(T Value, System.IDisposable Sync)>? observer) { }
         public System.Threading.Tasks.ValueTask LockValueTask<T>(T item, System.IObserver<(T Value, System.IDisposable Sync)>? observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_value}, Completed = {_completed}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("CurrentValueSubject: Value = {_value}, Completed = {_completed}, Disposed = {_disposed}")]
     public sealed class CurrentValueSubject<T> : System.IDisposable, System.IObservable<T>, System.IObserver<T>
     {
         public CurrentValueSubject(T initialValue) { }
@@ -962,7 +962,7 @@ namespace ReactiveUI.Primitives.Extensions
     {
         public static System.Threading.Tasks.ValueTask<T> FirstAsValueTask(System.IObservable<T> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsHeartbeat = {IsHeartbeat}, Update = {Update}")]
+    [System.Diagnostics.DebuggerDisplay("Heartbeat: IsHeartbeat = {IsHeartbeat}, Update = {Update}")]
     public readonly record struct Heartbeat<T> : ReactiveUI.Primitives.Extensions.IHeartbeat<T>, System.IEquatable<ReactiveUI.Primitives.Extensions.Heartbeat<T>>
     {
         public Heartbeat() { }
@@ -1011,7 +1011,7 @@ namespace ReactiveUI.Primitives.Extensions
         public SingleValueSignal(T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsStale = {IsStale}")]
+    [System.Diagnostics.DebuggerDisplay("Stale: IsStale = {IsStale}")]
     public readonly record struct Stale<T> : ReactiveUI.Primitives.Extensions.IStale<T>, System.IEquatable<ReactiveUI.Primitives.Extensions.Stale<T>>
     {
         public Stale() { }
@@ -1019,7 +1019,7 @@ namespace ReactiveUI.Primitives.Extensions
         public bool IsStale { get; }
         public T? Update { get; }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {Done}, Timer = {Timer}")]
+    [System.Diagnostics.DebuggerDisplay("TimerSinkState: Done = {Done}, Timer = {Timer}")]
     public sealed class TimerSinkState<T>
     {
         public TimerSinkState(System.IObserver<T> downstream) { }
@@ -1032,13 +1032,13 @@ namespace ReactiveUI.Primitives.Extensions
 }
 namespace ReactiveUI.Primitives.Extensions.Operators
 {
-    [System.Diagnostics.DebuggerDisplay("Left = {_left}, Right = {_right}")]
+    [System.Diagnostics.DebuggerDisplay("BinaryMinMaxObservable: Left = {_left}, Right = {_right}")]
     public sealed class BinaryMinMaxObservable<T> : System.IObservable<T> where T : struct, System.IComparable<T>
     {
         public BinaryMinMaxObservable(System.IObservable<T> left, System.IObservable<T> right, bool emitMaximum) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sourceList}")]
+    [System.Diagnostics.DebuggerDisplay("BooleanReduceObservable: Sources = {_sourceList}")]
     public sealed class BooleanReduceObservable : System.IObservable<bool>
     {
         public BooleanReduceObservable(System.Collections.Generic.IEnumerable<System.IObservable<bool>> sources, bool target) { }
@@ -1059,7 +1059,7 @@ namespace ReactiveUI.Primitives.Extensions.Operators
         public CatchIgnoreEmptyObservable(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, ErrorAction = {_errorAction}")]
+    [System.Diagnostics.DebuggerDisplay("CatchIgnoreObservable: Source = {_source}, ErrorAction = {_errorAction}")]
     public sealed class CatchIgnoreObservable<TSource, TException> : System.IObservable<TSource> where TException : System.Exception
     {
         public CatchIgnoreObservable(System.IObservable<TSource> source, System.Action<TException> errorAction) { }
@@ -1094,7 +1094,7 @@ namespace ReactiveUI.Primitives.Extensions.Operators
     {
         public FirstMatchFromCandidatesObservable(System.Collections.Generic.IReadOnlyList<TKey> candidates, System.Func<TKey, System.IObservable<TRaw>> project, System.Func<TRaw, TResult> transform, System.Func<TResult, bool> predicate, TResult fallback) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
-        [System.Diagnostics.DebuggerDisplay("Completed = {Completed}, HasValue = {HasValue}, Value = {Value}")]
+        [System.Diagnostics.DebuggerDisplay("SyncProbe: Completed = {Completed}, HasValue = {HasValue}, Value = {Value}")]
         public sealed class SyncProbe : System.IObserver<TRaw>
         {
             public SyncProbe() { }
@@ -1115,7 +1115,7 @@ namespace ReactiveUI.Primitives.Extensions.Operators
         public LogErrorsObservable(System.IObservable<T> source, System.Action<System.Exception> logger) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sourceList.Count}")]
+    [System.Diagnostics.DebuggerDisplay("MinMaxObservable: Sources = {_sourceList.Count}")]
     public sealed class MinMaxObservable<T> : System.IObservable<T> where T : struct, System.IComparable<T>
     {
         public MinMaxObservable(System.Collections.Generic.IReadOnlyList<System.IObservable<T>> sources, bool emitMaximum) { }
@@ -1131,7 +1131,7 @@ namespace ReactiveUI.Primitives.Extensions.Operators
         public PairwiseObservable(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<(T Previous, T Current)> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, Subscriptions = {_subscriptionCount}")]
+    [System.Diagnostics.DebuggerDisplay("PartitionObservable: Source = {_source}, Subscriptions = {_subscriptionCount}")]
     public sealed class PartitionObservable<T>
     {
         public PartitionObservable(System.IObservable<T> source, System.Func<T, bool> predicate) { }
@@ -1193,7 +1193,7 @@ namespace ReactiveUI.Primitives.Extensions.Operators
         public SkipWhileNullObservable(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Queued = {_queue.Count}, Processing = {_isProcessing}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("SubscribeAsyncObservable: Queued = {_queue.Count}, Processing = {_isProcessing}, Done = {_done}")]
     public sealed class SubscribeAsyncObservable<T> : System.IDisposable
     {
         public SubscribeAsyncObservable(System.IObservable<T> source, System.Func<T, System.Threading.Tasks.ValueTask> onNext, System.Action<System.Exception>? onError, System.Action? onCompleted) { }
@@ -1265,7 +1265,7 @@ namespace ReactiveUI.Primitives.Signals
         public void RemoveObserver(System.IObserver<T> observer) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Callback = {_callback}, Context = {_context}")]
+    [System.Diagnostics.DebuggerDisplay("AwaitWitness: Callback = {_callback}, Context = {_context}")]
     public sealed class AwaitWitness<T> : System.IObserver<T>
     {
         public AwaitWitness(System.Action callback, bool originalContext) { }
@@ -1297,7 +1297,7 @@ namespace ReactiveUI.Primitives.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public bool TryGetValue(out T? value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_observers}")]
+    [System.Diagnostics.DebuggerDisplay("Broadcaster: Observers = {_observers}")]
     public struct Broadcaster<T> : System.IEquatable<ReactiveUI.Primitives.Signals.Broadcaster<T>>
     {
         public bool HasObservers { get; }
@@ -1316,7 +1316,7 @@ namespace ReactiveUI.Primitives.Signals
         public static bool operator ==(ReactiveUI.Primitives.Signals.Broadcaster<T> left, ReactiveUI.Primitives.Signals.Broadcaster<T> right) { }
         public static bool operator !=(ReactiveUI.Primitives.Signals.Broadcaster<T> left, ReactiveUI.Primitives.Signals.Broadcaster<T> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Task = {_task}, Result = {_result}, Exception = {_exception}")]
+    [System.Diagnostics.DebuggerDisplay("CommandExecution: Task = {_task}, Result = {_result}, Exception = {_exception}")]
     public readonly record struct CommandExecution<TResult> : System.IEquatable<ReactiveUI.Primitives.Signals.CommandExecution<TResult>>
     {
         public CommandExecution(System.Exception exception) { }
@@ -1324,7 +1324,7 @@ namespace ReactiveUI.Primitives.Signals
         public CommandExecution(TResult result) { }
         public readonly ReactiveUI.Primitives.Signals.CommandExecution<TResult> ConfigureAwait(bool continueOnCapturedContext) { }
         public readonly ReactiveUI.Primitives.Signals.CommandExecution<TResult>.Awaiter GetAwaiter() { }
-        [System.Diagnostics.DebuggerDisplay("IsCompleted = {IsCompleted}, Result = {_result}, Exception = {_exception}")]
+        [System.Diagnostics.DebuggerDisplay("Awaiter: IsCompleted = {IsCompleted}, Result = {_result}, Exception = {_exception}")]
         public readonly record struct Awaiter : System.IEquatable<ReactiveUI.Primitives.Signals.CommandExecution<TResult>.Awaiter>, System.Runtime.CompilerServices.ICriticalNotifyCompletion
         {
             public Awaiter(System.Threading.Tasks.Task<TResult>? task, TResult? result, System.Exception? exception, bool continueOnCapturedContext) { }
@@ -1353,7 +1353,7 @@ namespace ReactiveUI.Primitives.Signals
         public ReactiveUI.Primitives.Signals.CommandExecution<TResult> ExecuteAsync(System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Buffer = {_buffer}")]
+    [System.Diagnostics.DebuggerDisplay("DelayableNotificationSignal: Stopped = {_stopped}, Buffer = {_buffer}")]
     public sealed class DelayableNotificationSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T>
     {
         public DelayableNotificationSignal(System.Func<bool> isDelayed, System.Func<System.Collections.Generic.IList<T>, System.Collections.Generic.IEnumerable<T>> flushDistinct) { }
@@ -1366,7 +1366,7 @@ namespace ReactiveUI.Primitives.Signals
         public void OnNext(T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("OnNext = {_onNext}")]
+    [System.Diagnostics.DebuggerDisplay("DelegateWitness: OnNext = {_onNext}")]
     public sealed class DelegateWitness<T> : System.IObserver<T>
     {
         public DelegateWitness(System.Action<T> onNext, System.Action<System.Exception>? onError = null, System.Action? onCompleted = null) { }
@@ -1397,41 +1397,41 @@ namespace ReactiveUI.Primitives.Signals
         System.IObservable<T>? Source { get; }
         void GetOperationCanceled(System.IObserver<System.Exception> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, Predicate = {_predicate}")]
+    [System.Diagnostics.DebuggerDisplay("KeepSignal: Source = {_source}, Predicate = {_predicate}")]
     public sealed class KeepSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public KeepSignal(System.IObservable<T> source, System.Func<T, bool> predicate) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, State = {_state}")]
+    [System.Diagnostics.DebuggerDisplay("KeepWithSignal: Source = {_source}, State = {_state}")]
     public sealed class KeepWithSignal<T, TState> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public KeepWithSignal(System.IObservable<T> source, TState state, System.Func<TState, T, bool> predicate) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, Selector = {_selector}")]
+    [System.Diagnostics.DebuggerDisplay("MapSignal: Source = {_source}, Selector = {_selector}")]
     public sealed class MapSignal<TSource, TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public MapSignal(System.IObservable<TSource> source, System.Func<TSource, TResult> selector) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, State = {_state}")]
+    [System.Diagnostics.DebuggerDisplay("MapWithSignal: Source = {_source}, State = {_state}")]
     public sealed class MapWithSignal<TSource, TState, TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public MapWithSignal(System.IObservable<TSource> source, TState state, System.Func<TState, TSource, TResult> selector) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Subject = {_subject}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("ObserverHandler: Subject = {_subject}, Observer = {_observer}")]
     public sealed class ObserverHandler<T> : System.IDisposable
     {
         public ObserverHandler(ReactiveUI.Primitives.Signals.AsyncSignal<T> subject, System.IObserver<T> observer) { }
         public void Dispose() { }
     }
-    [System.Diagnostics.DebuggerDisplay("{Value}")]
+    [System.Diagnostics.DebuggerDisplay("ProjectedReadOnlyState: {Value}")]
     public sealed class ProjectedReadOnlyState<TSource, TResult> : System.IDisposable, System.IObservable<TResult>, System.IObserver<TSource>
     {
         public System.IObservable<TResult> Changed { get; }
@@ -1493,7 +1493,7 @@ namespace ReactiveUI.Primitives.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public bool TryGetValue(out T? value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, State = {_state}")]
+    [System.Diagnostics.DebuggerDisplay("TapWithSignal: Source = {_source}, State = {_state}")]
     public sealed class TapWithSignal<T, TState> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public TapWithSignal(System.IObservable<T> source, TState state, System.Action<TState, T> onNext) { }

--- a/src/ReactiveUI.Primitives.Core/PublicAPI/net472/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Core/PublicAPI/net472/PublicAPI.txt
@@ -6,7 +6,7 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Primitives.Tests")]
 namespace ReactiveUI.Primitives
 {
-    [System.Diagnostics.DebuggerDisplay("Subscribe = {_subscribe}")]
+    [System.Diagnostics.DebuggerDisplay("AnonymousSignal: Subscribe = {_subscribe}")]
     public sealed class AnonymousSignal<T> : System.IObservable<T>
     {
         public AnonymousSignal(System.Func<System.IObserver<T>, System.IDisposable> subscribe) { }
@@ -48,7 +48,7 @@ namespace ReactiveUI.Primitives
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public static ReactiveUI.Primitives.Optional<T> Some<T>(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasValue = {HasValue}, Value = {_value}")]
+    [System.Diagnostics.DebuggerDisplay("Optional: HasValue = {HasValue}, Value = {_value}")]
     public readonly record struct Optional<T> : System.IEquatable<ReactiveUI.Primitives.Optional<T>>
     {
         public Optional() { }
@@ -67,7 +67,7 @@ namespace ReactiveUI.Primitives
         public static explicit operator T?(in ReactiveUI.Primitives.Optional<T> value) { }
         public static implicit operator ReactiveUI.Primitives.Optional<T>(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsSuccess = {IsSuccess}, Exception = {Exception}")]
+    [System.Diagnostics.DebuggerDisplay("Result: IsSuccess = {IsSuccess}, Exception = {Exception}")]
     public readonly record struct Result : System.IEquatable<ReactiveUI.Primitives.Result>
     {
         public Result(System.Exception exception) { }
@@ -108,7 +108,7 @@ namespace ReactiveUI.Primitives
 }
 namespace ReactiveUI.Primitives.Advanced
 {
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, Aggregator = {_aggregator}")]
+    [System.Diagnostics.DebuggerDisplay("AggregateWitness: Done = {_done}, Aggregator = {_aggregator}")]
     public sealed class AggregateWitness<T, TResult, TAggregator> : System.IDisposable, System.IObserver<T> where TAggregator : struct, ReactiveUI.Primitives.Advanced.IAggregator<T, TResult, TAggregator>
     {
         public AggregateWitness(System.IObserver<TResult> observer, TAggregator aggregator) { }
@@ -122,7 +122,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("AllPredicateWitness: Done = {_done}, Observer = {_observer}")]
     public sealed class AllPredicateWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public AllPredicateWitness(System.IObserver<bool> observer, System.Func<T, bool> predicate) { }
@@ -136,7 +136,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("AnyPredicateWitness: Done = {_done}, Observer = {_observer}")]
     public sealed class AnyPredicateWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public AnyPredicateWitness(System.IObserver<bool> observer, System.Func<T, bool> predicate) { }
@@ -150,7 +150,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("AnyWitness: Done = {_done}, Observer = {_observer}")]
     public sealed class AnyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public AnyWitness(System.IObserver<bool> observer) { }
@@ -165,7 +165,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_value}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("AppendDelegateWitness: Value = {_value}, Subscription = {_subscription}")]
     public sealed class AppendDelegateWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public AppendDelegateWitness(System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted, T value) { }
@@ -177,7 +177,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("AppendedValue = {_value}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("AppendWitness: AppendedValue = {_value}, Observer = {_observer}")]
     public sealed class AppendWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public AppendWitness(System.IObserver<T> observer, T value) { }
@@ -191,7 +191,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Skip = {_skip}, Index = {_index}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("BufferWitness: Count = {_count}, Skip = {_skip}, Index = {_index}, Done = {_done}")]
     public sealed class BufferWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public BufferWitness(System.IObserver<System.Collections.Generic.IList<T>> observer, int count, int skip) { }
@@ -202,7 +202,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("OnNext = {_onNext}, OnError = {_onError}, OnCompleted = {_onCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("CallbackWitness: OnNext = {_onNext}, OnError = {_onError}, OnCompleted = {_onCompleted}")]
     public sealed class CallbackWitness<T> : System.IObserver<T>
     {
         public CallbackWitness(System.Action<T> onNext, System.Action<System.Exception>? onError, System.Action<ReactiveUI.Primitives.Result>? onCompleted) { }
@@ -213,7 +213,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_values.Count}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("CollectArrayWitness: Count = {_values.Count}, Subscription = {_subscription}")]
     public sealed class CollectArrayWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CollectArrayWitness(System.IObserver<T[]> observer) { }
@@ -228,7 +228,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_values.Count}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("CollectListWitness: Count = {_values.Count}, Subscription = {_subscription}")]
     public sealed class CollectListWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CollectListWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -243,7 +243,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SoughtValue = {_value}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("ContainsWitness: SoughtValue = {_value}, Done = {_done}")]
     public sealed class ContainsWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public ContainsWitness(System.IObserver<bool> observer, T value, System.Collections.Generic.IEqualityComparer<T> comparer) { }
@@ -257,7 +257,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {Items.Length}")]
+    [System.Diagnostics.DebuggerDisplay("CopyOnWriteList: Count = {Items.Length}")]
     public sealed class CopyOnWriteList<T>
     {
         public CopyOnWriteList(T[] data) { }
@@ -267,20 +267,20 @@ namespace ReactiveUI.Primitives.Advanced
         public int IndexOf(T value) { }
         public ReactiveUI.Primitives.Advanced.CopyOnWriteList<T> Remove(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Result = {Result}")]
+    [System.Diagnostics.DebuggerDisplay("CountAggregator: Result = {Result}")]
     public readonly record struct CountAggregator<T> : ReactiveUI.Primitives.Advanced.IAggregator<T, int, ReactiveUI.Primitives.Advanced.CountAggregator<T>>, System.IEquatable<ReactiveUI.Primitives.Advanced.CountAggregator<T>>
     {
         public int Result { get; }
         public readonly ReactiveUI.Primitives.Advanced.CountAggregator<T> Add(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Result = {Result}, Predicate = {_predicate}")]
+    [System.Diagnostics.DebuggerDisplay("CountPredicateAggregator: Result = {Result}, Predicate = {_predicate}")]
     public readonly record struct CountPredicateAggregator<T> : ReactiveUI.Primitives.Advanced.IAggregator<T, int, ReactiveUI.Primitives.Advanced.CountPredicateAggregator<T>>, System.IEquatable<ReactiveUI.Primitives.Advanced.CountPredicateAggregator<T>>
     {
         public CountPredicateAggregator(System.Func<T, bool> predicate) { }
         public int Result { get; }
         public readonly ReactiveUI.Primitives.Advanced.CountPredicateAggregator<T> Add(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Seen = {_seen}, DefaultValue = {_defaultValue}")]
+    [System.Diagnostics.DebuggerDisplay("DefaultIfEmptyWitness: Seen = {_seen}, DefaultValue = {_defaultValue}")]
     public sealed class DefaultIfEmptyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public DefaultIfEmptyWitness(System.IObserver<T> observer, T defaultValue) { }
@@ -305,21 +305,21 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Result = {Result}, Seen = {_seen}")]
+    [System.Diagnostics.DebuggerDisplay("DistinctByCountAggregator: Result = {Result}, Seen = {_seen}")]
     public readonly record struct DistinctByCountAggregator<T, TKey> : ReactiveUI.Primitives.Advanced.IAggregator<T, int, ReactiveUI.Primitives.Advanced.DistinctByCountAggregator<T, TKey>>, System.IEquatable<ReactiveUI.Primitives.Advanced.DistinctByCountAggregator<T, TKey>>
     {
         public DistinctByCountAggregator(System.Func<T, TKey> keySelector, System.Collections.Generic.IEqualityComparer<TKey>? comparer) { }
         public int Result { get; }
         public readonly ReactiveUI.Primitives.Advanced.DistinctByCountAggregator<T, TKey> Add(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Result = {Result}, Seen = {_seen}")]
+    [System.Diagnostics.DebuggerDisplay("DistinctByLongCountAggregator: Result = {Result}, Seen = {_seen}")]
     public readonly record struct DistinctByLongCountAggregator<T, TKey> : ReactiveUI.Primitives.Advanced.IAggregator<T, long, ReactiveUI.Primitives.Advanced.DistinctByLongCountAggregator<T, TKey>>, System.IEquatable<ReactiveUI.Primitives.Advanced.DistinctByLongCountAggregator<T, TKey>>
     {
         public DistinctByLongCountAggregator(System.Func<T, TKey> keySelector, System.Collections.Generic.IEqualityComparer<TKey>? comparer) { }
         public long Result { get; }
         public readonly ReactiveUI.Primitives.Advanced.DistinctByLongCountAggregator<T, TKey> Add(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, SeenKeys = {_seen.Count}")]
+    [System.Diagnostics.DebuggerDisplay("DistinctByWitness: Done = {_done}, SeenKeys = {_seen.Count}")]
     public sealed class DistinctByWitness<T, TKey> : System.IDisposable, System.IObserver<T>
     {
         public DistinctByWitness(System.IObserver<T> observer, System.Func<T, TKey> keySelector, System.Collections.Generic.IEqualityComparer<TKey>? comparer) { }
@@ -333,7 +333,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Seen = {_seen.Count}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("DistinctWitness: Seen = {_seen.Count}, Subscription = {_subscription}")]
     public sealed class DistinctWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public DistinctWitness(System.IObserver<T> observer, System.Collections.Generic.HashSet<T> seen) { }
@@ -347,7 +347,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("OnNext = {_onNext}, OnError = {_onError}, OnCompleted = {_onCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("EmptyWitness: OnNext = {_onNext}, OnError = {_onError}, OnCompleted = {_onCompleted}")]
     public sealed class EmptyWitness<T> : System.IObserver<T>
     {
         public EmptyWitness(System.Action<T> onNext) { }
@@ -362,7 +362,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Current = {_current}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("FoldWitness: Current = {_current}, Observer = {_observer}")]
     public sealed class FoldWitness<TSource, TAccumulate> : System.IDisposable, System.IObserver<TSource>
     {
         public FoldWitness(System.IObserver<TAccumulate> observer, TAccumulate seed, System.Func<TAccumulate, TSource, TAccumulate> accumulator) { }
@@ -376,7 +376,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("ForwardingWitness: Observer = {_observer}")]
     public sealed class ForwardingWitness<T> : System.IObserver<T>
     {
         public ForwardingWitness(System.IObserver<T> observer) { }
@@ -387,7 +387,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Values = {_values}, CancellationToken = {_cancellationToken}")]
+    [System.Diagnostics.DebuggerDisplay("FromEnumerableSignal: Values = {_values}, CancellationToken = {_cancellationToken}")]
     public sealed class FromEnumerableSignal<T> : ReactiveUI.Primitives.Advanced.IInlineSignal<T>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public FromEnumerableSignal(System.Collections.Generic.IEnumerable<T> values) { }
@@ -411,7 +411,7 @@ namespace ReactiveUI.Primitives.Advanced
     {
         bool IsRequiredSubscribeOnCurrentThread() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("IgnoreValuesWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class IgnoreValuesWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public IgnoreValuesWitness(System.IObserver<T> observer) { }
@@ -425,7 +425,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_value}")]
+    [System.Diagnostics.DebuggerDisplay("ImmediateReturnSignal: Value = {_value}")]
     public sealed class ImmediateReturnSignal<T> : ReactiveUI.Primitives.Advanced.IInlineSignal<T>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ImmediateReturnSignal(T value) { }
@@ -434,7 +434,7 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
         public System.IDisposable Subscribe(System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Error = {_error}")]
+    [System.Diagnostics.DebuggerDisplay("ImmediateThrowSignal: Error = {_error}")]
     public sealed class ImmediateThrowSignal<T> : ReactiveUI.Primitives.Advanced.IInlineSignal<T>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ImmediateThrowSignal(System.Exception error) { }
@@ -468,7 +468,7 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<bool> observer) { }
         public System.IDisposable Subscribe(System.Action<bool> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_x}")]
+    [System.Diagnostics.DebuggerDisplay("ImmutableReturnInt32Signal: Value = {_x}")]
     public sealed class ImmutableReturnInt32Signal : ReactiveUI.Primitives.Advanced.IInlineSignal<int>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<int>
     {
         public ImmutableReturnInt32Signal(int x) { }
@@ -486,7 +486,7 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<bool> observer) { }
         public System.IDisposable Subscribe(System.Action<bool> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("KeepNotNullWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class KeepNotNullWitness<T> : System.IDisposable, System.IObserver<T?> where T : class
     {
         public KeepNotNullWitness(System.IObserver<T> observer) { }
@@ -500,7 +500,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("KeepTypeWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class KeepTypeWitness<TResult> : System.IDisposable, System.IObserver<object?>
     {
         public KeepTypeWitness(System.IObserver<TResult> observer) { }
@@ -514,7 +514,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasObservers = {HasObservers}, Count = {_observers.Items.Length}")]
+    [System.Diagnostics.DebuggerDisplay("ListWitness: HasObservers = {HasObservers}, Count = {_observers.Items.Length}")]
     public sealed class ListWitness<T> : System.IObserver<T>
     {
         public ListWitness(ReactiveUI.Primitives.Advanced.CopyOnWriteList<System.IObserver<T>> observers) { }
@@ -523,20 +523,20 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Result = {Result}")]
+    [System.Diagnostics.DebuggerDisplay("LongCountAggregator: Result = {Result}")]
     public readonly record struct LongCountAggregator<T> : ReactiveUI.Primitives.Advanced.IAggregator<T, long, ReactiveUI.Primitives.Advanced.LongCountAggregator<T>>, System.IEquatable<ReactiveUI.Primitives.Advanced.LongCountAggregator<T>>
     {
         public long Result { get; }
         public readonly ReactiveUI.Primitives.Advanced.LongCountAggregator<T> Add(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Result = {Result}, Predicate = {_predicate}")]
+    [System.Diagnostics.DebuggerDisplay("LongCountPredicateAggregator: Result = {Result}, Predicate = {_predicate}")]
     public readonly record struct LongCountPredicateAggregator<T> : ReactiveUI.Primitives.Advanced.IAggregator<T, long, ReactiveUI.Primitives.Advanced.LongCountPredicateAggregator<T>>, System.IEquatable<ReactiveUI.Primitives.Advanced.LongCountPredicateAggregator<T>>
     {
         public LongCountPredicateAggregator(System.Func<T, bool> predicate) { }
         public long Result { get; }
         public readonly ReactiveUI.Primitives.Advanced.LongCountPredicateAggregator<T> Add(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Ranges = {_ranges.Length}")]
+    [System.Diagnostics.DebuggerDisplay("RangeConcatSignal: Ranges = {_ranges.Length}")]
     public sealed class RangeConcatSignal : ReactiveUI.Primitives.Advanced.IInlineSignal<int>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<int>
     {
         public RangeConcatSignal(ReactiveUI.Primitives.Advanced.RangeSignal[] ranges) { }
@@ -545,7 +545,7 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<int> observer) { }
         public System.IDisposable Subscribe(System.Action<int> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Start = {Start}, Count = {Count}")]
+    [System.Diagnostics.DebuggerDisplay("RangeSignal: Start = {Start}, Count = {Count}")]
     public sealed class RangeSignal : ReactiveUI.Primitives.Advanced.IInlineSignal<int>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<int>
     {
         public RangeSignal(int start, int count) { }
@@ -556,7 +556,7 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<int> observer) { }
         public System.IDisposable Subscribe(System.Action<int> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, LeftStart = {_leftStart}, RightStart = {_rightStart}")]
+    [System.Diagnostics.DebuggerDisplay("RangeZipSignal: Count = {_count}, LeftStart = {_leftStart}, RightStart = {_rightStart}")]
     public sealed class RangeZipSignal<TResult> : ReactiveUI.Primitives.Advanced.IInlineSignal<TResult>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public RangeZipSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
@@ -565,7 +565,7 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
         public System.IDisposable Subscribe(System.Action<TResult> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Current = {_current}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("ReduceWitness: Current = {_current}, Subscription = {_subscription}")]
     public sealed class ReduceWitness<TSource, TAccumulate> : System.IDisposable, System.IObserver<TSource>
     {
         public ReduceWitness(System.IObserver<TAccumulate> observer, TAccumulate seed, System.Func<TAccumulate, TSource, TAccumulate> accumulator) { }
@@ -579,7 +579,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_value}, Count = {_count}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSignal: Value = {_value}, Count = {_count}")]
     public sealed class RepeatSignal<T> : ReactiveUI.Primitives.Advanced.IInlineSignal<T>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public RepeatSignal(T value, int count) { }
@@ -604,7 +604,7 @@ namespace ReactiveUI.Primitives.Advanced
         public static void Fault<TResult>(System.IObserver<TResult> observer, System.Exception error, System.IDisposable sink) { }
         public static void Fault<TResult>(System.IObserver<TResult> observer, System.Exception error, System.IDisposable sink, ref bool done) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Skipping = {_skipping}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SkipWhileWitness: Skipping = {_skipping}, Subscription = {_subscription}")]
     public sealed class SkipWhileWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SkipWhileWitness(System.IObserver<T> observer, System.Func<T, bool> predicate) { }
@@ -618,7 +618,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Remaining = {_remaining}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SkipWitness: Remaining = {_remaining}, Observer = {_observer}")]
     public sealed class SkipWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SkipWitness(System.IObserver<T> observer, int count) { }
@@ -632,7 +632,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("State = {_state}, OnError = {_onError}")]
+    [System.Diagnostics.DebuggerDisplay("StatefulWitness: State = {_state}, OnError = {_onError}")]
     public sealed class StatefulWitness<T, TState> : System.IObserver<T>
     {
         public StatefulWitness(TState state, System.Action<T, TState> onNext, System.Action<System.Exception, TState>? onError, System.Action<ReactiveUI.Primitives.Result, TState>? onCompleted) { }
@@ -649,7 +649,7 @@ namespace ReactiveUI.Primitives.Advanced
         public static void Assign(ref System.IDisposable? slot, System.IDisposable subscription) { }
         public static void Release(ref System.IDisposable? slot) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SynchronizeWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SynchronizeWitness(System.IObserver<T> observer) { }
@@ -662,7 +662,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {_completed}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("TakeWhileWitness: Completed = {_completed}, Subscription = {_subscription}")]
     public sealed class TakeWhileWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TakeWhileWitness(System.IObserver<T> observer, System.Func<T, bool> predicate) { }
@@ -675,7 +675,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Remaining = {_remaining}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TakeWitness: Remaining = {_remaining}, Stopped = {_stopped}")]
     public sealed class TakeWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TakeWitness(System.IObserver<T> observer, int count) { }
@@ -687,7 +687,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("TapWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class TapWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TapWitness(System.IObserver<T> observer, System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
@@ -707,7 +707,7 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("InitialState = {_initialState}, Condition = {_condition}")]
+    [System.Diagnostics.DebuggerDisplay("UnfoldSignal: InitialState = {_initialState}, Condition = {_condition}")]
     public sealed class UnfoldSignal<TState, TResult> : ReactiveUI.Primitives.Advanced.IInlineSignal<TResult>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public UnfoldSignal(TState initialState, System.Func<TState, bool> condition, System.Func<TState, TState> iterate, System.Func<TState, TResult> resultSelector) { }
@@ -716,7 +716,7 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
         public System.IDisposable Subscribe(System.Action<TResult> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLast = {_hasLast}, Last = {_last}")]
+    [System.Diagnostics.DebuggerDisplay("UniqueByWitness: HasLast = {_hasLast}, Last = {_last}")]
     public sealed class UniqueByWitness<T, TKey> : System.IDisposable, System.IObserver<T>
     {
         public UniqueByWitness(System.IObserver<T> observer, System.Func<T, TKey> keySelector, System.Collections.Generic.IEqualityComparer<TKey> comparer) { }
@@ -730,7 +730,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLast = {_hasLast}, Last = {_last}")]
+    [System.Diagnostics.DebuggerDisplay("UniqueWitness: HasLast = {_hasLast}, Last = {_last}")]
     public sealed class UniqueWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public UniqueWitness(System.IObserver<T> observer, System.Collections.Generic.IEqualityComparer<T> comparer) { }
@@ -744,7 +744,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ResourceFactory = {_resourceFactory}, SignalFactory = {_signalFactory}")]
+    [System.Diagnostics.DebuggerDisplay("UseSignal: ResourceFactory = {_resourceFactory}, SignalFactory = {_signalFactory}")]
     public sealed class UseSignal<TResource, T> : System.IObservable<T> where TResource : System.IDisposable
     {
         public UseSignal(System.Func<TResource> resourceFactory, System.Func<TResource, System.IObservable<T>> signalFactory) { }
@@ -875,7 +875,7 @@ namespace ReactiveUI.Primitives.Core
         public static bool operator ==(ReactiveUI.Primitives.Core.Moment<T> first, ReactiveUI.Primitives.Core.Moment<T> second) { }
         public static bool operator !=(ReactiveUI.Primitives.Core.Moment<T> first, ReactiveUI.Primitives.Core.Moment<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {Count}, Capacity = {_items.Length}")]
+    [System.Diagnostics.DebuggerDisplay("PriorityQueue: Count = {Count}, Capacity = {_items.Length}")]
     public sealed class PriorityQueue<T> where T : System.IComparable<T>
     {
         public PriorityQueue() { }
@@ -918,14 +918,14 @@ namespace ReactiveUI.Primitives.Core
 }
 namespace ReactiveUI.Primitives.Extensions
 {
-    [System.Diagnostics.DebuggerDisplay("Outstanding = {_outstanding}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("ConcurrencyLimiter: Outstanding = {_outstanding}, Disposed = {_disposed}")]
     public sealed class ConcurrencyLimiter<T> : System.IObservable<T>
     {
         public ConcurrencyLimiter(System.Collections.Generic.IEnumerable<System.Threading.Tasks.Task<T>> taskFunctions, int maxConcurrency) { }
         public System.IObservable<T> Observable { get; }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Locked = {_locked}, CompletedPhases = {CompletedPhases}")]
+    [System.Diagnostics.DebuggerDisplay("Continuation: Locked = {_locked}, CompletedPhases = {CompletedPhases}")]
     public class Continuation : System.IDisposable
     {
         public Continuation() { }
@@ -935,7 +935,7 @@ namespace ReactiveUI.Primitives.Extensions
         public System.Threading.Tasks.Task Lock<T>(T item, System.IObserver<(T Value, System.IDisposable Sync)>? observer) { }
         public System.Threading.Tasks.ValueTask LockValueTask<T>(T item, System.IObserver<(T Value, System.IDisposable Sync)>? observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_value}, Completed = {_completed}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("CurrentValueSubject: Value = {_value}, Completed = {_completed}, Disposed = {_disposed}")]
     public sealed class CurrentValueSubject<T> : System.IDisposable, System.IObservable<T>, System.IObserver<T>
     {
         public CurrentValueSubject(T initialValue) { }
@@ -962,7 +962,7 @@ namespace ReactiveUI.Primitives.Extensions
     {
         public static System.Threading.Tasks.ValueTask<T> FirstAsValueTask(System.IObservable<T> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsHeartbeat = {IsHeartbeat}, Update = {Update}")]
+    [System.Diagnostics.DebuggerDisplay("Heartbeat: IsHeartbeat = {IsHeartbeat}, Update = {Update}")]
     public readonly record struct Heartbeat<T> : ReactiveUI.Primitives.Extensions.IHeartbeat<T>, System.IEquatable<ReactiveUI.Primitives.Extensions.Heartbeat<T>>
     {
         public Heartbeat() { }
@@ -1011,7 +1011,7 @@ namespace ReactiveUI.Primitives.Extensions
         public SingleValueSignal(T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsStale = {IsStale}")]
+    [System.Diagnostics.DebuggerDisplay("Stale: IsStale = {IsStale}")]
     public readonly record struct Stale<T> : ReactiveUI.Primitives.Extensions.IStale<T>, System.IEquatable<ReactiveUI.Primitives.Extensions.Stale<T>>
     {
         public Stale() { }
@@ -1019,7 +1019,7 @@ namespace ReactiveUI.Primitives.Extensions
         public bool IsStale { get; }
         public T? Update { get; }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {Done}, Timer = {Timer}")]
+    [System.Diagnostics.DebuggerDisplay("TimerSinkState: Done = {Done}, Timer = {Timer}")]
     public sealed class TimerSinkState<T>
     {
         public TimerSinkState(System.IObserver<T> downstream) { }
@@ -1032,13 +1032,13 @@ namespace ReactiveUI.Primitives.Extensions
 }
 namespace ReactiveUI.Primitives.Extensions.Operators
 {
-    [System.Diagnostics.DebuggerDisplay("Left = {_left}, Right = {_right}")]
+    [System.Diagnostics.DebuggerDisplay("BinaryMinMaxObservable: Left = {_left}, Right = {_right}")]
     public sealed class BinaryMinMaxObservable<T> : System.IObservable<T> where T : struct, System.IComparable<T>
     {
         public BinaryMinMaxObservable(System.IObservable<T> left, System.IObservable<T> right, bool emitMaximum) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sourceList}")]
+    [System.Diagnostics.DebuggerDisplay("BooleanReduceObservable: Sources = {_sourceList}")]
     public sealed class BooleanReduceObservable : System.IObservable<bool>
     {
         public BooleanReduceObservable(System.Collections.Generic.IEnumerable<System.IObservable<bool>> sources, bool target) { }
@@ -1059,7 +1059,7 @@ namespace ReactiveUI.Primitives.Extensions.Operators
         public CatchIgnoreEmptyObservable(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, ErrorAction = {_errorAction}")]
+    [System.Diagnostics.DebuggerDisplay("CatchIgnoreObservable: Source = {_source}, ErrorAction = {_errorAction}")]
     public sealed class CatchIgnoreObservable<TSource, TException> : System.IObservable<TSource> where TException : System.Exception
     {
         public CatchIgnoreObservable(System.IObservable<TSource> source, System.Action<TException> errorAction) { }
@@ -1094,7 +1094,7 @@ namespace ReactiveUI.Primitives.Extensions.Operators
     {
         public FirstMatchFromCandidatesObservable(System.Collections.Generic.IReadOnlyList<TKey> candidates, System.Func<TKey, System.IObservable<TRaw>> project, System.Func<TRaw, TResult> transform, System.Func<TResult, bool> predicate, TResult fallback) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
-        [System.Diagnostics.DebuggerDisplay("Completed = {Completed}, HasValue = {HasValue}, Value = {Value}")]
+        [System.Diagnostics.DebuggerDisplay("SyncProbe: Completed = {Completed}, HasValue = {HasValue}, Value = {Value}")]
         public sealed class SyncProbe : System.IObserver<TRaw>
         {
             public SyncProbe() { }
@@ -1115,7 +1115,7 @@ namespace ReactiveUI.Primitives.Extensions.Operators
         public LogErrorsObservable(System.IObservable<T> source, System.Action<System.Exception> logger) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sourceList.Count}")]
+    [System.Diagnostics.DebuggerDisplay("MinMaxObservable: Sources = {_sourceList.Count}")]
     public sealed class MinMaxObservable<T> : System.IObservable<T> where T : struct, System.IComparable<T>
     {
         public MinMaxObservable(System.Collections.Generic.IReadOnlyList<System.IObservable<T>> sources, bool emitMaximum) { }
@@ -1131,7 +1131,7 @@ namespace ReactiveUI.Primitives.Extensions.Operators
         public PairwiseObservable(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<(T Previous, T Current)> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, Subscriptions = {_subscriptionCount}")]
+    [System.Diagnostics.DebuggerDisplay("PartitionObservable: Source = {_source}, Subscriptions = {_subscriptionCount}")]
     public sealed class PartitionObservable<T>
     {
         public PartitionObservable(System.IObservable<T> source, System.Func<T, bool> predicate) { }
@@ -1193,7 +1193,7 @@ namespace ReactiveUI.Primitives.Extensions.Operators
         public SkipWhileNullObservable(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Queued = {_queue.Count}, Processing = {_isProcessing}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("SubscribeAsyncObservable: Queued = {_queue.Count}, Processing = {_isProcessing}, Done = {_done}")]
     public sealed class SubscribeAsyncObservable<T> : System.IDisposable
     {
         public SubscribeAsyncObservable(System.IObservable<T> source, System.Func<T, System.Threading.Tasks.ValueTask> onNext, System.Action<System.Exception>? onError, System.Action? onCompleted) { }
@@ -1265,7 +1265,7 @@ namespace ReactiveUI.Primitives.Signals
         public void RemoveObserver(System.IObserver<T> observer) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Callback = {_callback}, Context = {_context}")]
+    [System.Diagnostics.DebuggerDisplay("AwaitWitness: Callback = {_callback}, Context = {_context}")]
     public sealed class AwaitWitness<T> : System.IObserver<T>
     {
         public AwaitWitness(System.Action callback, bool originalContext) { }
@@ -1297,7 +1297,7 @@ namespace ReactiveUI.Primitives.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public bool TryGetValue(out T? value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_observers}")]
+    [System.Diagnostics.DebuggerDisplay("Broadcaster: Observers = {_observers}")]
     public struct Broadcaster<T> : System.IEquatable<ReactiveUI.Primitives.Signals.Broadcaster<T>>
     {
         public bool HasObservers { get; }
@@ -1316,7 +1316,7 @@ namespace ReactiveUI.Primitives.Signals
         public static bool operator ==(ReactiveUI.Primitives.Signals.Broadcaster<T> left, ReactiveUI.Primitives.Signals.Broadcaster<T> right) { }
         public static bool operator !=(ReactiveUI.Primitives.Signals.Broadcaster<T> left, ReactiveUI.Primitives.Signals.Broadcaster<T> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Task = {_task}, Result = {_result}, Exception = {_exception}")]
+    [System.Diagnostics.DebuggerDisplay("CommandExecution: Task = {_task}, Result = {_result}, Exception = {_exception}")]
     public readonly record struct CommandExecution<TResult> : System.IEquatable<ReactiveUI.Primitives.Signals.CommandExecution<TResult>>
     {
         public CommandExecution(System.Exception exception) { }
@@ -1324,7 +1324,7 @@ namespace ReactiveUI.Primitives.Signals
         public CommandExecution(TResult result) { }
         public readonly ReactiveUI.Primitives.Signals.CommandExecution<TResult> ConfigureAwait(bool continueOnCapturedContext) { }
         public readonly ReactiveUI.Primitives.Signals.CommandExecution<TResult>.Awaiter GetAwaiter() { }
-        [System.Diagnostics.DebuggerDisplay("IsCompleted = {IsCompleted}, Result = {_result}, Exception = {_exception}")]
+        [System.Diagnostics.DebuggerDisplay("Awaiter: IsCompleted = {IsCompleted}, Result = {_result}, Exception = {_exception}")]
         public readonly record struct Awaiter : System.IEquatable<ReactiveUI.Primitives.Signals.CommandExecution<TResult>.Awaiter>, System.Runtime.CompilerServices.ICriticalNotifyCompletion
         {
             public Awaiter(System.Threading.Tasks.Task<TResult>? task, TResult? result, System.Exception? exception, bool continueOnCapturedContext) { }
@@ -1353,7 +1353,7 @@ namespace ReactiveUI.Primitives.Signals
         public ReactiveUI.Primitives.Signals.CommandExecution<TResult> ExecuteAsync(System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Buffer = {_buffer}")]
+    [System.Diagnostics.DebuggerDisplay("DelayableNotificationSignal: Stopped = {_stopped}, Buffer = {_buffer}")]
     public sealed class DelayableNotificationSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T>
     {
         public DelayableNotificationSignal(System.Func<bool> isDelayed, System.Func<System.Collections.Generic.IList<T>, System.Collections.Generic.IEnumerable<T>> flushDistinct) { }
@@ -1366,7 +1366,7 @@ namespace ReactiveUI.Primitives.Signals
         public void OnNext(T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("OnNext = {_onNext}")]
+    [System.Diagnostics.DebuggerDisplay("DelegateWitness: OnNext = {_onNext}")]
     public sealed class DelegateWitness<T> : System.IObserver<T>
     {
         public DelegateWitness(System.Action<T> onNext, System.Action<System.Exception>? onError = null, System.Action? onCompleted = null) { }
@@ -1397,41 +1397,41 @@ namespace ReactiveUI.Primitives.Signals
         System.IObservable<T>? Source { get; }
         void GetOperationCanceled(System.IObserver<System.Exception> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, Predicate = {_predicate}")]
+    [System.Diagnostics.DebuggerDisplay("KeepSignal: Source = {_source}, Predicate = {_predicate}")]
     public sealed class KeepSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public KeepSignal(System.IObservable<T> source, System.Func<T, bool> predicate) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, State = {_state}")]
+    [System.Diagnostics.DebuggerDisplay("KeepWithSignal: Source = {_source}, State = {_state}")]
     public sealed class KeepWithSignal<T, TState> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public KeepWithSignal(System.IObservable<T> source, TState state, System.Func<TState, T, bool> predicate) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, Selector = {_selector}")]
+    [System.Diagnostics.DebuggerDisplay("MapSignal: Source = {_source}, Selector = {_selector}")]
     public sealed class MapSignal<TSource, TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public MapSignal(System.IObservable<TSource> source, System.Func<TSource, TResult> selector) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, State = {_state}")]
+    [System.Diagnostics.DebuggerDisplay("MapWithSignal: Source = {_source}, State = {_state}")]
     public sealed class MapWithSignal<TSource, TState, TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public MapWithSignal(System.IObservable<TSource> source, TState state, System.Func<TState, TSource, TResult> selector) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Subject = {_subject}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("ObserverHandler: Subject = {_subject}, Observer = {_observer}")]
     public sealed class ObserverHandler<T> : System.IDisposable
     {
         public ObserverHandler(ReactiveUI.Primitives.Signals.AsyncSignal<T> subject, System.IObserver<T> observer) { }
         public void Dispose() { }
     }
-    [System.Diagnostics.DebuggerDisplay("{Value}")]
+    [System.Diagnostics.DebuggerDisplay("ProjectedReadOnlyState: {Value}")]
     public sealed class ProjectedReadOnlyState<TSource, TResult> : System.IDisposable, System.IObservable<TResult>, System.IObserver<TSource>
     {
         public System.IObservable<TResult> Changed { get; }
@@ -1493,7 +1493,7 @@ namespace ReactiveUI.Primitives.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public bool TryGetValue(out T? value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, State = {_state}")]
+    [System.Diagnostics.DebuggerDisplay("TapWithSignal: Source = {_source}, State = {_state}")]
     public sealed class TapWithSignal<T, TState> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public TapWithSignal(System.IObservable<T> source, TState state, System.Action<TState, T> onNext) { }

--- a/src/ReactiveUI.Primitives.Core/PublicAPI/net48/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Core/PublicAPI/net48/PublicAPI.txt
@@ -6,7 +6,7 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Primitives.Tests")]
 namespace ReactiveUI.Primitives
 {
-    [System.Diagnostics.DebuggerDisplay("Subscribe = {_subscribe}")]
+    [System.Diagnostics.DebuggerDisplay("AnonymousSignal: Subscribe = {_subscribe}")]
     public sealed class AnonymousSignal<T> : System.IObservable<T>
     {
         public AnonymousSignal(System.Func<System.IObserver<T>, System.IDisposable> subscribe) { }
@@ -48,7 +48,7 @@ namespace ReactiveUI.Primitives
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public static ReactiveUI.Primitives.Optional<T> Some<T>(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasValue = {HasValue}, Value = {_value}")]
+    [System.Diagnostics.DebuggerDisplay("Optional: HasValue = {HasValue}, Value = {_value}")]
     public readonly record struct Optional<T> : System.IEquatable<ReactiveUI.Primitives.Optional<T>>
     {
         public Optional() { }
@@ -67,7 +67,7 @@ namespace ReactiveUI.Primitives
         public static explicit operator T?(in ReactiveUI.Primitives.Optional<T> value) { }
         public static implicit operator ReactiveUI.Primitives.Optional<T>(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsSuccess = {IsSuccess}, Exception = {Exception}")]
+    [System.Diagnostics.DebuggerDisplay("Result: IsSuccess = {IsSuccess}, Exception = {Exception}")]
     public readonly record struct Result : System.IEquatable<ReactiveUI.Primitives.Result>
     {
         public Result(System.Exception exception) { }
@@ -108,7 +108,7 @@ namespace ReactiveUI.Primitives
 }
 namespace ReactiveUI.Primitives.Advanced
 {
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, Aggregator = {_aggregator}")]
+    [System.Diagnostics.DebuggerDisplay("AggregateWitness: Done = {_done}, Aggregator = {_aggregator}")]
     public sealed class AggregateWitness<T, TResult, TAggregator> : System.IDisposable, System.IObserver<T> where TAggregator : struct, ReactiveUI.Primitives.Advanced.IAggregator<T, TResult, TAggregator>
     {
         public AggregateWitness(System.IObserver<TResult> observer, TAggregator aggregator) { }
@@ -122,7 +122,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("AllPredicateWitness: Done = {_done}, Observer = {_observer}")]
     public sealed class AllPredicateWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public AllPredicateWitness(System.IObserver<bool> observer, System.Func<T, bool> predicate) { }
@@ -136,7 +136,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("AnyPredicateWitness: Done = {_done}, Observer = {_observer}")]
     public sealed class AnyPredicateWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public AnyPredicateWitness(System.IObserver<bool> observer, System.Func<T, bool> predicate) { }
@@ -150,7 +150,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("AnyWitness: Done = {_done}, Observer = {_observer}")]
     public sealed class AnyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public AnyWitness(System.IObserver<bool> observer) { }
@@ -165,7 +165,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_value}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("AppendDelegateWitness: Value = {_value}, Subscription = {_subscription}")]
     public sealed class AppendDelegateWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public AppendDelegateWitness(System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted, T value) { }
@@ -177,7 +177,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("AppendedValue = {_value}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("AppendWitness: AppendedValue = {_value}, Observer = {_observer}")]
     public sealed class AppendWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public AppendWitness(System.IObserver<T> observer, T value) { }
@@ -191,7 +191,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Skip = {_skip}, Index = {_index}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("BufferWitness: Count = {_count}, Skip = {_skip}, Index = {_index}, Done = {_done}")]
     public sealed class BufferWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public BufferWitness(System.IObserver<System.Collections.Generic.IList<T>> observer, int count, int skip) { }
@@ -202,7 +202,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("OnNext = {_onNext}, OnError = {_onError}, OnCompleted = {_onCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("CallbackWitness: OnNext = {_onNext}, OnError = {_onError}, OnCompleted = {_onCompleted}")]
     public sealed class CallbackWitness<T> : System.IObserver<T>
     {
         public CallbackWitness(System.Action<T> onNext, System.Action<System.Exception>? onError, System.Action<ReactiveUI.Primitives.Result>? onCompleted) { }
@@ -213,7 +213,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_values.Count}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("CollectArrayWitness: Count = {_values.Count}, Subscription = {_subscription}")]
     public sealed class CollectArrayWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CollectArrayWitness(System.IObserver<T[]> observer) { }
@@ -228,7 +228,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_values.Count}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("CollectListWitness: Count = {_values.Count}, Subscription = {_subscription}")]
     public sealed class CollectListWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CollectListWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -243,7 +243,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SoughtValue = {_value}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("ContainsWitness: SoughtValue = {_value}, Done = {_done}")]
     public sealed class ContainsWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public ContainsWitness(System.IObserver<bool> observer, T value, System.Collections.Generic.IEqualityComparer<T> comparer) { }
@@ -257,7 +257,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {Items.Length}")]
+    [System.Diagnostics.DebuggerDisplay("CopyOnWriteList: Count = {Items.Length}")]
     public sealed class CopyOnWriteList<T>
     {
         public CopyOnWriteList(T[] data) { }
@@ -267,20 +267,20 @@ namespace ReactiveUI.Primitives.Advanced
         public int IndexOf(T value) { }
         public ReactiveUI.Primitives.Advanced.CopyOnWriteList<T> Remove(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Result = {Result}")]
+    [System.Diagnostics.DebuggerDisplay("CountAggregator: Result = {Result}")]
     public readonly record struct CountAggregator<T> : ReactiveUI.Primitives.Advanced.IAggregator<T, int, ReactiveUI.Primitives.Advanced.CountAggregator<T>>, System.IEquatable<ReactiveUI.Primitives.Advanced.CountAggregator<T>>
     {
         public int Result { get; }
         public readonly ReactiveUI.Primitives.Advanced.CountAggregator<T> Add(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Result = {Result}, Predicate = {_predicate}")]
+    [System.Diagnostics.DebuggerDisplay("CountPredicateAggregator: Result = {Result}, Predicate = {_predicate}")]
     public readonly record struct CountPredicateAggregator<T> : ReactiveUI.Primitives.Advanced.IAggregator<T, int, ReactiveUI.Primitives.Advanced.CountPredicateAggregator<T>>, System.IEquatable<ReactiveUI.Primitives.Advanced.CountPredicateAggregator<T>>
     {
         public CountPredicateAggregator(System.Func<T, bool> predicate) { }
         public int Result { get; }
         public readonly ReactiveUI.Primitives.Advanced.CountPredicateAggregator<T> Add(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Seen = {_seen}, DefaultValue = {_defaultValue}")]
+    [System.Diagnostics.DebuggerDisplay("DefaultIfEmptyWitness: Seen = {_seen}, DefaultValue = {_defaultValue}")]
     public sealed class DefaultIfEmptyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public DefaultIfEmptyWitness(System.IObserver<T> observer, T defaultValue) { }
@@ -305,21 +305,21 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Result = {Result}, Seen = {_seen}")]
+    [System.Diagnostics.DebuggerDisplay("DistinctByCountAggregator: Result = {Result}, Seen = {_seen}")]
     public readonly record struct DistinctByCountAggregator<T, TKey> : ReactiveUI.Primitives.Advanced.IAggregator<T, int, ReactiveUI.Primitives.Advanced.DistinctByCountAggregator<T, TKey>>, System.IEquatable<ReactiveUI.Primitives.Advanced.DistinctByCountAggregator<T, TKey>>
     {
         public DistinctByCountAggregator(System.Func<T, TKey> keySelector, System.Collections.Generic.IEqualityComparer<TKey>? comparer) { }
         public int Result { get; }
         public readonly ReactiveUI.Primitives.Advanced.DistinctByCountAggregator<T, TKey> Add(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Result = {Result}, Seen = {_seen}")]
+    [System.Diagnostics.DebuggerDisplay("DistinctByLongCountAggregator: Result = {Result}, Seen = {_seen}")]
     public readonly record struct DistinctByLongCountAggregator<T, TKey> : ReactiveUI.Primitives.Advanced.IAggregator<T, long, ReactiveUI.Primitives.Advanced.DistinctByLongCountAggregator<T, TKey>>, System.IEquatable<ReactiveUI.Primitives.Advanced.DistinctByLongCountAggregator<T, TKey>>
     {
         public DistinctByLongCountAggregator(System.Func<T, TKey> keySelector, System.Collections.Generic.IEqualityComparer<TKey>? comparer) { }
         public long Result { get; }
         public readonly ReactiveUI.Primitives.Advanced.DistinctByLongCountAggregator<T, TKey> Add(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, SeenKeys = {_seen.Count}")]
+    [System.Diagnostics.DebuggerDisplay("DistinctByWitness: Done = {_done}, SeenKeys = {_seen.Count}")]
     public sealed class DistinctByWitness<T, TKey> : System.IDisposable, System.IObserver<T>
     {
         public DistinctByWitness(System.IObserver<T> observer, System.Func<T, TKey> keySelector, System.Collections.Generic.IEqualityComparer<TKey>? comparer) { }
@@ -333,7 +333,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Seen = {_seen.Count}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("DistinctWitness: Seen = {_seen.Count}, Subscription = {_subscription}")]
     public sealed class DistinctWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public DistinctWitness(System.IObserver<T> observer, System.Collections.Generic.HashSet<T> seen) { }
@@ -347,7 +347,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("OnNext = {_onNext}, OnError = {_onError}, OnCompleted = {_onCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("EmptyWitness: OnNext = {_onNext}, OnError = {_onError}, OnCompleted = {_onCompleted}")]
     public sealed class EmptyWitness<T> : System.IObserver<T>
     {
         public EmptyWitness(System.Action<T> onNext) { }
@@ -362,7 +362,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Current = {_current}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("FoldWitness: Current = {_current}, Observer = {_observer}")]
     public sealed class FoldWitness<TSource, TAccumulate> : System.IDisposable, System.IObserver<TSource>
     {
         public FoldWitness(System.IObserver<TAccumulate> observer, TAccumulate seed, System.Func<TAccumulate, TSource, TAccumulate> accumulator) { }
@@ -376,7 +376,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("ForwardingWitness: Observer = {_observer}")]
     public sealed class ForwardingWitness<T> : System.IObserver<T>
     {
         public ForwardingWitness(System.IObserver<T> observer) { }
@@ -387,7 +387,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Values = {_values}, CancellationToken = {_cancellationToken}")]
+    [System.Diagnostics.DebuggerDisplay("FromEnumerableSignal: Values = {_values}, CancellationToken = {_cancellationToken}")]
     public sealed class FromEnumerableSignal<T> : ReactiveUI.Primitives.Advanced.IInlineSignal<T>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public FromEnumerableSignal(System.Collections.Generic.IEnumerable<T> values) { }
@@ -411,7 +411,7 @@ namespace ReactiveUI.Primitives.Advanced
     {
         bool IsRequiredSubscribeOnCurrentThread() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("IgnoreValuesWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class IgnoreValuesWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public IgnoreValuesWitness(System.IObserver<T> observer) { }
@@ -425,7 +425,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_value}")]
+    [System.Diagnostics.DebuggerDisplay("ImmediateReturnSignal: Value = {_value}")]
     public sealed class ImmediateReturnSignal<T> : ReactiveUI.Primitives.Advanced.IInlineSignal<T>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ImmediateReturnSignal(T value) { }
@@ -434,7 +434,7 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
         public System.IDisposable Subscribe(System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Error = {_error}")]
+    [System.Diagnostics.DebuggerDisplay("ImmediateThrowSignal: Error = {_error}")]
     public sealed class ImmediateThrowSignal<T> : ReactiveUI.Primitives.Advanced.IInlineSignal<T>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ImmediateThrowSignal(System.Exception error) { }
@@ -468,7 +468,7 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<bool> observer) { }
         public System.IDisposable Subscribe(System.Action<bool> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_x}")]
+    [System.Diagnostics.DebuggerDisplay("ImmutableReturnInt32Signal: Value = {_x}")]
     public sealed class ImmutableReturnInt32Signal : ReactiveUI.Primitives.Advanced.IInlineSignal<int>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<int>
     {
         public ImmutableReturnInt32Signal(int x) { }
@@ -486,7 +486,7 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<bool> observer) { }
         public System.IDisposable Subscribe(System.Action<bool> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("KeepNotNullWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class KeepNotNullWitness<T> : System.IDisposable, System.IObserver<T?> where T : class
     {
         public KeepNotNullWitness(System.IObserver<T> observer) { }
@@ -500,7 +500,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("KeepTypeWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class KeepTypeWitness<TResult> : System.IDisposable, System.IObserver<object?>
     {
         public KeepTypeWitness(System.IObserver<TResult> observer) { }
@@ -514,7 +514,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasObservers = {HasObservers}, Count = {_observers.Items.Length}")]
+    [System.Diagnostics.DebuggerDisplay("ListWitness: HasObservers = {HasObservers}, Count = {_observers.Items.Length}")]
     public sealed class ListWitness<T> : System.IObserver<T>
     {
         public ListWitness(ReactiveUI.Primitives.Advanced.CopyOnWriteList<System.IObserver<T>> observers) { }
@@ -523,20 +523,20 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Result = {Result}")]
+    [System.Diagnostics.DebuggerDisplay("LongCountAggregator: Result = {Result}")]
     public readonly record struct LongCountAggregator<T> : ReactiveUI.Primitives.Advanced.IAggregator<T, long, ReactiveUI.Primitives.Advanced.LongCountAggregator<T>>, System.IEquatable<ReactiveUI.Primitives.Advanced.LongCountAggregator<T>>
     {
         public long Result { get; }
         public readonly ReactiveUI.Primitives.Advanced.LongCountAggregator<T> Add(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Result = {Result}, Predicate = {_predicate}")]
+    [System.Diagnostics.DebuggerDisplay("LongCountPredicateAggregator: Result = {Result}, Predicate = {_predicate}")]
     public readonly record struct LongCountPredicateAggregator<T> : ReactiveUI.Primitives.Advanced.IAggregator<T, long, ReactiveUI.Primitives.Advanced.LongCountPredicateAggregator<T>>, System.IEquatable<ReactiveUI.Primitives.Advanced.LongCountPredicateAggregator<T>>
     {
         public LongCountPredicateAggregator(System.Func<T, bool> predicate) { }
         public long Result { get; }
         public readonly ReactiveUI.Primitives.Advanced.LongCountPredicateAggregator<T> Add(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Ranges = {_ranges.Length}")]
+    [System.Diagnostics.DebuggerDisplay("RangeConcatSignal: Ranges = {_ranges.Length}")]
     public sealed class RangeConcatSignal : ReactiveUI.Primitives.Advanced.IInlineSignal<int>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<int>
     {
         public RangeConcatSignal(ReactiveUI.Primitives.Advanced.RangeSignal[] ranges) { }
@@ -545,7 +545,7 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<int> observer) { }
         public System.IDisposable Subscribe(System.Action<int> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Start = {Start}, Count = {Count}")]
+    [System.Diagnostics.DebuggerDisplay("RangeSignal: Start = {Start}, Count = {Count}")]
     public sealed class RangeSignal : ReactiveUI.Primitives.Advanced.IInlineSignal<int>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<int>
     {
         public RangeSignal(int start, int count) { }
@@ -556,7 +556,7 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<int> observer) { }
         public System.IDisposable Subscribe(System.Action<int> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, LeftStart = {_leftStart}, RightStart = {_rightStart}")]
+    [System.Diagnostics.DebuggerDisplay("RangeZipSignal: Count = {_count}, LeftStart = {_leftStart}, RightStart = {_rightStart}")]
     public sealed class RangeZipSignal<TResult> : ReactiveUI.Primitives.Advanced.IInlineSignal<TResult>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public RangeZipSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
@@ -565,7 +565,7 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
         public System.IDisposable Subscribe(System.Action<TResult> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Current = {_current}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("ReduceWitness: Current = {_current}, Subscription = {_subscription}")]
     public sealed class ReduceWitness<TSource, TAccumulate> : System.IDisposable, System.IObserver<TSource>
     {
         public ReduceWitness(System.IObserver<TAccumulate> observer, TAccumulate seed, System.Func<TAccumulate, TSource, TAccumulate> accumulator) { }
@@ -579,7 +579,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_value}, Count = {_count}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSignal: Value = {_value}, Count = {_count}")]
     public sealed class RepeatSignal<T> : ReactiveUI.Primitives.Advanced.IInlineSignal<T>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public RepeatSignal(T value, int count) { }
@@ -604,7 +604,7 @@ namespace ReactiveUI.Primitives.Advanced
         public static void Fault<TResult>(System.IObserver<TResult> observer, System.Exception error, System.IDisposable sink) { }
         public static void Fault<TResult>(System.IObserver<TResult> observer, System.Exception error, System.IDisposable sink, ref bool done) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Skipping = {_skipping}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SkipWhileWitness: Skipping = {_skipping}, Subscription = {_subscription}")]
     public sealed class SkipWhileWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SkipWhileWitness(System.IObserver<T> observer, System.Func<T, bool> predicate) { }
@@ -618,7 +618,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Remaining = {_remaining}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SkipWitness: Remaining = {_remaining}, Observer = {_observer}")]
     public sealed class SkipWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SkipWitness(System.IObserver<T> observer, int count) { }
@@ -632,7 +632,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("State = {_state}, OnError = {_onError}")]
+    [System.Diagnostics.DebuggerDisplay("StatefulWitness: State = {_state}, OnError = {_onError}")]
     public sealed class StatefulWitness<T, TState> : System.IObserver<T>
     {
         public StatefulWitness(TState state, System.Action<T, TState> onNext, System.Action<System.Exception, TState>? onError, System.Action<ReactiveUI.Primitives.Result, TState>? onCompleted) { }
@@ -649,7 +649,7 @@ namespace ReactiveUI.Primitives.Advanced
         public static void Assign(ref System.IDisposable? slot, System.IDisposable subscription) { }
         public static void Release(ref System.IDisposable? slot) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SynchronizeWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SynchronizeWitness(System.IObserver<T> observer) { }
@@ -662,7 +662,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {_completed}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("TakeWhileWitness: Completed = {_completed}, Subscription = {_subscription}")]
     public sealed class TakeWhileWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TakeWhileWitness(System.IObserver<T> observer, System.Func<T, bool> predicate) { }
@@ -675,7 +675,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Remaining = {_remaining}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TakeWitness: Remaining = {_remaining}, Stopped = {_stopped}")]
     public sealed class TakeWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TakeWitness(System.IObserver<T> observer, int count) { }
@@ -687,7 +687,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("TapWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class TapWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TapWitness(System.IObserver<T> observer, System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
@@ -707,7 +707,7 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("InitialState = {_initialState}, Condition = {_condition}")]
+    [System.Diagnostics.DebuggerDisplay("UnfoldSignal: InitialState = {_initialState}, Condition = {_condition}")]
     public sealed class UnfoldSignal<TState, TResult> : ReactiveUI.Primitives.Advanced.IInlineSignal<TResult>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public UnfoldSignal(TState initialState, System.Func<TState, bool> condition, System.Func<TState, TState> iterate, System.Func<TState, TResult> resultSelector) { }
@@ -716,7 +716,7 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
         public System.IDisposable Subscribe(System.Action<TResult> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLast = {_hasLast}, Last = {_last}")]
+    [System.Diagnostics.DebuggerDisplay("UniqueByWitness: HasLast = {_hasLast}, Last = {_last}")]
     public sealed class UniqueByWitness<T, TKey> : System.IDisposable, System.IObserver<T>
     {
         public UniqueByWitness(System.IObserver<T> observer, System.Func<T, TKey> keySelector, System.Collections.Generic.IEqualityComparer<TKey> comparer) { }
@@ -730,7 +730,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLast = {_hasLast}, Last = {_last}")]
+    [System.Diagnostics.DebuggerDisplay("UniqueWitness: HasLast = {_hasLast}, Last = {_last}")]
     public sealed class UniqueWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public UniqueWitness(System.IObserver<T> observer, System.Collections.Generic.IEqualityComparer<T> comparer) { }
@@ -744,7 +744,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ResourceFactory = {_resourceFactory}, SignalFactory = {_signalFactory}")]
+    [System.Diagnostics.DebuggerDisplay("UseSignal: ResourceFactory = {_resourceFactory}, SignalFactory = {_signalFactory}")]
     public sealed class UseSignal<TResource, T> : System.IObservable<T> where TResource : System.IDisposable
     {
         public UseSignal(System.Func<TResource> resourceFactory, System.Func<TResource, System.IObservable<T>> signalFactory) { }
@@ -875,7 +875,7 @@ namespace ReactiveUI.Primitives.Core
         public static bool operator ==(ReactiveUI.Primitives.Core.Moment<T> first, ReactiveUI.Primitives.Core.Moment<T> second) { }
         public static bool operator !=(ReactiveUI.Primitives.Core.Moment<T> first, ReactiveUI.Primitives.Core.Moment<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {Count}, Capacity = {_items.Length}")]
+    [System.Diagnostics.DebuggerDisplay("PriorityQueue: Count = {Count}, Capacity = {_items.Length}")]
     public sealed class PriorityQueue<T> where T : System.IComparable<T>
     {
         public PriorityQueue() { }
@@ -918,14 +918,14 @@ namespace ReactiveUI.Primitives.Core
 }
 namespace ReactiveUI.Primitives.Extensions
 {
-    [System.Diagnostics.DebuggerDisplay("Outstanding = {_outstanding}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("ConcurrencyLimiter: Outstanding = {_outstanding}, Disposed = {_disposed}")]
     public sealed class ConcurrencyLimiter<T> : System.IObservable<T>
     {
         public ConcurrencyLimiter(System.Collections.Generic.IEnumerable<System.Threading.Tasks.Task<T>> taskFunctions, int maxConcurrency) { }
         public System.IObservable<T> Observable { get; }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Locked = {_locked}, CompletedPhases = {CompletedPhases}")]
+    [System.Diagnostics.DebuggerDisplay("Continuation: Locked = {_locked}, CompletedPhases = {CompletedPhases}")]
     public class Continuation : System.IDisposable
     {
         public Continuation() { }
@@ -935,7 +935,7 @@ namespace ReactiveUI.Primitives.Extensions
         public System.Threading.Tasks.Task Lock<T>(T item, System.IObserver<(T Value, System.IDisposable Sync)>? observer) { }
         public System.Threading.Tasks.ValueTask LockValueTask<T>(T item, System.IObserver<(T Value, System.IDisposable Sync)>? observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_value}, Completed = {_completed}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("CurrentValueSubject: Value = {_value}, Completed = {_completed}, Disposed = {_disposed}")]
     public sealed class CurrentValueSubject<T> : System.IDisposable, System.IObservable<T>, System.IObserver<T>
     {
         public CurrentValueSubject(T initialValue) { }
@@ -962,7 +962,7 @@ namespace ReactiveUI.Primitives.Extensions
     {
         public static System.Threading.Tasks.ValueTask<T> FirstAsValueTask(System.IObservable<T> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsHeartbeat = {IsHeartbeat}, Update = {Update}")]
+    [System.Diagnostics.DebuggerDisplay("Heartbeat: IsHeartbeat = {IsHeartbeat}, Update = {Update}")]
     public readonly record struct Heartbeat<T> : ReactiveUI.Primitives.Extensions.IHeartbeat<T>, System.IEquatable<ReactiveUI.Primitives.Extensions.Heartbeat<T>>
     {
         public Heartbeat() { }
@@ -1011,7 +1011,7 @@ namespace ReactiveUI.Primitives.Extensions
         public SingleValueSignal(T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsStale = {IsStale}")]
+    [System.Diagnostics.DebuggerDisplay("Stale: IsStale = {IsStale}")]
     public readonly record struct Stale<T> : ReactiveUI.Primitives.Extensions.IStale<T>, System.IEquatable<ReactiveUI.Primitives.Extensions.Stale<T>>
     {
         public Stale() { }
@@ -1019,7 +1019,7 @@ namespace ReactiveUI.Primitives.Extensions
         public bool IsStale { get; }
         public T? Update { get; }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {Done}, Timer = {Timer}")]
+    [System.Diagnostics.DebuggerDisplay("TimerSinkState: Done = {Done}, Timer = {Timer}")]
     public sealed class TimerSinkState<T>
     {
         public TimerSinkState(System.IObserver<T> downstream) { }
@@ -1032,13 +1032,13 @@ namespace ReactiveUI.Primitives.Extensions
 }
 namespace ReactiveUI.Primitives.Extensions.Operators
 {
-    [System.Diagnostics.DebuggerDisplay("Left = {_left}, Right = {_right}")]
+    [System.Diagnostics.DebuggerDisplay("BinaryMinMaxObservable: Left = {_left}, Right = {_right}")]
     public sealed class BinaryMinMaxObservable<T> : System.IObservable<T> where T : struct, System.IComparable<T>
     {
         public BinaryMinMaxObservable(System.IObservable<T> left, System.IObservable<T> right, bool emitMaximum) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sourceList}")]
+    [System.Diagnostics.DebuggerDisplay("BooleanReduceObservable: Sources = {_sourceList}")]
     public sealed class BooleanReduceObservable : System.IObservable<bool>
     {
         public BooleanReduceObservable(System.Collections.Generic.IEnumerable<System.IObservable<bool>> sources, bool target) { }
@@ -1059,7 +1059,7 @@ namespace ReactiveUI.Primitives.Extensions.Operators
         public CatchIgnoreEmptyObservable(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, ErrorAction = {_errorAction}")]
+    [System.Diagnostics.DebuggerDisplay("CatchIgnoreObservable: Source = {_source}, ErrorAction = {_errorAction}")]
     public sealed class CatchIgnoreObservable<TSource, TException> : System.IObservable<TSource> where TException : System.Exception
     {
         public CatchIgnoreObservable(System.IObservable<TSource> source, System.Action<TException> errorAction) { }
@@ -1094,7 +1094,7 @@ namespace ReactiveUI.Primitives.Extensions.Operators
     {
         public FirstMatchFromCandidatesObservable(System.Collections.Generic.IReadOnlyList<TKey> candidates, System.Func<TKey, System.IObservable<TRaw>> project, System.Func<TRaw, TResult> transform, System.Func<TResult, bool> predicate, TResult fallback) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
-        [System.Diagnostics.DebuggerDisplay("Completed = {Completed}, HasValue = {HasValue}, Value = {Value}")]
+        [System.Diagnostics.DebuggerDisplay("SyncProbe: Completed = {Completed}, HasValue = {HasValue}, Value = {Value}")]
         public sealed class SyncProbe : System.IObserver<TRaw>
         {
             public SyncProbe() { }
@@ -1115,7 +1115,7 @@ namespace ReactiveUI.Primitives.Extensions.Operators
         public LogErrorsObservable(System.IObservable<T> source, System.Action<System.Exception> logger) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sourceList.Count}")]
+    [System.Diagnostics.DebuggerDisplay("MinMaxObservable: Sources = {_sourceList.Count}")]
     public sealed class MinMaxObservable<T> : System.IObservable<T> where T : struct, System.IComparable<T>
     {
         public MinMaxObservable(System.Collections.Generic.IReadOnlyList<System.IObservable<T>> sources, bool emitMaximum) { }
@@ -1131,7 +1131,7 @@ namespace ReactiveUI.Primitives.Extensions.Operators
         public PairwiseObservable(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<(T Previous, T Current)> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, Subscriptions = {_subscriptionCount}")]
+    [System.Diagnostics.DebuggerDisplay("PartitionObservable: Source = {_source}, Subscriptions = {_subscriptionCount}")]
     public sealed class PartitionObservable<T>
     {
         public PartitionObservable(System.IObservable<T> source, System.Func<T, bool> predicate) { }
@@ -1193,7 +1193,7 @@ namespace ReactiveUI.Primitives.Extensions.Operators
         public SkipWhileNullObservable(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Queued = {_queue.Count}, Processing = {_isProcessing}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("SubscribeAsyncObservable: Queued = {_queue.Count}, Processing = {_isProcessing}, Done = {_done}")]
     public sealed class SubscribeAsyncObservable<T> : System.IDisposable
     {
         public SubscribeAsyncObservable(System.IObservable<T> source, System.Func<T, System.Threading.Tasks.ValueTask> onNext, System.Action<System.Exception>? onError, System.Action? onCompleted) { }
@@ -1265,7 +1265,7 @@ namespace ReactiveUI.Primitives.Signals
         public void RemoveObserver(System.IObserver<T> observer) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Callback = {_callback}, Context = {_context}")]
+    [System.Diagnostics.DebuggerDisplay("AwaitWitness: Callback = {_callback}, Context = {_context}")]
     public sealed class AwaitWitness<T> : System.IObserver<T>
     {
         public AwaitWitness(System.Action callback, bool originalContext) { }
@@ -1297,7 +1297,7 @@ namespace ReactiveUI.Primitives.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public bool TryGetValue(out T? value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_observers}")]
+    [System.Diagnostics.DebuggerDisplay("Broadcaster: Observers = {_observers}")]
     public struct Broadcaster<T> : System.IEquatable<ReactiveUI.Primitives.Signals.Broadcaster<T>>
     {
         public bool HasObservers { get; }
@@ -1316,7 +1316,7 @@ namespace ReactiveUI.Primitives.Signals
         public static bool operator ==(ReactiveUI.Primitives.Signals.Broadcaster<T> left, ReactiveUI.Primitives.Signals.Broadcaster<T> right) { }
         public static bool operator !=(ReactiveUI.Primitives.Signals.Broadcaster<T> left, ReactiveUI.Primitives.Signals.Broadcaster<T> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Task = {_task}, Result = {_result}, Exception = {_exception}")]
+    [System.Diagnostics.DebuggerDisplay("CommandExecution: Task = {_task}, Result = {_result}, Exception = {_exception}")]
     public readonly record struct CommandExecution<TResult> : System.IEquatable<ReactiveUI.Primitives.Signals.CommandExecution<TResult>>
     {
         public CommandExecution(System.Exception exception) { }
@@ -1324,7 +1324,7 @@ namespace ReactiveUI.Primitives.Signals
         public CommandExecution(TResult result) { }
         public readonly ReactiveUI.Primitives.Signals.CommandExecution<TResult> ConfigureAwait(bool continueOnCapturedContext) { }
         public readonly ReactiveUI.Primitives.Signals.CommandExecution<TResult>.Awaiter GetAwaiter() { }
-        [System.Diagnostics.DebuggerDisplay("IsCompleted = {IsCompleted}, Result = {_result}, Exception = {_exception}")]
+        [System.Diagnostics.DebuggerDisplay("Awaiter: IsCompleted = {IsCompleted}, Result = {_result}, Exception = {_exception}")]
         public readonly record struct Awaiter : System.IEquatable<ReactiveUI.Primitives.Signals.CommandExecution<TResult>.Awaiter>, System.Runtime.CompilerServices.ICriticalNotifyCompletion
         {
             public Awaiter(System.Threading.Tasks.Task<TResult>? task, TResult? result, System.Exception? exception, bool continueOnCapturedContext) { }
@@ -1353,7 +1353,7 @@ namespace ReactiveUI.Primitives.Signals
         public ReactiveUI.Primitives.Signals.CommandExecution<TResult> ExecuteAsync(System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Buffer = {_buffer}")]
+    [System.Diagnostics.DebuggerDisplay("DelayableNotificationSignal: Stopped = {_stopped}, Buffer = {_buffer}")]
     public sealed class DelayableNotificationSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T>
     {
         public DelayableNotificationSignal(System.Func<bool> isDelayed, System.Func<System.Collections.Generic.IList<T>, System.Collections.Generic.IEnumerable<T>> flushDistinct) { }
@@ -1366,7 +1366,7 @@ namespace ReactiveUI.Primitives.Signals
         public void OnNext(T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("OnNext = {_onNext}")]
+    [System.Diagnostics.DebuggerDisplay("DelegateWitness: OnNext = {_onNext}")]
     public sealed class DelegateWitness<T> : System.IObserver<T>
     {
         public DelegateWitness(System.Action<T> onNext, System.Action<System.Exception>? onError = null, System.Action? onCompleted = null) { }
@@ -1397,41 +1397,41 @@ namespace ReactiveUI.Primitives.Signals
         System.IObservable<T>? Source { get; }
         void GetOperationCanceled(System.IObserver<System.Exception> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, Predicate = {_predicate}")]
+    [System.Diagnostics.DebuggerDisplay("KeepSignal: Source = {_source}, Predicate = {_predicate}")]
     public sealed class KeepSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public KeepSignal(System.IObservable<T> source, System.Func<T, bool> predicate) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, State = {_state}")]
+    [System.Diagnostics.DebuggerDisplay("KeepWithSignal: Source = {_source}, State = {_state}")]
     public sealed class KeepWithSignal<T, TState> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public KeepWithSignal(System.IObservable<T> source, TState state, System.Func<TState, T, bool> predicate) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, Selector = {_selector}")]
+    [System.Diagnostics.DebuggerDisplay("MapSignal: Source = {_source}, Selector = {_selector}")]
     public sealed class MapSignal<TSource, TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public MapSignal(System.IObservable<TSource> source, System.Func<TSource, TResult> selector) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, State = {_state}")]
+    [System.Diagnostics.DebuggerDisplay("MapWithSignal: Source = {_source}, State = {_state}")]
     public sealed class MapWithSignal<TSource, TState, TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public MapWithSignal(System.IObservable<TSource> source, TState state, System.Func<TState, TSource, TResult> selector) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Subject = {_subject}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("ObserverHandler: Subject = {_subject}, Observer = {_observer}")]
     public sealed class ObserverHandler<T> : System.IDisposable
     {
         public ObserverHandler(ReactiveUI.Primitives.Signals.AsyncSignal<T> subject, System.IObserver<T> observer) { }
         public void Dispose() { }
     }
-    [System.Diagnostics.DebuggerDisplay("{Value}")]
+    [System.Diagnostics.DebuggerDisplay("ProjectedReadOnlyState: {Value}")]
     public sealed class ProjectedReadOnlyState<TSource, TResult> : System.IDisposable, System.IObservable<TResult>, System.IObserver<TSource>
     {
         public System.IObservable<TResult> Changed { get; }
@@ -1493,7 +1493,7 @@ namespace ReactiveUI.Primitives.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public bool TryGetValue(out T? value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, State = {_state}")]
+    [System.Diagnostics.DebuggerDisplay("TapWithSignal: Source = {_source}, State = {_state}")]
     public sealed class TapWithSignal<T, TState> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public TapWithSignal(System.IObservable<T> source, TState state, System.Action<TState, T> onNext) { }

--- a/src/ReactiveUI.Primitives.Core/PublicAPI/net481/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Core/PublicAPI/net481/PublicAPI.txt
@@ -6,7 +6,7 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Primitives.Tests")]
 namespace ReactiveUI.Primitives
 {
-    [System.Diagnostics.DebuggerDisplay("Subscribe = {_subscribe}")]
+    [System.Diagnostics.DebuggerDisplay("AnonymousSignal: Subscribe = {_subscribe}")]
     public sealed class AnonymousSignal<T> : System.IObservable<T>
     {
         public AnonymousSignal(System.Func<System.IObserver<T>, System.IDisposable> subscribe) { }
@@ -48,7 +48,7 @@ namespace ReactiveUI.Primitives
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public static ReactiveUI.Primitives.Optional<T> Some<T>(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasValue = {HasValue}, Value = {_value}")]
+    [System.Diagnostics.DebuggerDisplay("Optional: HasValue = {HasValue}, Value = {_value}")]
     public readonly record struct Optional<T> : System.IEquatable<ReactiveUI.Primitives.Optional<T>>
     {
         public Optional() { }
@@ -67,7 +67,7 @@ namespace ReactiveUI.Primitives
         public static explicit operator T?(in ReactiveUI.Primitives.Optional<T> value) { }
         public static implicit operator ReactiveUI.Primitives.Optional<T>(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsSuccess = {IsSuccess}, Exception = {Exception}")]
+    [System.Diagnostics.DebuggerDisplay("Result: IsSuccess = {IsSuccess}, Exception = {Exception}")]
     public readonly record struct Result : System.IEquatable<ReactiveUI.Primitives.Result>
     {
         public Result(System.Exception exception) { }
@@ -108,7 +108,7 @@ namespace ReactiveUI.Primitives
 }
 namespace ReactiveUI.Primitives.Advanced
 {
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, Aggregator = {_aggregator}")]
+    [System.Diagnostics.DebuggerDisplay("AggregateWitness: Done = {_done}, Aggregator = {_aggregator}")]
     public sealed class AggregateWitness<T, TResult, TAggregator> : System.IDisposable, System.IObserver<T> where TAggregator : struct, ReactiveUI.Primitives.Advanced.IAggregator<T, TResult, TAggregator>
     {
         public AggregateWitness(System.IObserver<TResult> observer, TAggregator aggregator) { }
@@ -122,7 +122,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("AllPredicateWitness: Done = {_done}, Observer = {_observer}")]
     public sealed class AllPredicateWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public AllPredicateWitness(System.IObserver<bool> observer, System.Func<T, bool> predicate) { }
@@ -136,7 +136,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("AnyPredicateWitness: Done = {_done}, Observer = {_observer}")]
     public sealed class AnyPredicateWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public AnyPredicateWitness(System.IObserver<bool> observer, System.Func<T, bool> predicate) { }
@@ -150,7 +150,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("AnyWitness: Done = {_done}, Observer = {_observer}")]
     public sealed class AnyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public AnyWitness(System.IObserver<bool> observer) { }
@@ -165,7 +165,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_value}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("AppendDelegateWitness: Value = {_value}, Subscription = {_subscription}")]
     public sealed class AppendDelegateWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public AppendDelegateWitness(System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted, T value) { }
@@ -177,7 +177,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("AppendedValue = {_value}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("AppendWitness: AppendedValue = {_value}, Observer = {_observer}")]
     public sealed class AppendWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public AppendWitness(System.IObserver<T> observer, T value) { }
@@ -191,7 +191,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Skip = {_skip}, Index = {_index}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("BufferWitness: Count = {_count}, Skip = {_skip}, Index = {_index}, Done = {_done}")]
     public sealed class BufferWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public BufferWitness(System.IObserver<System.Collections.Generic.IList<T>> observer, int count, int skip) { }
@@ -202,7 +202,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("OnNext = {_onNext}, OnError = {_onError}, OnCompleted = {_onCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("CallbackWitness: OnNext = {_onNext}, OnError = {_onError}, OnCompleted = {_onCompleted}")]
     public sealed class CallbackWitness<T> : System.IObserver<T>
     {
         public CallbackWitness(System.Action<T> onNext, System.Action<System.Exception>? onError, System.Action<ReactiveUI.Primitives.Result>? onCompleted) { }
@@ -213,7 +213,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_values.Count}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("CollectArrayWitness: Count = {_values.Count}, Subscription = {_subscription}")]
     public sealed class CollectArrayWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CollectArrayWitness(System.IObserver<T[]> observer) { }
@@ -228,7 +228,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_values.Count}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("CollectListWitness: Count = {_values.Count}, Subscription = {_subscription}")]
     public sealed class CollectListWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CollectListWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -243,7 +243,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SoughtValue = {_value}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("ContainsWitness: SoughtValue = {_value}, Done = {_done}")]
     public sealed class ContainsWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public ContainsWitness(System.IObserver<bool> observer, T value, System.Collections.Generic.IEqualityComparer<T> comparer) { }
@@ -257,7 +257,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {Items.Length}")]
+    [System.Diagnostics.DebuggerDisplay("CopyOnWriteList: Count = {Items.Length}")]
     public sealed class CopyOnWriteList<T>
     {
         public CopyOnWriteList(T[] data) { }
@@ -267,20 +267,20 @@ namespace ReactiveUI.Primitives.Advanced
         public int IndexOf(T value) { }
         public ReactiveUI.Primitives.Advanced.CopyOnWriteList<T> Remove(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Result = {Result}")]
+    [System.Diagnostics.DebuggerDisplay("CountAggregator: Result = {Result}")]
     public readonly record struct CountAggregator<T> : ReactiveUI.Primitives.Advanced.IAggregator<T, int, ReactiveUI.Primitives.Advanced.CountAggregator<T>>, System.IEquatable<ReactiveUI.Primitives.Advanced.CountAggregator<T>>
     {
         public int Result { get; }
         public readonly ReactiveUI.Primitives.Advanced.CountAggregator<T> Add(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Result = {Result}, Predicate = {_predicate}")]
+    [System.Diagnostics.DebuggerDisplay("CountPredicateAggregator: Result = {Result}, Predicate = {_predicate}")]
     public readonly record struct CountPredicateAggregator<T> : ReactiveUI.Primitives.Advanced.IAggregator<T, int, ReactiveUI.Primitives.Advanced.CountPredicateAggregator<T>>, System.IEquatable<ReactiveUI.Primitives.Advanced.CountPredicateAggregator<T>>
     {
         public CountPredicateAggregator(System.Func<T, bool> predicate) { }
         public int Result { get; }
         public readonly ReactiveUI.Primitives.Advanced.CountPredicateAggregator<T> Add(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Seen = {_seen}, DefaultValue = {_defaultValue}")]
+    [System.Diagnostics.DebuggerDisplay("DefaultIfEmptyWitness: Seen = {_seen}, DefaultValue = {_defaultValue}")]
     public sealed class DefaultIfEmptyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public DefaultIfEmptyWitness(System.IObserver<T> observer, T defaultValue) { }
@@ -305,21 +305,21 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Result = {Result}, Seen = {_seen}")]
+    [System.Diagnostics.DebuggerDisplay("DistinctByCountAggregator: Result = {Result}, Seen = {_seen}")]
     public readonly record struct DistinctByCountAggregator<T, TKey> : ReactiveUI.Primitives.Advanced.IAggregator<T, int, ReactiveUI.Primitives.Advanced.DistinctByCountAggregator<T, TKey>>, System.IEquatable<ReactiveUI.Primitives.Advanced.DistinctByCountAggregator<T, TKey>>
     {
         public DistinctByCountAggregator(System.Func<T, TKey> keySelector, System.Collections.Generic.IEqualityComparer<TKey>? comparer) { }
         public int Result { get; }
         public readonly ReactiveUI.Primitives.Advanced.DistinctByCountAggregator<T, TKey> Add(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Result = {Result}, Seen = {_seen}")]
+    [System.Diagnostics.DebuggerDisplay("DistinctByLongCountAggregator: Result = {Result}, Seen = {_seen}")]
     public readonly record struct DistinctByLongCountAggregator<T, TKey> : ReactiveUI.Primitives.Advanced.IAggregator<T, long, ReactiveUI.Primitives.Advanced.DistinctByLongCountAggregator<T, TKey>>, System.IEquatable<ReactiveUI.Primitives.Advanced.DistinctByLongCountAggregator<T, TKey>>
     {
         public DistinctByLongCountAggregator(System.Func<T, TKey> keySelector, System.Collections.Generic.IEqualityComparer<TKey>? comparer) { }
         public long Result { get; }
         public readonly ReactiveUI.Primitives.Advanced.DistinctByLongCountAggregator<T, TKey> Add(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, SeenKeys = {_seen.Count}")]
+    [System.Diagnostics.DebuggerDisplay("DistinctByWitness: Done = {_done}, SeenKeys = {_seen.Count}")]
     public sealed class DistinctByWitness<T, TKey> : System.IDisposable, System.IObserver<T>
     {
         public DistinctByWitness(System.IObserver<T> observer, System.Func<T, TKey> keySelector, System.Collections.Generic.IEqualityComparer<TKey>? comparer) { }
@@ -333,7 +333,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Seen = {_seen.Count}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("DistinctWitness: Seen = {_seen.Count}, Subscription = {_subscription}")]
     public sealed class DistinctWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public DistinctWitness(System.IObserver<T> observer, System.Collections.Generic.HashSet<T> seen) { }
@@ -347,7 +347,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("OnNext = {_onNext}, OnError = {_onError}, OnCompleted = {_onCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("EmptyWitness: OnNext = {_onNext}, OnError = {_onError}, OnCompleted = {_onCompleted}")]
     public sealed class EmptyWitness<T> : System.IObserver<T>
     {
         public EmptyWitness(System.Action<T> onNext) { }
@@ -362,7 +362,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Current = {_current}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("FoldWitness: Current = {_current}, Observer = {_observer}")]
     public sealed class FoldWitness<TSource, TAccumulate> : System.IDisposable, System.IObserver<TSource>
     {
         public FoldWitness(System.IObserver<TAccumulate> observer, TAccumulate seed, System.Func<TAccumulate, TSource, TAccumulate> accumulator) { }
@@ -376,7 +376,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("ForwardingWitness: Observer = {_observer}")]
     public sealed class ForwardingWitness<T> : System.IObserver<T>
     {
         public ForwardingWitness(System.IObserver<T> observer) { }
@@ -387,7 +387,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Values = {_values}, CancellationToken = {_cancellationToken}")]
+    [System.Diagnostics.DebuggerDisplay("FromEnumerableSignal: Values = {_values}, CancellationToken = {_cancellationToken}")]
     public sealed class FromEnumerableSignal<T> : ReactiveUI.Primitives.Advanced.IInlineSignal<T>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public FromEnumerableSignal(System.Collections.Generic.IEnumerable<T> values) { }
@@ -411,7 +411,7 @@ namespace ReactiveUI.Primitives.Advanced
     {
         bool IsRequiredSubscribeOnCurrentThread() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("IgnoreValuesWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class IgnoreValuesWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public IgnoreValuesWitness(System.IObserver<T> observer) { }
@@ -425,7 +425,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_value}")]
+    [System.Diagnostics.DebuggerDisplay("ImmediateReturnSignal: Value = {_value}")]
     public sealed class ImmediateReturnSignal<T> : ReactiveUI.Primitives.Advanced.IInlineSignal<T>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ImmediateReturnSignal(T value) { }
@@ -434,7 +434,7 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
         public System.IDisposable Subscribe(System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Error = {_error}")]
+    [System.Diagnostics.DebuggerDisplay("ImmediateThrowSignal: Error = {_error}")]
     public sealed class ImmediateThrowSignal<T> : ReactiveUI.Primitives.Advanced.IInlineSignal<T>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ImmediateThrowSignal(System.Exception error) { }
@@ -468,7 +468,7 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<bool> observer) { }
         public System.IDisposable Subscribe(System.Action<bool> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_x}")]
+    [System.Diagnostics.DebuggerDisplay("ImmutableReturnInt32Signal: Value = {_x}")]
     public sealed class ImmutableReturnInt32Signal : ReactiveUI.Primitives.Advanced.IInlineSignal<int>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<int>
     {
         public ImmutableReturnInt32Signal(int x) { }
@@ -486,7 +486,7 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<bool> observer) { }
         public System.IDisposable Subscribe(System.Action<bool> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("KeepNotNullWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class KeepNotNullWitness<T> : System.IDisposable, System.IObserver<T?> where T : class
     {
         public KeepNotNullWitness(System.IObserver<T> observer) { }
@@ -500,7 +500,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("KeepTypeWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class KeepTypeWitness<TResult> : System.IDisposable, System.IObserver<object?>
     {
         public KeepTypeWitness(System.IObserver<TResult> observer) { }
@@ -514,7 +514,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasObservers = {HasObservers}, Count = {_observers.Items.Length}")]
+    [System.Diagnostics.DebuggerDisplay("ListWitness: HasObservers = {HasObservers}, Count = {_observers.Items.Length}")]
     public sealed class ListWitness<T> : System.IObserver<T>
     {
         public ListWitness(ReactiveUI.Primitives.Advanced.CopyOnWriteList<System.IObserver<T>> observers) { }
@@ -523,20 +523,20 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Result = {Result}")]
+    [System.Diagnostics.DebuggerDisplay("LongCountAggregator: Result = {Result}")]
     public readonly record struct LongCountAggregator<T> : ReactiveUI.Primitives.Advanced.IAggregator<T, long, ReactiveUI.Primitives.Advanced.LongCountAggregator<T>>, System.IEquatable<ReactiveUI.Primitives.Advanced.LongCountAggregator<T>>
     {
         public long Result { get; }
         public readonly ReactiveUI.Primitives.Advanced.LongCountAggregator<T> Add(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Result = {Result}, Predicate = {_predicate}")]
+    [System.Diagnostics.DebuggerDisplay("LongCountPredicateAggregator: Result = {Result}, Predicate = {_predicate}")]
     public readonly record struct LongCountPredicateAggregator<T> : ReactiveUI.Primitives.Advanced.IAggregator<T, long, ReactiveUI.Primitives.Advanced.LongCountPredicateAggregator<T>>, System.IEquatable<ReactiveUI.Primitives.Advanced.LongCountPredicateAggregator<T>>
     {
         public LongCountPredicateAggregator(System.Func<T, bool> predicate) { }
         public long Result { get; }
         public readonly ReactiveUI.Primitives.Advanced.LongCountPredicateAggregator<T> Add(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Ranges = {_ranges.Length}")]
+    [System.Diagnostics.DebuggerDisplay("RangeConcatSignal: Ranges = {_ranges.Length}")]
     public sealed class RangeConcatSignal : ReactiveUI.Primitives.Advanced.IInlineSignal<int>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<int>
     {
         public RangeConcatSignal(ReactiveUI.Primitives.Advanced.RangeSignal[] ranges) { }
@@ -545,7 +545,7 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<int> observer) { }
         public System.IDisposable Subscribe(System.Action<int> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Start = {Start}, Count = {Count}")]
+    [System.Diagnostics.DebuggerDisplay("RangeSignal: Start = {Start}, Count = {Count}")]
     public sealed class RangeSignal : ReactiveUI.Primitives.Advanced.IInlineSignal<int>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<int>
     {
         public RangeSignal(int start, int count) { }
@@ -556,7 +556,7 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<int> observer) { }
         public System.IDisposable Subscribe(System.Action<int> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, LeftStart = {_leftStart}, RightStart = {_rightStart}")]
+    [System.Diagnostics.DebuggerDisplay("RangeZipSignal: Count = {_count}, LeftStart = {_leftStart}, RightStart = {_rightStart}")]
     public sealed class RangeZipSignal<TResult> : ReactiveUI.Primitives.Advanced.IInlineSignal<TResult>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public RangeZipSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
@@ -565,7 +565,7 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
         public System.IDisposable Subscribe(System.Action<TResult> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Current = {_current}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("ReduceWitness: Current = {_current}, Subscription = {_subscription}")]
     public sealed class ReduceWitness<TSource, TAccumulate> : System.IDisposable, System.IObserver<TSource>
     {
         public ReduceWitness(System.IObserver<TAccumulate> observer, TAccumulate seed, System.Func<TAccumulate, TSource, TAccumulate> accumulator) { }
@@ -579,7 +579,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_value}, Count = {_count}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSignal: Value = {_value}, Count = {_count}")]
     public sealed class RepeatSignal<T> : ReactiveUI.Primitives.Advanced.IInlineSignal<T>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public RepeatSignal(T value, int count) { }
@@ -604,7 +604,7 @@ namespace ReactiveUI.Primitives.Advanced
         public static void Fault<TResult>(System.IObserver<TResult> observer, System.Exception error, System.IDisposable sink) { }
         public static void Fault<TResult>(System.IObserver<TResult> observer, System.Exception error, System.IDisposable sink, ref bool done) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Skipping = {_skipping}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SkipWhileWitness: Skipping = {_skipping}, Subscription = {_subscription}")]
     public sealed class SkipWhileWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SkipWhileWitness(System.IObserver<T> observer, System.Func<T, bool> predicate) { }
@@ -618,7 +618,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Remaining = {_remaining}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SkipWitness: Remaining = {_remaining}, Observer = {_observer}")]
     public sealed class SkipWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SkipWitness(System.IObserver<T> observer, int count) { }
@@ -632,7 +632,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("State = {_state}, OnError = {_onError}")]
+    [System.Diagnostics.DebuggerDisplay("StatefulWitness: State = {_state}, OnError = {_onError}")]
     public sealed class StatefulWitness<T, TState> : System.IObserver<T>
     {
         public StatefulWitness(TState state, System.Action<T, TState> onNext, System.Action<System.Exception, TState>? onError, System.Action<ReactiveUI.Primitives.Result, TState>? onCompleted) { }
@@ -649,7 +649,7 @@ namespace ReactiveUI.Primitives.Advanced
         public static void Assign(ref System.IDisposable? slot, System.IDisposable subscription) { }
         public static void Release(ref System.IDisposable? slot) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SynchronizeWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SynchronizeWitness(System.IObserver<T> observer) { }
@@ -662,7 +662,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {_completed}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("TakeWhileWitness: Completed = {_completed}, Subscription = {_subscription}")]
     public sealed class TakeWhileWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TakeWhileWitness(System.IObserver<T> observer, System.Func<T, bool> predicate) { }
@@ -675,7 +675,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Remaining = {_remaining}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TakeWitness: Remaining = {_remaining}, Stopped = {_stopped}")]
     public sealed class TakeWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TakeWitness(System.IObserver<T> observer, int count) { }
@@ -687,7 +687,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("TapWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class TapWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TapWitness(System.IObserver<T> observer, System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
@@ -707,7 +707,7 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("InitialState = {_initialState}, Condition = {_condition}")]
+    [System.Diagnostics.DebuggerDisplay("UnfoldSignal: InitialState = {_initialState}, Condition = {_condition}")]
     public sealed class UnfoldSignal<TState, TResult> : ReactiveUI.Primitives.Advanced.IInlineSignal<TResult>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public UnfoldSignal(TState initialState, System.Func<TState, bool> condition, System.Func<TState, TState> iterate, System.Func<TState, TResult> resultSelector) { }
@@ -716,7 +716,7 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
         public System.IDisposable Subscribe(System.Action<TResult> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLast = {_hasLast}, Last = {_last}")]
+    [System.Diagnostics.DebuggerDisplay("UniqueByWitness: HasLast = {_hasLast}, Last = {_last}")]
     public sealed class UniqueByWitness<T, TKey> : System.IDisposable, System.IObserver<T>
     {
         public UniqueByWitness(System.IObserver<T> observer, System.Func<T, TKey> keySelector, System.Collections.Generic.IEqualityComparer<TKey> comparer) { }
@@ -730,7 +730,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLast = {_hasLast}, Last = {_last}")]
+    [System.Diagnostics.DebuggerDisplay("UniqueWitness: HasLast = {_hasLast}, Last = {_last}")]
     public sealed class UniqueWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public UniqueWitness(System.IObserver<T> observer, System.Collections.Generic.IEqualityComparer<T> comparer) { }
@@ -744,7 +744,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ResourceFactory = {_resourceFactory}, SignalFactory = {_signalFactory}")]
+    [System.Diagnostics.DebuggerDisplay("UseSignal: ResourceFactory = {_resourceFactory}, SignalFactory = {_signalFactory}")]
     public sealed class UseSignal<TResource, T> : System.IObservable<T> where TResource : System.IDisposable
     {
         public UseSignal(System.Func<TResource> resourceFactory, System.Func<TResource, System.IObservable<T>> signalFactory) { }
@@ -875,7 +875,7 @@ namespace ReactiveUI.Primitives.Core
         public static bool operator ==(ReactiveUI.Primitives.Core.Moment<T> first, ReactiveUI.Primitives.Core.Moment<T> second) { }
         public static bool operator !=(ReactiveUI.Primitives.Core.Moment<T> first, ReactiveUI.Primitives.Core.Moment<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {Count}, Capacity = {_items.Length}")]
+    [System.Diagnostics.DebuggerDisplay("PriorityQueue: Count = {Count}, Capacity = {_items.Length}")]
     public sealed class PriorityQueue<T> where T : System.IComparable<T>
     {
         public PriorityQueue() { }
@@ -918,14 +918,14 @@ namespace ReactiveUI.Primitives.Core
 }
 namespace ReactiveUI.Primitives.Extensions
 {
-    [System.Diagnostics.DebuggerDisplay("Outstanding = {_outstanding}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("ConcurrencyLimiter: Outstanding = {_outstanding}, Disposed = {_disposed}")]
     public sealed class ConcurrencyLimiter<T> : System.IObservable<T>
     {
         public ConcurrencyLimiter(System.Collections.Generic.IEnumerable<System.Threading.Tasks.Task<T>> taskFunctions, int maxConcurrency) { }
         public System.IObservable<T> Observable { get; }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Locked = {_locked}, CompletedPhases = {CompletedPhases}")]
+    [System.Diagnostics.DebuggerDisplay("Continuation: Locked = {_locked}, CompletedPhases = {CompletedPhases}")]
     public class Continuation : System.IDisposable
     {
         public Continuation() { }
@@ -935,7 +935,7 @@ namespace ReactiveUI.Primitives.Extensions
         public System.Threading.Tasks.Task Lock<T>(T item, System.IObserver<(T Value, System.IDisposable Sync)>? observer) { }
         public System.Threading.Tasks.ValueTask LockValueTask<T>(T item, System.IObserver<(T Value, System.IDisposable Sync)>? observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_value}, Completed = {_completed}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("CurrentValueSubject: Value = {_value}, Completed = {_completed}, Disposed = {_disposed}")]
     public sealed class CurrentValueSubject<T> : System.IDisposable, System.IObservable<T>, System.IObserver<T>
     {
         public CurrentValueSubject(T initialValue) { }
@@ -962,7 +962,7 @@ namespace ReactiveUI.Primitives.Extensions
     {
         public static System.Threading.Tasks.ValueTask<T> FirstAsValueTask(System.IObservable<T> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsHeartbeat = {IsHeartbeat}, Update = {Update}")]
+    [System.Diagnostics.DebuggerDisplay("Heartbeat: IsHeartbeat = {IsHeartbeat}, Update = {Update}")]
     public readonly record struct Heartbeat<T> : ReactiveUI.Primitives.Extensions.IHeartbeat<T>, System.IEquatable<ReactiveUI.Primitives.Extensions.Heartbeat<T>>
     {
         public Heartbeat() { }
@@ -1011,7 +1011,7 @@ namespace ReactiveUI.Primitives.Extensions
         public SingleValueSignal(T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsStale = {IsStale}")]
+    [System.Diagnostics.DebuggerDisplay("Stale: IsStale = {IsStale}")]
     public readonly record struct Stale<T> : ReactiveUI.Primitives.Extensions.IStale<T>, System.IEquatable<ReactiveUI.Primitives.Extensions.Stale<T>>
     {
         public Stale() { }
@@ -1019,7 +1019,7 @@ namespace ReactiveUI.Primitives.Extensions
         public bool IsStale { get; }
         public T? Update { get; }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {Done}, Timer = {Timer}")]
+    [System.Diagnostics.DebuggerDisplay("TimerSinkState: Done = {Done}, Timer = {Timer}")]
     public sealed class TimerSinkState<T>
     {
         public TimerSinkState(System.IObserver<T> downstream) { }
@@ -1032,13 +1032,13 @@ namespace ReactiveUI.Primitives.Extensions
 }
 namespace ReactiveUI.Primitives.Extensions.Operators
 {
-    [System.Diagnostics.DebuggerDisplay("Left = {_left}, Right = {_right}")]
+    [System.Diagnostics.DebuggerDisplay("BinaryMinMaxObservable: Left = {_left}, Right = {_right}")]
     public sealed class BinaryMinMaxObservable<T> : System.IObservable<T> where T : struct, System.IComparable<T>
     {
         public BinaryMinMaxObservable(System.IObservable<T> left, System.IObservable<T> right, bool emitMaximum) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sourceList}")]
+    [System.Diagnostics.DebuggerDisplay("BooleanReduceObservable: Sources = {_sourceList}")]
     public sealed class BooleanReduceObservable : System.IObservable<bool>
     {
         public BooleanReduceObservable(System.Collections.Generic.IEnumerable<System.IObservable<bool>> sources, bool target) { }
@@ -1059,7 +1059,7 @@ namespace ReactiveUI.Primitives.Extensions.Operators
         public CatchIgnoreEmptyObservable(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, ErrorAction = {_errorAction}")]
+    [System.Diagnostics.DebuggerDisplay("CatchIgnoreObservable: Source = {_source}, ErrorAction = {_errorAction}")]
     public sealed class CatchIgnoreObservable<TSource, TException> : System.IObservable<TSource> where TException : System.Exception
     {
         public CatchIgnoreObservable(System.IObservable<TSource> source, System.Action<TException> errorAction) { }
@@ -1094,7 +1094,7 @@ namespace ReactiveUI.Primitives.Extensions.Operators
     {
         public FirstMatchFromCandidatesObservable(System.Collections.Generic.IReadOnlyList<TKey> candidates, System.Func<TKey, System.IObservable<TRaw>> project, System.Func<TRaw, TResult> transform, System.Func<TResult, bool> predicate, TResult fallback) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
-        [System.Diagnostics.DebuggerDisplay("Completed = {Completed}, HasValue = {HasValue}, Value = {Value}")]
+        [System.Diagnostics.DebuggerDisplay("SyncProbe: Completed = {Completed}, HasValue = {HasValue}, Value = {Value}")]
         public sealed class SyncProbe : System.IObserver<TRaw>
         {
             public SyncProbe() { }
@@ -1115,7 +1115,7 @@ namespace ReactiveUI.Primitives.Extensions.Operators
         public LogErrorsObservable(System.IObservable<T> source, System.Action<System.Exception> logger) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sourceList.Count}")]
+    [System.Diagnostics.DebuggerDisplay("MinMaxObservable: Sources = {_sourceList.Count}")]
     public sealed class MinMaxObservable<T> : System.IObservable<T> where T : struct, System.IComparable<T>
     {
         public MinMaxObservable(System.Collections.Generic.IReadOnlyList<System.IObservable<T>> sources, bool emitMaximum) { }
@@ -1131,7 +1131,7 @@ namespace ReactiveUI.Primitives.Extensions.Operators
         public PairwiseObservable(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<(T Previous, T Current)> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, Subscriptions = {_subscriptionCount}")]
+    [System.Diagnostics.DebuggerDisplay("PartitionObservable: Source = {_source}, Subscriptions = {_subscriptionCount}")]
     public sealed class PartitionObservable<T>
     {
         public PartitionObservable(System.IObservable<T> source, System.Func<T, bool> predicate) { }
@@ -1193,7 +1193,7 @@ namespace ReactiveUI.Primitives.Extensions.Operators
         public SkipWhileNullObservable(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Queued = {_queue.Count}, Processing = {_isProcessing}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("SubscribeAsyncObservable: Queued = {_queue.Count}, Processing = {_isProcessing}, Done = {_done}")]
     public sealed class SubscribeAsyncObservable<T> : System.IDisposable
     {
         public SubscribeAsyncObservable(System.IObservable<T> source, System.Func<T, System.Threading.Tasks.ValueTask> onNext, System.Action<System.Exception>? onError, System.Action? onCompleted) { }
@@ -1265,7 +1265,7 @@ namespace ReactiveUI.Primitives.Signals
         public void RemoveObserver(System.IObserver<T> observer) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Callback = {_callback}, Context = {_context}")]
+    [System.Diagnostics.DebuggerDisplay("AwaitWitness: Callback = {_callback}, Context = {_context}")]
     public sealed class AwaitWitness<T> : System.IObserver<T>
     {
         public AwaitWitness(System.Action callback, bool originalContext) { }
@@ -1297,7 +1297,7 @@ namespace ReactiveUI.Primitives.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public bool TryGetValue(out T? value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_observers}")]
+    [System.Diagnostics.DebuggerDisplay("Broadcaster: Observers = {_observers}")]
     public struct Broadcaster<T> : System.IEquatable<ReactiveUI.Primitives.Signals.Broadcaster<T>>
     {
         public bool HasObservers { get; }
@@ -1316,7 +1316,7 @@ namespace ReactiveUI.Primitives.Signals
         public static bool operator ==(ReactiveUI.Primitives.Signals.Broadcaster<T> left, ReactiveUI.Primitives.Signals.Broadcaster<T> right) { }
         public static bool operator !=(ReactiveUI.Primitives.Signals.Broadcaster<T> left, ReactiveUI.Primitives.Signals.Broadcaster<T> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Task = {_task}, Result = {_result}, Exception = {_exception}")]
+    [System.Diagnostics.DebuggerDisplay("CommandExecution: Task = {_task}, Result = {_result}, Exception = {_exception}")]
     public readonly record struct CommandExecution<TResult> : System.IEquatable<ReactiveUI.Primitives.Signals.CommandExecution<TResult>>
     {
         public CommandExecution(System.Exception exception) { }
@@ -1324,7 +1324,7 @@ namespace ReactiveUI.Primitives.Signals
         public CommandExecution(TResult result) { }
         public readonly ReactiveUI.Primitives.Signals.CommandExecution<TResult> ConfigureAwait(bool continueOnCapturedContext) { }
         public readonly ReactiveUI.Primitives.Signals.CommandExecution<TResult>.Awaiter GetAwaiter() { }
-        [System.Diagnostics.DebuggerDisplay("IsCompleted = {IsCompleted}, Result = {_result}, Exception = {_exception}")]
+        [System.Diagnostics.DebuggerDisplay("Awaiter: IsCompleted = {IsCompleted}, Result = {_result}, Exception = {_exception}")]
         public readonly record struct Awaiter : System.IEquatable<ReactiveUI.Primitives.Signals.CommandExecution<TResult>.Awaiter>, System.Runtime.CompilerServices.ICriticalNotifyCompletion
         {
             public Awaiter(System.Threading.Tasks.Task<TResult>? task, TResult? result, System.Exception? exception, bool continueOnCapturedContext) { }
@@ -1353,7 +1353,7 @@ namespace ReactiveUI.Primitives.Signals
         public ReactiveUI.Primitives.Signals.CommandExecution<TResult> ExecuteAsync(System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Buffer = {_buffer}")]
+    [System.Diagnostics.DebuggerDisplay("DelayableNotificationSignal: Stopped = {_stopped}, Buffer = {_buffer}")]
     public sealed class DelayableNotificationSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T>
     {
         public DelayableNotificationSignal(System.Func<bool> isDelayed, System.Func<System.Collections.Generic.IList<T>, System.Collections.Generic.IEnumerable<T>> flushDistinct) { }
@@ -1366,7 +1366,7 @@ namespace ReactiveUI.Primitives.Signals
         public void OnNext(T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("OnNext = {_onNext}")]
+    [System.Diagnostics.DebuggerDisplay("DelegateWitness: OnNext = {_onNext}")]
     public sealed class DelegateWitness<T> : System.IObserver<T>
     {
         public DelegateWitness(System.Action<T> onNext, System.Action<System.Exception>? onError = null, System.Action? onCompleted = null) { }
@@ -1397,41 +1397,41 @@ namespace ReactiveUI.Primitives.Signals
         System.IObservable<T>? Source { get; }
         void GetOperationCanceled(System.IObserver<System.Exception> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, Predicate = {_predicate}")]
+    [System.Diagnostics.DebuggerDisplay("KeepSignal: Source = {_source}, Predicate = {_predicate}")]
     public sealed class KeepSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public KeepSignal(System.IObservable<T> source, System.Func<T, bool> predicate) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, State = {_state}")]
+    [System.Diagnostics.DebuggerDisplay("KeepWithSignal: Source = {_source}, State = {_state}")]
     public sealed class KeepWithSignal<T, TState> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public KeepWithSignal(System.IObservable<T> source, TState state, System.Func<TState, T, bool> predicate) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, Selector = {_selector}")]
+    [System.Diagnostics.DebuggerDisplay("MapSignal: Source = {_source}, Selector = {_selector}")]
     public sealed class MapSignal<TSource, TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public MapSignal(System.IObservable<TSource> source, System.Func<TSource, TResult> selector) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, State = {_state}")]
+    [System.Diagnostics.DebuggerDisplay("MapWithSignal: Source = {_source}, State = {_state}")]
     public sealed class MapWithSignal<TSource, TState, TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public MapWithSignal(System.IObservable<TSource> source, TState state, System.Func<TState, TSource, TResult> selector) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Subject = {_subject}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("ObserverHandler: Subject = {_subject}, Observer = {_observer}")]
     public sealed class ObserverHandler<T> : System.IDisposable
     {
         public ObserverHandler(ReactiveUI.Primitives.Signals.AsyncSignal<T> subject, System.IObserver<T> observer) { }
         public void Dispose() { }
     }
-    [System.Diagnostics.DebuggerDisplay("{Value}")]
+    [System.Diagnostics.DebuggerDisplay("ProjectedReadOnlyState: {Value}")]
     public sealed class ProjectedReadOnlyState<TSource, TResult> : System.IDisposable, System.IObservable<TResult>, System.IObserver<TSource>
     {
         public System.IObservable<TResult> Changed { get; }
@@ -1493,7 +1493,7 @@ namespace ReactiveUI.Primitives.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public bool TryGetValue(out T? value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, State = {_state}")]
+    [System.Diagnostics.DebuggerDisplay("TapWithSignal: Source = {_source}, State = {_state}")]
     public sealed class TapWithSignal<T, TState> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public TapWithSignal(System.IObservable<T> source, TState state, System.Action<TState, T> onNext) { }

--- a/src/ReactiveUI.Primitives.Core/PublicAPI/net8.0/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Core/PublicAPI/net8.0/PublicAPI.txt
@@ -6,7 +6,7 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Primitives.Tests")]
 namespace ReactiveUI.Primitives
 {
-    [System.Diagnostics.DebuggerDisplay("Subscribe = {_subscribe}")]
+    [System.Diagnostics.DebuggerDisplay("AnonymousSignal: Subscribe = {_subscribe}")]
     public sealed class AnonymousSignal<T> : System.IObservable<T>
     {
         public AnonymousSignal(System.Func<System.IObserver<T>, System.IDisposable> subscribe) { }
@@ -48,7 +48,7 @@ namespace ReactiveUI.Primitives
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public static ReactiveUI.Primitives.Optional<T> Some<T>(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasValue = {HasValue}, Value = {_value}")]
+    [System.Diagnostics.DebuggerDisplay("Optional: HasValue = {HasValue}, Value = {_value}")]
     public readonly record struct Optional<T> : System.IEquatable<ReactiveUI.Primitives.Optional<T>>
     {
         public Optional() { }
@@ -68,7 +68,7 @@ namespace ReactiveUI.Primitives
         public static explicit operator T?(in ReactiveUI.Primitives.Optional<T> value) { }
         public static implicit operator ReactiveUI.Primitives.Optional<T>(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsSuccess = {IsSuccess}, Exception = {Exception}")]
+    [System.Diagnostics.DebuggerDisplay("Result: IsSuccess = {IsSuccess}, Exception = {Exception}")]
     public readonly record struct Result : System.IEquatable<ReactiveUI.Primitives.Result>
     {
         public Result(System.Exception exception) { }
@@ -111,7 +111,7 @@ namespace ReactiveUI.Primitives
 }
 namespace ReactiveUI.Primitives.Advanced
 {
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, Aggregator = {_aggregator}")]
+    [System.Diagnostics.DebuggerDisplay("AggregateWitness: Done = {_done}, Aggregator = {_aggregator}")]
     public sealed class AggregateWitness<T, TResult, TAggregator> : System.IDisposable, System.IObserver<T> where TAggregator : struct, ReactiveUI.Primitives.Advanced.IAggregator<T, TResult, TAggregator>
     {
         public AggregateWitness(System.IObserver<TResult> observer, TAggregator aggregator) { }
@@ -125,7 +125,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("AllPredicateWitness: Done = {_done}, Observer = {_observer}")]
     public sealed class AllPredicateWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public AllPredicateWitness(System.IObserver<bool> observer, System.Func<T, bool> predicate) { }
@@ -139,7 +139,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("AnyPredicateWitness: Done = {_done}, Observer = {_observer}")]
     public sealed class AnyPredicateWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public AnyPredicateWitness(System.IObserver<bool> observer, System.Func<T, bool> predicate) { }
@@ -153,7 +153,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("AnyWitness: Done = {_done}, Observer = {_observer}")]
     public sealed class AnyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public AnyWitness(System.IObserver<bool> observer) { }
@@ -168,7 +168,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_value}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("AppendDelegateWitness: Value = {_value}, Subscription = {_subscription}")]
     public sealed class AppendDelegateWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public AppendDelegateWitness(System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted, T value) { }
@@ -180,7 +180,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("AppendedValue = {_value}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("AppendWitness: AppendedValue = {_value}, Observer = {_observer}")]
     public sealed class AppendWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public AppendWitness(System.IObserver<T> observer, T value) { }
@@ -202,7 +202,7 @@ namespace ReactiveUI.Primitives.Advanced
         public System.Collections.Generic.IAsyncEnumerable<T> Values { get; }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Skip = {_skip}, Index = {_index}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("BufferWitness: Count = {_count}, Skip = {_skip}, Index = {_index}, Done = {_done}")]
     public sealed class BufferWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public BufferWitness(System.IObserver<System.Collections.Generic.IList<T>> observer, int count, int skip) { }
@@ -213,7 +213,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("OnNext = {_onNext}, OnError = {_onError}, OnCompleted = {_onCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("CallbackWitness: OnNext = {_onNext}, OnError = {_onError}, OnCompleted = {_onCompleted}")]
     public sealed class CallbackWitness<T> : System.IObserver<T>
     {
         public CallbackWitness(System.Action<T> onNext, System.Action<System.Exception>? onError, System.Action<ReactiveUI.Primitives.Result>? onCompleted) { }
@@ -224,7 +224,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_values.Count}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("CollectArrayWitness: Count = {_values.Count}, Subscription = {_subscription}")]
     public sealed class CollectArrayWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CollectArrayWitness(System.IObserver<T[]> observer) { }
@@ -239,7 +239,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_values.Count}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("CollectListWitness: Count = {_values.Count}, Subscription = {_subscription}")]
     public sealed class CollectListWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CollectListWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -254,7 +254,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SoughtValue = {_value}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("ContainsWitness: SoughtValue = {_value}, Done = {_done}")]
     public sealed class ContainsWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public ContainsWitness(System.IObserver<bool> observer, T value, System.Collections.Generic.IEqualityComparer<T> comparer) { }
@@ -268,7 +268,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {Items.Length}")]
+    [System.Diagnostics.DebuggerDisplay("CopyOnWriteList: Count = {Items.Length}")]
     public sealed class CopyOnWriteList<T>
     {
         public CopyOnWriteList(T[] data) { }
@@ -278,20 +278,20 @@ namespace ReactiveUI.Primitives.Advanced
         public int IndexOf(T value) { }
         public ReactiveUI.Primitives.Advanced.CopyOnWriteList<T> Remove(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Result = {Result}")]
+    [System.Diagnostics.DebuggerDisplay("CountAggregator: Result = {Result}")]
     public readonly record struct CountAggregator<T> : ReactiveUI.Primitives.Advanced.IAggregator<T, int, ReactiveUI.Primitives.Advanced.CountAggregator<T>>, System.IEquatable<ReactiveUI.Primitives.Advanced.CountAggregator<T>>
     {
         public int Result { get; }
         public readonly ReactiveUI.Primitives.Advanced.CountAggregator<T> Add(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Result = {Result}, Predicate = {_predicate}")]
+    [System.Diagnostics.DebuggerDisplay("CountPredicateAggregator: Result = {Result}, Predicate = {_predicate}")]
     public readonly record struct CountPredicateAggregator<T> : ReactiveUI.Primitives.Advanced.IAggregator<T, int, ReactiveUI.Primitives.Advanced.CountPredicateAggregator<T>>, System.IEquatable<ReactiveUI.Primitives.Advanced.CountPredicateAggregator<T>>
     {
         public CountPredicateAggregator(System.Func<T, bool> predicate) { }
         public int Result { get; }
         public readonly ReactiveUI.Primitives.Advanced.CountPredicateAggregator<T> Add(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Seen = {_seen}, DefaultValue = {_defaultValue}")]
+    [System.Diagnostics.DebuggerDisplay("DefaultIfEmptyWitness: Seen = {_seen}, DefaultValue = {_defaultValue}")]
     public sealed class DefaultIfEmptyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public DefaultIfEmptyWitness(System.IObserver<T> observer, T defaultValue) { }
@@ -316,21 +316,21 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Result = {Result}, Seen = {_seen}")]
+    [System.Diagnostics.DebuggerDisplay("DistinctByCountAggregator: Result = {Result}, Seen = {_seen}")]
     public readonly record struct DistinctByCountAggregator<T, TKey> : ReactiveUI.Primitives.Advanced.IAggregator<T, int, ReactiveUI.Primitives.Advanced.DistinctByCountAggregator<T, TKey>>, System.IEquatable<ReactiveUI.Primitives.Advanced.DistinctByCountAggregator<T, TKey>>
     {
         public DistinctByCountAggregator(System.Func<T, TKey> keySelector, System.Collections.Generic.IEqualityComparer<TKey>? comparer) { }
         public int Result { get; }
         public readonly ReactiveUI.Primitives.Advanced.DistinctByCountAggregator<T, TKey> Add(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Result = {Result}, Seen = {_seen}")]
+    [System.Diagnostics.DebuggerDisplay("DistinctByLongCountAggregator: Result = {Result}, Seen = {_seen}")]
     public readonly record struct DistinctByLongCountAggregator<T, TKey> : ReactiveUI.Primitives.Advanced.IAggregator<T, long, ReactiveUI.Primitives.Advanced.DistinctByLongCountAggregator<T, TKey>>, System.IEquatable<ReactiveUI.Primitives.Advanced.DistinctByLongCountAggregator<T, TKey>>
     {
         public DistinctByLongCountAggregator(System.Func<T, TKey> keySelector, System.Collections.Generic.IEqualityComparer<TKey>? comparer) { }
         public long Result { get; }
         public readonly ReactiveUI.Primitives.Advanced.DistinctByLongCountAggregator<T, TKey> Add(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, SeenKeys = {_seen.Count}")]
+    [System.Diagnostics.DebuggerDisplay("DistinctByWitness: Done = {_done}, SeenKeys = {_seen.Count}")]
     public sealed class DistinctByWitness<T, TKey> : System.IDisposable, System.IObserver<T>
     {
         public DistinctByWitness(System.IObserver<T> observer, System.Func<T, TKey> keySelector, System.Collections.Generic.IEqualityComparer<TKey>? comparer) { }
@@ -344,7 +344,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Seen = {_seen.Count}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("DistinctWitness: Seen = {_seen.Count}, Subscription = {_subscription}")]
     public sealed class DistinctWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public DistinctWitness(System.IObserver<T> observer, System.Collections.Generic.HashSet<T> seen) { }
@@ -358,7 +358,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("OnNext = {_onNext}, OnError = {_onError}, OnCompleted = {_onCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("EmptyWitness: OnNext = {_onNext}, OnError = {_onError}, OnCompleted = {_onCompleted}")]
     public sealed class EmptyWitness<T> : System.IObserver<T>
     {
         public EmptyWitness(System.Action<T> onNext) { }
@@ -373,7 +373,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Current = {_current}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("FoldWitness: Current = {_current}, Observer = {_observer}")]
     public sealed class FoldWitness<TSource, TAccumulate> : System.IDisposable, System.IObserver<TSource>
     {
         public FoldWitness(System.IObserver<TAccumulate> observer, TAccumulate seed, System.Func<TAccumulate, TSource, TAccumulate> accumulator) { }
@@ -387,7 +387,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("ForwardingWitness: Observer = {_observer}")]
     public sealed class ForwardingWitness<T> : System.IObserver<T>
     {
         public ForwardingWitness(System.IObserver<T> observer) { }
@@ -398,7 +398,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Values = {_values}, CancellationToken = {_cancellationToken}")]
+    [System.Diagnostics.DebuggerDisplay("FromEnumerableSignal: Values = {_values}, CancellationToken = {_cancellationToken}")]
     public sealed class FromEnumerableSignal<T> : ReactiveUI.Primitives.Advanced.IInlineSignal<T>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public FromEnumerableSignal(System.Collections.Generic.IEnumerable<T> values) { }
@@ -427,7 +427,7 @@ namespace ReactiveUI.Primitives.Advanced
     {
         bool IsRequiredSubscribeOnCurrentThread() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("IgnoreValuesWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class IgnoreValuesWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public IgnoreValuesWitness(System.IObserver<T> observer) { }
@@ -441,7 +441,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_value}")]
+    [System.Diagnostics.DebuggerDisplay("ImmediateReturnSignal: Value = {_value}")]
     public sealed class ImmediateReturnSignal<T> : ReactiveUI.Primitives.Advanced.IInlineSignal<T>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ImmediateReturnSignal(T value) { }
@@ -450,7 +450,7 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
         public System.IDisposable Subscribe(System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Error = {_error}")]
+    [System.Diagnostics.DebuggerDisplay("ImmediateThrowSignal: Error = {_error}")]
     public sealed class ImmediateThrowSignal<T> : ReactiveUI.Primitives.Advanced.IInlineSignal<T>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ImmediateThrowSignal(System.Exception error) { }
@@ -484,7 +484,7 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<bool> observer) { }
         public System.IDisposable Subscribe(System.Action<bool> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_x}")]
+    [System.Diagnostics.DebuggerDisplay("ImmutableReturnInt32Signal: Value = {_x}")]
     public sealed class ImmutableReturnInt32Signal : ReactiveUI.Primitives.Advanced.IInlineSignal<int>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<int>
     {
         public ImmutableReturnInt32Signal(int x) { }
@@ -502,7 +502,7 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<bool> observer) { }
         public System.IDisposable Subscribe(System.Action<bool> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("KeepNotNullWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class KeepNotNullWitness<T> : System.IDisposable, System.IObserver<T?> where T : class
     {
         public KeepNotNullWitness(System.IObserver<T> observer) { }
@@ -516,7 +516,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("KeepTypeWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class KeepTypeWitness<TResult> : System.IDisposable, System.IObserver<object?>
     {
         public KeepTypeWitness(System.IObserver<TResult> observer) { }
@@ -530,7 +530,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasObservers = {HasObservers}, Count = {_observers.Items.Length}")]
+    [System.Diagnostics.DebuggerDisplay("ListWitness: HasObservers = {HasObservers}, Count = {_observers.Items.Length}")]
     public sealed class ListWitness<T> : System.IObserver<T>
     {
         public ListWitness(ReactiveUI.Primitives.Advanced.CopyOnWriteList<System.IObserver<T>> observers) { }
@@ -539,20 +539,20 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Result = {Result}")]
+    [System.Diagnostics.DebuggerDisplay("LongCountAggregator: Result = {Result}")]
     public readonly record struct LongCountAggregator<T> : ReactiveUI.Primitives.Advanced.IAggregator<T, long, ReactiveUI.Primitives.Advanced.LongCountAggregator<T>>, System.IEquatable<ReactiveUI.Primitives.Advanced.LongCountAggregator<T>>
     {
         public long Result { get; }
         public readonly ReactiveUI.Primitives.Advanced.LongCountAggregator<T> Add(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Result = {Result}, Predicate = {_predicate}")]
+    [System.Diagnostics.DebuggerDisplay("LongCountPredicateAggregator: Result = {Result}, Predicate = {_predicate}")]
     public readonly record struct LongCountPredicateAggregator<T> : ReactiveUI.Primitives.Advanced.IAggregator<T, long, ReactiveUI.Primitives.Advanced.LongCountPredicateAggregator<T>>, System.IEquatable<ReactiveUI.Primitives.Advanced.LongCountPredicateAggregator<T>>
     {
         public LongCountPredicateAggregator(System.Func<T, bool> predicate) { }
         public long Result { get; }
         public readonly ReactiveUI.Primitives.Advanced.LongCountPredicateAggregator<T> Add(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Ranges = {_ranges.Length}")]
+    [System.Diagnostics.DebuggerDisplay("RangeConcatSignal: Ranges = {_ranges.Length}")]
     public sealed class RangeConcatSignal : ReactiveUI.Primitives.Advanced.IInlineSignal<int>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<int>
     {
         public RangeConcatSignal(ReactiveUI.Primitives.Advanced.RangeSignal[] ranges) { }
@@ -561,7 +561,7 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<int> observer) { }
         public System.IDisposable Subscribe(System.Action<int> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Start = {Start}, Count = {Count}")]
+    [System.Diagnostics.DebuggerDisplay("RangeSignal: Start = {Start}, Count = {Count}")]
     public sealed class RangeSignal : ReactiveUI.Primitives.Advanced.IInlineSignal<int>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<int>
     {
         public RangeSignal(int start, int count) { }
@@ -572,7 +572,7 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<int> observer) { }
         public System.IDisposable Subscribe(System.Action<int> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, LeftStart = {_leftStart}, RightStart = {_rightStart}")]
+    [System.Diagnostics.DebuggerDisplay("RangeZipSignal: Count = {_count}, LeftStart = {_leftStart}, RightStart = {_rightStart}")]
     public sealed class RangeZipSignal<TResult> : ReactiveUI.Primitives.Advanced.IInlineSignal<TResult>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public RangeZipSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
@@ -581,7 +581,7 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
         public System.IDisposable Subscribe(System.Action<TResult> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Current = {_current}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("ReduceWitness: Current = {_current}, Subscription = {_subscription}")]
     public sealed class ReduceWitness<TSource, TAccumulate> : System.IDisposable, System.IObserver<TSource>
     {
         public ReduceWitness(System.IObserver<TAccumulate> observer, TAccumulate seed, System.Func<TAccumulate, TSource, TAccumulate> accumulator) { }
@@ -595,7 +595,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_value}, Count = {_count}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSignal: Value = {_value}, Count = {_count}")]
     public sealed class RepeatSignal<T> : ReactiveUI.Primitives.Advanced.IInlineSignal<T>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public RepeatSignal(T value, int count) { }
@@ -620,7 +620,7 @@ namespace ReactiveUI.Primitives.Advanced
         public static void Fault<TResult>(System.IObserver<TResult> observer, System.Exception error, System.IDisposable sink) { }
         public static void Fault<TResult>(System.IObserver<TResult> observer, System.Exception error, System.IDisposable sink, ref bool done) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Skipping = {_skipping}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SkipWhileWitness: Skipping = {_skipping}, Subscription = {_subscription}")]
     public sealed class SkipWhileWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SkipWhileWitness(System.IObserver<T> observer, System.Func<T, bool> predicate) { }
@@ -634,7 +634,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Remaining = {_remaining}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SkipWitness: Remaining = {_remaining}, Observer = {_observer}")]
     public sealed class SkipWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SkipWitness(System.IObserver<T> observer, int count) { }
@@ -648,7 +648,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("State = {_state}, OnError = {_onError}")]
+    [System.Diagnostics.DebuggerDisplay("StatefulWitness: State = {_state}, OnError = {_onError}")]
     public sealed class StatefulWitness<T, TState> : System.IObserver<T>
     {
         public StatefulWitness(TState state, System.Action<T, TState> onNext, System.Action<System.Exception, TState>? onError, System.Action<ReactiveUI.Primitives.Result, TState>? onCompleted) { }
@@ -665,7 +665,7 @@ namespace ReactiveUI.Primitives.Advanced
         public static void Assign(ref System.IDisposable? slot, System.IDisposable subscription) { }
         public static void Release(ref System.IDisposable? slot) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SynchronizeWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SynchronizeWitness(System.IObserver<T> observer) { }
@@ -678,7 +678,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {_completed}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("TakeWhileWitness: Completed = {_completed}, Subscription = {_subscription}")]
     public sealed class TakeWhileWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TakeWhileWitness(System.IObserver<T> observer, System.Func<T, bool> predicate) { }
@@ -691,7 +691,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Remaining = {_remaining}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TakeWitness: Remaining = {_remaining}, Stopped = {_stopped}")]
     public sealed class TakeWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TakeWitness(System.IObserver<T> observer, int count) { }
@@ -703,7 +703,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("TapWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class TapWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TapWitness(System.IObserver<T> observer, System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
@@ -723,7 +723,7 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("InitialState = {_initialState}, Condition = {_condition}")]
+    [System.Diagnostics.DebuggerDisplay("UnfoldSignal: InitialState = {_initialState}, Condition = {_condition}")]
     public sealed class UnfoldSignal<TState, TResult> : ReactiveUI.Primitives.Advanced.IInlineSignal<TResult>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public UnfoldSignal(TState initialState, System.Func<TState, bool> condition, System.Func<TState, TState> iterate, System.Func<TState, TResult> resultSelector) { }
@@ -732,7 +732,7 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
         public System.IDisposable Subscribe(System.Action<TResult> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLast = {_hasLast}, Last = {_last}")]
+    [System.Diagnostics.DebuggerDisplay("UniqueByWitness: HasLast = {_hasLast}, Last = {_last}")]
     public sealed class UniqueByWitness<T, TKey> : System.IDisposable, System.IObserver<T>
     {
         public UniqueByWitness(System.IObserver<T> observer, System.Func<T, TKey> keySelector, System.Collections.Generic.IEqualityComparer<TKey> comparer) { }
@@ -746,7 +746,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLast = {_hasLast}, Last = {_last}")]
+    [System.Diagnostics.DebuggerDisplay("UniqueWitness: HasLast = {_hasLast}, Last = {_last}")]
     public sealed class UniqueWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public UniqueWitness(System.IObserver<T> observer, System.Collections.Generic.IEqualityComparer<T> comparer) { }
@@ -760,7 +760,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ResourceFactory = {_resourceFactory}, SignalFactory = {_signalFactory}")]
+    [System.Diagnostics.DebuggerDisplay("UseSignal: ResourceFactory = {_resourceFactory}, SignalFactory = {_signalFactory}")]
     public sealed class UseSignal<TResource, T> : System.IObservable<T> where TResource : System.IDisposable
     {
         public UseSignal(System.Func<TResource> resourceFactory, System.Func<TResource, System.IObservable<T>> signalFactory) { }
@@ -891,7 +891,7 @@ namespace ReactiveUI.Primitives.Core
         public static bool operator ==(ReactiveUI.Primitives.Core.Moment<T> first, ReactiveUI.Primitives.Core.Moment<T> second) { }
         public static bool operator !=(ReactiveUI.Primitives.Core.Moment<T> first, ReactiveUI.Primitives.Core.Moment<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {Count}, Capacity = {_items.Length}")]
+    [System.Diagnostics.DebuggerDisplay("PriorityQueue: Count = {Count}, Capacity = {_items.Length}")]
     public sealed class PriorityQueue<T> where T : System.IComparable<T>
     {
         public PriorityQueue() { }
@@ -934,14 +934,14 @@ namespace ReactiveUI.Primitives.Core
 }
 namespace ReactiveUI.Primitives.Extensions
 {
-    [System.Diagnostics.DebuggerDisplay("Outstanding = {_outstanding}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("ConcurrencyLimiter: Outstanding = {_outstanding}, Disposed = {_disposed}")]
     public sealed class ConcurrencyLimiter<T> : System.IObservable<T>
     {
         public ConcurrencyLimiter(System.Collections.Generic.IEnumerable<System.Threading.Tasks.Task<T>> taskFunctions, int maxConcurrency) { }
         public System.IObservable<T> Observable { get; }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Locked = {_locked}, CompletedPhases = {CompletedPhases}")]
+    [System.Diagnostics.DebuggerDisplay("Continuation: Locked = {_locked}, CompletedPhases = {CompletedPhases}")]
     public class Continuation : System.IDisposable
     {
         public Continuation() { }
@@ -951,7 +951,7 @@ namespace ReactiveUI.Primitives.Extensions
         public System.Threading.Tasks.Task Lock<T>(T item, System.IObserver<(T Value, System.IDisposable Sync)>? observer) { }
         public System.Threading.Tasks.ValueTask LockValueTask<T>(T item, System.IObserver<(T Value, System.IDisposable Sync)>? observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_value}, Completed = {_completed}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("CurrentValueSubject: Value = {_value}, Completed = {_completed}, Disposed = {_disposed}")]
     public sealed class CurrentValueSubject<T> : System.IDisposable, System.IObservable<T>, System.IObserver<T>
     {
         public CurrentValueSubject(T initialValue) { }
@@ -978,7 +978,7 @@ namespace ReactiveUI.Primitives.Extensions
     {
         public static System.Threading.Tasks.ValueTask<T> FirstAsValueTask(System.IObservable<T> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsHeartbeat = {IsHeartbeat}, Update = {Update}")]
+    [System.Diagnostics.DebuggerDisplay("Heartbeat: IsHeartbeat = {IsHeartbeat}, Update = {Update}")]
     public readonly record struct Heartbeat<T> : ReactiveUI.Primitives.Extensions.IHeartbeat<T>, System.IEquatable<ReactiveUI.Primitives.Extensions.Heartbeat<T>>
     {
         public Heartbeat() { }
@@ -1027,7 +1027,7 @@ namespace ReactiveUI.Primitives.Extensions
         public SingleValueSignal(T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsStale = {IsStale}")]
+    [System.Diagnostics.DebuggerDisplay("Stale: IsStale = {IsStale}")]
     public readonly record struct Stale<T> : ReactiveUI.Primitives.Extensions.IStale<T>, System.IEquatable<ReactiveUI.Primitives.Extensions.Stale<T>>
     {
         public Stale() { }
@@ -1035,7 +1035,7 @@ namespace ReactiveUI.Primitives.Extensions
         public bool IsStale { get; }
         public T? Update { get; }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {Done}, Timer = {Timer}")]
+    [System.Diagnostics.DebuggerDisplay("TimerSinkState: Done = {Done}, Timer = {Timer}")]
     public sealed class TimerSinkState<T>
     {
         public TimerSinkState(System.IObserver<T> downstream) { }
@@ -1048,13 +1048,13 @@ namespace ReactiveUI.Primitives.Extensions
 }
 namespace ReactiveUI.Primitives.Extensions.Operators
 {
-    [System.Diagnostics.DebuggerDisplay("Left = {_left}, Right = {_right}")]
+    [System.Diagnostics.DebuggerDisplay("BinaryMinMaxObservable: Left = {_left}, Right = {_right}")]
     public sealed class BinaryMinMaxObservable<T> : System.IObservable<T> where T : struct, System.IComparable<T>
     {
         public BinaryMinMaxObservable(System.IObservable<T> left, System.IObservable<T> right, bool emitMaximum) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sourceList}")]
+    [System.Diagnostics.DebuggerDisplay("BooleanReduceObservable: Sources = {_sourceList}")]
     public sealed class BooleanReduceObservable : System.IObservable<bool>
     {
         public BooleanReduceObservable(System.Collections.Generic.IEnumerable<System.IObservable<bool>> sources, bool target) { }
@@ -1075,7 +1075,7 @@ namespace ReactiveUI.Primitives.Extensions.Operators
         public CatchIgnoreEmptyObservable(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, ErrorAction = {_errorAction}")]
+    [System.Diagnostics.DebuggerDisplay("CatchIgnoreObservable: Source = {_source}, ErrorAction = {_errorAction}")]
     public sealed class CatchIgnoreObservable<TSource, TException> : System.IObservable<TSource> where TException : System.Exception
     {
         public CatchIgnoreObservable(System.IObservable<TSource> source, System.Action<TException> errorAction) { }
@@ -1110,7 +1110,7 @@ namespace ReactiveUI.Primitives.Extensions.Operators
     {
         public FirstMatchFromCandidatesObservable(System.Collections.Generic.IReadOnlyList<TKey> candidates, System.Func<TKey, System.IObservable<TRaw>> project, System.Func<TRaw, TResult> transform, System.Func<TResult, bool> predicate, TResult fallback) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
-        [System.Diagnostics.DebuggerDisplay("Completed = {Completed}, HasValue = {HasValue}, Value = {Value}")]
+        [System.Diagnostics.DebuggerDisplay("SyncProbe: Completed = {Completed}, HasValue = {HasValue}, Value = {Value}")]
         public sealed class SyncProbe : System.IObserver<TRaw>
         {
             public SyncProbe() { }
@@ -1131,7 +1131,7 @@ namespace ReactiveUI.Primitives.Extensions.Operators
         public LogErrorsObservable(System.IObservable<T> source, System.Action<System.Exception> logger) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sourceList.Count}")]
+    [System.Diagnostics.DebuggerDisplay("MinMaxObservable: Sources = {_sourceList.Count}")]
     public sealed class MinMaxObservable<T> : System.IObservable<T> where T : struct, System.IComparable<T>
     {
         public MinMaxObservable(System.Collections.Generic.IReadOnlyList<System.IObservable<T>> sources, bool emitMaximum) { }
@@ -1147,7 +1147,7 @@ namespace ReactiveUI.Primitives.Extensions.Operators
         public PairwiseObservable(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<(T Previous, T Current)> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, Subscriptions = {_subscriptionCount}")]
+    [System.Diagnostics.DebuggerDisplay("PartitionObservable: Source = {_source}, Subscriptions = {_subscriptionCount}")]
     public sealed class PartitionObservable<T>
     {
         public PartitionObservable(System.IObservable<T> source, System.Func<T, bool> predicate) { }
@@ -1209,7 +1209,7 @@ namespace ReactiveUI.Primitives.Extensions.Operators
         public SkipWhileNullObservable(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Queued = {_queue.Count}, Processing = {_isProcessing}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("SubscribeAsyncObservable: Queued = {_queue.Count}, Processing = {_isProcessing}, Done = {_done}")]
     public sealed class SubscribeAsyncObservable<T> : System.IDisposable
     {
         public SubscribeAsyncObservable(System.IObservable<T> source, System.Func<T, System.Threading.Tasks.ValueTask> onNext, System.Action<System.Exception>? onError, System.Action? onCompleted) { }
@@ -1281,7 +1281,7 @@ namespace ReactiveUI.Primitives.Signals
         public void RemoveObserver(System.IObserver<T> observer) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Callback = {_callback}, Context = {_context}")]
+    [System.Diagnostics.DebuggerDisplay("AwaitWitness: Callback = {_callback}, Context = {_context}")]
     public sealed class AwaitWitness<T> : System.IObserver<T>
     {
         public AwaitWitness(System.Action callback, bool originalContext) { }
@@ -1313,7 +1313,7 @@ namespace ReactiveUI.Primitives.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public bool TryGetValue(out T? value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_observers}")]
+    [System.Diagnostics.DebuggerDisplay("Broadcaster: Observers = {_observers}")]
     public struct Broadcaster<T> : System.IEquatable<ReactiveUI.Primitives.Signals.Broadcaster<T>>
     {
         public bool HasObservers { get; }
@@ -1332,7 +1332,7 @@ namespace ReactiveUI.Primitives.Signals
         public static bool operator ==(ReactiveUI.Primitives.Signals.Broadcaster<T> left, ReactiveUI.Primitives.Signals.Broadcaster<T> right) { }
         public static bool operator !=(ReactiveUI.Primitives.Signals.Broadcaster<T> left, ReactiveUI.Primitives.Signals.Broadcaster<T> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Task = {_task}, Result = {_result}, Exception = {_exception}")]
+    [System.Diagnostics.DebuggerDisplay("CommandExecution: Task = {_task}, Result = {_result}, Exception = {_exception}")]
     public readonly record struct CommandExecution<TResult> : System.IEquatable<ReactiveUI.Primitives.Signals.CommandExecution<TResult>>
     {
         public CommandExecution(System.Exception exception) { }
@@ -1340,7 +1340,7 @@ namespace ReactiveUI.Primitives.Signals
         public CommandExecution(TResult result) { }
         public readonly ReactiveUI.Primitives.Signals.CommandExecution<TResult> ConfigureAwait(bool continueOnCapturedContext) { }
         public readonly ReactiveUI.Primitives.Signals.CommandExecution<TResult>.Awaiter GetAwaiter() { }
-        [System.Diagnostics.DebuggerDisplay("IsCompleted = {IsCompleted}, Result = {_result}, Exception = {_exception}")]
+        [System.Diagnostics.DebuggerDisplay("Awaiter: IsCompleted = {IsCompleted}, Result = {_result}, Exception = {_exception}")]
         public readonly record struct Awaiter : System.IEquatable<ReactiveUI.Primitives.Signals.CommandExecution<TResult>.Awaiter>, System.Runtime.CompilerServices.ICriticalNotifyCompletion
         {
             public Awaiter(System.Threading.Tasks.Task<TResult>? task, TResult? result, System.Exception? exception, bool continueOnCapturedContext) { }
@@ -1369,7 +1369,7 @@ namespace ReactiveUI.Primitives.Signals
         public ReactiveUI.Primitives.Signals.CommandExecution<TResult> ExecuteAsync(System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Buffer = {_buffer}")]
+    [System.Diagnostics.DebuggerDisplay("DelayableNotificationSignal: Stopped = {_stopped}, Buffer = {_buffer}")]
     public sealed class DelayableNotificationSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T>
     {
         public DelayableNotificationSignal(System.Func<bool> isDelayed, System.Func<System.Collections.Generic.IList<T>, System.Collections.Generic.IEnumerable<T>> flushDistinct) { }
@@ -1382,7 +1382,7 @@ namespace ReactiveUI.Primitives.Signals
         public void OnNext(T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("OnNext = {_onNext}")]
+    [System.Diagnostics.DebuggerDisplay("DelegateWitness: OnNext = {_onNext}")]
     public sealed class DelegateWitness<T> : System.IObserver<T>
     {
         public DelegateWitness(System.Action<T> onNext, System.Action<System.Exception>? onError = null, System.Action? onCompleted = null) { }
@@ -1413,41 +1413,41 @@ namespace ReactiveUI.Primitives.Signals
         System.IObservable<T>? Source { get; }
         void GetOperationCanceled(System.IObserver<System.Exception> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, Predicate = {_predicate}")]
+    [System.Diagnostics.DebuggerDisplay("KeepSignal: Source = {_source}, Predicate = {_predicate}")]
     public sealed class KeepSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public KeepSignal(System.IObservable<T> source, System.Func<T, bool> predicate) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, State = {_state}")]
+    [System.Diagnostics.DebuggerDisplay("KeepWithSignal: Source = {_source}, State = {_state}")]
     public sealed class KeepWithSignal<T, TState> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public KeepWithSignal(System.IObservable<T> source, TState state, System.Func<TState, T, bool> predicate) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, Selector = {_selector}")]
+    [System.Diagnostics.DebuggerDisplay("MapSignal: Source = {_source}, Selector = {_selector}")]
     public sealed class MapSignal<TSource, TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public MapSignal(System.IObservable<TSource> source, System.Func<TSource, TResult> selector) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, State = {_state}")]
+    [System.Diagnostics.DebuggerDisplay("MapWithSignal: Source = {_source}, State = {_state}")]
     public sealed class MapWithSignal<TSource, TState, TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public MapWithSignal(System.IObservable<TSource> source, TState state, System.Func<TState, TSource, TResult> selector) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Subject = {_subject}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("ObserverHandler: Subject = {_subject}, Observer = {_observer}")]
     public sealed class ObserverHandler<T> : System.IDisposable
     {
         public ObserverHandler(ReactiveUI.Primitives.Signals.AsyncSignal<T> subject, System.IObserver<T> observer) { }
         public void Dispose() { }
     }
-    [System.Diagnostics.DebuggerDisplay("{Value}")]
+    [System.Diagnostics.DebuggerDisplay("ProjectedReadOnlyState: {Value}")]
     public sealed class ProjectedReadOnlyState<TSource, TResult> : System.IDisposable, System.IObservable<TResult>, System.IObserver<TSource>
     {
         public System.IObservable<TResult> Changed { get; }
@@ -1509,7 +1509,7 @@ namespace ReactiveUI.Primitives.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public bool TryGetValue(out T? value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, State = {_state}")]
+    [System.Diagnostics.DebuggerDisplay("TapWithSignal: Source = {_source}, State = {_state}")]
     public sealed class TapWithSignal<T, TState> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public TapWithSignal(System.IObservable<T> source, TState state, System.Action<TState, T> onNext) { }

--- a/src/ReactiveUI.Primitives.Core/PublicAPI/net9.0/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Core/PublicAPI/net9.0/PublicAPI.txt
@@ -6,7 +6,7 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Primitives.Tests")]
 namespace ReactiveUI.Primitives
 {
-    [System.Diagnostics.DebuggerDisplay("Subscribe = {_subscribe}")]
+    [System.Diagnostics.DebuggerDisplay("AnonymousSignal: Subscribe = {_subscribe}")]
     public sealed class AnonymousSignal<T> : System.IObservable<T>
     {
         public AnonymousSignal(System.Func<System.IObserver<T>, System.IDisposable> subscribe) { }
@@ -48,7 +48,7 @@ namespace ReactiveUI.Primitives
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public static ReactiveUI.Primitives.Optional<T> Some<T>(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasValue = {HasValue}, Value = {_value}")]
+    [System.Diagnostics.DebuggerDisplay("Optional: HasValue = {HasValue}, Value = {_value}")]
     public readonly record struct Optional<T> : System.IEquatable<ReactiveUI.Primitives.Optional<T>>
     {
         public Optional() { }
@@ -68,7 +68,7 @@ namespace ReactiveUI.Primitives
         public static explicit operator T?(in ReactiveUI.Primitives.Optional<T> value) { }
         public static implicit operator ReactiveUI.Primitives.Optional<T>(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsSuccess = {IsSuccess}, Exception = {Exception}")]
+    [System.Diagnostics.DebuggerDisplay("Result: IsSuccess = {IsSuccess}, Exception = {Exception}")]
     public readonly record struct Result : System.IEquatable<ReactiveUI.Primitives.Result>
     {
         public Result(System.Exception exception) { }
@@ -111,7 +111,7 @@ namespace ReactiveUI.Primitives
 }
 namespace ReactiveUI.Primitives.Advanced
 {
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, Aggregator = {_aggregator}")]
+    [System.Diagnostics.DebuggerDisplay("AggregateWitness: Done = {_done}, Aggregator = {_aggregator}")]
     public sealed class AggregateWitness<T, TResult, TAggregator> : System.IDisposable, System.IObserver<T> where TAggregator : struct, ReactiveUI.Primitives.Advanced.IAggregator<T, TResult, TAggregator>
     {
         public AggregateWitness(System.IObserver<TResult> observer, TAggregator aggregator) { }
@@ -125,7 +125,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("AllPredicateWitness: Done = {_done}, Observer = {_observer}")]
     public sealed class AllPredicateWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public AllPredicateWitness(System.IObserver<bool> observer, System.Func<T, bool> predicate) { }
@@ -139,7 +139,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("AnyPredicateWitness: Done = {_done}, Observer = {_observer}")]
     public sealed class AnyPredicateWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public AnyPredicateWitness(System.IObserver<bool> observer, System.Func<T, bool> predicate) { }
@@ -153,7 +153,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("AnyWitness: Done = {_done}, Observer = {_observer}")]
     public sealed class AnyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public AnyWitness(System.IObserver<bool> observer) { }
@@ -168,7 +168,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_value}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("AppendDelegateWitness: Value = {_value}, Subscription = {_subscription}")]
     public sealed class AppendDelegateWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public AppendDelegateWitness(System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted, T value) { }
@@ -180,7 +180,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("AppendedValue = {_value}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("AppendWitness: AppendedValue = {_value}, Observer = {_observer}")]
     public sealed class AppendWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public AppendWitness(System.IObserver<T> observer, T value) { }
@@ -202,7 +202,7 @@ namespace ReactiveUI.Primitives.Advanced
         public System.Collections.Generic.IAsyncEnumerable<T> Values { get; }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Skip = {_skip}, Index = {_index}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("BufferWitness: Count = {_count}, Skip = {_skip}, Index = {_index}, Done = {_done}")]
     public sealed class BufferWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public BufferWitness(System.IObserver<System.Collections.Generic.IList<T>> observer, int count, int skip) { }
@@ -213,7 +213,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("OnNext = {_onNext}, OnError = {_onError}, OnCompleted = {_onCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("CallbackWitness: OnNext = {_onNext}, OnError = {_onError}, OnCompleted = {_onCompleted}")]
     public sealed class CallbackWitness<T> : System.IObserver<T>
     {
         public CallbackWitness(System.Action<T> onNext, System.Action<System.Exception>? onError, System.Action<ReactiveUI.Primitives.Result>? onCompleted) { }
@@ -224,7 +224,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_values.Count}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("CollectArrayWitness: Count = {_values.Count}, Subscription = {_subscription}")]
     public sealed class CollectArrayWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CollectArrayWitness(System.IObserver<T[]> observer) { }
@@ -239,7 +239,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_values.Count}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("CollectListWitness: Count = {_values.Count}, Subscription = {_subscription}")]
     public sealed class CollectListWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CollectListWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -254,7 +254,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("SoughtValue = {_value}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("ContainsWitness: SoughtValue = {_value}, Done = {_done}")]
     public sealed class ContainsWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public ContainsWitness(System.IObserver<bool> observer, T value, System.Collections.Generic.IEqualityComparer<T> comparer) { }
@@ -268,7 +268,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {Items.Length}")]
+    [System.Diagnostics.DebuggerDisplay("CopyOnWriteList: Count = {Items.Length}")]
     public sealed class CopyOnWriteList<T>
     {
         public CopyOnWriteList(T[] data) { }
@@ -278,20 +278,20 @@ namespace ReactiveUI.Primitives.Advanced
         public int IndexOf(T value) { }
         public ReactiveUI.Primitives.Advanced.CopyOnWriteList<T> Remove(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Result = {Result}")]
+    [System.Diagnostics.DebuggerDisplay("CountAggregator: Result = {Result}")]
     public readonly record struct CountAggregator<T> : ReactiveUI.Primitives.Advanced.IAggregator<T, int, ReactiveUI.Primitives.Advanced.CountAggregator<T>>, System.IEquatable<ReactiveUI.Primitives.Advanced.CountAggregator<T>>
     {
         public int Result { get; }
         public readonly ReactiveUI.Primitives.Advanced.CountAggregator<T> Add(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Result = {Result}, Predicate = {_predicate}")]
+    [System.Diagnostics.DebuggerDisplay("CountPredicateAggregator: Result = {Result}, Predicate = {_predicate}")]
     public readonly record struct CountPredicateAggregator<T> : ReactiveUI.Primitives.Advanced.IAggregator<T, int, ReactiveUI.Primitives.Advanced.CountPredicateAggregator<T>>, System.IEquatable<ReactiveUI.Primitives.Advanced.CountPredicateAggregator<T>>
     {
         public CountPredicateAggregator(System.Func<T, bool> predicate) { }
         public int Result { get; }
         public readonly ReactiveUI.Primitives.Advanced.CountPredicateAggregator<T> Add(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Seen = {_seen}, DefaultValue = {_defaultValue}")]
+    [System.Diagnostics.DebuggerDisplay("DefaultIfEmptyWitness: Seen = {_seen}, DefaultValue = {_defaultValue}")]
     public sealed class DefaultIfEmptyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public DefaultIfEmptyWitness(System.IObserver<T> observer, T defaultValue) { }
@@ -316,21 +316,21 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Result = {Result}, Seen = {_seen}")]
+    [System.Diagnostics.DebuggerDisplay("DistinctByCountAggregator: Result = {Result}, Seen = {_seen}")]
     public readonly record struct DistinctByCountAggregator<T, TKey> : ReactiveUI.Primitives.Advanced.IAggregator<T, int, ReactiveUI.Primitives.Advanced.DistinctByCountAggregator<T, TKey>>, System.IEquatable<ReactiveUI.Primitives.Advanced.DistinctByCountAggregator<T, TKey>>
     {
         public DistinctByCountAggregator(System.Func<T, TKey> keySelector, System.Collections.Generic.IEqualityComparer<TKey>? comparer) { }
         public int Result { get; }
         public readonly ReactiveUI.Primitives.Advanced.DistinctByCountAggregator<T, TKey> Add(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Result = {Result}, Seen = {_seen}")]
+    [System.Diagnostics.DebuggerDisplay("DistinctByLongCountAggregator: Result = {Result}, Seen = {_seen}")]
     public readonly record struct DistinctByLongCountAggregator<T, TKey> : ReactiveUI.Primitives.Advanced.IAggregator<T, long, ReactiveUI.Primitives.Advanced.DistinctByLongCountAggregator<T, TKey>>, System.IEquatable<ReactiveUI.Primitives.Advanced.DistinctByLongCountAggregator<T, TKey>>
     {
         public DistinctByLongCountAggregator(System.Func<T, TKey> keySelector, System.Collections.Generic.IEqualityComparer<TKey>? comparer) { }
         public long Result { get; }
         public readonly ReactiveUI.Primitives.Advanced.DistinctByLongCountAggregator<T, TKey> Add(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, SeenKeys = {_seen.Count}")]
+    [System.Diagnostics.DebuggerDisplay("DistinctByWitness: Done = {_done}, SeenKeys = {_seen.Count}")]
     public sealed class DistinctByWitness<T, TKey> : System.IDisposable, System.IObserver<T>
     {
         public DistinctByWitness(System.IObserver<T> observer, System.Func<T, TKey> keySelector, System.Collections.Generic.IEqualityComparer<TKey>? comparer) { }
@@ -344,7 +344,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Seen = {_seen.Count}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("DistinctWitness: Seen = {_seen.Count}, Subscription = {_subscription}")]
     public sealed class DistinctWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public DistinctWitness(System.IObserver<T> observer, System.Collections.Generic.HashSet<T> seen) { }
@@ -358,7 +358,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("OnNext = {_onNext}, OnError = {_onError}, OnCompleted = {_onCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("EmptyWitness: OnNext = {_onNext}, OnError = {_onError}, OnCompleted = {_onCompleted}")]
     public sealed class EmptyWitness<T> : System.IObserver<T>
     {
         public EmptyWitness(System.Action<T> onNext) { }
@@ -373,7 +373,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Current = {_current}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("FoldWitness: Current = {_current}, Observer = {_observer}")]
     public sealed class FoldWitness<TSource, TAccumulate> : System.IDisposable, System.IObserver<TSource>
     {
         public FoldWitness(System.IObserver<TAccumulate> observer, TAccumulate seed, System.Func<TAccumulate, TSource, TAccumulate> accumulator) { }
@@ -387,7 +387,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("ForwardingWitness: Observer = {_observer}")]
     public sealed class ForwardingWitness<T> : System.IObserver<T>
     {
         public ForwardingWitness(System.IObserver<T> observer) { }
@@ -398,7 +398,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Values = {_values}, CancellationToken = {_cancellationToken}")]
+    [System.Diagnostics.DebuggerDisplay("FromEnumerableSignal: Values = {_values}, CancellationToken = {_cancellationToken}")]
     public sealed class FromEnumerableSignal<T> : ReactiveUI.Primitives.Advanced.IInlineSignal<T>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public FromEnumerableSignal(System.Collections.Generic.IEnumerable<T> values) { }
@@ -427,7 +427,7 @@ namespace ReactiveUI.Primitives.Advanced
     {
         bool IsRequiredSubscribeOnCurrentThread() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("IgnoreValuesWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class IgnoreValuesWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public IgnoreValuesWitness(System.IObserver<T> observer) { }
@@ -441,7 +441,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_value}")]
+    [System.Diagnostics.DebuggerDisplay("ImmediateReturnSignal: Value = {_value}")]
     public sealed class ImmediateReturnSignal<T> : ReactiveUI.Primitives.Advanced.IInlineSignal<T>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ImmediateReturnSignal(T value) { }
@@ -450,7 +450,7 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
         public System.IDisposable Subscribe(System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Error = {_error}")]
+    [System.Diagnostics.DebuggerDisplay("ImmediateThrowSignal: Error = {_error}")]
     public sealed class ImmediateThrowSignal<T> : ReactiveUI.Primitives.Advanced.IInlineSignal<T>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ImmediateThrowSignal(System.Exception error) { }
@@ -484,7 +484,7 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<bool> observer) { }
         public System.IDisposable Subscribe(System.Action<bool> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_x}")]
+    [System.Diagnostics.DebuggerDisplay("ImmutableReturnInt32Signal: Value = {_x}")]
     public sealed class ImmutableReturnInt32Signal : ReactiveUI.Primitives.Advanced.IInlineSignal<int>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<int>
     {
         public ImmutableReturnInt32Signal(int x) { }
@@ -502,7 +502,7 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<bool> observer) { }
         public System.IDisposable Subscribe(System.Action<bool> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("KeepNotNullWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class KeepNotNullWitness<T> : System.IDisposable, System.IObserver<T?> where T : class
     {
         public KeepNotNullWitness(System.IObserver<T> observer) { }
@@ -516,7 +516,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("KeepTypeWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class KeepTypeWitness<TResult> : System.IDisposable, System.IObserver<object?>
     {
         public KeepTypeWitness(System.IObserver<TResult> observer) { }
@@ -530,7 +530,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasObservers = {HasObservers}, Count = {_observers.Items.Length}")]
+    [System.Diagnostics.DebuggerDisplay("ListWitness: HasObservers = {HasObservers}, Count = {_observers.Items.Length}")]
     public sealed class ListWitness<T> : System.IObserver<T>
     {
         public ListWitness(ReactiveUI.Primitives.Advanced.CopyOnWriteList<System.IObserver<T>> observers) { }
@@ -539,20 +539,20 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Result = {Result}")]
+    [System.Diagnostics.DebuggerDisplay("LongCountAggregator: Result = {Result}")]
     public readonly record struct LongCountAggregator<T> : ReactiveUI.Primitives.Advanced.IAggregator<T, long, ReactiveUI.Primitives.Advanced.LongCountAggregator<T>>, System.IEquatable<ReactiveUI.Primitives.Advanced.LongCountAggregator<T>>
     {
         public long Result { get; }
         public readonly ReactiveUI.Primitives.Advanced.LongCountAggregator<T> Add(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Result = {Result}, Predicate = {_predicate}")]
+    [System.Diagnostics.DebuggerDisplay("LongCountPredicateAggregator: Result = {Result}, Predicate = {_predicate}")]
     public readonly record struct LongCountPredicateAggregator<T> : ReactiveUI.Primitives.Advanced.IAggregator<T, long, ReactiveUI.Primitives.Advanced.LongCountPredicateAggregator<T>>, System.IEquatable<ReactiveUI.Primitives.Advanced.LongCountPredicateAggregator<T>>
     {
         public LongCountPredicateAggregator(System.Func<T, bool> predicate) { }
         public long Result { get; }
         public readonly ReactiveUI.Primitives.Advanced.LongCountPredicateAggregator<T> Add(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Ranges = {_ranges.Length}")]
+    [System.Diagnostics.DebuggerDisplay("RangeConcatSignal: Ranges = {_ranges.Length}")]
     public sealed class RangeConcatSignal : ReactiveUI.Primitives.Advanced.IInlineSignal<int>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<int>
     {
         public RangeConcatSignal(ReactiveUI.Primitives.Advanced.RangeSignal[] ranges) { }
@@ -561,7 +561,7 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<int> observer) { }
         public System.IDisposable Subscribe(System.Action<int> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Start = {Start}, Count = {Count}")]
+    [System.Diagnostics.DebuggerDisplay("RangeSignal: Start = {Start}, Count = {Count}")]
     public sealed class RangeSignal : ReactiveUI.Primitives.Advanced.IInlineSignal<int>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<int>
     {
         public RangeSignal(int start, int count) { }
@@ -572,7 +572,7 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<int> observer) { }
         public System.IDisposable Subscribe(System.Action<int> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, LeftStart = {_leftStart}, RightStart = {_rightStart}")]
+    [System.Diagnostics.DebuggerDisplay("RangeZipSignal: Count = {_count}, LeftStart = {_leftStart}, RightStart = {_rightStart}")]
     public sealed class RangeZipSignal<TResult> : ReactiveUI.Primitives.Advanced.IInlineSignal<TResult>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public RangeZipSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
@@ -581,7 +581,7 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
         public System.IDisposable Subscribe(System.Action<TResult> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Current = {_current}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("ReduceWitness: Current = {_current}, Subscription = {_subscription}")]
     public sealed class ReduceWitness<TSource, TAccumulate> : System.IDisposable, System.IObserver<TSource>
     {
         public ReduceWitness(System.IObserver<TAccumulate> observer, TAccumulate seed, System.Func<TAccumulate, TSource, TAccumulate> accumulator) { }
@@ -595,7 +595,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_value}, Count = {_count}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSignal: Value = {_value}, Count = {_count}")]
     public sealed class RepeatSignal<T> : ReactiveUI.Primitives.Advanced.IInlineSignal<T>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public RepeatSignal(T value, int count) { }
@@ -620,7 +620,7 @@ namespace ReactiveUI.Primitives.Advanced
         public static void Fault<TResult>(System.IObserver<TResult> observer, System.Exception error, System.IDisposable sink) { }
         public static void Fault<TResult>(System.IObserver<TResult> observer, System.Exception error, System.IDisposable sink, ref bool done) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Skipping = {_skipping}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SkipWhileWitness: Skipping = {_skipping}, Subscription = {_subscription}")]
     public sealed class SkipWhileWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SkipWhileWitness(System.IObserver<T> observer, System.Func<T, bool> predicate) { }
@@ -634,7 +634,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Remaining = {_remaining}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SkipWitness: Remaining = {_remaining}, Observer = {_observer}")]
     public sealed class SkipWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SkipWitness(System.IObserver<T> observer, int count) { }
@@ -648,7 +648,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("State = {_state}, OnError = {_onError}")]
+    [System.Diagnostics.DebuggerDisplay("StatefulWitness: State = {_state}, OnError = {_onError}")]
     public sealed class StatefulWitness<T, TState> : System.IObserver<T>
     {
         public StatefulWitness(TState state, System.Action<T, TState> onNext, System.Action<System.Exception, TState>? onError, System.Action<ReactiveUI.Primitives.Result, TState>? onCompleted) { }
@@ -665,7 +665,7 @@ namespace ReactiveUI.Primitives.Advanced
         public static void Assign(ref System.IDisposable? slot, System.IDisposable subscription) { }
         public static void Release(ref System.IDisposable? slot) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SynchronizeWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SynchronizeWitness(System.IObserver<T> observer) { }
@@ -678,7 +678,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {_completed}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("TakeWhileWitness: Completed = {_completed}, Subscription = {_subscription}")]
     public sealed class TakeWhileWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TakeWhileWitness(System.IObserver<T> observer, System.Func<T, bool> predicate) { }
@@ -691,7 +691,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Remaining = {_remaining}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TakeWitness: Remaining = {_remaining}, Stopped = {_stopped}")]
     public sealed class TakeWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TakeWitness(System.IObserver<T> observer, int count) { }
@@ -703,7 +703,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("TapWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class TapWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TapWitness(System.IObserver<T> observer, System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
@@ -723,7 +723,7 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("InitialState = {_initialState}, Condition = {_condition}")]
+    [System.Diagnostics.DebuggerDisplay("UnfoldSignal: InitialState = {_initialState}, Condition = {_condition}")]
     public sealed class UnfoldSignal<TState, TResult> : ReactiveUI.Primitives.Advanced.IInlineSignal<TResult>, ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public UnfoldSignal(TState initialState, System.Func<TState, bool> condition, System.Func<TState, TState> iterate, System.Func<TState, TResult> resultSelector) { }
@@ -732,7 +732,7 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
         public System.IDisposable Subscribe(System.Action<TResult> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLast = {_hasLast}, Last = {_last}")]
+    [System.Diagnostics.DebuggerDisplay("UniqueByWitness: HasLast = {_hasLast}, Last = {_last}")]
     public sealed class UniqueByWitness<T, TKey> : System.IDisposable, System.IObserver<T>
     {
         public UniqueByWitness(System.IObserver<T> observer, System.Func<T, TKey> keySelector, System.Collections.Generic.IEqualityComparer<TKey> comparer) { }
@@ -746,7 +746,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLast = {_hasLast}, Last = {_last}")]
+    [System.Diagnostics.DebuggerDisplay("UniqueWitness: HasLast = {_hasLast}, Last = {_last}")]
     public sealed class UniqueWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public UniqueWitness(System.IObserver<T> observer, System.Collections.Generic.IEqualityComparer<T> comparer) { }
@@ -760,7 +760,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ResourceFactory = {_resourceFactory}, SignalFactory = {_signalFactory}")]
+    [System.Diagnostics.DebuggerDisplay("UseSignal: ResourceFactory = {_resourceFactory}, SignalFactory = {_signalFactory}")]
     public sealed class UseSignal<TResource, T> : System.IObservable<T> where TResource : System.IDisposable
     {
         public UseSignal(System.Func<TResource> resourceFactory, System.Func<TResource, System.IObservable<T>> signalFactory) { }
@@ -891,7 +891,7 @@ namespace ReactiveUI.Primitives.Core
         public static bool operator ==(ReactiveUI.Primitives.Core.Moment<T> first, ReactiveUI.Primitives.Core.Moment<T> second) { }
         public static bool operator !=(ReactiveUI.Primitives.Core.Moment<T> first, ReactiveUI.Primitives.Core.Moment<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {Count}, Capacity = {_items.Length}")]
+    [System.Diagnostics.DebuggerDisplay("PriorityQueue: Count = {Count}, Capacity = {_items.Length}")]
     public sealed class PriorityQueue<T> where T : System.IComparable<T>
     {
         public PriorityQueue() { }
@@ -934,14 +934,14 @@ namespace ReactiveUI.Primitives.Core
 }
 namespace ReactiveUI.Primitives.Extensions
 {
-    [System.Diagnostics.DebuggerDisplay("Outstanding = {_outstanding}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("ConcurrencyLimiter: Outstanding = {_outstanding}, Disposed = {_disposed}")]
     public sealed class ConcurrencyLimiter<T> : System.IObservable<T>
     {
         public ConcurrencyLimiter(System.Collections.Generic.IEnumerable<System.Threading.Tasks.Task<T>> taskFunctions, int maxConcurrency) { }
         public System.IObservable<T> Observable { get; }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Locked = {_locked}, CompletedPhases = {CompletedPhases}")]
+    [System.Diagnostics.DebuggerDisplay("Continuation: Locked = {_locked}, CompletedPhases = {CompletedPhases}")]
     public class Continuation : System.IDisposable
     {
         public Continuation() { }
@@ -951,7 +951,7 @@ namespace ReactiveUI.Primitives.Extensions
         public System.Threading.Tasks.Task Lock<T>(T item, System.IObserver<(T Value, System.IDisposable Sync)>? observer) { }
         public System.Threading.Tasks.ValueTask LockValueTask<T>(T item, System.IObserver<(T Value, System.IDisposable Sync)>? observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_value}, Completed = {_completed}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("CurrentValueSubject: Value = {_value}, Completed = {_completed}, Disposed = {_disposed}")]
     public sealed class CurrentValueSubject<T> : System.IDisposable, System.IObservable<T>, System.IObserver<T>
     {
         public CurrentValueSubject(T initialValue) { }
@@ -978,7 +978,7 @@ namespace ReactiveUI.Primitives.Extensions
     {
         public static System.Threading.Tasks.ValueTask<T> FirstAsValueTask(System.IObservable<T> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsHeartbeat = {IsHeartbeat}, Update = {Update}")]
+    [System.Diagnostics.DebuggerDisplay("Heartbeat: IsHeartbeat = {IsHeartbeat}, Update = {Update}")]
     public readonly record struct Heartbeat<T> : ReactiveUI.Primitives.Extensions.IHeartbeat<T>, System.IEquatable<ReactiveUI.Primitives.Extensions.Heartbeat<T>>
     {
         public Heartbeat() { }
@@ -1027,7 +1027,7 @@ namespace ReactiveUI.Primitives.Extensions
         public SingleValueSignal(T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsStale = {IsStale}")]
+    [System.Diagnostics.DebuggerDisplay("Stale: IsStale = {IsStale}")]
     public readonly record struct Stale<T> : ReactiveUI.Primitives.Extensions.IStale<T>, System.IEquatable<ReactiveUI.Primitives.Extensions.Stale<T>>
     {
         public Stale() { }
@@ -1035,7 +1035,7 @@ namespace ReactiveUI.Primitives.Extensions
         public bool IsStale { get; }
         public T? Update { get; }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {Done}, Timer = {Timer}")]
+    [System.Diagnostics.DebuggerDisplay("TimerSinkState: Done = {Done}, Timer = {Timer}")]
     public sealed class TimerSinkState<T>
     {
         public TimerSinkState(System.IObserver<T> downstream) { }
@@ -1048,13 +1048,13 @@ namespace ReactiveUI.Primitives.Extensions
 }
 namespace ReactiveUI.Primitives.Extensions.Operators
 {
-    [System.Diagnostics.DebuggerDisplay("Left = {_left}, Right = {_right}")]
+    [System.Diagnostics.DebuggerDisplay("BinaryMinMaxObservable: Left = {_left}, Right = {_right}")]
     public sealed class BinaryMinMaxObservable<T> : System.IObservable<T> where T : struct, System.IComparable<T>
     {
         public BinaryMinMaxObservable(System.IObservable<T> left, System.IObservable<T> right, bool emitMaximum) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sourceList}")]
+    [System.Diagnostics.DebuggerDisplay("BooleanReduceObservable: Sources = {_sourceList}")]
     public sealed class BooleanReduceObservable : System.IObservable<bool>
     {
         public BooleanReduceObservable(System.Collections.Generic.IEnumerable<System.IObservable<bool>> sources, bool target) { }
@@ -1075,7 +1075,7 @@ namespace ReactiveUI.Primitives.Extensions.Operators
         public CatchIgnoreEmptyObservable(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, ErrorAction = {_errorAction}")]
+    [System.Diagnostics.DebuggerDisplay("CatchIgnoreObservable: Source = {_source}, ErrorAction = {_errorAction}")]
     public sealed class CatchIgnoreObservable<TSource, TException> : System.IObservable<TSource> where TException : System.Exception
     {
         public CatchIgnoreObservable(System.IObservable<TSource> source, System.Action<TException> errorAction) { }
@@ -1110,7 +1110,7 @@ namespace ReactiveUI.Primitives.Extensions.Operators
     {
         public FirstMatchFromCandidatesObservable(System.Collections.Generic.IReadOnlyList<TKey> candidates, System.Func<TKey, System.IObservable<TRaw>> project, System.Func<TRaw, TResult> transform, System.Func<TResult, bool> predicate, TResult fallback) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
-        [System.Diagnostics.DebuggerDisplay("Completed = {Completed}, HasValue = {HasValue}, Value = {Value}")]
+        [System.Diagnostics.DebuggerDisplay("SyncProbe: Completed = {Completed}, HasValue = {HasValue}, Value = {Value}")]
         public sealed class SyncProbe : System.IObserver<TRaw>
         {
             public SyncProbe() { }
@@ -1131,7 +1131,7 @@ namespace ReactiveUI.Primitives.Extensions.Operators
         public LogErrorsObservable(System.IObservable<T> source, System.Action<System.Exception> logger) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sourceList.Count}")]
+    [System.Diagnostics.DebuggerDisplay("MinMaxObservable: Sources = {_sourceList.Count}")]
     public sealed class MinMaxObservable<T> : System.IObservable<T> where T : struct, System.IComparable<T>
     {
         public MinMaxObservable(System.Collections.Generic.IReadOnlyList<System.IObservable<T>> sources, bool emitMaximum) { }
@@ -1147,7 +1147,7 @@ namespace ReactiveUI.Primitives.Extensions.Operators
         public PairwiseObservable(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<(T Previous, T Current)> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, Subscriptions = {_subscriptionCount}")]
+    [System.Diagnostics.DebuggerDisplay("PartitionObservable: Source = {_source}, Subscriptions = {_subscriptionCount}")]
     public sealed class PartitionObservable<T>
     {
         public PartitionObservable(System.IObservable<T> source, System.Func<T, bool> predicate) { }
@@ -1209,7 +1209,7 @@ namespace ReactiveUI.Primitives.Extensions.Operators
         public SkipWhileNullObservable(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Queued = {_queue.Count}, Processing = {_isProcessing}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("SubscribeAsyncObservable: Queued = {_queue.Count}, Processing = {_isProcessing}, Done = {_done}")]
     public sealed class SubscribeAsyncObservable<T> : System.IDisposable
     {
         public SubscribeAsyncObservable(System.IObservable<T> source, System.Func<T, System.Threading.Tasks.ValueTask> onNext, System.Action<System.Exception>? onError, System.Action? onCompleted) { }
@@ -1281,7 +1281,7 @@ namespace ReactiveUI.Primitives.Signals
         public void RemoveObserver(System.IObserver<T> observer) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Callback = {_callback}, Context = {_context}")]
+    [System.Diagnostics.DebuggerDisplay("AwaitWitness: Callback = {_callback}, Context = {_context}")]
     public sealed class AwaitWitness<T> : System.IObserver<T>
     {
         public AwaitWitness(System.Action callback, bool originalContext) { }
@@ -1313,7 +1313,7 @@ namespace ReactiveUI.Primitives.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public bool TryGetValue(out T? value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_observers}")]
+    [System.Diagnostics.DebuggerDisplay("Broadcaster: Observers = {_observers}")]
     public struct Broadcaster<T> : System.IEquatable<ReactiveUI.Primitives.Signals.Broadcaster<T>>
     {
         public bool HasObservers { get; }
@@ -1332,7 +1332,7 @@ namespace ReactiveUI.Primitives.Signals
         public static bool operator ==(ReactiveUI.Primitives.Signals.Broadcaster<T> left, ReactiveUI.Primitives.Signals.Broadcaster<T> right) { }
         public static bool operator !=(ReactiveUI.Primitives.Signals.Broadcaster<T> left, ReactiveUI.Primitives.Signals.Broadcaster<T> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Task = {_task}, Result = {_result}, Exception = {_exception}")]
+    [System.Diagnostics.DebuggerDisplay("CommandExecution: Task = {_task}, Result = {_result}, Exception = {_exception}")]
     public readonly record struct CommandExecution<TResult> : System.IEquatable<ReactiveUI.Primitives.Signals.CommandExecution<TResult>>
     {
         public CommandExecution(System.Exception exception) { }
@@ -1340,7 +1340,7 @@ namespace ReactiveUI.Primitives.Signals
         public CommandExecution(TResult result) { }
         public readonly ReactiveUI.Primitives.Signals.CommandExecution<TResult> ConfigureAwait(bool continueOnCapturedContext) { }
         public readonly ReactiveUI.Primitives.Signals.CommandExecution<TResult>.Awaiter GetAwaiter() { }
-        [System.Diagnostics.DebuggerDisplay("IsCompleted = {IsCompleted}, Result = {_result}, Exception = {_exception}")]
+        [System.Diagnostics.DebuggerDisplay("Awaiter: IsCompleted = {IsCompleted}, Result = {_result}, Exception = {_exception}")]
         public readonly record struct Awaiter : System.IEquatable<ReactiveUI.Primitives.Signals.CommandExecution<TResult>.Awaiter>, System.Runtime.CompilerServices.ICriticalNotifyCompletion
         {
             public Awaiter(System.Threading.Tasks.Task<TResult>? task, TResult? result, System.Exception? exception, bool continueOnCapturedContext) { }
@@ -1369,7 +1369,7 @@ namespace ReactiveUI.Primitives.Signals
         public ReactiveUI.Primitives.Signals.CommandExecution<TResult> ExecuteAsync(System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Buffer = {_buffer}")]
+    [System.Diagnostics.DebuggerDisplay("DelayableNotificationSignal: Stopped = {_stopped}, Buffer = {_buffer}")]
     public sealed class DelayableNotificationSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T>
     {
         public DelayableNotificationSignal(System.Func<bool> isDelayed, System.Func<System.Collections.Generic.IList<T>, System.Collections.Generic.IEnumerable<T>> flushDistinct) { }
@@ -1382,7 +1382,7 @@ namespace ReactiveUI.Primitives.Signals
         public void OnNext(T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("OnNext = {_onNext}")]
+    [System.Diagnostics.DebuggerDisplay("DelegateWitness: OnNext = {_onNext}")]
     public sealed class DelegateWitness<T> : System.IObserver<T>
     {
         public DelegateWitness(System.Action<T> onNext, System.Action<System.Exception>? onError = null, System.Action? onCompleted = null) { }
@@ -1413,41 +1413,41 @@ namespace ReactiveUI.Primitives.Signals
         System.IObservable<T>? Source { get; }
         void GetOperationCanceled(System.IObserver<System.Exception> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, Predicate = {_predicate}")]
+    [System.Diagnostics.DebuggerDisplay("KeepSignal: Source = {_source}, Predicate = {_predicate}")]
     public sealed class KeepSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public KeepSignal(System.IObservable<T> source, System.Func<T, bool> predicate) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, State = {_state}")]
+    [System.Diagnostics.DebuggerDisplay("KeepWithSignal: Source = {_source}, State = {_state}")]
     public sealed class KeepWithSignal<T, TState> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public KeepWithSignal(System.IObservable<T> source, TState state, System.Func<TState, T, bool> predicate) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, Selector = {_selector}")]
+    [System.Diagnostics.DebuggerDisplay("MapSignal: Source = {_source}, Selector = {_selector}")]
     public sealed class MapSignal<TSource, TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public MapSignal(System.IObservable<TSource> source, System.Func<TSource, TResult> selector) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, State = {_state}")]
+    [System.Diagnostics.DebuggerDisplay("MapWithSignal: Source = {_source}, State = {_state}")]
     public sealed class MapWithSignal<TSource, TState, TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public MapWithSignal(System.IObservable<TSource> source, TState state, System.Func<TState, TSource, TResult> selector) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Subject = {_subject}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("ObserverHandler: Subject = {_subject}, Observer = {_observer}")]
     public sealed class ObserverHandler<T> : System.IDisposable
     {
         public ObserverHandler(ReactiveUI.Primitives.Signals.AsyncSignal<T> subject, System.IObserver<T> observer) { }
         public void Dispose() { }
     }
-    [System.Diagnostics.DebuggerDisplay("{Value}")]
+    [System.Diagnostics.DebuggerDisplay("ProjectedReadOnlyState: {Value}")]
     public sealed class ProjectedReadOnlyState<TSource, TResult> : System.IDisposable, System.IObservable<TResult>, System.IObserver<TSource>
     {
         public System.IObservable<TResult> Changed { get; }
@@ -1509,7 +1509,7 @@ namespace ReactiveUI.Primitives.Signals
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public bool TryGetValue(out T? value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, State = {_state}")]
+    [System.Diagnostics.DebuggerDisplay("TapWithSignal: Source = {_source}, State = {_state}")]
     public sealed class TapWithSignal<T, TState> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public TapWithSignal(System.IObservable<T> source, TState state, System.Action<TState, T> onNext) { }

--- a/src/ReactiveUI.Primitives.Core/Result.cs
+++ b/src/ReactiveUI.Primitives.Core/Result.cs
@@ -13,7 +13,7 @@ namespace ReactiveUI.Primitives;
 /// successful results and <see cref="Failure(Exception)"/> to create failed results. The <see cref="IsSuccess"/> and
 /// <see cref="IsFailure"/> properties allow callers to check the operation's status before accessing error information
 /// or propagating exceptions. This struct is immutable and thread-safe.</remarks>
-[System.Diagnostics.DebuggerDisplay("IsSuccess = {IsSuccess}, Exception = {Exception}")]
+[System.Diagnostics.DebuggerDisplay("Result: IsSuccess = {IsSuccess}, Exception = {Exception}")]
 public readonly record struct Result
 {
     /// <summary>Initializes a new instance of the <see cref="Result"/> struct. Initializes a new instance of the Result class with the specified exception.</summary>

--- a/src/ReactiveUI.Primitives.Core/Signals/AnonymousSignal.cs
+++ b/src/ReactiveUI.Primitives.Core/Signals/AnonymousSignal.cs
@@ -8,7 +8,7 @@ namespace ReactiveUI.Primitives;
 
 /// <summary>Observable backed by a subscription delegate.</summary>
 /// <typeparam name="T">The observed value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Subscribe = {_subscribe}")]
+[System.Diagnostics.DebuggerDisplay("AnonymousSignal: Subscribe = {_subscribe}")]
 public sealed class AnonymousSignal<T> : IObservable<T>
 {
     /// <summary>Subscription delegate.</summary>

--- a/src/ReactiveUI.Primitives.Core/Signals/AwaitWitness.cs
+++ b/src/ReactiveUI.Primitives.Core/Signals/AwaitWitness.cs
@@ -8,7 +8,7 @@ namespace ReactiveUI.Primitives.Signals;
 
 /// <summary>Represents the AwaitWitness class.</summary>
 /// <typeparam name="T">The Type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Callback = {_callback}, Context = {_context}")]
+[System.Diagnostics.DebuggerDisplay("AwaitWitness: Callback = {_callback}, Context = {_context}")]
 public sealed class AwaitWitness<T> : IObserver<T>
 {
     /// <summary>Stores state for the signal implementation.</summary>

--- a/src/ReactiveUI.Primitives.Core/Signals/Broadcaster{T}.cs
+++ b/src/ReactiveUI.Primitives.Core/Signals/Broadcaster{T}.cs
@@ -9,7 +9,7 @@ namespace ReactiveUI.Primitives.Signals;
 
 /// <summary>Copy-on-write observer broadcaster optimized for zero-allocation single-subscriber delivery.</summary>
 /// <typeparam name="T">The value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Observers = {_observers}")]
+[System.Diagnostics.DebuggerDisplay("Broadcaster: Observers = {_observers}")]
 public struct Broadcaster<T> : IEquatable<Broadcaster<T>>
 {
     /// <summary>The starting value the observer hashes are folded into.</summary>

--- a/src/ReactiveUI.Primitives.Core/Signals/CommandExecution{TResult}.cs
+++ b/src/ReactiveUI.Primitives.Core/Signals/CommandExecution{TResult}.cs
@@ -9,7 +9,7 @@ namespace ReactiveUI.Primitives.Signals;
 
 /// <summary>Awaitable command execution result that avoids allocating a completed task for synchronous commands.</summary>
 /// <typeparam name="TResult">The command result type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Task = {_task}, Result = {_result}, Exception = {_exception}")]
+[System.Diagnostics.DebuggerDisplay("CommandExecution: Task = {_task}, Result = {_result}, Exception = {_exception}")]
 public readonly record struct CommandExecution<TResult>
 {
     /// <summary>Asynchronous execution task, when execution did not complete synchronously.</summary>
@@ -80,7 +80,7 @@ public readonly record struct CommandExecution<TResult>
     public Awaiter GetAwaiter() => new(_task, _result, _exception, _continueOnCapturedContext);
 
     /// <summary>Awaiter for command execution.</summary>
-    [System.Diagnostics.DebuggerDisplay("IsCompleted = {IsCompleted}, Result = {_result}, Exception = {_exception}")]
+    [System.Diagnostics.DebuggerDisplay("Awaiter: IsCompleted = {IsCompleted}, Result = {_result}, Exception = {_exception}")]
     public readonly record struct Awaiter : ICriticalNotifyCompletion
     {
         /// <summary>Asynchronous execution task.</summary>

--- a/src/ReactiveUI.Primitives.Core/Signals/DelayableNotificationSignal{T}.cs
+++ b/src/ReactiveUI.Primitives.Core/Signals/DelayableNotificationSignal{T}.cs
@@ -13,7 +13,7 @@ namespace ReactiveUI.Primitives.Signals;
 /// Fuses the <c>Buffer(boundary).SelectMany(distinct).Publish().RefCount()</c> pipeline into one allocation-light sink.
 /// </summary>
 /// <typeparam name="T">The notification type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Buffer = {_buffer}")]
+[System.Diagnostics.DebuggerDisplay("DelayableNotificationSignal: Stopped = {_stopped}, Buffer = {_buffer}")]
 public sealed class DelayableNotificationSignal<T> : ISignal<T>
 {
     /// <summary>Guards the observer set, buffer, and terminal state.</summary>

--- a/src/ReactiveUI.Primitives.Core/Signals/DelegateWitness{T}.cs
+++ b/src/ReactiveUI.Primitives.Core/Signals/DelegateWitness{T}.cs
@@ -16,7 +16,7 @@ namespace ReactiveUI.Primitives.Signals;
 /// <param name="onNext">The delegate invoked with each value pushed to <see cref="IObserver{T}.OnNext"/>.</param>
 /// <param name="onError">The optional delegate invoked with the exception when the sequence faults via <see cref="IObserver{T}.OnError"/>.</param>
 /// <param name="onCompleted">The optional delegate invoked when the sequence finishes via <see cref="IObserver{T}.OnCompleted"/>.</param>
-[System.Diagnostics.DebuggerDisplay("OnNext = {_onNext}")]
+[System.Diagnostics.DebuggerDisplay("DelegateWitness: OnNext = {_onNext}")]
 public sealed class DelegateWitness<T>(
     Action<T> onNext,
     Action<Exception>? onError = null,

--- a/src/ReactiveUI.Primitives.Core/Signals/KeepSignal{T}.cs
+++ b/src/ReactiveUI.Primitives.Core/Signals/KeepSignal{T}.cs
@@ -10,7 +10,7 @@ namespace ReactiveUI.Primitives.Signals;
 /// <typeparam name="T">The T type.</typeparam>
 /// <param name="source">The source value.</param>
 /// <param name="predicate">The predicate value.</param>
-[System.Diagnostics.DebuggerDisplay("Source = {_source}, Predicate = {_predicate}")]
+[System.Diagnostics.DebuggerDisplay("KeepSignal: Source = {_source}, Predicate = {_predicate}")]
 public sealed class KeepSignal<T>(IObservable<T> source, Func<T, bool> predicate) : IRequireCurrentThread<T>
 {
     /// <summary>Stores state for the signal implementation.</summary>

--- a/src/ReactiveUI.Primitives.Core/Signals/KeepWithSignal{T,TState}.cs
+++ b/src/ReactiveUI.Primitives.Core/Signals/KeepWithSignal{T,TState}.cs
@@ -15,7 +15,7 @@ namespace ReactiveUI.Primitives.Signals;
 /// <param name="source">The source sequence.</param>
 /// <param name="state">The state passed to the predicate.</param>
 /// <param name="predicate">The predicate applied to each source value and the state.</param>
-[System.Diagnostics.DebuggerDisplay("Source = {_source}, State = {_state}")]
+[System.Diagnostics.DebuggerDisplay("KeepWithSignal: Source = {_source}, State = {_state}")]
 public sealed class KeepWithSignal<T, TState>(IObservable<T> source, TState state, Func<TState, T, bool> predicate) : IRequireCurrentThread<T>
 {
     /// <summary>The source sequence.</summary>

--- a/src/ReactiveUI.Primitives.Core/Signals/MapSignal{TSource,TResult}.cs
+++ b/src/ReactiveUI.Primitives.Core/Signals/MapSignal{TSource,TResult}.cs
@@ -11,7 +11,7 @@ namespace ReactiveUI.Primitives.Signals;
 /// <typeparam name="TResult">The TResult type.</typeparam>
 /// <param name="source">The source value.</param>
 /// <param name="selector">The selector value.</param>
-[System.Diagnostics.DebuggerDisplay("Source = {_source}, Selector = {_selector}")]
+[System.Diagnostics.DebuggerDisplay("MapSignal: Source = {_source}, Selector = {_selector}")]
 public sealed class MapSignal<TSource, TResult>(IObservable<TSource> source, Func<TSource, TResult> selector) : IRequireCurrentThread<TResult>
 {
     /// <summary>Stores state for the signal implementation.</summary>

--- a/src/ReactiveUI.Primitives.Core/Signals/MapWithSignal{TSource,TState,TResult}.cs
+++ b/src/ReactiveUI.Primitives.Core/Signals/MapWithSignal{TSource,TState,TResult}.cs
@@ -16,7 +16,7 @@ namespace ReactiveUI.Primitives.Signals;
 /// <param name="source">The source sequence.</param>
 /// <param name="state">The state passed to the selector.</param>
 /// <param name="selector">The transform applied to each source value and the state.</param>
-[System.Diagnostics.DebuggerDisplay("Source = {_source}, State = {_state}")]
+[System.Diagnostics.DebuggerDisplay("MapWithSignal: Source = {_source}, State = {_state}")]
 public sealed class MapWithSignal<TSource, TState, TResult>(
     IObservable<TSource> source,
     TState state,

--- a/src/ReactiveUI.Primitives.Core/Signals/ObserverHandler.cs
+++ b/src/ReactiveUI.Primitives.Core/Signals/ObserverHandler.cs
@@ -8,7 +8,7 @@ namespace ReactiveUI.Primitives.Signals;
 /// <typeparam name="T">The Type.</typeparam>
 /// <param name="subject">The subject value.</param>
 /// <param name="observer">The observer value.</param>
-[System.Diagnostics.DebuggerDisplay("Subject = {_subject}, Observer = {_observer}")]
+[System.Diagnostics.DebuggerDisplay("ObserverHandler: Subject = {_subject}, Observer = {_observer}")]
 public sealed class ObserverHandler<T>(AsyncSignal<T> subject, IObserver<T> observer) : IDisposable
 {
     /// <summary>Executes the new operation.</summary>

--- a/src/ReactiveUI.Primitives.Core/Signals/ProjectedReadOnlyState{TSource,TResult}.cs
+++ b/src/ReactiveUI.Primitives.Core/Signals/ProjectedReadOnlyState{TSource,TResult}.cs
@@ -9,7 +9,7 @@ namespace ReactiveUI.Primitives.Signals;
 /// <summary>Read-only state projection backed directly by a source state signal.</summary>
 /// <typeparam name="TSource">The source value type.</typeparam>
 /// <typeparam name="TResult">The projected value type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("{Value}")]
+[System.Diagnostics.DebuggerDisplay("ProjectedReadOnlyState: {Value}")]
 public sealed class ProjectedReadOnlyState<TSource, TResult> : IObservable<TResult>, IObserver<TSource>, IDisposable
 {
     /// <summary>Projection function.</summary>

--- a/src/ReactiveUI.Primitives.Core/Signals/TapWithSignal{T,TState}.cs
+++ b/src/ReactiveUI.Primitives.Core/Signals/TapWithSignal{T,TState}.cs
@@ -15,7 +15,7 @@ namespace ReactiveUI.Primitives.Signals;
 /// <param name="source">The source sequence.</param>
 /// <param name="state">The state passed to the action.</param>
 /// <param name="onNext">The action invoked for each value and the state.</param>
-[System.Diagnostics.DebuggerDisplay("Source = {_source}, State = {_state}")]
+[System.Diagnostics.DebuggerDisplay("TapWithSignal: Source = {_source}, State = {_state}")]
 public sealed class TapWithSignal<T, TState>(IObservable<T> source, TState state, Action<TState, T> onNext) : IRequireCurrentThread<T>
 {
     /// <summary>The source sequence.</summary>

--- a/src/ReactiveUI.Primitives.Extensions.Core/ConcurrencyLimiter.cs
+++ b/src/ReactiveUI.Primitives.Extensions.Core/ConcurrencyLimiter.cs
@@ -17,7 +17,7 @@ namespace ReactiveUI.Primitives.Extensions;
 /// <typeparam name="T">The type of the task results.</typeparam>
 /// <param name="taskFunctions">The task functions to drain.</param>
 /// <param name="maxConcurrency">The maximum concurrency.</param>
-[System.Diagnostics.DebuggerDisplay("Outstanding = {_outstanding}, Disposed = {_disposed}")]
+[System.Diagnostics.DebuggerDisplay("ConcurrencyLimiter: Outstanding = {_outstanding}, Disposed = {_disposed}")]
 public sealed class ConcurrencyLimiter<T>(IEnumerable<Task<T>> taskFunctions, int maxConcurrency) : IObservable<T>
 {
     /// <summary>The synchronization gate protecting task scheduling and completion state.</summary>

--- a/src/ReactiveUI.Primitives.Extensions.Core/Continuation.cs
+++ b/src/ReactiveUI.Primitives.Extensions.Core/Continuation.cs
@@ -7,7 +7,7 @@ using System.Runtime.CompilerServices;
 namespace ReactiveUI.Primitives.Extensions;
 
 /// <summary>Coordinates phase synchronization between a lock holder and its continuation.</summary>
-[System.Diagnostics.DebuggerDisplay("Locked = {_locked}, CompletedPhases = {CompletedPhases}")]
+[System.Diagnostics.DebuggerDisplay("Continuation: Locked = {_locked}, CompletedPhases = {CompletedPhases}")]
 public class Continuation : IDisposable
 {
     /// <summary>The barrier used to synchronize phases between the lock holder and the continuation.</summary>

--- a/src/ReactiveUI.Primitives.Extensions.Core/CurrentValueSubject.cs
+++ b/src/ReactiveUI.Primitives.Extensions.Core/CurrentValueSubject.cs
@@ -17,7 +17,7 @@ namespace ReactiveUI.Primitives.Extensions;
 /// </list>
 /// </summary>
 /// <typeparam name="T">The element type.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Value = {_value}, Completed = {_completed}, Disposed = {_disposed}")]
+[System.Diagnostics.DebuggerDisplay("CurrentValueSubject: Value = {_value}, Completed = {_completed}, Disposed = {_disposed}")]
 public sealed class CurrentValueSubject<T> : IObservable<T>, IObserver<T>, IDisposable
 {
     /// <summary>Lock guarding state mutations; held only across snapshot reads and field writes.</summary>

--- a/src/ReactiveUI.Primitives.Extensions.Core/Heartbeat.cs
+++ b/src/ReactiveUI.Primitives.Extensions.Core/Heartbeat.cs
@@ -11,7 +11,7 @@ namespace ReactiveUI.Primitives.Extensions;
 /// <c>new Heartbeat&lt;T&gt;()</c> to construct a heartbeat tick.
 /// </summary>
 /// <typeparam name="T">The type of the update value.</typeparam>
-[System.Diagnostics.DebuggerDisplay("IsHeartbeat = {IsHeartbeat}, Update = {Update}")]
+[System.Diagnostics.DebuggerDisplay("Heartbeat: IsHeartbeat = {IsHeartbeat}, Update = {Update}")]
 public readonly record struct Heartbeat<T> : IHeartbeat<T>
 {
     /// <summary>Initializes a new instance of the <see cref="Heartbeat{T}"/> struct representing a heartbeat tick.</summary>

--- a/src/ReactiveUI.Primitives.Extensions.Core/Operators/BinaryMinMaxObservable.cs
+++ b/src/ReactiveUI.Primitives.Extensions.Core/Operators/BinaryMinMaxObservable.cs
@@ -12,7 +12,7 @@ namespace ReactiveUI.Primitives.Extensions.Operators;
 /// <param name="left">The first source.</param>
 /// <param name="right">The second source.</param>
 /// <param name="emitMaximum"><c>true</c> to emit the maximum; <c>false</c> to emit the minimum.</param>
-[System.Diagnostics.DebuggerDisplay("Left = {_left}, Right = {_right}")]
+[System.Diagnostics.DebuggerDisplay("BinaryMinMaxObservable: Left = {_left}, Right = {_right}")]
 public sealed class BinaryMinMaxObservable<T>(IObservable<T> left, IObservable<T> right, bool emitMaximum) : IObservable<T>
     where T : struct, IComparable<T>
 {

--- a/src/ReactiveUI.Primitives.Extensions.Core/Operators/BooleanReduceObservable.cs
+++ b/src/ReactiveUI.Primitives.Extensions.Core/Operators/BooleanReduceObservable.cs
@@ -16,7 +16,7 @@ namespace ReactiveUI.Primitives.Extensions.Operators;
 /// </summary>
 /// <param name="sources">The source observables.</param>
 /// <param name="target">The value every source must hold for the operator to emit <c>true</c>.</param>
-[System.Diagnostics.DebuggerDisplay("Sources = {_sourceList}")]
+[System.Diagnostics.DebuggerDisplay("BooleanReduceObservable: Sources = {_sourceList}")]
 public sealed class BooleanReduceObservable(IEnumerable<IObservable<bool>> sources, bool target) : IObservable<bool>
 {
     /// <summary>Capacity the materialization buffer starts at when the source count is not known up front.</summary>

--- a/src/ReactiveUI.Primitives.Extensions.Core/Operators/CatchIgnoreObservable.cs
+++ b/src/ReactiveUI.Primitives.Extensions.Core/Operators/CatchIgnoreObservable.cs
@@ -11,7 +11,7 @@ namespace ReactiveUI.Primitives.Extensions.Operators;
 /// <typeparam name="TException">The type of the exception to catch.</typeparam>
 /// <param name="source">The source observable sequence.</param>
 /// <param name="errorAction">Action to invoke when an exception of type <typeparamref name="TException"/> occurs.</param>
-[System.Diagnostics.DebuggerDisplay("Source = {_source}, ErrorAction = {_errorAction}")]
+[System.Diagnostics.DebuggerDisplay("CatchIgnoreObservable: Source = {_source}, ErrorAction = {_errorAction}")]
 public sealed class CatchIgnoreObservable<TSource, TException>(
     IObservable<TSource> source,
     Action<TException> errorAction) : IObservable<TSource>

--- a/src/ReactiveUI.Primitives.Extensions.Core/Operators/FirstMatchFromCandidatesObservable.cs
+++ b/src/ReactiveUI.Primitives.Extensions.Core/Operators/FirstMatchFromCandidatesObservable.cs
@@ -122,7 +122,7 @@ public sealed class FirstMatchFromCandidatesObservable<TKey, TRaw, TResult>(
     /// of a one-shot projection. Cheaper than <see cref="AsyncSink"/> because it
     /// carries no downstream observer, candidate list, or delegate references.
     /// </summary>
-    [System.Diagnostics.DebuggerDisplay("Completed = {Completed}, HasValue = {HasValue}, Value = {Value}")]
+    [System.Diagnostics.DebuggerDisplay("SyncProbe: Completed = {Completed}, HasValue = {HasValue}, Value = {Value}")]
     public sealed class SyncProbe : IObserver<TRaw>
     {
         /// <summary>Per-thread cached instance; rented on entry to <c>TrySyncLoop</c> and returned

--- a/src/ReactiveUI.Primitives.Extensions.Core/Operators/MinMaxObservable.cs
+++ b/src/ReactiveUI.Primitives.Extensions.Core/Operators/MinMaxObservable.cs
@@ -17,7 +17,7 @@ namespace ReactiveUI.Primitives.Extensions.Operators;
 /// <typeparam name="T">The value type.</typeparam>
 /// <param name="sources">The source observables.</param>
 /// <param name="emitMaximum"><c>true</c> to emit the maximum; <c>false</c> to emit the minimum.</param>
-[System.Diagnostics.DebuggerDisplay("Sources = {_sourceList.Count}")]
+[System.Diagnostics.DebuggerDisplay("MinMaxObservable: Sources = {_sourceList.Count}")]
 public sealed class MinMaxObservable<T>(IReadOnlyList<IObservable<T>> sources, bool emitMaximum) : IObservable<T>
     where T : struct, IComparable<T>
 {

--- a/src/ReactiveUI.Primitives.Extensions.Core/Operators/PartitionObservable.cs
+++ b/src/ReactiveUI.Primitives.Extensions.Core/Operators/PartitionObservable.cs
@@ -10,7 +10,7 @@ namespace ReactiveUI.Primitives.Extensions.Operators;
 
 /// <summary>Partitions a sequence into two observables based on a predicate.</summary>
 /// <typeparam name="T">The type of elements in the source sequence.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Source = {_source}, Subscriptions = {_subscriptionCount}")]
+[System.Diagnostics.DebuggerDisplay("PartitionObservable: Source = {_source}, Subscriptions = {_subscriptionCount}")]
 public sealed class PartitionObservable<T>
 {
     /// <summary>The source observable.</summary>

--- a/src/ReactiveUI.Primitives.Extensions.Core/Operators/SubscribeAsyncObservable.cs
+++ b/src/ReactiveUI.Primitives.Extensions.Core/Operators/SubscribeAsyncObservable.cs
@@ -8,7 +8,7 @@ namespace ReactiveUI.Primitives.Extensions.Operators;
 
 /// <summary>Subscribes to an observable sequence and executes an asynchronous handler for each element.</summary>
 /// <typeparam name="T">The type of elements in the source sequence.</typeparam>
-[System.Diagnostics.DebuggerDisplay("Queued = {_queue.Count}, Processing = {_isProcessing}, Done = {_done}")]
+[System.Diagnostics.DebuggerDisplay("SubscribeAsyncObservable: Queued = {_queue.Count}, Processing = {_isProcessing}, Done = {_done}")]
 public sealed class SubscribeAsyncObservable<T> : IDisposable
 {
     /// <summary>The gate for state access.</summary>

--- a/src/ReactiveUI.Primitives.Extensions.Core/Stale.cs
+++ b/src/ReactiveUI.Primitives.Extensions.Core/Stale.cs
@@ -11,7 +11,7 @@ namespace ReactiveUI.Primitives.Extensions;
 /// <c>new Stale&lt;T&gt;()</c> to construct a staleness signal.
 /// </summary>
 /// <typeparam name="T">The type of the update value.</typeparam>
-[System.Diagnostics.DebuggerDisplay("IsStale = {IsStale}")]
+[System.Diagnostics.DebuggerDisplay("Stale: IsStale = {IsStale}")]
 public readonly record struct Stale<T> : IStale<T>
 {
     /// <summary>Initializes a new instance of the <see cref="Stale{T}"/> struct representing a stale signal.</summary>

--- a/src/ReactiveUI.Primitives.Extensions.Core/TimerSinkState.cs
+++ b/src/ReactiveUI.Primitives.Extensions.Core/TimerSinkState.cs
@@ -22,7 +22,7 @@ namespace ReactiveUI.Primitives.Extensions;
         "The timer's lifetime is owned by the parent operator sink, which releases it under its own gate through "
         + "HandleErrorLocked/HandleCompletedLocked/HandleDisposeLocked. This state object is deliberately not independently "
         + "IDisposable: adding IDisposable would expose an ungated disposal path that races the sink's gate.")]
-[System.Diagnostics.DebuggerDisplay("Done = {Done}, Timer = {Timer}")]
+[System.Diagnostics.DebuggerDisplay("TimerSinkState: Done = {Done}, Timer = {Timer}")]
 public sealed class TimerSinkState<T>(IObserver<T> downstream)
 {
     /// <summary>Gets the timer slot used by the operator's OnNext logic to schedule deferred emissions.</summary>

--- a/src/ReactiveUI.Primitives.Maui.Reactive/Concurrency/MauiDispatcherSequencer.cs
+++ b/src/ReactiveUI.Primitives.Maui.Reactive/Concurrency/MauiDispatcherSequencer.cs
@@ -9,7 +9,7 @@ namespace ReactiveUI.Primitives.Reactive.Concurrency;
 
 /// <summary>MAUI dispatcher scheduler that coalesces scheduled work through an <see cref="IDispatcher"/>.</summary>
 /// <seealso cref="System.Reactive.Concurrency.IScheduler" />
-[System.Diagnostics.DebuggerDisplay("Dispatcher = {Dispatcher}")]
+[System.Diagnostics.DebuggerDisplay("MauiDispatcherSequencer: Dispatcher = {Dispatcher}")]
 public sealed class MauiDispatcherSequencer : CoalescingDispatchScheduler
 {
     /// <summary>Initializes a new instance of the <see cref="MauiDispatcherSequencer"/> class.</summary>

--- a/src/ReactiveUI.Primitives.Maui.Reactive/PublicAPI/net10.0/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Maui.Reactive/PublicAPI/net10.0/PublicAPI.txt
@@ -1,7 +1,7 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Primitives.Maui.Reactive.Tests")]
 namespace ReactiveUI.Primitives.Reactive.Concurrency;
 
-[System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
+[System.Diagnostics.DebuggerDisplay("CoalescingDispatchScheduler: ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
 public abstract class CoalescingDispatchScheduler : System.Reactive.Concurrency.LocalScheduler
 {
     protected CoalescingDispatchScheduler() { }
@@ -12,7 +12,7 @@ public abstract class CoalescingDispatchScheduler : System.Reactive.Concurrency.
     public override System.IDisposable Schedule<TState>(TState state, System.TimeSpan dueTime, System.Func<System.Reactive.Concurrency.IScheduler, TState, System.IDisposable> action) { }
     protected virtual System.IDisposable ScheduleOnDispatcher(System.Action work, System.TimeSpan dueTime) { }
 }
-[System.Diagnostics.DebuggerDisplay("Dispatcher = {Dispatcher}")]
+[System.Diagnostics.DebuggerDisplay("MauiDispatcherSequencer: Dispatcher = {Dispatcher}")]
 public sealed class MauiDispatcherSequencer : ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler
 {
     public MauiDispatcherSequencer(Microsoft.Maui.Dispatching.IDispatcher dispatcher) { }

--- a/src/ReactiveUI.Primitives.Maui.Reactive/PublicAPI/net11.0/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Maui.Reactive/PublicAPI/net11.0/PublicAPI.txt
@@ -1,7 +1,7 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Primitives.Maui.Reactive.Tests")]
 namespace ReactiveUI.Primitives.Reactive.Concurrency;
 
-[System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
+[System.Diagnostics.DebuggerDisplay("CoalescingDispatchScheduler: ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
 public abstract class CoalescingDispatchScheduler : System.Reactive.Concurrency.LocalScheduler
 {
     protected CoalescingDispatchScheduler() { }
@@ -12,7 +12,7 @@ public abstract class CoalescingDispatchScheduler : System.Reactive.Concurrency.
     public override System.IDisposable Schedule<TState>(TState state, System.TimeSpan dueTime, System.Func<System.Reactive.Concurrency.IScheduler, TState, System.IDisposable> action) { }
     protected virtual System.IDisposable ScheduleOnDispatcher(System.Action work, System.TimeSpan dueTime) { }
 }
-[System.Diagnostics.DebuggerDisplay("Dispatcher = {Dispatcher}")]
+[System.Diagnostics.DebuggerDisplay("MauiDispatcherSequencer: Dispatcher = {Dispatcher}")]
 public sealed class MauiDispatcherSequencer : ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler
 {
     public MauiDispatcherSequencer(Microsoft.Maui.Dispatching.IDispatcher dispatcher) { }

--- a/src/ReactiveUI.Primitives.Reactive/Concurrency/WasmScheduler.cs
+++ b/src/ReactiveUI.Primitives.Reactive/Concurrency/WasmScheduler.cs
@@ -17,7 +17,7 @@ namespace ReactiveUI.Primitives.Reactive.Concurrency;
 /// backs with the JS event loop. Successor to the retired <c>Reactive.Wasm</c> package's scheduler, whose runtime
 /// reflection no longer exists on modern .NET.
 /// </summary>
-[System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainState = {_drainState}, Disposed = {_isDisposed}")]
+[System.Diagnostics.DebuggerDisplay("WasmScheduler: ReadyCount = {_readyCount}, DrainState = {_drainState}, Disposed = {_isDisposed}")]
 public sealed class WasmScheduler : LocalScheduler, ISchedulerPeriodic, IDisposable
 {
     /// <summary>Drain state indicating no drain is in flight.</summary>

--- a/src/ReactiveUI.Primitives.Reactive/Disposables/ContainerDisposable.cs
+++ b/src/ReactiveUI.Primitives.Reactive/Disposables/ContainerDisposable.cs
@@ -24,7 +24,7 @@ namespace ReactiveUI.Primitives.Reactive.Disposables;
 /// and <c>Contains</c>/<c>Remove</c> do not see through it.
 /// </para>
 /// </remarks>
-[System.Diagnostics.DebuggerDisplay("Count = {Count}, IsDisposed = {IsDisposed}")]
+[System.Diagnostics.DebuggerDisplay("ContainerDisposable: Count = {Count}, IsDisposed = {IsDisposed}")]
 public sealed class ContainerDisposable : MultipleDisposable
 {
     /// <summary>Serializes creation of the composite.</summary>

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-android/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-android/PublicAPI.txt
@@ -849,7 +849,7 @@ namespace ReactiveUI.Primitives.Reactive
 }
 namespace ReactiveUI.Primitives.Reactive.Advanced
 {
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Period = {_period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSignal: DueTime = {_dueTime}, Period = {_period}")]
     public sealed class AfterSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
     {
         public AfterSignal(System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -857,7 +857,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<long> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSubscription: Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
     public sealed class AfterSubscription : System.IDisposable
     {
         public AfterSubscription(System.IObserver<long> observer, System.Reactive.Concurrency.IScheduler scheduler, System.TimeSpan dueTime, System.TimeSpan? period) { }
@@ -865,21 +865,21 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.AfterSubscription Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("SubscribeAsync = {SubscribeAsync}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncCreateSignal: SubscribeAsync = {SubscribeAsync}")]
     public sealed class AsyncCreateSignal<T> : System.IObservable<T>
     {
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ObservableFactory = {ObservableFactory}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncDeferSignal: ObservableFactory = {ObservableFactory}")]
     public sealed class AsyncDeferSignal<T> : System.IObservable<T>
     {
         public AsyncDeferSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public AsyncDeferSignal(System.Func<System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncSubscriptionLifetime: Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
     public sealed class AsyncSubscriptionLifetime : System.IDisposable
     {
         public AsyncSubscriptionLifetime() { }
@@ -890,33 +890,33 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable? disposable) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connected = {_connected}")]
+    [System.Diagnostics.DebuggerDisplay("AutoConnectSignal: Count = {_count}, Connected = {_connected}")]
     public sealed class AutoConnectSignal<T> : System.IObservable<T>
     {
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount) { }
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount, System.Action<System.IDisposable>? onConnect) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connection = {_connection}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSignal: Count = {_count}, Connection = {_connection}")]
     public sealed class AutoShareSignal<T> : System.IObservable<T>
     {
         public AutoShareSignal(ReactiveUI.Primitives.ConnectableSignal<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Owner = {_owner}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSubscription: Owner = {_owner}, Subscription = {Subscription}")]
     public sealed class AutoShareSubscription<T> : System.IDisposable
     {
         public AutoShareSubscription(ReactiveUI.Primitives.Reactive.Advanced.AutoShareSignal<T> owner, System.IDisposable subscription) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void Dispose() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("BlendSignal: Sources = {Sources}")]
     public sealed class BlendSignal<T> : System.IObservable<T>
     {
         public BlendSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("BlendWitness: ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
     public sealed class BlendWitness<T> : System.IDisposable
     {
         public BlendWitness(System.IObserver<T> observer) { }
@@ -925,7 +925,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.BlendWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.BlendWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("BufferEachWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class BufferEachWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public BufferEachWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -939,20 +939,20 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Window = {Window}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("BufferSignal: Window = {Window}, Source = {Source}")]
     public sealed class BufferSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public BufferSignal(System.IObservable<T> source, System.TimeSpan timeSpan, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("CastSignal: Source = {Source}")]
     public sealed class CastSignal<TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public CastSignal(System.IObservable<object?> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CastWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CastWitness<TResult> : System.IDisposable, System.IObserver<object?>
     {
         public CastWitness(System.IObserver<TResult> observer) { }
@@ -966,7 +966,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
+    [System.Diagnostics.DebuggerDisplay("ChainSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
     public sealed class ChainSignal<T> : System.IObservable<T>
     {
         public ChainSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -974,7 +974,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ChainSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("ChainWitness: IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
     public sealed class ChainWitness<T> : System.IDisposable
     {
         public ChainWitness(System.IObserver<T> observer) { }
@@ -984,13 +984,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.ChainWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.ChainWitness<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, TimeSpan = {TimeSpan}")]
+    [System.Diagnostics.DebuggerDisplay("CollectSignal: Source = {Source}, TimeSpan = {TimeSpan}")]
     public sealed class CollectSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public CollectSignal(System.IObservable<T> source, System.TimeSpan timeSpan, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Buffered = {Values.Count}")]
+    [System.Diagnostics.DebuggerDisplay("CollectWitness: Stopped = {_stopped}, Buffered = {Values.Count}")]
     public sealed class CollectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CollectWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -1002,7 +1002,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateSink: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class CreateSink<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateSink(System.IObserver<T> observer, bool disposeOnNextThrow) { }
@@ -1014,7 +1014,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CreateWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateWitness(System.IObserver<T> observer) { }
@@ -1028,13 +1028,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {DueTime}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietSignal: DueTime = {DueTime}, Source = {Source}")]
     public sealed class EmitIfQuietSignal<T> : System.IObservable<T>
     {
         public EmitIfQuietSignal(System.IObservable<T> source, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietWitness: HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
     public sealed class EmitIfQuietWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public EmitIfQuietWitness(System.IObserver<T> observer, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer) { }
@@ -1045,7 +1045,16 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("EmptySignal: Scheduler = {_scheduler}")]
+    public sealed class EmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public EmptySignal(System.Reactive.Concurrency.IScheduler scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("EnumerableBlendSignal: Sources = {Sources}")]
     public sealed class EnumerableBlendSignal<T> : System.IObservable<T>
     {
         public EnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -1055,7 +1064,14 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
     {
         public static System.IDisposable Attach<TEventHandler>(TEventHandler handler, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Reactive.Concurrency.IScheduler? scheduler) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
+    [System.Diagnostics.DebuggerDisplay("EverySignal: Period = {_period}, Scheduler = {_scheduler}")]
+    public sealed class EverySignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
+    {
+        public EverySignal(System.TimeSpan period, System.Reactive.Concurrency.IScheduler scheduler) { }
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<long> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ExpireCoordinator: Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
     public sealed class ExpireCoordinator<T> : System.IDisposable, System.IObserver<T>
     {
         public ExpireCoordinator(System.IObservable<T> source, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer, System.IObserver<T> observer) { }
@@ -1065,39 +1081,48 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnNext(T value) { }
         public ReactiveUI.Primitives.Reactive.Advanced.ExpireCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("ExpireSignal: DueTime = {_dueTime}, Source = {_source}")]
     public sealed class ExpireSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ExpireSignal(System.IObservable<T> source, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("FinallySignal: Source = {_source}")]
+    public sealed class FinallySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public FinallySignal(System.IObservable<T> source, System.Action finallyAction) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ForkJoinSignal: Left = {Left}, Right = {Right}")]
     public sealed class ForkJoinSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public ForkJoinSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("ForkJoinWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
     public sealed class ForkJoinWitness<TLeft, TRight, TResult>
     {
         public ForkJoinWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("CancellationRequested = {CancellationToken.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncExternalCancellationSignal: CancellationRequested = {CancellationToken.IsCancellationRequested}")]
     public sealed class FromAsyncExternalCancellationSignal<T> : System.IObservable<T>
     {
         public FromAsyncExternalCancellationSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSignal: TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
     public sealed class FromAsyncSignal<T> : System.IObservable<T>
     {
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSubscription: Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
     public sealed class FromAsyncSubscription<T> : System.IDisposable
     {
         public FromAsyncSubscription(System.IObserver<T> observer, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
@@ -1110,14 +1135,14 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public FromEventConversionSignal(System.Func<TCallback, TEventHandler> conversion, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Func<System.IObserver<TResult>, TCallback> callback, System.Reactive.Concurrency.IScheduler? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
+    [System.Diagnostics.DebuggerDisplay("FromEventPatternSignal: AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
     public sealed class FromEventPatternSignal<TEventHandler, TEventArgs> : System.IObservable<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> where TEventHandler : System.Delegate where TEventArgs : System.EventArgs
     {
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler) { }
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Reactive.Concurrency.IScheduler? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Disposed = {_disposed}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("GuardedWitness: Disposed = {_disposed}, Observer = {_observer}")]
     public sealed class GuardedWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public GuardedWitness(System.IObserver<T> observer, System.IDisposable cancel) { }
@@ -1127,7 +1152,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IgnoreValuesSignal: Source = {Source}")]
     public sealed class IgnoreValuesSignal<T> : System.IObservable<T>
     {
         public IgnoreValuesSignal(System.IObservable<T> source) { }
@@ -1141,14 +1166,14 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public System.IDisposable Subscribe(System.IObserver<System.Reactive.Unit> observer) { }
         public System.IDisposable Subscribe(System.Action<System.Reactive.Unit> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptySignal: Source = {Source}")]
     public sealed class IsEmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<bool>
     {
         public IsEmptySignal(System.IObservable<T> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<bool> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptyWitness: Stopped = {_stopped}, Subscription = {Subscription}")]
     public sealed class IsEmptyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public IsEmptyWitness(System.IObserver<bool> observer) { }
@@ -1161,14 +1186,23 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {Value}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("LeadSignal: Value = {Value}, Source = {Source}")]
     public sealed class LeadSignal<T> : ReactiveUI.Primitives.Advanced.IInlineSignal<T>
     {
         public LeadSignal(System.IObservable<T> source, T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
         public System.IDisposable Subscribe(System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("LoopSignal: Value = {Value}")]
+    public sealed class LoopSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public LoopSignal(T value) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("MapIndexedSignal: Source = {_source}")]
     public sealed class MapIndexedSignal<TSource, TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public MapIndexedSignal(System.IObservable<TSource> source, System.Func<TSource, int, TResult> selector) { }
@@ -1176,7 +1210,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Index = {_index}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("MapIndexedWitness: Index = {_index}, Stopped = {_stopped}")]
     public sealed class MapIndexedWitness<TSource, TResult> : System.IObserver<TSource>
     {
         public MapIndexedWitness(System.IObserver<TResult> observer, System.Func<TSource, int, TResult> selector) { }
@@ -1184,20 +1218,20 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(TSource value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentBlendCoordinator: Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
     public sealed class MaxConcurrentBlendCoordinator<T> : System.IDisposable
     {
         public MaxConcurrentBlendCoordinator(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.MaxConcurrentBlendCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentEnumerableBlendSignal: Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
     public sealed class MaxConcurrentEnumerableBlendSignal<T> : System.IObservable<T>
     {
         public MaxConcurrentEnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("MergeCoordinator: Active = {Active}, Done = {Done}")]
     public sealed class MergeCoordinator<T> : System.IDisposable
     {
         public MergeCoordinator(System.IObserver<T> observer) { }
@@ -1208,7 +1242,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.MergeCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.MergeCoordinator<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MergeSignal: Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
     public sealed class MergeSignal<T> : System.IObservable<T>
     {
         public MergeSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -1216,32 +1250,39 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public MergeSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("OnErrorResumeNextSignal: Sources = {_sources}")]
+    public sealed class OnErrorResumeNextSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("PairSignal: Left = {Left}, Right = {Right}")]
     public sealed class PairSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public PairSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
+    [System.Diagnostics.DebuggerDisplay("PairWitness: IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
     public sealed class PairWitness<TLeft, TRight, TResult>
     {
         public PairWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("PublishSelectorSignal: Source = {Source}, Selector = {Selector}")]
     public sealed class PublishSelectorSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public PublishSelectorSignal(System.IObservable<TSource> source, System.Func<System.IObservable<TSource>, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
+    [System.Diagnostics.DebuggerDisplay("RaceSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
     public sealed class RaceSignal<T> : System.IObservable<T>
     {
         public RaceSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public RaceSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Arms = {_arms}")]
+    [System.Diagnostics.DebuggerDisplay("RaceWitness: Arms = {_arms}")]
     public sealed class RaceWitness<T> : System.IDisposable
     {
         public RaceWitness(System.IObserver<T> observer) { }
@@ -1250,40 +1291,48 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.RaceWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.RaceWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeCombineLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeCombineLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeCombineLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
+    [System.Diagnostics.DebuggerDisplay("RangeForkJoinSignal: Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
     public sealed class RangeForkJoinSignal<TResult> : System.IObservable<TResult>
     {
         public RangeForkJoinSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeSyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeSyncLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeSyncLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeWithLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeWithLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeWithLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Remaining = {_remaining}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("RecoverSignal: Source = {_source}")]
+    public sealed class RecoverSignal<T, TException> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T> where TException : System.Exception
+    {
+        public RecoverSignal(System.IObservable<T> source, System.Func<TException, System.IObservable<T>> handler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceCoordinator: Remaining = {_remaining}, Disposed = {_disposed}")]
     public sealed class RepeatSourceCoordinator<T> : System.IDisposable
     {
         public RepeatSourceCoordinator(System.IObservable<T> source, int? repeatCount, System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.RepeatSourceCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, RepeatCount = {_repeatCount}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceSignal: Source = {_source}, RepeatCount = {_repeatCount}")]
     public sealed class RepeatSourceSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public RepeatSourceSignal(System.IObservable<T> source, int? repeatCount) { }
@@ -1291,7 +1340,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Generation = {_generation}, Terminated = {_terminated}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceWitness: Generation = {_generation}, Terminated = {_terminated}")]
     public sealed class RepeatSourceWitness<T> : System.IObserver<T>
     {
         public RepeatSourceWitness(ReactiveUI.Primitives.Reactive.Advanced.RepeatSourceCoordinator<T> parent, int generation) { }
@@ -1299,7 +1348,15 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_value}, Scheduler = {_scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ResumeSignal: Source = {_source}, Fallback = {_fallback}")]
+    public sealed class ResumeSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ResumeSignal(System.IObservable<T> source, System.IObservable<T> fallback) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ReturnSignal: Value = {_value}, Scheduler = {_scheduler}")]
     public sealed class ReturnSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ReturnSignal(T value, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -1308,13 +1365,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Values = {Values}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledEnumerableSignal: Values = {Values}, Scheduler = {Scheduler}")]
     public sealed class ScheduledEnumerableSignal<T> : System.IObservable<T>
     {
         public ScheduledEnumerableSignal(System.Collections.Generic.IEnumerable<T> values, System.Reactive.Concurrency.IScheduler scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyCoordinator<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TResult>> selector) { }
@@ -1328,13 +1385,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Reactive.Advanced.SelectManyCoordinator<TSource, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableSignal: Source = {_source}")]
     public sealed class SelectManyEnumerableSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManyEnumerableSignal(System.IObservable<TSource> source, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SelectManyEnumerableWitness<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyEnumerableWitness(System.IObserver<TResult> observer, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
@@ -1348,7 +1405,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyResultCoordinator<TSource, TCollection, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyResultCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
@@ -1361,20 +1418,20 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Reactive.Advanced.SelectManyResultCoordinator<TSource, TCollection, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, CollectionSelector = {CollectionSelector}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultSignal: Source = {Source}, CollectionSelector = {CollectionSelector}")]
     public sealed class SelectManyResultSignal<TSource, TCollection, TResult> : System.IObservable<TResult>
     {
         public SelectManyResultSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManySignal: Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
     public sealed class SelectManySignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManySignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public SelectManySignal(System.IObservable<TSource> source, System.IObservable<TResult> inner) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Start = {Start}, Count = {Count}")]
+    [System.Diagnostics.DebuggerDisplay("SequenceSignal: Start = {Start}, Count = {Count}")]
     public sealed class SequenceSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<int>
     {
         public SequenceSignal(int start, int count, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -1385,13 +1442,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
     {
         public static System.IDisposable Subscribe<T>(System.IObserver<T> observer, bool currentThreadRequired, System.Func<System.IObserver<T>, System.IDisposable, System.IDisposable> subscribeCore) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SparkSignal: Source = {Source}")]
     public sealed class SparkSignal<T> : System.IObservable<ReactiveUI.Primitives.Reactive.Core.Spark<T>>
     {
         public SparkSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Reactive.Core.Spark<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SparkWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SparkWitness(System.IObserver<ReactiveUI.Primitives.Reactive.Core.Spark<T>> observer) { }
@@ -1406,21 +1463,21 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Action = {Action}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Action = {Action}, Scheduler = {Scheduler}")]
     public sealed class StartSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<System.Reactive.Unit>
     {
         public StartSignal(System.Action action, System.Reactive.Concurrency.IScheduler scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<System.Reactive.Unit> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Function = {Function}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Function = {Function}, Scheduler = {Scheduler}")]
     public sealed class StartSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public StartSignal(System.Func<T> function, System.Reactive.Concurrency.IScheduler scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SubscribeSafeWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SubscribeSafeWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SubscribeSafeWitness(System.IObserver<T> observer) { }
@@ -1434,50 +1491,50 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, SkipNullSources = {_skipNullSources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchMapSignal: Source = {_source}, SkipNullSources = {_skipNullSources}")]
     public sealed class SwitchMapSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SwitchMapSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchSignal: Sources = {Sources}")]
     public sealed class SwitchSignal<T> : System.IObservable<T>
     {
         public SwitchSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Version = {_version}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchWitness: Version = {_version}, IsDone = {IsDone}")]
     public sealed class SwitchWitness<T> : System.IDisposable
     {
         public SwitchWitness(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.SwitchWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class SyncLatestSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public SyncLatestSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
     public sealed class SyncLatestWitness<TLeft, TRight, TResult>
     {
         public SyncLatestWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Gate = {Gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeGateSignal: Source = {Source}, Gate = {Gate}")]
     public sealed class SynchronizeGateSignal<T> : System.IObservable<T>
     {
         public SynchronizeGateSignal(System.IObservable<T> source, System.Threading.Lock gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, Gate = {_gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectSignal: Source = {_source}, Gate = {_gate}")]
     public sealed class SynchronizeObjectSignal<T> : System.IObservable<T>
     {
         public SynchronizeObjectSignal(System.IObservable<T> source, object gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SynchronizeObjectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SynchronizeObjectWitness(System.IObserver<T> observer, object gate) { }
@@ -1489,19 +1546,19 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeSignal: Source = {Source}")]
     public sealed class SynchronizeSignal<T> : System.IObservable<T>
     {
         public SynchronizeSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("TapSignal: Source = {Source}")]
     public sealed class TapSignal<T> : System.IObservable<T>
     {
         public TapSignal(System.IObservable<T> source, System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskAnyWitness: Stopped = {_stopped}, Task = {Task}")]
     public sealed class TaskAnyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskAnyWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1517,7 +1574,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainCoordinator: Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
     public sealed class TaskChainCoordinator<T> : System.IDisposable
     {
         public TaskChainCoordinator(System.IObserver<T> observer) { }
@@ -1525,13 +1582,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.TaskChainCoordinator<T> Run(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainSignal: Sources = {_sources}")]
     public sealed class TaskChainSignal<T> : System.IObservable<T>
     {
         public TaskChainSignal(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskCountWitness: Count = {_count}, Stopped = {_stopped}")]
     public sealed class TaskCountWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskCountWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1547,13 +1604,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSignal: Task = {Task}")]
     public sealed class TaskInstanceSignal<T> : System.IObservable<T>
     {
         public TaskInstanceSignal(System.Threading.Tasks.Task<T> task) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSubscription: Stopped = {_stopped}")]
     public sealed class TaskInstanceSubscription : System.IDisposable
     {
         public TaskInstanceSubscription() { }
@@ -1561,13 +1618,22 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void Dispose() { }
         public bool TryStop() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Sequencer = {Sequencer}")]
+    [System.Diagnostics.DebuggerDisplay("ThrowSignal: Error = {_error}, Scheduler = {_scheduler}")]
+    public sealed class ThrowSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ThrowSignal(System.Exception error, System.Reactive.Concurrency.IScheduler scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalSignal: Source = {Source}, Sequencer = {Sequencer}")]
     public sealed class TimeIntervalSignal<T> : System.IObservable<ReactiveUI.Primitives.Core.TimeInterval<T>>
     {
         public TimeIntervalSignal(System.IObservable<T> source, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("First = {_first}, Last = {_last}")]
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalWitness: First = {_first}, Last = {_last}")]
     public sealed class TimeIntervalWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TimeIntervalWitness(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -1585,13 +1651,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
     {
         public static void Arm(ReactiveUI.Primitives.Disposables.SingleReplaceableDisposable slot, System.Reactive.Concurrency.IScheduler sequencer, System.TimeSpan delay, System.Action tick) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkSignal: Source = {Source}")]
     public sealed class UnsparkSignal<T> : System.IObservable<T>
     {
         public UnsparkSignal(System.IObservable<ReactiveUI.Primitives.Reactive.Core.Spark<T>> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class UnsparkWitness<T> : System.IDisposable, System.IObserver<ReactiveUI.Primitives.Reactive.Core.Spark<T>>
     {
         public UnsparkWitness(System.IObserver<T> observer) { }
@@ -1609,7 +1675,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
 }
 namespace ReactiveUI.Primitives.Reactive.Concurrency
 {
-    [System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
+    [System.Diagnostics.DebuggerDisplay("CoalescingDispatchScheduler: ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
     public abstract class CoalescingDispatchScheduler : System.Reactive.Concurrency.LocalScheduler
     {
         protected CoalescingDispatchScheduler() { }
@@ -1636,7 +1702,7 @@ namespace ReactiveUI.Primitives.Reactive.Concurrency
         public static ReactiveUI.Primitives.Concurrency.ScheduledItem<TAbsolute> Create<TAbsolute, TValue>(System.Reactive.Concurrency.IScheduler scheduler, TValue state, System.Func<System.Reactive.Concurrency.IScheduler, TValue, System.IDisposable> action, TAbsolute dueTime) where TAbsolute : System.IComparable<TAbsolute> { }
         public static ReactiveUI.Primitives.Concurrency.ScheduledItem<TAbsolute> Create<TAbsolute, TValue>(System.Reactive.Concurrency.IScheduler scheduler, TValue state, System.Func<System.Reactive.Concurrency.IScheduler, TValue, System.IDisposable> action, TAbsolute dueTime, System.Collections.Generic.IComparer<TAbsolute> comparer) where TAbsolute : System.IComparable<TAbsolute> { }
     }
-    [System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainState = {_drainState}, Disposed = {_isDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("WasmScheduler: ReadyCount = {_readyCount}, DrainState = {_drainState}, Disposed = {_isDisposed}")]
     public sealed class WasmScheduler : System.Reactive.Concurrency.LocalScheduler, System.IDisposable, System.Reactive.Concurrency.ISchedulerPeriodic
     {
         public static ReactiveUI.Primitives.Reactive.Concurrency.WasmScheduler Default { get; }
@@ -1678,7 +1744,7 @@ namespace ReactiveUI.Primitives.Reactive.Core
 }
 namespace ReactiveUI.Primitives.Reactive.Disposables
 {
-    [System.Diagnostics.DebuggerDisplay("Count = {Count}, IsDisposed = {IsDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ContainerDisposable: Count = {Count}, IsDisposed = {IsDisposed}")]
     public sealed class ContainerDisposable : ReactiveUI.Primitives.Disposables.MultipleDisposable
     {
         public ContainerDisposable() { }
@@ -1692,7 +1758,7 @@ namespace ReactiveUI.Primitives.Reactive.Disposables
 }
 namespace ReactiveUI.Primitives.Reactive.Signals
 {
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
+    [System.Diagnostics.DebuggerDisplay("PrioritySemaphoreSignal: Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
     public sealed class PrioritySemaphoreSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T> where T : System.IComparable<T>
     {
         public PrioritySemaphoreSignal(int maxCount) { }
@@ -1727,7 +1793,7 @@ namespace ReactiveUI.Primitives.Reactive.Signals
         public void OnNext(T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledSignal: Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
     public class ScheduledSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T>
     {
         public ScheduledSignal(System.Reactive.Concurrency.IScheduler scheduler) { }

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-ios/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-ios/PublicAPI.txt
@@ -845,7 +845,7 @@ namespace ReactiveUI.Primitives.Reactive
 }
 namespace ReactiveUI.Primitives.Reactive.Advanced
 {
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Period = {_period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSignal: DueTime = {_dueTime}, Period = {_period}")]
     public sealed class AfterSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
     {
         public AfterSignal(System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -853,7 +853,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<long> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSubscription: Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
     public sealed class AfterSubscription : System.IDisposable
     {
         public AfterSubscription(System.IObserver<long> observer, System.Reactive.Concurrency.IScheduler scheduler, System.TimeSpan dueTime, System.TimeSpan? period) { }
@@ -861,21 +861,21 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.AfterSubscription Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("SubscribeAsync = {SubscribeAsync}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncCreateSignal: SubscribeAsync = {SubscribeAsync}")]
     public sealed class AsyncCreateSignal<T> : System.IObservable<T>
     {
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ObservableFactory = {ObservableFactory}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncDeferSignal: ObservableFactory = {ObservableFactory}")]
     public sealed class AsyncDeferSignal<T> : System.IObservable<T>
     {
         public AsyncDeferSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public AsyncDeferSignal(System.Func<System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncSubscriptionLifetime: Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
     public sealed class AsyncSubscriptionLifetime : System.IDisposable
     {
         public AsyncSubscriptionLifetime() { }
@@ -886,33 +886,33 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable? disposable) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connected = {_connected}")]
+    [System.Diagnostics.DebuggerDisplay("AutoConnectSignal: Count = {_count}, Connected = {_connected}")]
     public sealed class AutoConnectSignal<T> : System.IObservable<T>
     {
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount) { }
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount, System.Action<System.IDisposable>? onConnect) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connection = {_connection}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSignal: Count = {_count}, Connection = {_connection}")]
     public sealed class AutoShareSignal<T> : System.IObservable<T>
     {
         public AutoShareSignal(ReactiveUI.Primitives.ConnectableSignal<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Owner = {_owner}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSubscription: Owner = {_owner}, Subscription = {Subscription}")]
     public sealed class AutoShareSubscription<T> : System.IDisposable
     {
         public AutoShareSubscription(ReactiveUI.Primitives.Reactive.Advanced.AutoShareSignal<T> owner, System.IDisposable subscription) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void Dispose() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("BlendSignal: Sources = {Sources}")]
     public sealed class BlendSignal<T> : System.IObservable<T>
     {
         public BlendSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("BlendWitness: ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
     public sealed class BlendWitness<T> : System.IDisposable
     {
         public BlendWitness(System.IObserver<T> observer) { }
@@ -921,7 +921,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.BlendWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.BlendWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("BufferEachWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class BufferEachWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public BufferEachWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -935,20 +935,20 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Window = {Window}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("BufferSignal: Window = {Window}, Source = {Source}")]
     public sealed class BufferSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public BufferSignal(System.IObservable<T> source, System.TimeSpan timeSpan, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("CastSignal: Source = {Source}")]
     public sealed class CastSignal<TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public CastSignal(System.IObservable<object?> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CastWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CastWitness<TResult> : System.IDisposable, System.IObserver<object?>
     {
         public CastWitness(System.IObserver<TResult> observer) { }
@@ -962,7 +962,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
+    [System.Diagnostics.DebuggerDisplay("ChainSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
     public sealed class ChainSignal<T> : System.IObservable<T>
     {
         public ChainSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -970,7 +970,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ChainSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("ChainWitness: IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
     public sealed class ChainWitness<T> : System.IDisposable
     {
         public ChainWitness(System.IObserver<T> observer) { }
@@ -980,13 +980,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.ChainWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.ChainWitness<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, TimeSpan = {TimeSpan}")]
+    [System.Diagnostics.DebuggerDisplay("CollectSignal: Source = {Source}, TimeSpan = {TimeSpan}")]
     public sealed class CollectSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public CollectSignal(System.IObservable<T> source, System.TimeSpan timeSpan, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Buffered = {Values.Count}")]
+    [System.Diagnostics.DebuggerDisplay("CollectWitness: Stopped = {_stopped}, Buffered = {Values.Count}")]
     public sealed class CollectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CollectWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -998,7 +998,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateSink: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class CreateSink<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateSink(System.IObserver<T> observer, bool disposeOnNextThrow) { }
@@ -1010,7 +1010,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CreateWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateWitness(System.IObserver<T> observer) { }
@@ -1024,13 +1024,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {DueTime}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietSignal: DueTime = {DueTime}, Source = {Source}")]
     public sealed class EmitIfQuietSignal<T> : System.IObservable<T>
     {
         public EmitIfQuietSignal(System.IObservable<T> source, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietWitness: HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
     public sealed class EmitIfQuietWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public EmitIfQuietWitness(System.IObserver<T> observer, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer) { }
@@ -1041,7 +1041,16 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("EmptySignal: Scheduler = {_scheduler}")]
+    public sealed class EmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public EmptySignal(System.Reactive.Concurrency.IScheduler scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("EnumerableBlendSignal: Sources = {Sources}")]
     public sealed class EnumerableBlendSignal<T> : System.IObservable<T>
     {
         public EnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -1051,7 +1060,14 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
     {
         public static System.IDisposable Attach<TEventHandler>(TEventHandler handler, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Reactive.Concurrency.IScheduler? scheduler) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
+    [System.Diagnostics.DebuggerDisplay("EverySignal: Period = {_period}, Scheduler = {_scheduler}")]
+    public sealed class EverySignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
+    {
+        public EverySignal(System.TimeSpan period, System.Reactive.Concurrency.IScheduler scheduler) { }
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<long> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ExpireCoordinator: Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
     public sealed class ExpireCoordinator<T> : System.IDisposable, System.IObserver<T>
     {
         public ExpireCoordinator(System.IObservable<T> source, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer, System.IObserver<T> observer) { }
@@ -1061,39 +1077,48 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnNext(T value) { }
         public ReactiveUI.Primitives.Reactive.Advanced.ExpireCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("ExpireSignal: DueTime = {_dueTime}, Source = {_source}")]
     public sealed class ExpireSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ExpireSignal(System.IObservable<T> source, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("FinallySignal: Source = {_source}")]
+    public sealed class FinallySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public FinallySignal(System.IObservable<T> source, System.Action finallyAction) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ForkJoinSignal: Left = {Left}, Right = {Right}")]
     public sealed class ForkJoinSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public ForkJoinSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("ForkJoinWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
     public sealed class ForkJoinWitness<TLeft, TRight, TResult>
     {
         public ForkJoinWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("CancellationRequested = {CancellationToken.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncExternalCancellationSignal: CancellationRequested = {CancellationToken.IsCancellationRequested}")]
     public sealed class FromAsyncExternalCancellationSignal<T> : System.IObservable<T>
     {
         public FromAsyncExternalCancellationSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSignal: TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
     public sealed class FromAsyncSignal<T> : System.IObservable<T>
     {
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSubscription: Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
     public sealed class FromAsyncSubscription<T> : System.IDisposable
     {
         public FromAsyncSubscription(System.IObserver<T> observer, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
@@ -1106,14 +1131,14 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public FromEventConversionSignal(System.Func<TCallback, TEventHandler> conversion, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Func<System.IObserver<TResult>, TCallback> callback, System.Reactive.Concurrency.IScheduler? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
+    [System.Diagnostics.DebuggerDisplay("FromEventPatternSignal: AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
     public sealed class FromEventPatternSignal<TEventHandler, TEventArgs> : System.IObservable<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> where TEventHandler : System.Delegate where TEventArgs : System.EventArgs
     {
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler) { }
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Reactive.Concurrency.IScheduler? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Disposed = {_disposed}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("GuardedWitness: Disposed = {_disposed}, Observer = {_observer}")]
     public sealed class GuardedWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public GuardedWitness(System.IObserver<T> observer, System.IDisposable cancel) { }
@@ -1123,7 +1148,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IgnoreValuesSignal: Source = {Source}")]
     public sealed class IgnoreValuesSignal<T> : System.IObservable<T>
     {
         public IgnoreValuesSignal(System.IObservable<T> source) { }
@@ -1137,14 +1162,14 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public System.IDisposable Subscribe(System.IObserver<System.Reactive.Unit> observer) { }
         public System.IDisposable Subscribe(System.Action<System.Reactive.Unit> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptySignal: Source = {Source}")]
     public sealed class IsEmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<bool>
     {
         public IsEmptySignal(System.IObservable<T> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<bool> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptyWitness: Stopped = {_stopped}, Subscription = {Subscription}")]
     public sealed class IsEmptyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public IsEmptyWitness(System.IObserver<bool> observer) { }
@@ -1157,14 +1182,23 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {Value}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("LeadSignal: Value = {Value}, Source = {Source}")]
     public sealed class LeadSignal<T> : ReactiveUI.Primitives.Advanced.IInlineSignal<T>
     {
         public LeadSignal(System.IObservable<T> source, T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
         public System.IDisposable Subscribe(System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("LoopSignal: Value = {Value}")]
+    public sealed class LoopSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public LoopSignal(T value) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("MapIndexedSignal: Source = {_source}")]
     public sealed class MapIndexedSignal<TSource, TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public MapIndexedSignal(System.IObservable<TSource> source, System.Func<TSource, int, TResult> selector) { }
@@ -1172,7 +1206,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Index = {_index}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("MapIndexedWitness: Index = {_index}, Stopped = {_stopped}")]
     public sealed class MapIndexedWitness<TSource, TResult> : System.IObserver<TSource>
     {
         public MapIndexedWitness(System.IObserver<TResult> observer, System.Func<TSource, int, TResult> selector) { }
@@ -1180,20 +1214,20 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(TSource value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentBlendCoordinator: Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
     public sealed class MaxConcurrentBlendCoordinator<T> : System.IDisposable
     {
         public MaxConcurrentBlendCoordinator(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.MaxConcurrentBlendCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentEnumerableBlendSignal: Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
     public sealed class MaxConcurrentEnumerableBlendSignal<T> : System.IObservable<T>
     {
         public MaxConcurrentEnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("MergeCoordinator: Active = {Active}, Done = {Done}")]
     public sealed class MergeCoordinator<T> : System.IDisposable
     {
         public MergeCoordinator(System.IObserver<T> observer) { }
@@ -1204,7 +1238,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.MergeCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.MergeCoordinator<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MergeSignal: Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
     public sealed class MergeSignal<T> : System.IObservable<T>
     {
         public MergeSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -1212,32 +1246,39 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public MergeSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("OnErrorResumeNextSignal: Sources = {_sources}")]
+    public sealed class OnErrorResumeNextSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("PairSignal: Left = {Left}, Right = {Right}")]
     public sealed class PairSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public PairSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
+    [System.Diagnostics.DebuggerDisplay("PairWitness: IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
     public sealed class PairWitness<TLeft, TRight, TResult>
     {
         public PairWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("PublishSelectorSignal: Source = {Source}, Selector = {Selector}")]
     public sealed class PublishSelectorSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public PublishSelectorSignal(System.IObservable<TSource> source, System.Func<System.IObservable<TSource>, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
+    [System.Diagnostics.DebuggerDisplay("RaceSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
     public sealed class RaceSignal<T> : System.IObservable<T>
     {
         public RaceSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public RaceSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Arms = {_arms}")]
+    [System.Diagnostics.DebuggerDisplay("RaceWitness: Arms = {_arms}")]
     public sealed class RaceWitness<T> : System.IDisposable
     {
         public RaceWitness(System.IObserver<T> observer) { }
@@ -1246,40 +1287,48 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.RaceWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.RaceWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeCombineLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeCombineLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeCombineLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
+    [System.Diagnostics.DebuggerDisplay("RangeForkJoinSignal: Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
     public sealed class RangeForkJoinSignal<TResult> : System.IObservable<TResult>
     {
         public RangeForkJoinSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeSyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeSyncLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeSyncLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeWithLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeWithLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeWithLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Remaining = {_remaining}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("RecoverSignal: Source = {_source}")]
+    public sealed class RecoverSignal<T, TException> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T> where TException : System.Exception
+    {
+        public RecoverSignal(System.IObservable<T> source, System.Func<TException, System.IObservable<T>> handler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceCoordinator: Remaining = {_remaining}, Disposed = {_disposed}")]
     public sealed class RepeatSourceCoordinator<T> : System.IDisposable
     {
         public RepeatSourceCoordinator(System.IObservable<T> source, int? repeatCount, System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.RepeatSourceCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, RepeatCount = {_repeatCount}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceSignal: Source = {_source}, RepeatCount = {_repeatCount}")]
     public sealed class RepeatSourceSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public RepeatSourceSignal(System.IObservable<T> source, int? repeatCount) { }
@@ -1287,7 +1336,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Generation = {_generation}, Terminated = {_terminated}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceWitness: Generation = {_generation}, Terminated = {_terminated}")]
     public sealed class RepeatSourceWitness<T> : System.IObserver<T>
     {
         public RepeatSourceWitness(ReactiveUI.Primitives.Reactive.Advanced.RepeatSourceCoordinator<T> parent, int generation) { }
@@ -1295,7 +1344,15 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_value}, Scheduler = {_scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ResumeSignal: Source = {_source}, Fallback = {_fallback}")]
+    public sealed class ResumeSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ResumeSignal(System.IObservable<T> source, System.IObservable<T> fallback) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ReturnSignal: Value = {_value}, Scheduler = {_scheduler}")]
     public sealed class ReturnSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ReturnSignal(T value, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -1304,13 +1361,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Values = {Values}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledEnumerableSignal: Values = {Values}, Scheduler = {Scheduler}")]
     public sealed class ScheduledEnumerableSignal<T> : System.IObservable<T>
     {
         public ScheduledEnumerableSignal(System.Collections.Generic.IEnumerable<T> values, System.Reactive.Concurrency.IScheduler scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyCoordinator<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TResult>> selector) { }
@@ -1324,13 +1381,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Reactive.Advanced.SelectManyCoordinator<TSource, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableSignal: Source = {_source}")]
     public sealed class SelectManyEnumerableSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManyEnumerableSignal(System.IObservable<TSource> source, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SelectManyEnumerableWitness<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyEnumerableWitness(System.IObserver<TResult> observer, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
@@ -1344,7 +1401,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyResultCoordinator<TSource, TCollection, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyResultCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
@@ -1357,20 +1414,20 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Reactive.Advanced.SelectManyResultCoordinator<TSource, TCollection, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, CollectionSelector = {CollectionSelector}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultSignal: Source = {Source}, CollectionSelector = {CollectionSelector}")]
     public sealed class SelectManyResultSignal<TSource, TCollection, TResult> : System.IObservable<TResult>
     {
         public SelectManyResultSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManySignal: Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
     public sealed class SelectManySignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManySignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public SelectManySignal(System.IObservable<TSource> source, System.IObservable<TResult> inner) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Start = {Start}, Count = {Count}")]
+    [System.Diagnostics.DebuggerDisplay("SequenceSignal: Start = {Start}, Count = {Count}")]
     public sealed class SequenceSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<int>
     {
         public SequenceSignal(int start, int count, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -1381,13 +1438,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
     {
         public static System.IDisposable Subscribe<T>(System.IObserver<T> observer, bool currentThreadRequired, System.Func<System.IObserver<T>, System.IDisposable, System.IDisposable> subscribeCore) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SparkSignal: Source = {Source}")]
     public sealed class SparkSignal<T> : System.IObservable<ReactiveUI.Primitives.Reactive.Core.Spark<T>>
     {
         public SparkSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Reactive.Core.Spark<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SparkWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SparkWitness(System.IObserver<ReactiveUI.Primitives.Reactive.Core.Spark<T>> observer) { }
@@ -1402,21 +1459,21 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Action = {Action}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Action = {Action}, Scheduler = {Scheduler}")]
     public sealed class StartSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<System.Reactive.Unit>
     {
         public StartSignal(System.Action action, System.Reactive.Concurrency.IScheduler scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<System.Reactive.Unit> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Function = {Function}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Function = {Function}, Scheduler = {Scheduler}")]
     public sealed class StartSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public StartSignal(System.Func<T> function, System.Reactive.Concurrency.IScheduler scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SubscribeSafeWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SubscribeSafeWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SubscribeSafeWitness(System.IObserver<T> observer) { }
@@ -1430,50 +1487,50 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, SkipNullSources = {_skipNullSources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchMapSignal: Source = {_source}, SkipNullSources = {_skipNullSources}")]
     public sealed class SwitchMapSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SwitchMapSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchSignal: Sources = {Sources}")]
     public sealed class SwitchSignal<T> : System.IObservable<T>
     {
         public SwitchSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Version = {_version}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchWitness: Version = {_version}, IsDone = {IsDone}")]
     public sealed class SwitchWitness<T> : System.IDisposable
     {
         public SwitchWitness(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.SwitchWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class SyncLatestSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public SyncLatestSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
     public sealed class SyncLatestWitness<TLeft, TRight, TResult>
     {
         public SyncLatestWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Gate = {Gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeGateSignal: Source = {Source}, Gate = {Gate}")]
     public sealed class SynchronizeGateSignal<T> : System.IObservable<T>
     {
         public SynchronizeGateSignal(System.IObservable<T> source, System.Threading.Lock gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, Gate = {_gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectSignal: Source = {_source}, Gate = {_gate}")]
     public sealed class SynchronizeObjectSignal<T> : System.IObservable<T>
     {
         public SynchronizeObjectSignal(System.IObservable<T> source, object gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SynchronizeObjectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SynchronizeObjectWitness(System.IObserver<T> observer, object gate) { }
@@ -1485,19 +1542,19 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeSignal: Source = {Source}")]
     public sealed class SynchronizeSignal<T> : System.IObservable<T>
     {
         public SynchronizeSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("TapSignal: Source = {Source}")]
     public sealed class TapSignal<T> : System.IObservable<T>
     {
         public TapSignal(System.IObservable<T> source, System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskAnyWitness: Stopped = {_stopped}, Task = {Task}")]
     public sealed class TaskAnyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskAnyWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1513,7 +1570,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainCoordinator: Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
     public sealed class TaskChainCoordinator<T> : System.IDisposable
     {
         public TaskChainCoordinator(System.IObserver<T> observer) { }
@@ -1521,13 +1578,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.TaskChainCoordinator<T> Run(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainSignal: Sources = {_sources}")]
     public sealed class TaskChainSignal<T> : System.IObservable<T>
     {
         public TaskChainSignal(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskCountWitness: Count = {_count}, Stopped = {_stopped}")]
     public sealed class TaskCountWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskCountWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1543,13 +1600,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSignal: Task = {Task}")]
     public sealed class TaskInstanceSignal<T> : System.IObservable<T>
     {
         public TaskInstanceSignal(System.Threading.Tasks.Task<T> task) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSubscription: Stopped = {_stopped}")]
     public sealed class TaskInstanceSubscription : System.IDisposable
     {
         public TaskInstanceSubscription() { }
@@ -1557,13 +1614,22 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void Dispose() { }
         public bool TryStop() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Sequencer = {Sequencer}")]
+    [System.Diagnostics.DebuggerDisplay("ThrowSignal: Error = {_error}, Scheduler = {_scheduler}")]
+    public sealed class ThrowSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ThrowSignal(System.Exception error, System.Reactive.Concurrency.IScheduler scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalSignal: Source = {Source}, Sequencer = {Sequencer}")]
     public sealed class TimeIntervalSignal<T> : System.IObservable<ReactiveUI.Primitives.Core.TimeInterval<T>>
     {
         public TimeIntervalSignal(System.IObservable<T> source, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("First = {_first}, Last = {_last}")]
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalWitness: First = {_first}, Last = {_last}")]
     public sealed class TimeIntervalWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TimeIntervalWitness(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -1581,13 +1647,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
     {
         public static void Arm(ReactiveUI.Primitives.Disposables.SingleReplaceableDisposable slot, System.Reactive.Concurrency.IScheduler sequencer, System.TimeSpan delay, System.Action tick) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkSignal: Source = {Source}")]
     public sealed class UnsparkSignal<T> : System.IObservable<T>
     {
         public UnsparkSignal(System.IObservable<ReactiveUI.Primitives.Reactive.Core.Spark<T>> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class UnsparkWitness<T> : System.IDisposable, System.IObserver<ReactiveUI.Primitives.Reactive.Core.Spark<T>>
     {
         public UnsparkWitness(System.IObserver<T> observer) { }
@@ -1605,7 +1671,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
 }
 namespace ReactiveUI.Primitives.Reactive.Concurrency
 {
-    [System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
+    [System.Diagnostics.DebuggerDisplay("CoalescingDispatchScheduler: ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
     public abstract class CoalescingDispatchScheduler : System.Reactive.Concurrency.LocalScheduler
     {
         protected CoalescingDispatchScheduler() { }
@@ -1630,7 +1696,7 @@ namespace ReactiveUI.Primitives.Reactive.Concurrency
         public static ReactiveUI.Primitives.Concurrency.ScheduledItem<TAbsolute> Create<TAbsolute, TValue>(System.Reactive.Concurrency.IScheduler scheduler, TValue state, System.Func<System.Reactive.Concurrency.IScheduler, TValue, System.IDisposable> action, TAbsolute dueTime) where TAbsolute : System.IComparable<TAbsolute> { }
         public static ReactiveUI.Primitives.Concurrency.ScheduledItem<TAbsolute> Create<TAbsolute, TValue>(System.Reactive.Concurrency.IScheduler scheduler, TValue state, System.Func<System.Reactive.Concurrency.IScheduler, TValue, System.IDisposable> action, TAbsolute dueTime, System.Collections.Generic.IComparer<TAbsolute> comparer) where TAbsolute : System.IComparable<TAbsolute> { }
     }
-    [System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainState = {_drainState}, Disposed = {_isDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("WasmScheduler: ReadyCount = {_readyCount}, DrainState = {_drainState}, Disposed = {_isDisposed}")]
     public sealed class WasmScheduler : System.Reactive.Concurrency.LocalScheduler, System.IDisposable, System.Reactive.Concurrency.ISchedulerPeriodic
     {
         public static ReactiveUI.Primitives.Reactive.Concurrency.WasmScheduler Default { get; }
@@ -1672,7 +1738,7 @@ namespace ReactiveUI.Primitives.Reactive.Core
 }
 namespace ReactiveUI.Primitives.Reactive.Disposables
 {
-    [System.Diagnostics.DebuggerDisplay("Count = {Count}, IsDisposed = {IsDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ContainerDisposable: Count = {Count}, IsDisposed = {IsDisposed}")]
     public sealed class ContainerDisposable : ReactiveUI.Primitives.Disposables.MultipleDisposable
     {
         public ContainerDisposable() { }
@@ -1686,7 +1752,7 @@ namespace ReactiveUI.Primitives.Reactive.Disposables
 }
 namespace ReactiveUI.Primitives.Reactive.Signals
 {
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
+    [System.Diagnostics.DebuggerDisplay("PrioritySemaphoreSignal: Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
     public sealed class PrioritySemaphoreSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T> where T : System.IComparable<T>
     {
         public PrioritySemaphoreSignal(int maxCount) { }
@@ -1721,7 +1787,7 @@ namespace ReactiveUI.Primitives.Reactive.Signals
         public void OnNext(T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledSignal: Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
     public class ScheduledSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T>
     {
         public ScheduledSignal(System.Reactive.Concurrency.IScheduler scheduler) { }

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-maccatalyst/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-maccatalyst/PublicAPI.txt
@@ -845,7 +845,7 @@ namespace ReactiveUI.Primitives.Reactive
 }
 namespace ReactiveUI.Primitives.Reactive.Advanced
 {
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Period = {_period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSignal: DueTime = {_dueTime}, Period = {_period}")]
     public sealed class AfterSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
     {
         public AfterSignal(System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -853,7 +853,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<long> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSubscription: Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
     public sealed class AfterSubscription : System.IDisposable
     {
         public AfterSubscription(System.IObserver<long> observer, System.Reactive.Concurrency.IScheduler scheduler, System.TimeSpan dueTime, System.TimeSpan? period) { }
@@ -861,21 +861,21 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.AfterSubscription Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("SubscribeAsync = {SubscribeAsync}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncCreateSignal: SubscribeAsync = {SubscribeAsync}")]
     public sealed class AsyncCreateSignal<T> : System.IObservable<T>
     {
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ObservableFactory = {ObservableFactory}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncDeferSignal: ObservableFactory = {ObservableFactory}")]
     public sealed class AsyncDeferSignal<T> : System.IObservable<T>
     {
         public AsyncDeferSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public AsyncDeferSignal(System.Func<System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncSubscriptionLifetime: Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
     public sealed class AsyncSubscriptionLifetime : System.IDisposable
     {
         public AsyncSubscriptionLifetime() { }
@@ -886,33 +886,33 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable? disposable) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connected = {_connected}")]
+    [System.Diagnostics.DebuggerDisplay("AutoConnectSignal: Count = {_count}, Connected = {_connected}")]
     public sealed class AutoConnectSignal<T> : System.IObservable<T>
     {
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount) { }
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount, System.Action<System.IDisposable>? onConnect) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connection = {_connection}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSignal: Count = {_count}, Connection = {_connection}")]
     public sealed class AutoShareSignal<T> : System.IObservable<T>
     {
         public AutoShareSignal(ReactiveUI.Primitives.ConnectableSignal<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Owner = {_owner}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSubscription: Owner = {_owner}, Subscription = {Subscription}")]
     public sealed class AutoShareSubscription<T> : System.IDisposable
     {
         public AutoShareSubscription(ReactiveUI.Primitives.Reactive.Advanced.AutoShareSignal<T> owner, System.IDisposable subscription) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void Dispose() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("BlendSignal: Sources = {Sources}")]
     public sealed class BlendSignal<T> : System.IObservable<T>
     {
         public BlendSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("BlendWitness: ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
     public sealed class BlendWitness<T> : System.IDisposable
     {
         public BlendWitness(System.IObserver<T> observer) { }
@@ -921,7 +921,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.BlendWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.BlendWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("BufferEachWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class BufferEachWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public BufferEachWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -935,20 +935,20 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Window = {Window}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("BufferSignal: Window = {Window}, Source = {Source}")]
     public sealed class BufferSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public BufferSignal(System.IObservable<T> source, System.TimeSpan timeSpan, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("CastSignal: Source = {Source}")]
     public sealed class CastSignal<TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public CastSignal(System.IObservable<object?> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CastWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CastWitness<TResult> : System.IDisposable, System.IObserver<object?>
     {
         public CastWitness(System.IObserver<TResult> observer) { }
@@ -962,7 +962,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
+    [System.Diagnostics.DebuggerDisplay("ChainSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
     public sealed class ChainSignal<T> : System.IObservable<T>
     {
         public ChainSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -970,7 +970,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ChainSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("ChainWitness: IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
     public sealed class ChainWitness<T> : System.IDisposable
     {
         public ChainWitness(System.IObserver<T> observer) { }
@@ -980,13 +980,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.ChainWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.ChainWitness<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, TimeSpan = {TimeSpan}")]
+    [System.Diagnostics.DebuggerDisplay("CollectSignal: Source = {Source}, TimeSpan = {TimeSpan}")]
     public sealed class CollectSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public CollectSignal(System.IObservable<T> source, System.TimeSpan timeSpan, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Buffered = {Values.Count}")]
+    [System.Diagnostics.DebuggerDisplay("CollectWitness: Stopped = {_stopped}, Buffered = {Values.Count}")]
     public sealed class CollectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CollectWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -998,7 +998,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateSink: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class CreateSink<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateSink(System.IObserver<T> observer, bool disposeOnNextThrow) { }
@@ -1010,7 +1010,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CreateWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateWitness(System.IObserver<T> observer) { }
@@ -1024,13 +1024,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {DueTime}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietSignal: DueTime = {DueTime}, Source = {Source}")]
     public sealed class EmitIfQuietSignal<T> : System.IObservable<T>
     {
         public EmitIfQuietSignal(System.IObservable<T> source, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietWitness: HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
     public sealed class EmitIfQuietWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public EmitIfQuietWitness(System.IObserver<T> observer, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer) { }
@@ -1041,7 +1041,16 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("EmptySignal: Scheduler = {_scheduler}")]
+    public sealed class EmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public EmptySignal(System.Reactive.Concurrency.IScheduler scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("EnumerableBlendSignal: Sources = {Sources}")]
     public sealed class EnumerableBlendSignal<T> : System.IObservable<T>
     {
         public EnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -1051,7 +1060,14 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
     {
         public static System.IDisposable Attach<TEventHandler>(TEventHandler handler, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Reactive.Concurrency.IScheduler? scheduler) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
+    [System.Diagnostics.DebuggerDisplay("EverySignal: Period = {_period}, Scheduler = {_scheduler}")]
+    public sealed class EverySignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
+    {
+        public EverySignal(System.TimeSpan period, System.Reactive.Concurrency.IScheduler scheduler) { }
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<long> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ExpireCoordinator: Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
     public sealed class ExpireCoordinator<T> : System.IDisposable, System.IObserver<T>
     {
         public ExpireCoordinator(System.IObservable<T> source, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer, System.IObserver<T> observer) { }
@@ -1061,39 +1077,48 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnNext(T value) { }
         public ReactiveUI.Primitives.Reactive.Advanced.ExpireCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("ExpireSignal: DueTime = {_dueTime}, Source = {_source}")]
     public sealed class ExpireSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ExpireSignal(System.IObservable<T> source, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("FinallySignal: Source = {_source}")]
+    public sealed class FinallySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public FinallySignal(System.IObservable<T> source, System.Action finallyAction) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ForkJoinSignal: Left = {Left}, Right = {Right}")]
     public sealed class ForkJoinSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public ForkJoinSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("ForkJoinWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
     public sealed class ForkJoinWitness<TLeft, TRight, TResult>
     {
         public ForkJoinWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("CancellationRequested = {CancellationToken.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncExternalCancellationSignal: CancellationRequested = {CancellationToken.IsCancellationRequested}")]
     public sealed class FromAsyncExternalCancellationSignal<T> : System.IObservable<T>
     {
         public FromAsyncExternalCancellationSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSignal: TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
     public sealed class FromAsyncSignal<T> : System.IObservable<T>
     {
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSubscription: Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
     public sealed class FromAsyncSubscription<T> : System.IDisposable
     {
         public FromAsyncSubscription(System.IObserver<T> observer, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
@@ -1106,14 +1131,14 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public FromEventConversionSignal(System.Func<TCallback, TEventHandler> conversion, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Func<System.IObserver<TResult>, TCallback> callback, System.Reactive.Concurrency.IScheduler? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
+    [System.Diagnostics.DebuggerDisplay("FromEventPatternSignal: AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
     public sealed class FromEventPatternSignal<TEventHandler, TEventArgs> : System.IObservable<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> where TEventHandler : System.Delegate where TEventArgs : System.EventArgs
     {
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler) { }
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Reactive.Concurrency.IScheduler? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Disposed = {_disposed}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("GuardedWitness: Disposed = {_disposed}, Observer = {_observer}")]
     public sealed class GuardedWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public GuardedWitness(System.IObserver<T> observer, System.IDisposable cancel) { }
@@ -1123,7 +1148,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IgnoreValuesSignal: Source = {Source}")]
     public sealed class IgnoreValuesSignal<T> : System.IObservable<T>
     {
         public IgnoreValuesSignal(System.IObservable<T> source) { }
@@ -1137,14 +1162,14 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public System.IDisposable Subscribe(System.IObserver<System.Reactive.Unit> observer) { }
         public System.IDisposable Subscribe(System.Action<System.Reactive.Unit> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptySignal: Source = {Source}")]
     public sealed class IsEmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<bool>
     {
         public IsEmptySignal(System.IObservable<T> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<bool> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptyWitness: Stopped = {_stopped}, Subscription = {Subscription}")]
     public sealed class IsEmptyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public IsEmptyWitness(System.IObserver<bool> observer) { }
@@ -1157,14 +1182,23 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {Value}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("LeadSignal: Value = {Value}, Source = {Source}")]
     public sealed class LeadSignal<T> : ReactiveUI.Primitives.Advanced.IInlineSignal<T>
     {
         public LeadSignal(System.IObservable<T> source, T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
         public System.IDisposable Subscribe(System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("LoopSignal: Value = {Value}")]
+    public sealed class LoopSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public LoopSignal(T value) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("MapIndexedSignal: Source = {_source}")]
     public sealed class MapIndexedSignal<TSource, TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public MapIndexedSignal(System.IObservable<TSource> source, System.Func<TSource, int, TResult> selector) { }
@@ -1172,7 +1206,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Index = {_index}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("MapIndexedWitness: Index = {_index}, Stopped = {_stopped}")]
     public sealed class MapIndexedWitness<TSource, TResult> : System.IObserver<TSource>
     {
         public MapIndexedWitness(System.IObserver<TResult> observer, System.Func<TSource, int, TResult> selector) { }
@@ -1180,20 +1214,20 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(TSource value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentBlendCoordinator: Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
     public sealed class MaxConcurrentBlendCoordinator<T> : System.IDisposable
     {
         public MaxConcurrentBlendCoordinator(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.MaxConcurrentBlendCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentEnumerableBlendSignal: Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
     public sealed class MaxConcurrentEnumerableBlendSignal<T> : System.IObservable<T>
     {
         public MaxConcurrentEnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("MergeCoordinator: Active = {Active}, Done = {Done}")]
     public sealed class MergeCoordinator<T> : System.IDisposable
     {
         public MergeCoordinator(System.IObserver<T> observer) { }
@@ -1204,7 +1238,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.MergeCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.MergeCoordinator<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MergeSignal: Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
     public sealed class MergeSignal<T> : System.IObservable<T>
     {
         public MergeSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -1212,32 +1246,39 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public MergeSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("OnErrorResumeNextSignal: Sources = {_sources}")]
+    public sealed class OnErrorResumeNextSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("PairSignal: Left = {Left}, Right = {Right}")]
     public sealed class PairSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public PairSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
+    [System.Diagnostics.DebuggerDisplay("PairWitness: IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
     public sealed class PairWitness<TLeft, TRight, TResult>
     {
         public PairWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("PublishSelectorSignal: Source = {Source}, Selector = {Selector}")]
     public sealed class PublishSelectorSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public PublishSelectorSignal(System.IObservable<TSource> source, System.Func<System.IObservable<TSource>, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
+    [System.Diagnostics.DebuggerDisplay("RaceSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
     public sealed class RaceSignal<T> : System.IObservable<T>
     {
         public RaceSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public RaceSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Arms = {_arms}")]
+    [System.Diagnostics.DebuggerDisplay("RaceWitness: Arms = {_arms}")]
     public sealed class RaceWitness<T> : System.IDisposable
     {
         public RaceWitness(System.IObserver<T> observer) { }
@@ -1246,40 +1287,48 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.RaceWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.RaceWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeCombineLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeCombineLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeCombineLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
+    [System.Diagnostics.DebuggerDisplay("RangeForkJoinSignal: Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
     public sealed class RangeForkJoinSignal<TResult> : System.IObservable<TResult>
     {
         public RangeForkJoinSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeSyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeSyncLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeSyncLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeWithLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeWithLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeWithLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Remaining = {_remaining}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("RecoverSignal: Source = {_source}")]
+    public sealed class RecoverSignal<T, TException> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T> where TException : System.Exception
+    {
+        public RecoverSignal(System.IObservable<T> source, System.Func<TException, System.IObservable<T>> handler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceCoordinator: Remaining = {_remaining}, Disposed = {_disposed}")]
     public sealed class RepeatSourceCoordinator<T> : System.IDisposable
     {
         public RepeatSourceCoordinator(System.IObservable<T> source, int? repeatCount, System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.RepeatSourceCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, RepeatCount = {_repeatCount}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceSignal: Source = {_source}, RepeatCount = {_repeatCount}")]
     public sealed class RepeatSourceSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public RepeatSourceSignal(System.IObservable<T> source, int? repeatCount) { }
@@ -1287,7 +1336,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Generation = {_generation}, Terminated = {_terminated}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceWitness: Generation = {_generation}, Terminated = {_terminated}")]
     public sealed class RepeatSourceWitness<T> : System.IObserver<T>
     {
         public RepeatSourceWitness(ReactiveUI.Primitives.Reactive.Advanced.RepeatSourceCoordinator<T> parent, int generation) { }
@@ -1295,7 +1344,15 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_value}, Scheduler = {_scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ResumeSignal: Source = {_source}, Fallback = {_fallback}")]
+    public sealed class ResumeSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ResumeSignal(System.IObservable<T> source, System.IObservable<T> fallback) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ReturnSignal: Value = {_value}, Scheduler = {_scheduler}")]
     public sealed class ReturnSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ReturnSignal(T value, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -1304,13 +1361,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Values = {Values}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledEnumerableSignal: Values = {Values}, Scheduler = {Scheduler}")]
     public sealed class ScheduledEnumerableSignal<T> : System.IObservable<T>
     {
         public ScheduledEnumerableSignal(System.Collections.Generic.IEnumerable<T> values, System.Reactive.Concurrency.IScheduler scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyCoordinator<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TResult>> selector) { }
@@ -1324,13 +1381,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Reactive.Advanced.SelectManyCoordinator<TSource, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableSignal: Source = {_source}")]
     public sealed class SelectManyEnumerableSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManyEnumerableSignal(System.IObservable<TSource> source, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SelectManyEnumerableWitness<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyEnumerableWitness(System.IObserver<TResult> observer, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
@@ -1344,7 +1401,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyResultCoordinator<TSource, TCollection, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyResultCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
@@ -1357,20 +1414,20 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Reactive.Advanced.SelectManyResultCoordinator<TSource, TCollection, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, CollectionSelector = {CollectionSelector}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultSignal: Source = {Source}, CollectionSelector = {CollectionSelector}")]
     public sealed class SelectManyResultSignal<TSource, TCollection, TResult> : System.IObservable<TResult>
     {
         public SelectManyResultSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManySignal: Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
     public sealed class SelectManySignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManySignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public SelectManySignal(System.IObservable<TSource> source, System.IObservable<TResult> inner) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Start = {Start}, Count = {Count}")]
+    [System.Diagnostics.DebuggerDisplay("SequenceSignal: Start = {Start}, Count = {Count}")]
     public sealed class SequenceSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<int>
     {
         public SequenceSignal(int start, int count, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -1381,13 +1438,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
     {
         public static System.IDisposable Subscribe<T>(System.IObserver<T> observer, bool currentThreadRequired, System.Func<System.IObserver<T>, System.IDisposable, System.IDisposable> subscribeCore) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SparkSignal: Source = {Source}")]
     public sealed class SparkSignal<T> : System.IObservable<ReactiveUI.Primitives.Reactive.Core.Spark<T>>
     {
         public SparkSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Reactive.Core.Spark<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SparkWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SparkWitness(System.IObserver<ReactiveUI.Primitives.Reactive.Core.Spark<T>> observer) { }
@@ -1402,21 +1459,21 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Action = {Action}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Action = {Action}, Scheduler = {Scheduler}")]
     public sealed class StartSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<System.Reactive.Unit>
     {
         public StartSignal(System.Action action, System.Reactive.Concurrency.IScheduler scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<System.Reactive.Unit> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Function = {Function}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Function = {Function}, Scheduler = {Scheduler}")]
     public sealed class StartSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public StartSignal(System.Func<T> function, System.Reactive.Concurrency.IScheduler scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SubscribeSafeWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SubscribeSafeWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SubscribeSafeWitness(System.IObserver<T> observer) { }
@@ -1430,50 +1487,50 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, SkipNullSources = {_skipNullSources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchMapSignal: Source = {_source}, SkipNullSources = {_skipNullSources}")]
     public sealed class SwitchMapSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SwitchMapSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchSignal: Sources = {Sources}")]
     public sealed class SwitchSignal<T> : System.IObservable<T>
     {
         public SwitchSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Version = {_version}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchWitness: Version = {_version}, IsDone = {IsDone}")]
     public sealed class SwitchWitness<T> : System.IDisposable
     {
         public SwitchWitness(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.SwitchWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class SyncLatestSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public SyncLatestSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
     public sealed class SyncLatestWitness<TLeft, TRight, TResult>
     {
         public SyncLatestWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Gate = {Gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeGateSignal: Source = {Source}, Gate = {Gate}")]
     public sealed class SynchronizeGateSignal<T> : System.IObservable<T>
     {
         public SynchronizeGateSignal(System.IObservable<T> source, System.Threading.Lock gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, Gate = {_gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectSignal: Source = {_source}, Gate = {_gate}")]
     public sealed class SynchronizeObjectSignal<T> : System.IObservable<T>
     {
         public SynchronizeObjectSignal(System.IObservable<T> source, object gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SynchronizeObjectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SynchronizeObjectWitness(System.IObserver<T> observer, object gate) { }
@@ -1485,19 +1542,19 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeSignal: Source = {Source}")]
     public sealed class SynchronizeSignal<T> : System.IObservable<T>
     {
         public SynchronizeSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("TapSignal: Source = {Source}")]
     public sealed class TapSignal<T> : System.IObservable<T>
     {
         public TapSignal(System.IObservable<T> source, System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskAnyWitness: Stopped = {_stopped}, Task = {Task}")]
     public sealed class TaskAnyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskAnyWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1513,7 +1570,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainCoordinator: Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
     public sealed class TaskChainCoordinator<T> : System.IDisposable
     {
         public TaskChainCoordinator(System.IObserver<T> observer) { }
@@ -1521,13 +1578,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.TaskChainCoordinator<T> Run(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainSignal: Sources = {_sources}")]
     public sealed class TaskChainSignal<T> : System.IObservable<T>
     {
         public TaskChainSignal(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskCountWitness: Count = {_count}, Stopped = {_stopped}")]
     public sealed class TaskCountWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskCountWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1543,13 +1600,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSignal: Task = {Task}")]
     public sealed class TaskInstanceSignal<T> : System.IObservable<T>
     {
         public TaskInstanceSignal(System.Threading.Tasks.Task<T> task) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSubscription: Stopped = {_stopped}")]
     public sealed class TaskInstanceSubscription : System.IDisposable
     {
         public TaskInstanceSubscription() { }
@@ -1557,13 +1614,22 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void Dispose() { }
         public bool TryStop() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Sequencer = {Sequencer}")]
+    [System.Diagnostics.DebuggerDisplay("ThrowSignal: Error = {_error}, Scheduler = {_scheduler}")]
+    public sealed class ThrowSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ThrowSignal(System.Exception error, System.Reactive.Concurrency.IScheduler scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalSignal: Source = {Source}, Sequencer = {Sequencer}")]
     public sealed class TimeIntervalSignal<T> : System.IObservable<ReactiveUI.Primitives.Core.TimeInterval<T>>
     {
         public TimeIntervalSignal(System.IObservable<T> source, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("First = {_first}, Last = {_last}")]
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalWitness: First = {_first}, Last = {_last}")]
     public sealed class TimeIntervalWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TimeIntervalWitness(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -1581,13 +1647,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
     {
         public static void Arm(ReactiveUI.Primitives.Disposables.SingleReplaceableDisposable slot, System.Reactive.Concurrency.IScheduler sequencer, System.TimeSpan delay, System.Action tick) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkSignal: Source = {Source}")]
     public sealed class UnsparkSignal<T> : System.IObservable<T>
     {
         public UnsparkSignal(System.IObservable<ReactiveUI.Primitives.Reactive.Core.Spark<T>> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class UnsparkWitness<T> : System.IDisposable, System.IObserver<ReactiveUI.Primitives.Reactive.Core.Spark<T>>
     {
         public UnsparkWitness(System.IObserver<T> observer) { }
@@ -1605,7 +1671,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
 }
 namespace ReactiveUI.Primitives.Reactive.Concurrency
 {
-    [System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
+    [System.Diagnostics.DebuggerDisplay("CoalescingDispatchScheduler: ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
     public abstract class CoalescingDispatchScheduler : System.Reactive.Concurrency.LocalScheduler
     {
         protected CoalescingDispatchScheduler() { }
@@ -1630,7 +1696,7 @@ namespace ReactiveUI.Primitives.Reactive.Concurrency
         public static ReactiveUI.Primitives.Concurrency.ScheduledItem<TAbsolute> Create<TAbsolute, TValue>(System.Reactive.Concurrency.IScheduler scheduler, TValue state, System.Func<System.Reactive.Concurrency.IScheduler, TValue, System.IDisposable> action, TAbsolute dueTime) where TAbsolute : System.IComparable<TAbsolute> { }
         public static ReactiveUI.Primitives.Concurrency.ScheduledItem<TAbsolute> Create<TAbsolute, TValue>(System.Reactive.Concurrency.IScheduler scheduler, TValue state, System.Func<System.Reactive.Concurrency.IScheduler, TValue, System.IDisposable> action, TAbsolute dueTime, System.Collections.Generic.IComparer<TAbsolute> comparer) where TAbsolute : System.IComparable<TAbsolute> { }
     }
-    [System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainState = {_drainState}, Disposed = {_isDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("WasmScheduler: ReadyCount = {_readyCount}, DrainState = {_drainState}, Disposed = {_isDisposed}")]
     public sealed class WasmScheduler : System.Reactive.Concurrency.LocalScheduler, System.IDisposable, System.Reactive.Concurrency.ISchedulerPeriodic
     {
         public static ReactiveUI.Primitives.Reactive.Concurrency.WasmScheduler Default { get; }
@@ -1672,7 +1738,7 @@ namespace ReactiveUI.Primitives.Reactive.Core
 }
 namespace ReactiveUI.Primitives.Reactive.Disposables
 {
-    [System.Diagnostics.DebuggerDisplay("Count = {Count}, IsDisposed = {IsDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ContainerDisposable: Count = {Count}, IsDisposed = {IsDisposed}")]
     public sealed class ContainerDisposable : ReactiveUI.Primitives.Disposables.MultipleDisposable
     {
         public ContainerDisposable() { }
@@ -1686,7 +1752,7 @@ namespace ReactiveUI.Primitives.Reactive.Disposables
 }
 namespace ReactiveUI.Primitives.Reactive.Signals
 {
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
+    [System.Diagnostics.DebuggerDisplay("PrioritySemaphoreSignal: Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
     public sealed class PrioritySemaphoreSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T> where T : System.IComparable<T>
     {
         public PrioritySemaphoreSignal(int maxCount) { }
@@ -1721,7 +1787,7 @@ namespace ReactiveUI.Primitives.Reactive.Signals
         public void OnNext(T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledSignal: Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
     public class ScheduledSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T>
     {
         public ScheduledSignal(System.Reactive.Concurrency.IScheduler scheduler) { }

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-macos/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-macos/PublicAPI.txt
@@ -845,7 +845,7 @@ namespace ReactiveUI.Primitives.Reactive
 }
 namespace ReactiveUI.Primitives.Reactive.Advanced
 {
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Period = {_period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSignal: DueTime = {_dueTime}, Period = {_period}")]
     public sealed class AfterSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
     {
         public AfterSignal(System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -853,7 +853,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<long> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSubscription: Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
     public sealed class AfterSubscription : System.IDisposable
     {
         public AfterSubscription(System.IObserver<long> observer, System.Reactive.Concurrency.IScheduler scheduler, System.TimeSpan dueTime, System.TimeSpan? period) { }
@@ -861,21 +861,21 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.AfterSubscription Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("SubscribeAsync = {SubscribeAsync}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncCreateSignal: SubscribeAsync = {SubscribeAsync}")]
     public sealed class AsyncCreateSignal<T> : System.IObservable<T>
     {
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ObservableFactory = {ObservableFactory}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncDeferSignal: ObservableFactory = {ObservableFactory}")]
     public sealed class AsyncDeferSignal<T> : System.IObservable<T>
     {
         public AsyncDeferSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public AsyncDeferSignal(System.Func<System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncSubscriptionLifetime: Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
     public sealed class AsyncSubscriptionLifetime : System.IDisposable
     {
         public AsyncSubscriptionLifetime() { }
@@ -886,33 +886,33 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable? disposable) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connected = {_connected}")]
+    [System.Diagnostics.DebuggerDisplay("AutoConnectSignal: Count = {_count}, Connected = {_connected}")]
     public sealed class AutoConnectSignal<T> : System.IObservable<T>
     {
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount) { }
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount, System.Action<System.IDisposable>? onConnect) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connection = {_connection}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSignal: Count = {_count}, Connection = {_connection}")]
     public sealed class AutoShareSignal<T> : System.IObservable<T>
     {
         public AutoShareSignal(ReactiveUI.Primitives.ConnectableSignal<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Owner = {_owner}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSubscription: Owner = {_owner}, Subscription = {Subscription}")]
     public sealed class AutoShareSubscription<T> : System.IDisposable
     {
         public AutoShareSubscription(ReactiveUI.Primitives.Reactive.Advanced.AutoShareSignal<T> owner, System.IDisposable subscription) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void Dispose() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("BlendSignal: Sources = {Sources}")]
     public sealed class BlendSignal<T> : System.IObservable<T>
     {
         public BlendSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("BlendWitness: ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
     public sealed class BlendWitness<T> : System.IDisposable
     {
         public BlendWitness(System.IObserver<T> observer) { }
@@ -921,7 +921,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.BlendWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.BlendWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("BufferEachWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class BufferEachWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public BufferEachWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -935,20 +935,20 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Window = {Window}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("BufferSignal: Window = {Window}, Source = {Source}")]
     public sealed class BufferSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public BufferSignal(System.IObservable<T> source, System.TimeSpan timeSpan, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("CastSignal: Source = {Source}")]
     public sealed class CastSignal<TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public CastSignal(System.IObservable<object?> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CastWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CastWitness<TResult> : System.IDisposable, System.IObserver<object?>
     {
         public CastWitness(System.IObserver<TResult> observer) { }
@@ -962,7 +962,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
+    [System.Diagnostics.DebuggerDisplay("ChainSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
     public sealed class ChainSignal<T> : System.IObservable<T>
     {
         public ChainSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -970,7 +970,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ChainSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("ChainWitness: IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
     public sealed class ChainWitness<T> : System.IDisposable
     {
         public ChainWitness(System.IObserver<T> observer) { }
@@ -980,13 +980,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.ChainWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.ChainWitness<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, TimeSpan = {TimeSpan}")]
+    [System.Diagnostics.DebuggerDisplay("CollectSignal: Source = {Source}, TimeSpan = {TimeSpan}")]
     public sealed class CollectSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public CollectSignal(System.IObservable<T> source, System.TimeSpan timeSpan, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Buffered = {Values.Count}")]
+    [System.Diagnostics.DebuggerDisplay("CollectWitness: Stopped = {_stopped}, Buffered = {Values.Count}")]
     public sealed class CollectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CollectWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -998,7 +998,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateSink: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class CreateSink<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateSink(System.IObserver<T> observer, bool disposeOnNextThrow) { }
@@ -1010,7 +1010,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CreateWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateWitness(System.IObserver<T> observer) { }
@@ -1024,13 +1024,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {DueTime}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietSignal: DueTime = {DueTime}, Source = {Source}")]
     public sealed class EmitIfQuietSignal<T> : System.IObservable<T>
     {
         public EmitIfQuietSignal(System.IObservable<T> source, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietWitness: HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
     public sealed class EmitIfQuietWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public EmitIfQuietWitness(System.IObserver<T> observer, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer) { }
@@ -1041,7 +1041,16 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("EmptySignal: Scheduler = {_scheduler}")]
+    public sealed class EmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public EmptySignal(System.Reactive.Concurrency.IScheduler scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("EnumerableBlendSignal: Sources = {Sources}")]
     public sealed class EnumerableBlendSignal<T> : System.IObservable<T>
     {
         public EnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -1051,7 +1060,14 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
     {
         public static System.IDisposable Attach<TEventHandler>(TEventHandler handler, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Reactive.Concurrency.IScheduler? scheduler) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
+    [System.Diagnostics.DebuggerDisplay("EverySignal: Period = {_period}, Scheduler = {_scheduler}")]
+    public sealed class EverySignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
+    {
+        public EverySignal(System.TimeSpan period, System.Reactive.Concurrency.IScheduler scheduler) { }
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<long> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ExpireCoordinator: Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
     public sealed class ExpireCoordinator<T> : System.IDisposable, System.IObserver<T>
     {
         public ExpireCoordinator(System.IObservable<T> source, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer, System.IObserver<T> observer) { }
@@ -1061,39 +1077,48 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnNext(T value) { }
         public ReactiveUI.Primitives.Reactive.Advanced.ExpireCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("ExpireSignal: DueTime = {_dueTime}, Source = {_source}")]
     public sealed class ExpireSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ExpireSignal(System.IObservable<T> source, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("FinallySignal: Source = {_source}")]
+    public sealed class FinallySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public FinallySignal(System.IObservable<T> source, System.Action finallyAction) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ForkJoinSignal: Left = {Left}, Right = {Right}")]
     public sealed class ForkJoinSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public ForkJoinSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("ForkJoinWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
     public sealed class ForkJoinWitness<TLeft, TRight, TResult>
     {
         public ForkJoinWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("CancellationRequested = {CancellationToken.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncExternalCancellationSignal: CancellationRequested = {CancellationToken.IsCancellationRequested}")]
     public sealed class FromAsyncExternalCancellationSignal<T> : System.IObservable<T>
     {
         public FromAsyncExternalCancellationSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSignal: TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
     public sealed class FromAsyncSignal<T> : System.IObservable<T>
     {
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSubscription: Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
     public sealed class FromAsyncSubscription<T> : System.IDisposable
     {
         public FromAsyncSubscription(System.IObserver<T> observer, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
@@ -1106,14 +1131,14 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public FromEventConversionSignal(System.Func<TCallback, TEventHandler> conversion, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Func<System.IObserver<TResult>, TCallback> callback, System.Reactive.Concurrency.IScheduler? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
+    [System.Diagnostics.DebuggerDisplay("FromEventPatternSignal: AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
     public sealed class FromEventPatternSignal<TEventHandler, TEventArgs> : System.IObservable<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> where TEventHandler : System.Delegate where TEventArgs : System.EventArgs
     {
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler) { }
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Reactive.Concurrency.IScheduler? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Disposed = {_disposed}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("GuardedWitness: Disposed = {_disposed}, Observer = {_observer}")]
     public sealed class GuardedWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public GuardedWitness(System.IObserver<T> observer, System.IDisposable cancel) { }
@@ -1123,7 +1148,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IgnoreValuesSignal: Source = {Source}")]
     public sealed class IgnoreValuesSignal<T> : System.IObservable<T>
     {
         public IgnoreValuesSignal(System.IObservable<T> source) { }
@@ -1137,14 +1162,14 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public System.IDisposable Subscribe(System.IObserver<System.Reactive.Unit> observer) { }
         public System.IDisposable Subscribe(System.Action<System.Reactive.Unit> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptySignal: Source = {Source}")]
     public sealed class IsEmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<bool>
     {
         public IsEmptySignal(System.IObservable<T> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<bool> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptyWitness: Stopped = {_stopped}, Subscription = {Subscription}")]
     public sealed class IsEmptyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public IsEmptyWitness(System.IObserver<bool> observer) { }
@@ -1157,14 +1182,23 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {Value}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("LeadSignal: Value = {Value}, Source = {Source}")]
     public sealed class LeadSignal<T> : ReactiveUI.Primitives.Advanced.IInlineSignal<T>
     {
         public LeadSignal(System.IObservable<T> source, T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
         public System.IDisposable Subscribe(System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("LoopSignal: Value = {Value}")]
+    public sealed class LoopSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public LoopSignal(T value) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("MapIndexedSignal: Source = {_source}")]
     public sealed class MapIndexedSignal<TSource, TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public MapIndexedSignal(System.IObservable<TSource> source, System.Func<TSource, int, TResult> selector) { }
@@ -1172,7 +1206,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Index = {_index}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("MapIndexedWitness: Index = {_index}, Stopped = {_stopped}")]
     public sealed class MapIndexedWitness<TSource, TResult> : System.IObserver<TSource>
     {
         public MapIndexedWitness(System.IObserver<TResult> observer, System.Func<TSource, int, TResult> selector) { }
@@ -1180,20 +1214,20 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(TSource value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentBlendCoordinator: Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
     public sealed class MaxConcurrentBlendCoordinator<T> : System.IDisposable
     {
         public MaxConcurrentBlendCoordinator(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.MaxConcurrentBlendCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentEnumerableBlendSignal: Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
     public sealed class MaxConcurrentEnumerableBlendSignal<T> : System.IObservable<T>
     {
         public MaxConcurrentEnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("MergeCoordinator: Active = {Active}, Done = {Done}")]
     public sealed class MergeCoordinator<T> : System.IDisposable
     {
         public MergeCoordinator(System.IObserver<T> observer) { }
@@ -1204,7 +1238,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.MergeCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.MergeCoordinator<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MergeSignal: Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
     public sealed class MergeSignal<T> : System.IObservable<T>
     {
         public MergeSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -1212,32 +1246,39 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public MergeSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("OnErrorResumeNextSignal: Sources = {_sources}")]
+    public sealed class OnErrorResumeNextSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("PairSignal: Left = {Left}, Right = {Right}")]
     public sealed class PairSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public PairSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
+    [System.Diagnostics.DebuggerDisplay("PairWitness: IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
     public sealed class PairWitness<TLeft, TRight, TResult>
     {
         public PairWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("PublishSelectorSignal: Source = {Source}, Selector = {Selector}")]
     public sealed class PublishSelectorSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public PublishSelectorSignal(System.IObservable<TSource> source, System.Func<System.IObservable<TSource>, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
+    [System.Diagnostics.DebuggerDisplay("RaceSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
     public sealed class RaceSignal<T> : System.IObservable<T>
     {
         public RaceSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public RaceSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Arms = {_arms}")]
+    [System.Diagnostics.DebuggerDisplay("RaceWitness: Arms = {_arms}")]
     public sealed class RaceWitness<T> : System.IDisposable
     {
         public RaceWitness(System.IObserver<T> observer) { }
@@ -1246,40 +1287,48 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.RaceWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.RaceWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeCombineLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeCombineLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeCombineLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
+    [System.Diagnostics.DebuggerDisplay("RangeForkJoinSignal: Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
     public sealed class RangeForkJoinSignal<TResult> : System.IObservable<TResult>
     {
         public RangeForkJoinSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeSyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeSyncLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeSyncLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeWithLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeWithLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeWithLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Remaining = {_remaining}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("RecoverSignal: Source = {_source}")]
+    public sealed class RecoverSignal<T, TException> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T> where TException : System.Exception
+    {
+        public RecoverSignal(System.IObservable<T> source, System.Func<TException, System.IObservable<T>> handler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceCoordinator: Remaining = {_remaining}, Disposed = {_disposed}")]
     public sealed class RepeatSourceCoordinator<T> : System.IDisposable
     {
         public RepeatSourceCoordinator(System.IObservable<T> source, int? repeatCount, System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.RepeatSourceCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, RepeatCount = {_repeatCount}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceSignal: Source = {_source}, RepeatCount = {_repeatCount}")]
     public sealed class RepeatSourceSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public RepeatSourceSignal(System.IObservable<T> source, int? repeatCount) { }
@@ -1287,7 +1336,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Generation = {_generation}, Terminated = {_terminated}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceWitness: Generation = {_generation}, Terminated = {_terminated}")]
     public sealed class RepeatSourceWitness<T> : System.IObserver<T>
     {
         public RepeatSourceWitness(ReactiveUI.Primitives.Reactive.Advanced.RepeatSourceCoordinator<T> parent, int generation) { }
@@ -1295,7 +1344,15 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_value}, Scheduler = {_scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ResumeSignal: Source = {_source}, Fallback = {_fallback}")]
+    public sealed class ResumeSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ResumeSignal(System.IObservable<T> source, System.IObservable<T> fallback) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ReturnSignal: Value = {_value}, Scheduler = {_scheduler}")]
     public sealed class ReturnSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ReturnSignal(T value, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -1304,13 +1361,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Values = {Values}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledEnumerableSignal: Values = {Values}, Scheduler = {Scheduler}")]
     public sealed class ScheduledEnumerableSignal<T> : System.IObservable<T>
     {
         public ScheduledEnumerableSignal(System.Collections.Generic.IEnumerable<T> values, System.Reactive.Concurrency.IScheduler scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyCoordinator<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TResult>> selector) { }
@@ -1324,13 +1381,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Reactive.Advanced.SelectManyCoordinator<TSource, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableSignal: Source = {_source}")]
     public sealed class SelectManyEnumerableSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManyEnumerableSignal(System.IObservable<TSource> source, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SelectManyEnumerableWitness<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyEnumerableWitness(System.IObserver<TResult> observer, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
@@ -1344,7 +1401,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyResultCoordinator<TSource, TCollection, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyResultCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
@@ -1357,20 +1414,20 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Reactive.Advanced.SelectManyResultCoordinator<TSource, TCollection, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, CollectionSelector = {CollectionSelector}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultSignal: Source = {Source}, CollectionSelector = {CollectionSelector}")]
     public sealed class SelectManyResultSignal<TSource, TCollection, TResult> : System.IObservable<TResult>
     {
         public SelectManyResultSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManySignal: Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
     public sealed class SelectManySignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManySignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public SelectManySignal(System.IObservable<TSource> source, System.IObservable<TResult> inner) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Start = {Start}, Count = {Count}")]
+    [System.Diagnostics.DebuggerDisplay("SequenceSignal: Start = {Start}, Count = {Count}")]
     public sealed class SequenceSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<int>
     {
         public SequenceSignal(int start, int count, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -1381,13 +1438,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
     {
         public static System.IDisposable Subscribe<T>(System.IObserver<T> observer, bool currentThreadRequired, System.Func<System.IObserver<T>, System.IDisposable, System.IDisposable> subscribeCore) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SparkSignal: Source = {Source}")]
     public sealed class SparkSignal<T> : System.IObservable<ReactiveUI.Primitives.Reactive.Core.Spark<T>>
     {
         public SparkSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Reactive.Core.Spark<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SparkWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SparkWitness(System.IObserver<ReactiveUI.Primitives.Reactive.Core.Spark<T>> observer) { }
@@ -1402,21 +1459,21 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Action = {Action}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Action = {Action}, Scheduler = {Scheduler}")]
     public sealed class StartSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<System.Reactive.Unit>
     {
         public StartSignal(System.Action action, System.Reactive.Concurrency.IScheduler scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<System.Reactive.Unit> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Function = {Function}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Function = {Function}, Scheduler = {Scheduler}")]
     public sealed class StartSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public StartSignal(System.Func<T> function, System.Reactive.Concurrency.IScheduler scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SubscribeSafeWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SubscribeSafeWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SubscribeSafeWitness(System.IObserver<T> observer) { }
@@ -1430,50 +1487,50 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, SkipNullSources = {_skipNullSources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchMapSignal: Source = {_source}, SkipNullSources = {_skipNullSources}")]
     public sealed class SwitchMapSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SwitchMapSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchSignal: Sources = {Sources}")]
     public sealed class SwitchSignal<T> : System.IObservable<T>
     {
         public SwitchSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Version = {_version}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchWitness: Version = {_version}, IsDone = {IsDone}")]
     public sealed class SwitchWitness<T> : System.IDisposable
     {
         public SwitchWitness(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.SwitchWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class SyncLatestSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public SyncLatestSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
     public sealed class SyncLatestWitness<TLeft, TRight, TResult>
     {
         public SyncLatestWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Gate = {Gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeGateSignal: Source = {Source}, Gate = {Gate}")]
     public sealed class SynchronizeGateSignal<T> : System.IObservable<T>
     {
         public SynchronizeGateSignal(System.IObservable<T> source, System.Threading.Lock gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, Gate = {_gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectSignal: Source = {_source}, Gate = {_gate}")]
     public sealed class SynchronizeObjectSignal<T> : System.IObservable<T>
     {
         public SynchronizeObjectSignal(System.IObservable<T> source, object gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SynchronizeObjectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SynchronizeObjectWitness(System.IObserver<T> observer, object gate) { }
@@ -1485,19 +1542,19 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeSignal: Source = {Source}")]
     public sealed class SynchronizeSignal<T> : System.IObservable<T>
     {
         public SynchronizeSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("TapSignal: Source = {Source}")]
     public sealed class TapSignal<T> : System.IObservable<T>
     {
         public TapSignal(System.IObservable<T> source, System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskAnyWitness: Stopped = {_stopped}, Task = {Task}")]
     public sealed class TaskAnyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskAnyWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1513,7 +1570,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainCoordinator: Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
     public sealed class TaskChainCoordinator<T> : System.IDisposable
     {
         public TaskChainCoordinator(System.IObserver<T> observer) { }
@@ -1521,13 +1578,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.TaskChainCoordinator<T> Run(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainSignal: Sources = {_sources}")]
     public sealed class TaskChainSignal<T> : System.IObservable<T>
     {
         public TaskChainSignal(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskCountWitness: Count = {_count}, Stopped = {_stopped}")]
     public sealed class TaskCountWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskCountWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1543,13 +1600,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSignal: Task = {Task}")]
     public sealed class TaskInstanceSignal<T> : System.IObservable<T>
     {
         public TaskInstanceSignal(System.Threading.Tasks.Task<T> task) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSubscription: Stopped = {_stopped}")]
     public sealed class TaskInstanceSubscription : System.IDisposable
     {
         public TaskInstanceSubscription() { }
@@ -1557,13 +1614,22 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void Dispose() { }
         public bool TryStop() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Sequencer = {Sequencer}")]
+    [System.Diagnostics.DebuggerDisplay("ThrowSignal: Error = {_error}, Scheduler = {_scheduler}")]
+    public sealed class ThrowSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ThrowSignal(System.Exception error, System.Reactive.Concurrency.IScheduler scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalSignal: Source = {Source}, Sequencer = {Sequencer}")]
     public sealed class TimeIntervalSignal<T> : System.IObservable<ReactiveUI.Primitives.Core.TimeInterval<T>>
     {
         public TimeIntervalSignal(System.IObservable<T> source, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("First = {_first}, Last = {_last}")]
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalWitness: First = {_first}, Last = {_last}")]
     public sealed class TimeIntervalWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TimeIntervalWitness(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -1581,13 +1647,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
     {
         public static void Arm(ReactiveUI.Primitives.Disposables.SingleReplaceableDisposable slot, System.Reactive.Concurrency.IScheduler sequencer, System.TimeSpan delay, System.Action tick) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkSignal: Source = {Source}")]
     public sealed class UnsparkSignal<T> : System.IObservable<T>
     {
         public UnsparkSignal(System.IObservable<ReactiveUI.Primitives.Reactive.Core.Spark<T>> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class UnsparkWitness<T> : System.IDisposable, System.IObserver<ReactiveUI.Primitives.Reactive.Core.Spark<T>>
     {
         public UnsparkWitness(System.IObserver<T> observer) { }
@@ -1605,7 +1671,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
 }
 namespace ReactiveUI.Primitives.Reactive.Concurrency
 {
-    [System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
+    [System.Diagnostics.DebuggerDisplay("CoalescingDispatchScheduler: ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
     public abstract class CoalescingDispatchScheduler : System.Reactive.Concurrency.LocalScheduler
     {
         protected CoalescingDispatchScheduler() { }
@@ -1630,7 +1696,7 @@ namespace ReactiveUI.Primitives.Reactive.Concurrency
         public static ReactiveUI.Primitives.Concurrency.ScheduledItem<TAbsolute> Create<TAbsolute, TValue>(System.Reactive.Concurrency.IScheduler scheduler, TValue state, System.Func<System.Reactive.Concurrency.IScheduler, TValue, System.IDisposable> action, TAbsolute dueTime) where TAbsolute : System.IComparable<TAbsolute> { }
         public static ReactiveUI.Primitives.Concurrency.ScheduledItem<TAbsolute> Create<TAbsolute, TValue>(System.Reactive.Concurrency.IScheduler scheduler, TValue state, System.Func<System.Reactive.Concurrency.IScheduler, TValue, System.IDisposable> action, TAbsolute dueTime, System.Collections.Generic.IComparer<TAbsolute> comparer) where TAbsolute : System.IComparable<TAbsolute> { }
     }
-    [System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainState = {_drainState}, Disposed = {_isDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("WasmScheduler: ReadyCount = {_readyCount}, DrainState = {_drainState}, Disposed = {_isDisposed}")]
     public sealed class WasmScheduler : System.Reactive.Concurrency.LocalScheduler, System.IDisposable, System.Reactive.Concurrency.ISchedulerPeriodic
     {
         public static ReactiveUI.Primitives.Reactive.Concurrency.WasmScheduler Default { get; }
@@ -1672,7 +1738,7 @@ namespace ReactiveUI.Primitives.Reactive.Core
 }
 namespace ReactiveUI.Primitives.Reactive.Disposables
 {
-    [System.Diagnostics.DebuggerDisplay("Count = {Count}, IsDisposed = {IsDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ContainerDisposable: Count = {Count}, IsDisposed = {IsDisposed}")]
     public sealed class ContainerDisposable : ReactiveUI.Primitives.Disposables.MultipleDisposable
     {
         public ContainerDisposable() { }
@@ -1686,7 +1752,7 @@ namespace ReactiveUI.Primitives.Reactive.Disposables
 }
 namespace ReactiveUI.Primitives.Reactive.Signals
 {
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
+    [System.Diagnostics.DebuggerDisplay("PrioritySemaphoreSignal: Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
     public sealed class PrioritySemaphoreSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T> where T : System.IComparable<T>
     {
         public PrioritySemaphoreSignal(int maxCount) { }
@@ -1721,7 +1787,7 @@ namespace ReactiveUI.Primitives.Reactive.Signals
         public void OnNext(T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledSignal: Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
     public class ScheduledSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T>
     {
         public ScheduledSignal(System.Reactive.Concurrency.IScheduler scheduler) { }

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-tvos/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0-tvos/PublicAPI.txt
@@ -845,7 +845,7 @@ namespace ReactiveUI.Primitives.Reactive
 }
 namespace ReactiveUI.Primitives.Reactive.Advanced
 {
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Period = {_period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSignal: DueTime = {_dueTime}, Period = {_period}")]
     public sealed class AfterSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
     {
         public AfterSignal(System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -853,7 +853,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<long> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSubscription: Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
     public sealed class AfterSubscription : System.IDisposable
     {
         public AfterSubscription(System.IObserver<long> observer, System.Reactive.Concurrency.IScheduler scheduler, System.TimeSpan dueTime, System.TimeSpan? period) { }
@@ -861,21 +861,21 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.AfterSubscription Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("SubscribeAsync = {SubscribeAsync}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncCreateSignal: SubscribeAsync = {SubscribeAsync}")]
     public sealed class AsyncCreateSignal<T> : System.IObservable<T>
     {
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ObservableFactory = {ObservableFactory}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncDeferSignal: ObservableFactory = {ObservableFactory}")]
     public sealed class AsyncDeferSignal<T> : System.IObservable<T>
     {
         public AsyncDeferSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public AsyncDeferSignal(System.Func<System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncSubscriptionLifetime: Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
     public sealed class AsyncSubscriptionLifetime : System.IDisposable
     {
         public AsyncSubscriptionLifetime() { }
@@ -886,33 +886,33 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable? disposable) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connected = {_connected}")]
+    [System.Diagnostics.DebuggerDisplay("AutoConnectSignal: Count = {_count}, Connected = {_connected}")]
     public sealed class AutoConnectSignal<T> : System.IObservable<T>
     {
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount) { }
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount, System.Action<System.IDisposable>? onConnect) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connection = {_connection}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSignal: Count = {_count}, Connection = {_connection}")]
     public sealed class AutoShareSignal<T> : System.IObservable<T>
     {
         public AutoShareSignal(ReactiveUI.Primitives.ConnectableSignal<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Owner = {_owner}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSubscription: Owner = {_owner}, Subscription = {Subscription}")]
     public sealed class AutoShareSubscription<T> : System.IDisposable
     {
         public AutoShareSubscription(ReactiveUI.Primitives.Reactive.Advanced.AutoShareSignal<T> owner, System.IDisposable subscription) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void Dispose() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("BlendSignal: Sources = {Sources}")]
     public sealed class BlendSignal<T> : System.IObservable<T>
     {
         public BlendSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("BlendWitness: ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
     public sealed class BlendWitness<T> : System.IDisposable
     {
         public BlendWitness(System.IObserver<T> observer) { }
@@ -921,7 +921,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.BlendWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.BlendWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("BufferEachWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class BufferEachWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public BufferEachWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -935,20 +935,20 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Window = {Window}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("BufferSignal: Window = {Window}, Source = {Source}")]
     public sealed class BufferSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public BufferSignal(System.IObservable<T> source, System.TimeSpan timeSpan, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("CastSignal: Source = {Source}")]
     public sealed class CastSignal<TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public CastSignal(System.IObservable<object?> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CastWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CastWitness<TResult> : System.IDisposable, System.IObserver<object?>
     {
         public CastWitness(System.IObserver<TResult> observer) { }
@@ -962,7 +962,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
+    [System.Diagnostics.DebuggerDisplay("ChainSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
     public sealed class ChainSignal<T> : System.IObservable<T>
     {
         public ChainSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -970,7 +970,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ChainSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("ChainWitness: IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
     public sealed class ChainWitness<T> : System.IDisposable
     {
         public ChainWitness(System.IObserver<T> observer) { }
@@ -980,13 +980,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.ChainWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.ChainWitness<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, TimeSpan = {TimeSpan}")]
+    [System.Diagnostics.DebuggerDisplay("CollectSignal: Source = {Source}, TimeSpan = {TimeSpan}")]
     public sealed class CollectSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public CollectSignal(System.IObservable<T> source, System.TimeSpan timeSpan, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Buffered = {Values.Count}")]
+    [System.Diagnostics.DebuggerDisplay("CollectWitness: Stopped = {_stopped}, Buffered = {Values.Count}")]
     public sealed class CollectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CollectWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -998,7 +998,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateSink: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class CreateSink<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateSink(System.IObserver<T> observer, bool disposeOnNextThrow) { }
@@ -1010,7 +1010,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CreateWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateWitness(System.IObserver<T> observer) { }
@@ -1024,13 +1024,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {DueTime}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietSignal: DueTime = {DueTime}, Source = {Source}")]
     public sealed class EmitIfQuietSignal<T> : System.IObservable<T>
     {
         public EmitIfQuietSignal(System.IObservable<T> source, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietWitness: HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
     public sealed class EmitIfQuietWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public EmitIfQuietWitness(System.IObserver<T> observer, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer) { }
@@ -1041,7 +1041,16 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("EmptySignal: Scheduler = {_scheduler}")]
+    public sealed class EmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public EmptySignal(System.Reactive.Concurrency.IScheduler scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("EnumerableBlendSignal: Sources = {Sources}")]
     public sealed class EnumerableBlendSignal<T> : System.IObservable<T>
     {
         public EnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -1051,7 +1060,14 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
     {
         public static System.IDisposable Attach<TEventHandler>(TEventHandler handler, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Reactive.Concurrency.IScheduler? scheduler) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
+    [System.Diagnostics.DebuggerDisplay("EverySignal: Period = {_period}, Scheduler = {_scheduler}")]
+    public sealed class EverySignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
+    {
+        public EverySignal(System.TimeSpan period, System.Reactive.Concurrency.IScheduler scheduler) { }
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<long> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ExpireCoordinator: Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
     public sealed class ExpireCoordinator<T> : System.IDisposable, System.IObserver<T>
     {
         public ExpireCoordinator(System.IObservable<T> source, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer, System.IObserver<T> observer) { }
@@ -1061,39 +1077,48 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnNext(T value) { }
         public ReactiveUI.Primitives.Reactive.Advanced.ExpireCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("ExpireSignal: DueTime = {_dueTime}, Source = {_source}")]
     public sealed class ExpireSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ExpireSignal(System.IObservable<T> source, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("FinallySignal: Source = {_source}")]
+    public sealed class FinallySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public FinallySignal(System.IObservable<T> source, System.Action finallyAction) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ForkJoinSignal: Left = {Left}, Right = {Right}")]
     public sealed class ForkJoinSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public ForkJoinSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("ForkJoinWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
     public sealed class ForkJoinWitness<TLeft, TRight, TResult>
     {
         public ForkJoinWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("CancellationRequested = {CancellationToken.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncExternalCancellationSignal: CancellationRequested = {CancellationToken.IsCancellationRequested}")]
     public sealed class FromAsyncExternalCancellationSignal<T> : System.IObservable<T>
     {
         public FromAsyncExternalCancellationSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSignal: TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
     public sealed class FromAsyncSignal<T> : System.IObservable<T>
     {
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSubscription: Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
     public sealed class FromAsyncSubscription<T> : System.IDisposable
     {
         public FromAsyncSubscription(System.IObserver<T> observer, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
@@ -1106,14 +1131,14 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public FromEventConversionSignal(System.Func<TCallback, TEventHandler> conversion, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Func<System.IObserver<TResult>, TCallback> callback, System.Reactive.Concurrency.IScheduler? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
+    [System.Diagnostics.DebuggerDisplay("FromEventPatternSignal: AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
     public sealed class FromEventPatternSignal<TEventHandler, TEventArgs> : System.IObservable<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> where TEventHandler : System.Delegate where TEventArgs : System.EventArgs
     {
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler) { }
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Reactive.Concurrency.IScheduler? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Disposed = {_disposed}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("GuardedWitness: Disposed = {_disposed}, Observer = {_observer}")]
     public sealed class GuardedWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public GuardedWitness(System.IObserver<T> observer, System.IDisposable cancel) { }
@@ -1123,7 +1148,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IgnoreValuesSignal: Source = {Source}")]
     public sealed class IgnoreValuesSignal<T> : System.IObservable<T>
     {
         public IgnoreValuesSignal(System.IObservable<T> source) { }
@@ -1137,14 +1162,14 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public System.IDisposable Subscribe(System.IObserver<System.Reactive.Unit> observer) { }
         public System.IDisposable Subscribe(System.Action<System.Reactive.Unit> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptySignal: Source = {Source}")]
     public sealed class IsEmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<bool>
     {
         public IsEmptySignal(System.IObservable<T> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<bool> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptyWitness: Stopped = {_stopped}, Subscription = {Subscription}")]
     public sealed class IsEmptyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public IsEmptyWitness(System.IObserver<bool> observer) { }
@@ -1157,14 +1182,23 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {Value}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("LeadSignal: Value = {Value}, Source = {Source}")]
     public sealed class LeadSignal<T> : ReactiveUI.Primitives.Advanced.IInlineSignal<T>
     {
         public LeadSignal(System.IObservable<T> source, T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
         public System.IDisposable Subscribe(System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("LoopSignal: Value = {Value}")]
+    public sealed class LoopSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public LoopSignal(T value) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("MapIndexedSignal: Source = {_source}")]
     public sealed class MapIndexedSignal<TSource, TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public MapIndexedSignal(System.IObservable<TSource> source, System.Func<TSource, int, TResult> selector) { }
@@ -1172,7 +1206,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Index = {_index}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("MapIndexedWitness: Index = {_index}, Stopped = {_stopped}")]
     public sealed class MapIndexedWitness<TSource, TResult> : System.IObserver<TSource>
     {
         public MapIndexedWitness(System.IObserver<TResult> observer, System.Func<TSource, int, TResult> selector) { }
@@ -1180,20 +1214,20 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(TSource value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentBlendCoordinator: Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
     public sealed class MaxConcurrentBlendCoordinator<T> : System.IDisposable
     {
         public MaxConcurrentBlendCoordinator(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.MaxConcurrentBlendCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentEnumerableBlendSignal: Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
     public sealed class MaxConcurrentEnumerableBlendSignal<T> : System.IObservable<T>
     {
         public MaxConcurrentEnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("MergeCoordinator: Active = {Active}, Done = {Done}")]
     public sealed class MergeCoordinator<T> : System.IDisposable
     {
         public MergeCoordinator(System.IObserver<T> observer) { }
@@ -1204,7 +1238,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.MergeCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.MergeCoordinator<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MergeSignal: Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
     public sealed class MergeSignal<T> : System.IObservable<T>
     {
         public MergeSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -1212,32 +1246,39 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public MergeSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("OnErrorResumeNextSignal: Sources = {_sources}")]
+    public sealed class OnErrorResumeNextSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("PairSignal: Left = {Left}, Right = {Right}")]
     public sealed class PairSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public PairSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
+    [System.Diagnostics.DebuggerDisplay("PairWitness: IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
     public sealed class PairWitness<TLeft, TRight, TResult>
     {
         public PairWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("PublishSelectorSignal: Source = {Source}, Selector = {Selector}")]
     public sealed class PublishSelectorSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public PublishSelectorSignal(System.IObservable<TSource> source, System.Func<System.IObservable<TSource>, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
+    [System.Diagnostics.DebuggerDisplay("RaceSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
     public sealed class RaceSignal<T> : System.IObservable<T>
     {
         public RaceSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public RaceSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Arms = {_arms}")]
+    [System.Diagnostics.DebuggerDisplay("RaceWitness: Arms = {_arms}")]
     public sealed class RaceWitness<T> : System.IDisposable
     {
         public RaceWitness(System.IObserver<T> observer) { }
@@ -1246,40 +1287,48 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.RaceWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.RaceWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeCombineLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeCombineLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeCombineLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
+    [System.Diagnostics.DebuggerDisplay("RangeForkJoinSignal: Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
     public sealed class RangeForkJoinSignal<TResult> : System.IObservable<TResult>
     {
         public RangeForkJoinSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeSyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeSyncLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeSyncLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeWithLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeWithLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeWithLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Remaining = {_remaining}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("RecoverSignal: Source = {_source}")]
+    public sealed class RecoverSignal<T, TException> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T> where TException : System.Exception
+    {
+        public RecoverSignal(System.IObservable<T> source, System.Func<TException, System.IObservable<T>> handler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceCoordinator: Remaining = {_remaining}, Disposed = {_disposed}")]
     public sealed class RepeatSourceCoordinator<T> : System.IDisposable
     {
         public RepeatSourceCoordinator(System.IObservable<T> source, int? repeatCount, System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.RepeatSourceCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, RepeatCount = {_repeatCount}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceSignal: Source = {_source}, RepeatCount = {_repeatCount}")]
     public sealed class RepeatSourceSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public RepeatSourceSignal(System.IObservable<T> source, int? repeatCount) { }
@@ -1287,7 +1336,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Generation = {_generation}, Terminated = {_terminated}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceWitness: Generation = {_generation}, Terminated = {_terminated}")]
     public sealed class RepeatSourceWitness<T> : System.IObserver<T>
     {
         public RepeatSourceWitness(ReactiveUI.Primitives.Reactive.Advanced.RepeatSourceCoordinator<T> parent, int generation) { }
@@ -1295,7 +1344,15 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_value}, Scheduler = {_scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ResumeSignal: Source = {_source}, Fallback = {_fallback}")]
+    public sealed class ResumeSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ResumeSignal(System.IObservable<T> source, System.IObservable<T> fallback) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ReturnSignal: Value = {_value}, Scheduler = {_scheduler}")]
     public sealed class ReturnSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ReturnSignal(T value, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -1304,13 +1361,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Values = {Values}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledEnumerableSignal: Values = {Values}, Scheduler = {Scheduler}")]
     public sealed class ScheduledEnumerableSignal<T> : System.IObservable<T>
     {
         public ScheduledEnumerableSignal(System.Collections.Generic.IEnumerable<T> values, System.Reactive.Concurrency.IScheduler scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyCoordinator<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TResult>> selector) { }
@@ -1324,13 +1381,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Reactive.Advanced.SelectManyCoordinator<TSource, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableSignal: Source = {_source}")]
     public sealed class SelectManyEnumerableSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManyEnumerableSignal(System.IObservable<TSource> source, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SelectManyEnumerableWitness<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyEnumerableWitness(System.IObserver<TResult> observer, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
@@ -1344,7 +1401,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyResultCoordinator<TSource, TCollection, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyResultCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
@@ -1357,20 +1414,20 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Reactive.Advanced.SelectManyResultCoordinator<TSource, TCollection, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, CollectionSelector = {CollectionSelector}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultSignal: Source = {Source}, CollectionSelector = {CollectionSelector}")]
     public sealed class SelectManyResultSignal<TSource, TCollection, TResult> : System.IObservable<TResult>
     {
         public SelectManyResultSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManySignal: Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
     public sealed class SelectManySignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManySignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public SelectManySignal(System.IObservable<TSource> source, System.IObservable<TResult> inner) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Start = {Start}, Count = {Count}")]
+    [System.Diagnostics.DebuggerDisplay("SequenceSignal: Start = {Start}, Count = {Count}")]
     public sealed class SequenceSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<int>
     {
         public SequenceSignal(int start, int count, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -1381,13 +1438,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
     {
         public static System.IDisposable Subscribe<T>(System.IObserver<T> observer, bool currentThreadRequired, System.Func<System.IObserver<T>, System.IDisposable, System.IDisposable> subscribeCore) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SparkSignal: Source = {Source}")]
     public sealed class SparkSignal<T> : System.IObservable<ReactiveUI.Primitives.Reactive.Core.Spark<T>>
     {
         public SparkSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Reactive.Core.Spark<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SparkWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SparkWitness(System.IObserver<ReactiveUI.Primitives.Reactive.Core.Spark<T>> observer) { }
@@ -1402,21 +1459,21 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Action = {Action}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Action = {Action}, Scheduler = {Scheduler}")]
     public sealed class StartSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<System.Reactive.Unit>
     {
         public StartSignal(System.Action action, System.Reactive.Concurrency.IScheduler scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<System.Reactive.Unit> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Function = {Function}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Function = {Function}, Scheduler = {Scheduler}")]
     public sealed class StartSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public StartSignal(System.Func<T> function, System.Reactive.Concurrency.IScheduler scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SubscribeSafeWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SubscribeSafeWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SubscribeSafeWitness(System.IObserver<T> observer) { }
@@ -1430,50 +1487,50 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, SkipNullSources = {_skipNullSources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchMapSignal: Source = {_source}, SkipNullSources = {_skipNullSources}")]
     public sealed class SwitchMapSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SwitchMapSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchSignal: Sources = {Sources}")]
     public sealed class SwitchSignal<T> : System.IObservable<T>
     {
         public SwitchSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Version = {_version}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchWitness: Version = {_version}, IsDone = {IsDone}")]
     public sealed class SwitchWitness<T> : System.IDisposable
     {
         public SwitchWitness(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.SwitchWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class SyncLatestSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public SyncLatestSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
     public sealed class SyncLatestWitness<TLeft, TRight, TResult>
     {
         public SyncLatestWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Gate = {Gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeGateSignal: Source = {Source}, Gate = {Gate}")]
     public sealed class SynchronizeGateSignal<T> : System.IObservable<T>
     {
         public SynchronizeGateSignal(System.IObservable<T> source, System.Threading.Lock gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, Gate = {_gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectSignal: Source = {_source}, Gate = {_gate}")]
     public sealed class SynchronizeObjectSignal<T> : System.IObservable<T>
     {
         public SynchronizeObjectSignal(System.IObservable<T> source, object gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SynchronizeObjectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SynchronizeObjectWitness(System.IObserver<T> observer, object gate) { }
@@ -1485,19 +1542,19 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeSignal: Source = {Source}")]
     public sealed class SynchronizeSignal<T> : System.IObservable<T>
     {
         public SynchronizeSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("TapSignal: Source = {Source}")]
     public sealed class TapSignal<T> : System.IObservable<T>
     {
         public TapSignal(System.IObservable<T> source, System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskAnyWitness: Stopped = {_stopped}, Task = {Task}")]
     public sealed class TaskAnyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskAnyWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1513,7 +1570,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainCoordinator: Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
     public sealed class TaskChainCoordinator<T> : System.IDisposable
     {
         public TaskChainCoordinator(System.IObserver<T> observer) { }
@@ -1521,13 +1578,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.TaskChainCoordinator<T> Run(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainSignal: Sources = {_sources}")]
     public sealed class TaskChainSignal<T> : System.IObservable<T>
     {
         public TaskChainSignal(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskCountWitness: Count = {_count}, Stopped = {_stopped}")]
     public sealed class TaskCountWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskCountWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1543,13 +1600,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSignal: Task = {Task}")]
     public sealed class TaskInstanceSignal<T> : System.IObservable<T>
     {
         public TaskInstanceSignal(System.Threading.Tasks.Task<T> task) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSubscription: Stopped = {_stopped}")]
     public sealed class TaskInstanceSubscription : System.IDisposable
     {
         public TaskInstanceSubscription() { }
@@ -1557,13 +1614,22 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void Dispose() { }
         public bool TryStop() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Sequencer = {Sequencer}")]
+    [System.Diagnostics.DebuggerDisplay("ThrowSignal: Error = {_error}, Scheduler = {_scheduler}")]
+    public sealed class ThrowSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ThrowSignal(System.Exception error, System.Reactive.Concurrency.IScheduler scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalSignal: Source = {Source}, Sequencer = {Sequencer}")]
     public sealed class TimeIntervalSignal<T> : System.IObservable<ReactiveUI.Primitives.Core.TimeInterval<T>>
     {
         public TimeIntervalSignal(System.IObservable<T> source, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("First = {_first}, Last = {_last}")]
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalWitness: First = {_first}, Last = {_last}")]
     public sealed class TimeIntervalWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TimeIntervalWitness(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -1581,13 +1647,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
     {
         public static void Arm(ReactiveUI.Primitives.Disposables.SingleReplaceableDisposable slot, System.Reactive.Concurrency.IScheduler sequencer, System.TimeSpan delay, System.Action tick) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkSignal: Source = {Source}")]
     public sealed class UnsparkSignal<T> : System.IObservable<T>
     {
         public UnsparkSignal(System.IObservable<ReactiveUI.Primitives.Reactive.Core.Spark<T>> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class UnsparkWitness<T> : System.IDisposable, System.IObserver<ReactiveUI.Primitives.Reactive.Core.Spark<T>>
     {
         public UnsparkWitness(System.IObserver<T> observer) { }
@@ -1605,7 +1671,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
 }
 namespace ReactiveUI.Primitives.Reactive.Concurrency
 {
-    [System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
+    [System.Diagnostics.DebuggerDisplay("CoalescingDispatchScheduler: ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
     public abstract class CoalescingDispatchScheduler : System.Reactive.Concurrency.LocalScheduler
     {
         protected CoalescingDispatchScheduler() { }
@@ -1630,7 +1696,7 @@ namespace ReactiveUI.Primitives.Reactive.Concurrency
         public static ReactiveUI.Primitives.Concurrency.ScheduledItem<TAbsolute> Create<TAbsolute, TValue>(System.Reactive.Concurrency.IScheduler scheduler, TValue state, System.Func<System.Reactive.Concurrency.IScheduler, TValue, System.IDisposable> action, TAbsolute dueTime) where TAbsolute : System.IComparable<TAbsolute> { }
         public static ReactiveUI.Primitives.Concurrency.ScheduledItem<TAbsolute> Create<TAbsolute, TValue>(System.Reactive.Concurrency.IScheduler scheduler, TValue state, System.Func<System.Reactive.Concurrency.IScheduler, TValue, System.IDisposable> action, TAbsolute dueTime, System.Collections.Generic.IComparer<TAbsolute> comparer) where TAbsolute : System.IComparable<TAbsolute> { }
     }
-    [System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainState = {_drainState}, Disposed = {_isDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("WasmScheduler: ReadyCount = {_readyCount}, DrainState = {_drainState}, Disposed = {_isDisposed}")]
     public sealed class WasmScheduler : System.Reactive.Concurrency.LocalScheduler, System.IDisposable, System.Reactive.Concurrency.ISchedulerPeriodic
     {
         public static ReactiveUI.Primitives.Reactive.Concurrency.WasmScheduler Default { get; }
@@ -1672,7 +1738,7 @@ namespace ReactiveUI.Primitives.Reactive.Core
 }
 namespace ReactiveUI.Primitives.Reactive.Disposables
 {
-    [System.Diagnostics.DebuggerDisplay("Count = {Count}, IsDisposed = {IsDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ContainerDisposable: Count = {Count}, IsDisposed = {IsDisposed}")]
     public sealed class ContainerDisposable : ReactiveUI.Primitives.Disposables.MultipleDisposable
     {
         public ContainerDisposable() { }
@@ -1686,7 +1752,7 @@ namespace ReactiveUI.Primitives.Reactive.Disposables
 }
 namespace ReactiveUI.Primitives.Reactive.Signals
 {
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
+    [System.Diagnostics.DebuggerDisplay("PrioritySemaphoreSignal: Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
     public sealed class PrioritySemaphoreSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T> where T : System.IComparable<T>
     {
         public PrioritySemaphoreSignal(int maxCount) { }
@@ -1721,7 +1787,7 @@ namespace ReactiveUI.Primitives.Reactive.Signals
         public void OnNext(T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledSignal: Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
     public class ScheduledSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T>
     {
         public ScheduledSignal(System.Reactive.Concurrency.IScheduler scheduler) { }

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net10.0/PublicAPI.txt
@@ -844,7 +844,7 @@ namespace ReactiveUI.Primitives.Reactive
 }
 namespace ReactiveUI.Primitives.Reactive.Advanced
 {
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Period = {_period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSignal: DueTime = {_dueTime}, Period = {_period}")]
     public sealed class AfterSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
     {
         public AfterSignal(System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -852,7 +852,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<long> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSubscription: Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
     public sealed class AfterSubscription : System.IDisposable
     {
         public AfterSubscription(System.IObserver<long> observer, System.Reactive.Concurrency.IScheduler scheduler, System.TimeSpan dueTime, System.TimeSpan? period) { }
@@ -860,21 +860,21 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.AfterSubscription Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("SubscribeAsync = {SubscribeAsync}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncCreateSignal: SubscribeAsync = {SubscribeAsync}")]
     public sealed class AsyncCreateSignal<T> : System.IObservable<T>
     {
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ObservableFactory = {ObservableFactory}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncDeferSignal: ObservableFactory = {ObservableFactory}")]
     public sealed class AsyncDeferSignal<T> : System.IObservable<T>
     {
         public AsyncDeferSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public AsyncDeferSignal(System.Func<System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncSubscriptionLifetime: Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
     public sealed class AsyncSubscriptionLifetime : System.IDisposable
     {
         public AsyncSubscriptionLifetime() { }
@@ -885,33 +885,33 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable? disposable) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connected = {_connected}")]
+    [System.Diagnostics.DebuggerDisplay("AutoConnectSignal: Count = {_count}, Connected = {_connected}")]
     public sealed class AutoConnectSignal<T> : System.IObservable<T>
     {
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount) { }
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount, System.Action<System.IDisposable>? onConnect) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connection = {_connection}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSignal: Count = {_count}, Connection = {_connection}")]
     public sealed class AutoShareSignal<T> : System.IObservable<T>
     {
         public AutoShareSignal(ReactiveUI.Primitives.ConnectableSignal<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Owner = {_owner}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSubscription: Owner = {_owner}, Subscription = {Subscription}")]
     public sealed class AutoShareSubscription<T> : System.IDisposable
     {
         public AutoShareSubscription(ReactiveUI.Primitives.Reactive.Advanced.AutoShareSignal<T> owner, System.IDisposable subscription) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void Dispose() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("BlendSignal: Sources = {Sources}")]
     public sealed class BlendSignal<T> : System.IObservable<T>
     {
         public BlendSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("BlendWitness: ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
     public sealed class BlendWitness<T> : System.IDisposable
     {
         public BlendWitness(System.IObserver<T> observer) { }
@@ -920,7 +920,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.BlendWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.BlendWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("BufferEachWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class BufferEachWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public BufferEachWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -934,20 +934,20 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Window = {Window}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("BufferSignal: Window = {Window}, Source = {Source}")]
     public sealed class BufferSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public BufferSignal(System.IObservable<T> source, System.TimeSpan timeSpan, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("CastSignal: Source = {Source}")]
     public sealed class CastSignal<TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public CastSignal(System.IObservable<object?> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CastWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CastWitness<TResult> : System.IDisposable, System.IObserver<object?>
     {
         public CastWitness(System.IObserver<TResult> observer) { }
@@ -961,7 +961,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
+    [System.Diagnostics.DebuggerDisplay("ChainSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
     public sealed class ChainSignal<T> : System.IObservable<T>
     {
         public ChainSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -969,7 +969,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ChainSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("ChainWitness: IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
     public sealed class ChainWitness<T> : System.IDisposable
     {
         public ChainWitness(System.IObserver<T> observer) { }
@@ -979,13 +979,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.ChainWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.ChainWitness<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, TimeSpan = {TimeSpan}")]
+    [System.Diagnostics.DebuggerDisplay("CollectSignal: Source = {Source}, TimeSpan = {TimeSpan}")]
     public sealed class CollectSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public CollectSignal(System.IObservable<T> source, System.TimeSpan timeSpan, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Buffered = {Values.Count}")]
+    [System.Diagnostics.DebuggerDisplay("CollectWitness: Stopped = {_stopped}, Buffered = {Values.Count}")]
     public sealed class CollectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CollectWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -997,7 +997,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateSink: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class CreateSink<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateSink(System.IObserver<T> observer, bool disposeOnNextThrow) { }
@@ -1009,7 +1009,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CreateWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateWitness(System.IObserver<T> observer) { }
@@ -1023,13 +1023,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {DueTime}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietSignal: DueTime = {DueTime}, Source = {Source}")]
     public sealed class EmitIfQuietSignal<T> : System.IObservable<T>
     {
         public EmitIfQuietSignal(System.IObservable<T> source, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietWitness: HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
     public sealed class EmitIfQuietWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public EmitIfQuietWitness(System.IObserver<T> observer, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer) { }
@@ -1040,7 +1040,16 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("EmptySignal: Scheduler = {_scheduler}")]
+    public sealed class EmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public EmptySignal(System.Reactive.Concurrency.IScheduler scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("EnumerableBlendSignal: Sources = {Sources}")]
     public sealed class EnumerableBlendSignal<T> : System.IObservable<T>
     {
         public EnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -1050,7 +1059,14 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
     {
         public static System.IDisposable Attach<TEventHandler>(TEventHandler handler, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Reactive.Concurrency.IScheduler? scheduler) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
+    [System.Diagnostics.DebuggerDisplay("EverySignal: Period = {_period}, Scheduler = {_scheduler}")]
+    public sealed class EverySignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
+    {
+        public EverySignal(System.TimeSpan period, System.Reactive.Concurrency.IScheduler scheduler) { }
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<long> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ExpireCoordinator: Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
     public sealed class ExpireCoordinator<T> : System.IDisposable, System.IObserver<T>
     {
         public ExpireCoordinator(System.IObservable<T> source, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer, System.IObserver<T> observer) { }
@@ -1060,39 +1076,48 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnNext(T value) { }
         public ReactiveUI.Primitives.Reactive.Advanced.ExpireCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("ExpireSignal: DueTime = {_dueTime}, Source = {_source}")]
     public sealed class ExpireSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ExpireSignal(System.IObservable<T> source, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("FinallySignal: Source = {_source}")]
+    public sealed class FinallySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public FinallySignal(System.IObservable<T> source, System.Action finallyAction) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ForkJoinSignal: Left = {Left}, Right = {Right}")]
     public sealed class ForkJoinSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public ForkJoinSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("ForkJoinWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
     public sealed class ForkJoinWitness<TLeft, TRight, TResult>
     {
         public ForkJoinWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("CancellationRequested = {CancellationToken.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncExternalCancellationSignal: CancellationRequested = {CancellationToken.IsCancellationRequested}")]
     public sealed class FromAsyncExternalCancellationSignal<T> : System.IObservable<T>
     {
         public FromAsyncExternalCancellationSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSignal: TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
     public sealed class FromAsyncSignal<T> : System.IObservable<T>
     {
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSubscription: Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
     public sealed class FromAsyncSubscription<T> : System.IDisposable
     {
         public FromAsyncSubscription(System.IObserver<T> observer, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
@@ -1105,14 +1130,14 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public FromEventConversionSignal(System.Func<TCallback, TEventHandler> conversion, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Func<System.IObserver<TResult>, TCallback> callback, System.Reactive.Concurrency.IScheduler? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
+    [System.Diagnostics.DebuggerDisplay("FromEventPatternSignal: AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
     public sealed class FromEventPatternSignal<TEventHandler, TEventArgs> : System.IObservable<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> where TEventHandler : System.Delegate where TEventArgs : System.EventArgs
     {
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler) { }
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Reactive.Concurrency.IScheduler? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Disposed = {_disposed}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("GuardedWitness: Disposed = {_disposed}, Observer = {_observer}")]
     public sealed class GuardedWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public GuardedWitness(System.IObserver<T> observer, System.IDisposable cancel) { }
@@ -1122,7 +1147,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IgnoreValuesSignal: Source = {Source}")]
     public sealed class IgnoreValuesSignal<T> : System.IObservable<T>
     {
         public IgnoreValuesSignal(System.IObservable<T> source) { }
@@ -1136,14 +1161,14 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public System.IDisposable Subscribe(System.IObserver<System.Reactive.Unit> observer) { }
         public System.IDisposable Subscribe(System.Action<System.Reactive.Unit> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptySignal: Source = {Source}")]
     public sealed class IsEmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<bool>
     {
         public IsEmptySignal(System.IObservable<T> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<bool> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptyWitness: Stopped = {_stopped}, Subscription = {Subscription}")]
     public sealed class IsEmptyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public IsEmptyWitness(System.IObserver<bool> observer) { }
@@ -1156,14 +1181,23 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {Value}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("LeadSignal: Value = {Value}, Source = {Source}")]
     public sealed class LeadSignal<T> : ReactiveUI.Primitives.Advanced.IInlineSignal<T>
     {
         public LeadSignal(System.IObservable<T> source, T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
         public System.IDisposable Subscribe(System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("LoopSignal: Value = {Value}")]
+    public sealed class LoopSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public LoopSignal(T value) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("MapIndexedSignal: Source = {_source}")]
     public sealed class MapIndexedSignal<TSource, TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public MapIndexedSignal(System.IObservable<TSource> source, System.Func<TSource, int, TResult> selector) { }
@@ -1171,7 +1205,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Index = {_index}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("MapIndexedWitness: Index = {_index}, Stopped = {_stopped}")]
     public sealed class MapIndexedWitness<TSource, TResult> : System.IObserver<TSource>
     {
         public MapIndexedWitness(System.IObserver<TResult> observer, System.Func<TSource, int, TResult> selector) { }
@@ -1179,20 +1213,20 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(TSource value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentBlendCoordinator: Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
     public sealed class MaxConcurrentBlendCoordinator<T> : System.IDisposable
     {
         public MaxConcurrentBlendCoordinator(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.MaxConcurrentBlendCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentEnumerableBlendSignal: Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
     public sealed class MaxConcurrentEnumerableBlendSignal<T> : System.IObservable<T>
     {
         public MaxConcurrentEnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("MergeCoordinator: Active = {Active}, Done = {Done}")]
     public sealed class MergeCoordinator<T> : System.IDisposable
     {
         public MergeCoordinator(System.IObserver<T> observer) { }
@@ -1203,7 +1237,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.MergeCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.MergeCoordinator<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MergeSignal: Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
     public sealed class MergeSignal<T> : System.IObservable<T>
     {
         public MergeSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -1211,32 +1245,39 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public MergeSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("OnErrorResumeNextSignal: Sources = {_sources}")]
+    public sealed class OnErrorResumeNextSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("PairSignal: Left = {Left}, Right = {Right}")]
     public sealed class PairSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public PairSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
+    [System.Diagnostics.DebuggerDisplay("PairWitness: IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
     public sealed class PairWitness<TLeft, TRight, TResult>
     {
         public PairWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("PublishSelectorSignal: Source = {Source}, Selector = {Selector}")]
     public sealed class PublishSelectorSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public PublishSelectorSignal(System.IObservable<TSource> source, System.Func<System.IObservable<TSource>, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
+    [System.Diagnostics.DebuggerDisplay("RaceSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
     public sealed class RaceSignal<T> : System.IObservable<T>
     {
         public RaceSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public RaceSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Arms = {_arms}")]
+    [System.Diagnostics.DebuggerDisplay("RaceWitness: Arms = {_arms}")]
     public sealed class RaceWitness<T> : System.IDisposable
     {
         public RaceWitness(System.IObserver<T> observer) { }
@@ -1245,40 +1286,48 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.RaceWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.RaceWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeCombineLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeCombineLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeCombineLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
+    [System.Diagnostics.DebuggerDisplay("RangeForkJoinSignal: Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
     public sealed class RangeForkJoinSignal<TResult> : System.IObservable<TResult>
     {
         public RangeForkJoinSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeSyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeSyncLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeSyncLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeWithLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeWithLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeWithLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Remaining = {_remaining}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("RecoverSignal: Source = {_source}")]
+    public sealed class RecoverSignal<T, TException> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T> where TException : System.Exception
+    {
+        public RecoverSignal(System.IObservable<T> source, System.Func<TException, System.IObservable<T>> handler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceCoordinator: Remaining = {_remaining}, Disposed = {_disposed}")]
     public sealed class RepeatSourceCoordinator<T> : System.IDisposable
     {
         public RepeatSourceCoordinator(System.IObservable<T> source, int? repeatCount, System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.RepeatSourceCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, RepeatCount = {_repeatCount}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceSignal: Source = {_source}, RepeatCount = {_repeatCount}")]
     public sealed class RepeatSourceSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public RepeatSourceSignal(System.IObservable<T> source, int? repeatCount) { }
@@ -1286,7 +1335,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Generation = {_generation}, Terminated = {_terminated}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceWitness: Generation = {_generation}, Terminated = {_terminated}")]
     public sealed class RepeatSourceWitness<T> : System.IObserver<T>
     {
         public RepeatSourceWitness(ReactiveUI.Primitives.Reactive.Advanced.RepeatSourceCoordinator<T> parent, int generation) { }
@@ -1294,7 +1343,15 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_value}, Scheduler = {_scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ResumeSignal: Source = {_source}, Fallback = {_fallback}")]
+    public sealed class ResumeSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ResumeSignal(System.IObservable<T> source, System.IObservable<T> fallback) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ReturnSignal: Value = {_value}, Scheduler = {_scheduler}")]
     public sealed class ReturnSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ReturnSignal(T value, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -1303,13 +1360,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Values = {Values}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledEnumerableSignal: Values = {Values}, Scheduler = {Scheduler}")]
     public sealed class ScheduledEnumerableSignal<T> : System.IObservable<T>
     {
         public ScheduledEnumerableSignal(System.Collections.Generic.IEnumerable<T> values, System.Reactive.Concurrency.IScheduler scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyCoordinator<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TResult>> selector) { }
@@ -1323,13 +1380,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Reactive.Advanced.SelectManyCoordinator<TSource, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableSignal: Source = {_source}")]
     public sealed class SelectManyEnumerableSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManyEnumerableSignal(System.IObservable<TSource> source, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SelectManyEnumerableWitness<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyEnumerableWitness(System.IObserver<TResult> observer, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
@@ -1343,7 +1400,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyResultCoordinator<TSource, TCollection, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyResultCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
@@ -1356,20 +1413,20 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Reactive.Advanced.SelectManyResultCoordinator<TSource, TCollection, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, CollectionSelector = {CollectionSelector}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultSignal: Source = {Source}, CollectionSelector = {CollectionSelector}")]
     public sealed class SelectManyResultSignal<TSource, TCollection, TResult> : System.IObservable<TResult>
     {
         public SelectManyResultSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManySignal: Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
     public sealed class SelectManySignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManySignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public SelectManySignal(System.IObservable<TSource> source, System.IObservable<TResult> inner) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Start = {Start}, Count = {Count}")]
+    [System.Diagnostics.DebuggerDisplay("SequenceSignal: Start = {Start}, Count = {Count}")]
     public sealed class SequenceSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<int>
     {
         public SequenceSignal(int start, int count, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -1380,13 +1437,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
     {
         public static System.IDisposable Subscribe<T>(System.IObserver<T> observer, bool currentThreadRequired, System.Func<System.IObserver<T>, System.IDisposable, System.IDisposable> subscribeCore) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SparkSignal: Source = {Source}")]
     public sealed class SparkSignal<T> : System.IObservable<ReactiveUI.Primitives.Reactive.Core.Spark<T>>
     {
         public SparkSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Reactive.Core.Spark<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SparkWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SparkWitness(System.IObserver<ReactiveUI.Primitives.Reactive.Core.Spark<T>> observer) { }
@@ -1401,21 +1458,21 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Action = {Action}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Action = {Action}, Scheduler = {Scheduler}")]
     public sealed class StartSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<System.Reactive.Unit>
     {
         public StartSignal(System.Action action, System.Reactive.Concurrency.IScheduler scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<System.Reactive.Unit> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Function = {Function}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Function = {Function}, Scheduler = {Scheduler}")]
     public sealed class StartSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public StartSignal(System.Func<T> function, System.Reactive.Concurrency.IScheduler scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SubscribeSafeWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SubscribeSafeWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SubscribeSafeWitness(System.IObserver<T> observer) { }
@@ -1429,50 +1486,50 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, SkipNullSources = {_skipNullSources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchMapSignal: Source = {_source}, SkipNullSources = {_skipNullSources}")]
     public sealed class SwitchMapSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SwitchMapSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchSignal: Sources = {Sources}")]
     public sealed class SwitchSignal<T> : System.IObservable<T>
     {
         public SwitchSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Version = {_version}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchWitness: Version = {_version}, IsDone = {IsDone}")]
     public sealed class SwitchWitness<T> : System.IDisposable
     {
         public SwitchWitness(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.SwitchWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class SyncLatestSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public SyncLatestSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
     public sealed class SyncLatestWitness<TLeft, TRight, TResult>
     {
         public SyncLatestWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Gate = {Gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeGateSignal: Source = {Source}, Gate = {Gate}")]
     public sealed class SynchronizeGateSignal<T> : System.IObservable<T>
     {
         public SynchronizeGateSignal(System.IObservable<T> source, System.Threading.Lock gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, Gate = {_gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectSignal: Source = {_source}, Gate = {_gate}")]
     public sealed class SynchronizeObjectSignal<T> : System.IObservable<T>
     {
         public SynchronizeObjectSignal(System.IObservable<T> source, object gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SynchronizeObjectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SynchronizeObjectWitness(System.IObserver<T> observer, object gate) { }
@@ -1484,19 +1541,19 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeSignal: Source = {Source}")]
     public sealed class SynchronizeSignal<T> : System.IObservable<T>
     {
         public SynchronizeSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("TapSignal: Source = {Source}")]
     public sealed class TapSignal<T> : System.IObservable<T>
     {
         public TapSignal(System.IObservable<T> source, System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskAnyWitness: Stopped = {_stopped}, Task = {Task}")]
     public sealed class TaskAnyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskAnyWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1512,7 +1569,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainCoordinator: Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
     public sealed class TaskChainCoordinator<T> : System.IDisposable
     {
         public TaskChainCoordinator(System.IObserver<T> observer) { }
@@ -1520,13 +1577,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.TaskChainCoordinator<T> Run(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainSignal: Sources = {_sources}")]
     public sealed class TaskChainSignal<T> : System.IObservable<T>
     {
         public TaskChainSignal(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskCountWitness: Count = {_count}, Stopped = {_stopped}")]
     public sealed class TaskCountWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskCountWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1542,13 +1599,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSignal: Task = {Task}")]
     public sealed class TaskInstanceSignal<T> : System.IObservable<T>
     {
         public TaskInstanceSignal(System.Threading.Tasks.Task<T> task) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSubscription: Stopped = {_stopped}")]
     public sealed class TaskInstanceSubscription : System.IDisposable
     {
         public TaskInstanceSubscription() { }
@@ -1556,13 +1613,22 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void Dispose() { }
         public bool TryStop() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Sequencer = {Sequencer}")]
+    [System.Diagnostics.DebuggerDisplay("ThrowSignal: Error = {_error}, Scheduler = {_scheduler}")]
+    public sealed class ThrowSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ThrowSignal(System.Exception error, System.Reactive.Concurrency.IScheduler scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalSignal: Source = {Source}, Sequencer = {Sequencer}")]
     public sealed class TimeIntervalSignal<T> : System.IObservable<ReactiveUI.Primitives.Core.TimeInterval<T>>
     {
         public TimeIntervalSignal(System.IObservable<T> source, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("First = {_first}, Last = {_last}")]
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalWitness: First = {_first}, Last = {_last}")]
     public sealed class TimeIntervalWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TimeIntervalWitness(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -1580,13 +1646,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
     {
         public static void Arm(ReactiveUI.Primitives.Disposables.SingleReplaceableDisposable slot, System.Reactive.Concurrency.IScheduler sequencer, System.TimeSpan delay, System.Action tick) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkSignal: Source = {Source}")]
     public sealed class UnsparkSignal<T> : System.IObservable<T>
     {
         public UnsparkSignal(System.IObservable<ReactiveUI.Primitives.Reactive.Core.Spark<T>> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class UnsparkWitness<T> : System.IDisposable, System.IObserver<ReactiveUI.Primitives.Reactive.Core.Spark<T>>
     {
         public UnsparkWitness(System.IObserver<T> observer) { }
@@ -1610,7 +1676,7 @@ namespace ReactiveUI.Primitives.Reactive.Concurrency
         public static ReactiveUI.Primitives.Concurrency.ScheduledItem<TAbsolute> Create<TAbsolute, TValue>(System.Reactive.Concurrency.IScheduler scheduler, TValue state, System.Func<System.Reactive.Concurrency.IScheduler, TValue, System.IDisposable> action, TAbsolute dueTime) where TAbsolute : System.IComparable<TAbsolute> { }
         public static ReactiveUI.Primitives.Concurrency.ScheduledItem<TAbsolute> Create<TAbsolute, TValue>(System.Reactive.Concurrency.IScheduler scheduler, TValue state, System.Func<System.Reactive.Concurrency.IScheduler, TValue, System.IDisposable> action, TAbsolute dueTime, System.Collections.Generic.IComparer<TAbsolute> comparer) where TAbsolute : System.IComparable<TAbsolute> { }
     }
-    [System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainState = {_drainState}, Disposed = {_isDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("WasmScheduler: ReadyCount = {_readyCount}, DrainState = {_drainState}, Disposed = {_isDisposed}")]
     public sealed class WasmScheduler : System.Reactive.Concurrency.LocalScheduler, System.IDisposable, System.Reactive.Concurrency.ISchedulerPeriodic
     {
         public static ReactiveUI.Primitives.Reactive.Concurrency.WasmScheduler Default { get; }
@@ -1652,7 +1718,7 @@ namespace ReactiveUI.Primitives.Reactive.Core
 }
 namespace ReactiveUI.Primitives.Reactive.Disposables
 {
-    [System.Diagnostics.DebuggerDisplay("Count = {Count}, IsDisposed = {IsDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ContainerDisposable: Count = {Count}, IsDisposed = {IsDisposed}")]
     public sealed class ContainerDisposable : ReactiveUI.Primitives.Disposables.MultipleDisposable
     {
         public ContainerDisposable() { }
@@ -1666,7 +1732,7 @@ namespace ReactiveUI.Primitives.Reactive.Disposables
 }
 namespace ReactiveUI.Primitives.Reactive.Signals
 {
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
+    [System.Diagnostics.DebuggerDisplay("PrioritySemaphoreSignal: Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
     public sealed class PrioritySemaphoreSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T> where T : System.IComparable<T>
     {
         public PrioritySemaphoreSignal(int maxCount) { }
@@ -1701,7 +1767,7 @@ namespace ReactiveUI.Primitives.Reactive.Signals
         public void OnNext(T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledSignal: Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
     public class ScheduledSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T>
     {
         public ScheduledSignal(System.Reactive.Concurrency.IScheduler scheduler) { }

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-android/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-android/PublicAPI.txt
@@ -849,7 +849,7 @@ namespace ReactiveUI.Primitives.Reactive
 }
 namespace ReactiveUI.Primitives.Reactive.Advanced
 {
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Period = {_period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSignal: DueTime = {_dueTime}, Period = {_period}")]
     public sealed class AfterSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
     {
         public AfterSignal(System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -857,7 +857,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<long> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSubscription: Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
     public sealed class AfterSubscription : System.IDisposable
     {
         public AfterSubscription(System.IObserver<long> observer, System.Reactive.Concurrency.IScheduler scheduler, System.TimeSpan dueTime, System.TimeSpan? period) { }
@@ -865,21 +865,21 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.AfterSubscription Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("SubscribeAsync = {SubscribeAsync}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncCreateSignal: SubscribeAsync = {SubscribeAsync}")]
     public sealed class AsyncCreateSignal<T> : System.IObservable<T>
     {
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ObservableFactory = {ObservableFactory}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncDeferSignal: ObservableFactory = {ObservableFactory}")]
     public sealed class AsyncDeferSignal<T> : System.IObservable<T>
     {
         public AsyncDeferSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public AsyncDeferSignal(System.Func<System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncSubscriptionLifetime: Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
     public sealed class AsyncSubscriptionLifetime : System.IDisposable
     {
         public AsyncSubscriptionLifetime() { }
@@ -890,33 +890,33 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable? disposable) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connected = {_connected}")]
+    [System.Diagnostics.DebuggerDisplay("AutoConnectSignal: Count = {_count}, Connected = {_connected}")]
     public sealed class AutoConnectSignal<T> : System.IObservable<T>
     {
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount) { }
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount, System.Action<System.IDisposable>? onConnect) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connection = {_connection}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSignal: Count = {_count}, Connection = {_connection}")]
     public sealed class AutoShareSignal<T> : System.IObservable<T>
     {
         public AutoShareSignal(ReactiveUI.Primitives.ConnectableSignal<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Owner = {_owner}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSubscription: Owner = {_owner}, Subscription = {Subscription}")]
     public sealed class AutoShareSubscription<T> : System.IDisposable
     {
         public AutoShareSubscription(ReactiveUI.Primitives.Reactive.Advanced.AutoShareSignal<T> owner, System.IDisposable subscription) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void Dispose() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("BlendSignal: Sources = {Sources}")]
     public sealed class BlendSignal<T> : System.IObservable<T>
     {
         public BlendSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("BlendWitness: ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
     public sealed class BlendWitness<T> : System.IDisposable
     {
         public BlendWitness(System.IObserver<T> observer) { }
@@ -925,7 +925,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.BlendWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.BlendWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("BufferEachWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class BufferEachWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public BufferEachWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -939,20 +939,20 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Window = {Window}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("BufferSignal: Window = {Window}, Source = {Source}")]
     public sealed class BufferSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public BufferSignal(System.IObservable<T> source, System.TimeSpan timeSpan, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("CastSignal: Source = {Source}")]
     public sealed class CastSignal<TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public CastSignal(System.IObservable<object?> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CastWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CastWitness<TResult> : System.IDisposable, System.IObserver<object?>
     {
         public CastWitness(System.IObserver<TResult> observer) { }
@@ -966,7 +966,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
+    [System.Diagnostics.DebuggerDisplay("ChainSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
     public sealed class ChainSignal<T> : System.IObservable<T>
     {
         public ChainSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -974,7 +974,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ChainSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("ChainWitness: IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
     public sealed class ChainWitness<T> : System.IDisposable
     {
         public ChainWitness(System.IObserver<T> observer) { }
@@ -984,13 +984,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.ChainWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.ChainWitness<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, TimeSpan = {TimeSpan}")]
+    [System.Diagnostics.DebuggerDisplay("CollectSignal: Source = {Source}, TimeSpan = {TimeSpan}")]
     public sealed class CollectSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public CollectSignal(System.IObservable<T> source, System.TimeSpan timeSpan, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Buffered = {Values.Count}")]
+    [System.Diagnostics.DebuggerDisplay("CollectWitness: Stopped = {_stopped}, Buffered = {Values.Count}")]
     public sealed class CollectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CollectWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -1002,7 +1002,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateSink: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class CreateSink<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateSink(System.IObserver<T> observer, bool disposeOnNextThrow) { }
@@ -1014,7 +1014,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CreateWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateWitness(System.IObserver<T> observer) { }
@@ -1028,13 +1028,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {DueTime}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietSignal: DueTime = {DueTime}, Source = {Source}")]
     public sealed class EmitIfQuietSignal<T> : System.IObservable<T>
     {
         public EmitIfQuietSignal(System.IObservable<T> source, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietWitness: HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
     public sealed class EmitIfQuietWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public EmitIfQuietWitness(System.IObserver<T> observer, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer) { }
@@ -1045,7 +1045,16 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("EmptySignal: Scheduler = {_scheduler}")]
+    public sealed class EmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public EmptySignal(System.Reactive.Concurrency.IScheduler scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("EnumerableBlendSignal: Sources = {Sources}")]
     public sealed class EnumerableBlendSignal<T> : System.IObservable<T>
     {
         public EnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -1055,7 +1064,14 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
     {
         public static System.IDisposable Attach<TEventHandler>(TEventHandler handler, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Reactive.Concurrency.IScheduler? scheduler) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
+    [System.Diagnostics.DebuggerDisplay("EverySignal: Period = {_period}, Scheduler = {_scheduler}")]
+    public sealed class EverySignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
+    {
+        public EverySignal(System.TimeSpan period, System.Reactive.Concurrency.IScheduler scheduler) { }
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<long> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ExpireCoordinator: Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
     public sealed class ExpireCoordinator<T> : System.IDisposable, System.IObserver<T>
     {
         public ExpireCoordinator(System.IObservable<T> source, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer, System.IObserver<T> observer) { }
@@ -1065,39 +1081,48 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnNext(T value) { }
         public ReactiveUI.Primitives.Reactive.Advanced.ExpireCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("ExpireSignal: DueTime = {_dueTime}, Source = {_source}")]
     public sealed class ExpireSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ExpireSignal(System.IObservable<T> source, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("FinallySignal: Source = {_source}")]
+    public sealed class FinallySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public FinallySignal(System.IObservable<T> source, System.Action finallyAction) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ForkJoinSignal: Left = {Left}, Right = {Right}")]
     public sealed class ForkJoinSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public ForkJoinSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("ForkJoinWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
     public sealed class ForkJoinWitness<TLeft, TRight, TResult>
     {
         public ForkJoinWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("CancellationRequested = {CancellationToken.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncExternalCancellationSignal: CancellationRequested = {CancellationToken.IsCancellationRequested}")]
     public sealed class FromAsyncExternalCancellationSignal<T> : System.IObservable<T>
     {
         public FromAsyncExternalCancellationSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSignal: TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
     public sealed class FromAsyncSignal<T> : System.IObservable<T>
     {
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSubscription: Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
     public sealed class FromAsyncSubscription<T> : System.IDisposable
     {
         public FromAsyncSubscription(System.IObserver<T> observer, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
@@ -1110,14 +1135,14 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public FromEventConversionSignal(System.Func<TCallback, TEventHandler> conversion, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Func<System.IObserver<TResult>, TCallback> callback, System.Reactive.Concurrency.IScheduler? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
+    [System.Diagnostics.DebuggerDisplay("FromEventPatternSignal: AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
     public sealed class FromEventPatternSignal<TEventHandler, TEventArgs> : System.IObservable<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> where TEventHandler : System.Delegate where TEventArgs : System.EventArgs
     {
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler) { }
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Reactive.Concurrency.IScheduler? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Disposed = {_disposed}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("GuardedWitness: Disposed = {_disposed}, Observer = {_observer}")]
     public sealed class GuardedWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public GuardedWitness(System.IObserver<T> observer, System.IDisposable cancel) { }
@@ -1127,7 +1152,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IgnoreValuesSignal: Source = {Source}")]
     public sealed class IgnoreValuesSignal<T> : System.IObservable<T>
     {
         public IgnoreValuesSignal(System.IObservable<T> source) { }
@@ -1141,14 +1166,14 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public System.IDisposable Subscribe(System.IObserver<System.Reactive.Unit> observer) { }
         public System.IDisposable Subscribe(System.Action<System.Reactive.Unit> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptySignal: Source = {Source}")]
     public sealed class IsEmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<bool>
     {
         public IsEmptySignal(System.IObservable<T> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<bool> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptyWitness: Stopped = {_stopped}, Subscription = {Subscription}")]
     public sealed class IsEmptyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public IsEmptyWitness(System.IObserver<bool> observer) { }
@@ -1161,14 +1186,23 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {Value}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("LeadSignal: Value = {Value}, Source = {Source}")]
     public sealed class LeadSignal<T> : ReactiveUI.Primitives.Advanced.IInlineSignal<T>
     {
         public LeadSignal(System.IObservable<T> source, T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
         public System.IDisposable Subscribe(System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("LoopSignal: Value = {Value}")]
+    public sealed class LoopSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public LoopSignal(T value) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("MapIndexedSignal: Source = {_source}")]
     public sealed class MapIndexedSignal<TSource, TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public MapIndexedSignal(System.IObservable<TSource> source, System.Func<TSource, int, TResult> selector) { }
@@ -1176,7 +1210,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Index = {_index}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("MapIndexedWitness: Index = {_index}, Stopped = {_stopped}")]
     public sealed class MapIndexedWitness<TSource, TResult> : System.IObserver<TSource>
     {
         public MapIndexedWitness(System.IObserver<TResult> observer, System.Func<TSource, int, TResult> selector) { }
@@ -1184,20 +1218,20 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(TSource value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentBlendCoordinator: Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
     public sealed class MaxConcurrentBlendCoordinator<T> : System.IDisposable
     {
         public MaxConcurrentBlendCoordinator(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.MaxConcurrentBlendCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentEnumerableBlendSignal: Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
     public sealed class MaxConcurrentEnumerableBlendSignal<T> : System.IObservable<T>
     {
         public MaxConcurrentEnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("MergeCoordinator: Active = {Active}, Done = {Done}")]
     public sealed class MergeCoordinator<T> : System.IDisposable
     {
         public MergeCoordinator(System.IObserver<T> observer) { }
@@ -1208,7 +1242,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.MergeCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.MergeCoordinator<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MergeSignal: Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
     public sealed class MergeSignal<T> : System.IObservable<T>
     {
         public MergeSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -1216,32 +1250,39 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public MergeSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("OnErrorResumeNextSignal: Sources = {_sources}")]
+    public sealed class OnErrorResumeNextSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("PairSignal: Left = {Left}, Right = {Right}")]
     public sealed class PairSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public PairSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
+    [System.Diagnostics.DebuggerDisplay("PairWitness: IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
     public sealed class PairWitness<TLeft, TRight, TResult>
     {
         public PairWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("PublishSelectorSignal: Source = {Source}, Selector = {Selector}")]
     public sealed class PublishSelectorSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public PublishSelectorSignal(System.IObservable<TSource> source, System.Func<System.IObservable<TSource>, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
+    [System.Diagnostics.DebuggerDisplay("RaceSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
     public sealed class RaceSignal<T> : System.IObservable<T>
     {
         public RaceSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public RaceSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Arms = {_arms}")]
+    [System.Diagnostics.DebuggerDisplay("RaceWitness: Arms = {_arms}")]
     public sealed class RaceWitness<T> : System.IDisposable
     {
         public RaceWitness(System.IObserver<T> observer) { }
@@ -1250,40 +1291,48 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.RaceWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.RaceWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeCombineLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeCombineLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeCombineLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
+    [System.Diagnostics.DebuggerDisplay("RangeForkJoinSignal: Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
     public sealed class RangeForkJoinSignal<TResult> : System.IObservable<TResult>
     {
         public RangeForkJoinSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeSyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeSyncLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeSyncLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeWithLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeWithLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeWithLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Remaining = {_remaining}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("RecoverSignal: Source = {_source}")]
+    public sealed class RecoverSignal<T, TException> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T> where TException : System.Exception
+    {
+        public RecoverSignal(System.IObservable<T> source, System.Func<TException, System.IObservable<T>> handler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceCoordinator: Remaining = {_remaining}, Disposed = {_disposed}")]
     public sealed class RepeatSourceCoordinator<T> : System.IDisposable
     {
         public RepeatSourceCoordinator(System.IObservable<T> source, int? repeatCount, System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.RepeatSourceCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, RepeatCount = {_repeatCount}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceSignal: Source = {_source}, RepeatCount = {_repeatCount}")]
     public sealed class RepeatSourceSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public RepeatSourceSignal(System.IObservable<T> source, int? repeatCount) { }
@@ -1291,7 +1340,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Generation = {_generation}, Terminated = {_terminated}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceWitness: Generation = {_generation}, Terminated = {_terminated}")]
     public sealed class RepeatSourceWitness<T> : System.IObserver<T>
     {
         public RepeatSourceWitness(ReactiveUI.Primitives.Reactive.Advanced.RepeatSourceCoordinator<T> parent, int generation) { }
@@ -1299,7 +1348,15 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_value}, Scheduler = {_scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ResumeSignal: Source = {_source}, Fallback = {_fallback}")]
+    public sealed class ResumeSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ResumeSignal(System.IObservable<T> source, System.IObservable<T> fallback) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ReturnSignal: Value = {_value}, Scheduler = {_scheduler}")]
     public sealed class ReturnSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ReturnSignal(T value, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -1308,13 +1365,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Values = {Values}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledEnumerableSignal: Values = {Values}, Scheduler = {Scheduler}")]
     public sealed class ScheduledEnumerableSignal<T> : System.IObservable<T>
     {
         public ScheduledEnumerableSignal(System.Collections.Generic.IEnumerable<T> values, System.Reactive.Concurrency.IScheduler scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyCoordinator<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TResult>> selector) { }
@@ -1328,13 +1385,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Reactive.Advanced.SelectManyCoordinator<TSource, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableSignal: Source = {_source}")]
     public sealed class SelectManyEnumerableSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManyEnumerableSignal(System.IObservable<TSource> source, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SelectManyEnumerableWitness<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyEnumerableWitness(System.IObserver<TResult> observer, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
@@ -1348,7 +1405,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyResultCoordinator<TSource, TCollection, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyResultCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
@@ -1361,20 +1418,20 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Reactive.Advanced.SelectManyResultCoordinator<TSource, TCollection, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, CollectionSelector = {CollectionSelector}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultSignal: Source = {Source}, CollectionSelector = {CollectionSelector}")]
     public sealed class SelectManyResultSignal<TSource, TCollection, TResult> : System.IObservable<TResult>
     {
         public SelectManyResultSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManySignal: Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
     public sealed class SelectManySignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManySignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public SelectManySignal(System.IObservable<TSource> source, System.IObservable<TResult> inner) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Start = {Start}, Count = {Count}")]
+    [System.Diagnostics.DebuggerDisplay("SequenceSignal: Start = {Start}, Count = {Count}")]
     public sealed class SequenceSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<int>
     {
         public SequenceSignal(int start, int count, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -1385,13 +1442,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
     {
         public static System.IDisposable Subscribe<T>(System.IObserver<T> observer, bool currentThreadRequired, System.Func<System.IObserver<T>, System.IDisposable, System.IDisposable> subscribeCore) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SparkSignal: Source = {Source}")]
     public sealed class SparkSignal<T> : System.IObservable<ReactiveUI.Primitives.Reactive.Core.Spark<T>>
     {
         public SparkSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Reactive.Core.Spark<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SparkWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SparkWitness(System.IObserver<ReactiveUI.Primitives.Reactive.Core.Spark<T>> observer) { }
@@ -1406,21 +1463,21 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Action = {Action}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Action = {Action}, Scheduler = {Scheduler}")]
     public sealed class StartSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<System.Reactive.Unit>
     {
         public StartSignal(System.Action action, System.Reactive.Concurrency.IScheduler scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<System.Reactive.Unit> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Function = {Function}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Function = {Function}, Scheduler = {Scheduler}")]
     public sealed class StartSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public StartSignal(System.Func<T> function, System.Reactive.Concurrency.IScheduler scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SubscribeSafeWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SubscribeSafeWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SubscribeSafeWitness(System.IObserver<T> observer) { }
@@ -1434,50 +1491,50 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, SkipNullSources = {_skipNullSources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchMapSignal: Source = {_source}, SkipNullSources = {_skipNullSources}")]
     public sealed class SwitchMapSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SwitchMapSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchSignal: Sources = {Sources}")]
     public sealed class SwitchSignal<T> : System.IObservable<T>
     {
         public SwitchSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Version = {_version}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchWitness: Version = {_version}, IsDone = {IsDone}")]
     public sealed class SwitchWitness<T> : System.IDisposable
     {
         public SwitchWitness(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.SwitchWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class SyncLatestSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public SyncLatestSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
     public sealed class SyncLatestWitness<TLeft, TRight, TResult>
     {
         public SyncLatestWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Gate = {Gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeGateSignal: Source = {Source}, Gate = {Gate}")]
     public sealed class SynchronizeGateSignal<T> : System.IObservable<T>
     {
         public SynchronizeGateSignal(System.IObservable<T> source, System.Threading.Lock gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, Gate = {_gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectSignal: Source = {_source}, Gate = {_gate}")]
     public sealed class SynchronizeObjectSignal<T> : System.IObservable<T>
     {
         public SynchronizeObjectSignal(System.IObservable<T> source, object gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SynchronizeObjectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SynchronizeObjectWitness(System.IObserver<T> observer, object gate) { }
@@ -1489,19 +1546,19 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeSignal: Source = {Source}")]
     public sealed class SynchronizeSignal<T> : System.IObservable<T>
     {
         public SynchronizeSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("TapSignal: Source = {Source}")]
     public sealed class TapSignal<T> : System.IObservable<T>
     {
         public TapSignal(System.IObservable<T> source, System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskAnyWitness: Stopped = {_stopped}, Task = {Task}")]
     public sealed class TaskAnyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskAnyWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1517,7 +1574,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainCoordinator: Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
     public sealed class TaskChainCoordinator<T> : System.IDisposable
     {
         public TaskChainCoordinator(System.IObserver<T> observer) { }
@@ -1525,13 +1582,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.TaskChainCoordinator<T> Run(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainSignal: Sources = {_sources}")]
     public sealed class TaskChainSignal<T> : System.IObservable<T>
     {
         public TaskChainSignal(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskCountWitness: Count = {_count}, Stopped = {_stopped}")]
     public sealed class TaskCountWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskCountWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1547,13 +1604,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSignal: Task = {Task}")]
     public sealed class TaskInstanceSignal<T> : System.IObservable<T>
     {
         public TaskInstanceSignal(System.Threading.Tasks.Task<T> task) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSubscription: Stopped = {_stopped}")]
     public sealed class TaskInstanceSubscription : System.IDisposable
     {
         public TaskInstanceSubscription() { }
@@ -1561,13 +1618,22 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void Dispose() { }
         public bool TryStop() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Sequencer = {Sequencer}")]
+    [System.Diagnostics.DebuggerDisplay("ThrowSignal: Error = {_error}, Scheduler = {_scheduler}")]
+    public sealed class ThrowSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ThrowSignal(System.Exception error, System.Reactive.Concurrency.IScheduler scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalSignal: Source = {Source}, Sequencer = {Sequencer}")]
     public sealed class TimeIntervalSignal<T> : System.IObservable<ReactiveUI.Primitives.Core.TimeInterval<T>>
     {
         public TimeIntervalSignal(System.IObservable<T> source, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("First = {_first}, Last = {_last}")]
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalWitness: First = {_first}, Last = {_last}")]
     public sealed class TimeIntervalWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TimeIntervalWitness(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -1585,13 +1651,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
     {
         public static void Arm(ReactiveUI.Primitives.Disposables.SingleReplaceableDisposable slot, System.Reactive.Concurrency.IScheduler sequencer, System.TimeSpan delay, System.Action tick) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkSignal: Source = {Source}")]
     public sealed class UnsparkSignal<T> : System.IObservable<T>
     {
         public UnsparkSignal(System.IObservable<ReactiveUI.Primitives.Reactive.Core.Spark<T>> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class UnsparkWitness<T> : System.IDisposable, System.IObserver<ReactiveUI.Primitives.Reactive.Core.Spark<T>>
     {
         public UnsparkWitness(System.IObserver<T> observer) { }
@@ -1609,7 +1675,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
 }
 namespace ReactiveUI.Primitives.Reactive.Concurrency
 {
-    [System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
+    [System.Diagnostics.DebuggerDisplay("CoalescingDispatchScheduler: ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
     public abstract class CoalescingDispatchScheduler : System.Reactive.Concurrency.LocalScheduler
     {
         protected CoalescingDispatchScheduler() { }
@@ -1636,7 +1702,7 @@ namespace ReactiveUI.Primitives.Reactive.Concurrency
         public static ReactiveUI.Primitives.Concurrency.ScheduledItem<TAbsolute> Create<TAbsolute, TValue>(System.Reactive.Concurrency.IScheduler scheduler, TValue state, System.Func<System.Reactive.Concurrency.IScheduler, TValue, System.IDisposable> action, TAbsolute dueTime) where TAbsolute : System.IComparable<TAbsolute> { }
         public static ReactiveUI.Primitives.Concurrency.ScheduledItem<TAbsolute> Create<TAbsolute, TValue>(System.Reactive.Concurrency.IScheduler scheduler, TValue state, System.Func<System.Reactive.Concurrency.IScheduler, TValue, System.IDisposable> action, TAbsolute dueTime, System.Collections.Generic.IComparer<TAbsolute> comparer) where TAbsolute : System.IComparable<TAbsolute> { }
     }
-    [System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainState = {_drainState}, Disposed = {_isDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("WasmScheduler: ReadyCount = {_readyCount}, DrainState = {_drainState}, Disposed = {_isDisposed}")]
     public sealed class WasmScheduler : System.Reactive.Concurrency.LocalScheduler, System.IDisposable, System.Reactive.Concurrency.ISchedulerPeriodic
     {
         public static ReactiveUI.Primitives.Reactive.Concurrency.WasmScheduler Default { get; }
@@ -1678,7 +1744,7 @@ namespace ReactiveUI.Primitives.Reactive.Core
 }
 namespace ReactiveUI.Primitives.Reactive.Disposables
 {
-    [System.Diagnostics.DebuggerDisplay("Count = {Count}, IsDisposed = {IsDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ContainerDisposable: Count = {Count}, IsDisposed = {IsDisposed}")]
     public sealed class ContainerDisposable : ReactiveUI.Primitives.Disposables.MultipleDisposable
     {
         public ContainerDisposable() { }
@@ -1692,7 +1758,7 @@ namespace ReactiveUI.Primitives.Reactive.Disposables
 }
 namespace ReactiveUI.Primitives.Reactive.Signals
 {
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
+    [System.Diagnostics.DebuggerDisplay("PrioritySemaphoreSignal: Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
     public sealed class PrioritySemaphoreSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T> where T : System.IComparable<T>
     {
         public PrioritySemaphoreSignal(int maxCount) { }
@@ -1727,7 +1793,7 @@ namespace ReactiveUI.Primitives.Reactive.Signals
         public void OnNext(T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledSignal: Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
     public class ScheduledSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T>
     {
         public ScheduledSignal(System.Reactive.Concurrency.IScheduler scheduler) { }

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-ios/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-ios/PublicAPI.txt
@@ -845,7 +845,7 @@ namespace ReactiveUI.Primitives.Reactive
 }
 namespace ReactiveUI.Primitives.Reactive.Advanced
 {
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Period = {_period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSignal: DueTime = {_dueTime}, Period = {_period}")]
     public sealed class AfterSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
     {
         public AfterSignal(System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -853,7 +853,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<long> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSubscription: Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
     public sealed class AfterSubscription : System.IDisposable
     {
         public AfterSubscription(System.IObserver<long> observer, System.Reactive.Concurrency.IScheduler scheduler, System.TimeSpan dueTime, System.TimeSpan? period) { }
@@ -861,21 +861,21 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.AfterSubscription Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("SubscribeAsync = {SubscribeAsync}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncCreateSignal: SubscribeAsync = {SubscribeAsync}")]
     public sealed class AsyncCreateSignal<T> : System.IObservable<T>
     {
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ObservableFactory = {ObservableFactory}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncDeferSignal: ObservableFactory = {ObservableFactory}")]
     public sealed class AsyncDeferSignal<T> : System.IObservable<T>
     {
         public AsyncDeferSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public AsyncDeferSignal(System.Func<System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncSubscriptionLifetime: Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
     public sealed class AsyncSubscriptionLifetime : System.IDisposable
     {
         public AsyncSubscriptionLifetime() { }
@@ -886,33 +886,33 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable? disposable) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connected = {_connected}")]
+    [System.Diagnostics.DebuggerDisplay("AutoConnectSignal: Count = {_count}, Connected = {_connected}")]
     public sealed class AutoConnectSignal<T> : System.IObservable<T>
     {
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount) { }
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount, System.Action<System.IDisposable>? onConnect) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connection = {_connection}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSignal: Count = {_count}, Connection = {_connection}")]
     public sealed class AutoShareSignal<T> : System.IObservable<T>
     {
         public AutoShareSignal(ReactiveUI.Primitives.ConnectableSignal<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Owner = {_owner}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSubscription: Owner = {_owner}, Subscription = {Subscription}")]
     public sealed class AutoShareSubscription<T> : System.IDisposable
     {
         public AutoShareSubscription(ReactiveUI.Primitives.Reactive.Advanced.AutoShareSignal<T> owner, System.IDisposable subscription) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void Dispose() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("BlendSignal: Sources = {Sources}")]
     public sealed class BlendSignal<T> : System.IObservable<T>
     {
         public BlendSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("BlendWitness: ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
     public sealed class BlendWitness<T> : System.IDisposable
     {
         public BlendWitness(System.IObserver<T> observer) { }
@@ -921,7 +921,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.BlendWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.BlendWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("BufferEachWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class BufferEachWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public BufferEachWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -935,20 +935,20 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Window = {Window}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("BufferSignal: Window = {Window}, Source = {Source}")]
     public sealed class BufferSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public BufferSignal(System.IObservable<T> source, System.TimeSpan timeSpan, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("CastSignal: Source = {Source}")]
     public sealed class CastSignal<TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public CastSignal(System.IObservable<object?> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CastWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CastWitness<TResult> : System.IDisposable, System.IObserver<object?>
     {
         public CastWitness(System.IObserver<TResult> observer) { }
@@ -962,7 +962,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
+    [System.Diagnostics.DebuggerDisplay("ChainSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
     public sealed class ChainSignal<T> : System.IObservable<T>
     {
         public ChainSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -970,7 +970,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ChainSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("ChainWitness: IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
     public sealed class ChainWitness<T> : System.IDisposable
     {
         public ChainWitness(System.IObserver<T> observer) { }
@@ -980,13 +980,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.ChainWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.ChainWitness<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, TimeSpan = {TimeSpan}")]
+    [System.Diagnostics.DebuggerDisplay("CollectSignal: Source = {Source}, TimeSpan = {TimeSpan}")]
     public sealed class CollectSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public CollectSignal(System.IObservable<T> source, System.TimeSpan timeSpan, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Buffered = {Values.Count}")]
+    [System.Diagnostics.DebuggerDisplay("CollectWitness: Stopped = {_stopped}, Buffered = {Values.Count}")]
     public sealed class CollectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CollectWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -998,7 +998,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateSink: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class CreateSink<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateSink(System.IObserver<T> observer, bool disposeOnNextThrow) { }
@@ -1010,7 +1010,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CreateWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateWitness(System.IObserver<T> observer) { }
@@ -1024,13 +1024,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {DueTime}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietSignal: DueTime = {DueTime}, Source = {Source}")]
     public sealed class EmitIfQuietSignal<T> : System.IObservable<T>
     {
         public EmitIfQuietSignal(System.IObservable<T> source, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietWitness: HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
     public sealed class EmitIfQuietWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public EmitIfQuietWitness(System.IObserver<T> observer, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer) { }
@@ -1041,7 +1041,16 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("EmptySignal: Scheduler = {_scheduler}")]
+    public sealed class EmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public EmptySignal(System.Reactive.Concurrency.IScheduler scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("EnumerableBlendSignal: Sources = {Sources}")]
     public sealed class EnumerableBlendSignal<T> : System.IObservable<T>
     {
         public EnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -1051,7 +1060,14 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
     {
         public static System.IDisposable Attach<TEventHandler>(TEventHandler handler, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Reactive.Concurrency.IScheduler? scheduler) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
+    [System.Diagnostics.DebuggerDisplay("EverySignal: Period = {_period}, Scheduler = {_scheduler}")]
+    public sealed class EverySignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
+    {
+        public EverySignal(System.TimeSpan period, System.Reactive.Concurrency.IScheduler scheduler) { }
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<long> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ExpireCoordinator: Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
     public sealed class ExpireCoordinator<T> : System.IDisposable, System.IObserver<T>
     {
         public ExpireCoordinator(System.IObservable<T> source, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer, System.IObserver<T> observer) { }
@@ -1061,39 +1077,48 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnNext(T value) { }
         public ReactiveUI.Primitives.Reactive.Advanced.ExpireCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("ExpireSignal: DueTime = {_dueTime}, Source = {_source}")]
     public sealed class ExpireSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ExpireSignal(System.IObservable<T> source, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("FinallySignal: Source = {_source}")]
+    public sealed class FinallySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public FinallySignal(System.IObservable<T> source, System.Action finallyAction) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ForkJoinSignal: Left = {Left}, Right = {Right}")]
     public sealed class ForkJoinSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public ForkJoinSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("ForkJoinWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
     public sealed class ForkJoinWitness<TLeft, TRight, TResult>
     {
         public ForkJoinWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("CancellationRequested = {CancellationToken.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncExternalCancellationSignal: CancellationRequested = {CancellationToken.IsCancellationRequested}")]
     public sealed class FromAsyncExternalCancellationSignal<T> : System.IObservable<T>
     {
         public FromAsyncExternalCancellationSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSignal: TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
     public sealed class FromAsyncSignal<T> : System.IObservable<T>
     {
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSubscription: Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
     public sealed class FromAsyncSubscription<T> : System.IDisposable
     {
         public FromAsyncSubscription(System.IObserver<T> observer, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
@@ -1106,14 +1131,14 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public FromEventConversionSignal(System.Func<TCallback, TEventHandler> conversion, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Func<System.IObserver<TResult>, TCallback> callback, System.Reactive.Concurrency.IScheduler? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
+    [System.Diagnostics.DebuggerDisplay("FromEventPatternSignal: AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
     public sealed class FromEventPatternSignal<TEventHandler, TEventArgs> : System.IObservable<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> where TEventHandler : System.Delegate where TEventArgs : System.EventArgs
     {
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler) { }
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Reactive.Concurrency.IScheduler? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Disposed = {_disposed}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("GuardedWitness: Disposed = {_disposed}, Observer = {_observer}")]
     public sealed class GuardedWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public GuardedWitness(System.IObserver<T> observer, System.IDisposable cancel) { }
@@ -1123,7 +1148,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IgnoreValuesSignal: Source = {Source}")]
     public sealed class IgnoreValuesSignal<T> : System.IObservable<T>
     {
         public IgnoreValuesSignal(System.IObservable<T> source) { }
@@ -1137,14 +1162,14 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public System.IDisposable Subscribe(System.IObserver<System.Reactive.Unit> observer) { }
         public System.IDisposable Subscribe(System.Action<System.Reactive.Unit> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptySignal: Source = {Source}")]
     public sealed class IsEmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<bool>
     {
         public IsEmptySignal(System.IObservable<T> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<bool> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptyWitness: Stopped = {_stopped}, Subscription = {Subscription}")]
     public sealed class IsEmptyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public IsEmptyWitness(System.IObserver<bool> observer) { }
@@ -1157,14 +1182,23 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {Value}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("LeadSignal: Value = {Value}, Source = {Source}")]
     public sealed class LeadSignal<T> : ReactiveUI.Primitives.Advanced.IInlineSignal<T>
     {
         public LeadSignal(System.IObservable<T> source, T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
         public System.IDisposable Subscribe(System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("LoopSignal: Value = {Value}")]
+    public sealed class LoopSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public LoopSignal(T value) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("MapIndexedSignal: Source = {_source}")]
     public sealed class MapIndexedSignal<TSource, TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public MapIndexedSignal(System.IObservable<TSource> source, System.Func<TSource, int, TResult> selector) { }
@@ -1172,7 +1206,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Index = {_index}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("MapIndexedWitness: Index = {_index}, Stopped = {_stopped}")]
     public sealed class MapIndexedWitness<TSource, TResult> : System.IObserver<TSource>
     {
         public MapIndexedWitness(System.IObserver<TResult> observer, System.Func<TSource, int, TResult> selector) { }
@@ -1180,20 +1214,20 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(TSource value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentBlendCoordinator: Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
     public sealed class MaxConcurrentBlendCoordinator<T> : System.IDisposable
     {
         public MaxConcurrentBlendCoordinator(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.MaxConcurrentBlendCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentEnumerableBlendSignal: Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
     public sealed class MaxConcurrentEnumerableBlendSignal<T> : System.IObservable<T>
     {
         public MaxConcurrentEnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("MergeCoordinator: Active = {Active}, Done = {Done}")]
     public sealed class MergeCoordinator<T> : System.IDisposable
     {
         public MergeCoordinator(System.IObserver<T> observer) { }
@@ -1204,7 +1238,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.MergeCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.MergeCoordinator<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MergeSignal: Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
     public sealed class MergeSignal<T> : System.IObservable<T>
     {
         public MergeSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -1212,32 +1246,39 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public MergeSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("OnErrorResumeNextSignal: Sources = {_sources}")]
+    public sealed class OnErrorResumeNextSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("PairSignal: Left = {Left}, Right = {Right}")]
     public sealed class PairSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public PairSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
+    [System.Diagnostics.DebuggerDisplay("PairWitness: IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
     public sealed class PairWitness<TLeft, TRight, TResult>
     {
         public PairWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("PublishSelectorSignal: Source = {Source}, Selector = {Selector}")]
     public sealed class PublishSelectorSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public PublishSelectorSignal(System.IObservable<TSource> source, System.Func<System.IObservable<TSource>, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
+    [System.Diagnostics.DebuggerDisplay("RaceSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
     public sealed class RaceSignal<T> : System.IObservable<T>
     {
         public RaceSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public RaceSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Arms = {_arms}")]
+    [System.Diagnostics.DebuggerDisplay("RaceWitness: Arms = {_arms}")]
     public sealed class RaceWitness<T> : System.IDisposable
     {
         public RaceWitness(System.IObserver<T> observer) { }
@@ -1246,40 +1287,48 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.RaceWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.RaceWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeCombineLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeCombineLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeCombineLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
+    [System.Diagnostics.DebuggerDisplay("RangeForkJoinSignal: Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
     public sealed class RangeForkJoinSignal<TResult> : System.IObservable<TResult>
     {
         public RangeForkJoinSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeSyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeSyncLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeSyncLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeWithLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeWithLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeWithLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Remaining = {_remaining}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("RecoverSignal: Source = {_source}")]
+    public sealed class RecoverSignal<T, TException> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T> where TException : System.Exception
+    {
+        public RecoverSignal(System.IObservable<T> source, System.Func<TException, System.IObservable<T>> handler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceCoordinator: Remaining = {_remaining}, Disposed = {_disposed}")]
     public sealed class RepeatSourceCoordinator<T> : System.IDisposable
     {
         public RepeatSourceCoordinator(System.IObservable<T> source, int? repeatCount, System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.RepeatSourceCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, RepeatCount = {_repeatCount}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceSignal: Source = {_source}, RepeatCount = {_repeatCount}")]
     public sealed class RepeatSourceSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public RepeatSourceSignal(System.IObservable<T> source, int? repeatCount) { }
@@ -1287,7 +1336,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Generation = {_generation}, Terminated = {_terminated}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceWitness: Generation = {_generation}, Terminated = {_terminated}")]
     public sealed class RepeatSourceWitness<T> : System.IObserver<T>
     {
         public RepeatSourceWitness(ReactiveUI.Primitives.Reactive.Advanced.RepeatSourceCoordinator<T> parent, int generation) { }
@@ -1295,7 +1344,15 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_value}, Scheduler = {_scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ResumeSignal: Source = {_source}, Fallback = {_fallback}")]
+    public sealed class ResumeSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ResumeSignal(System.IObservable<T> source, System.IObservable<T> fallback) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ReturnSignal: Value = {_value}, Scheduler = {_scheduler}")]
     public sealed class ReturnSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ReturnSignal(T value, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -1304,13 +1361,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Values = {Values}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledEnumerableSignal: Values = {Values}, Scheduler = {Scheduler}")]
     public sealed class ScheduledEnumerableSignal<T> : System.IObservable<T>
     {
         public ScheduledEnumerableSignal(System.Collections.Generic.IEnumerable<T> values, System.Reactive.Concurrency.IScheduler scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyCoordinator<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TResult>> selector) { }
@@ -1324,13 +1381,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Reactive.Advanced.SelectManyCoordinator<TSource, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableSignal: Source = {_source}")]
     public sealed class SelectManyEnumerableSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManyEnumerableSignal(System.IObservable<TSource> source, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SelectManyEnumerableWitness<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyEnumerableWitness(System.IObserver<TResult> observer, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
@@ -1344,7 +1401,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyResultCoordinator<TSource, TCollection, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyResultCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
@@ -1357,20 +1414,20 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Reactive.Advanced.SelectManyResultCoordinator<TSource, TCollection, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, CollectionSelector = {CollectionSelector}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultSignal: Source = {Source}, CollectionSelector = {CollectionSelector}")]
     public sealed class SelectManyResultSignal<TSource, TCollection, TResult> : System.IObservable<TResult>
     {
         public SelectManyResultSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManySignal: Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
     public sealed class SelectManySignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManySignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public SelectManySignal(System.IObservable<TSource> source, System.IObservable<TResult> inner) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Start = {Start}, Count = {Count}")]
+    [System.Diagnostics.DebuggerDisplay("SequenceSignal: Start = {Start}, Count = {Count}")]
     public sealed class SequenceSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<int>
     {
         public SequenceSignal(int start, int count, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -1381,13 +1438,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
     {
         public static System.IDisposable Subscribe<T>(System.IObserver<T> observer, bool currentThreadRequired, System.Func<System.IObserver<T>, System.IDisposable, System.IDisposable> subscribeCore) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SparkSignal: Source = {Source}")]
     public sealed class SparkSignal<T> : System.IObservable<ReactiveUI.Primitives.Reactive.Core.Spark<T>>
     {
         public SparkSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Reactive.Core.Spark<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SparkWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SparkWitness(System.IObserver<ReactiveUI.Primitives.Reactive.Core.Spark<T>> observer) { }
@@ -1402,21 +1459,21 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Action = {Action}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Action = {Action}, Scheduler = {Scheduler}")]
     public sealed class StartSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<System.Reactive.Unit>
     {
         public StartSignal(System.Action action, System.Reactive.Concurrency.IScheduler scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<System.Reactive.Unit> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Function = {Function}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Function = {Function}, Scheduler = {Scheduler}")]
     public sealed class StartSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public StartSignal(System.Func<T> function, System.Reactive.Concurrency.IScheduler scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SubscribeSafeWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SubscribeSafeWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SubscribeSafeWitness(System.IObserver<T> observer) { }
@@ -1430,50 +1487,50 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, SkipNullSources = {_skipNullSources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchMapSignal: Source = {_source}, SkipNullSources = {_skipNullSources}")]
     public sealed class SwitchMapSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SwitchMapSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchSignal: Sources = {Sources}")]
     public sealed class SwitchSignal<T> : System.IObservable<T>
     {
         public SwitchSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Version = {_version}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchWitness: Version = {_version}, IsDone = {IsDone}")]
     public sealed class SwitchWitness<T> : System.IDisposable
     {
         public SwitchWitness(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.SwitchWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class SyncLatestSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public SyncLatestSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
     public sealed class SyncLatestWitness<TLeft, TRight, TResult>
     {
         public SyncLatestWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Gate = {Gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeGateSignal: Source = {Source}, Gate = {Gate}")]
     public sealed class SynchronizeGateSignal<T> : System.IObservable<T>
     {
         public SynchronizeGateSignal(System.IObservable<T> source, System.Threading.Lock gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, Gate = {_gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectSignal: Source = {_source}, Gate = {_gate}")]
     public sealed class SynchronizeObjectSignal<T> : System.IObservable<T>
     {
         public SynchronizeObjectSignal(System.IObservable<T> source, object gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SynchronizeObjectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SynchronizeObjectWitness(System.IObserver<T> observer, object gate) { }
@@ -1485,19 +1542,19 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeSignal: Source = {Source}")]
     public sealed class SynchronizeSignal<T> : System.IObservable<T>
     {
         public SynchronizeSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("TapSignal: Source = {Source}")]
     public sealed class TapSignal<T> : System.IObservable<T>
     {
         public TapSignal(System.IObservable<T> source, System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskAnyWitness: Stopped = {_stopped}, Task = {Task}")]
     public sealed class TaskAnyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskAnyWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1513,7 +1570,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainCoordinator: Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
     public sealed class TaskChainCoordinator<T> : System.IDisposable
     {
         public TaskChainCoordinator(System.IObserver<T> observer) { }
@@ -1521,13 +1578,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.TaskChainCoordinator<T> Run(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainSignal: Sources = {_sources}")]
     public sealed class TaskChainSignal<T> : System.IObservable<T>
     {
         public TaskChainSignal(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskCountWitness: Count = {_count}, Stopped = {_stopped}")]
     public sealed class TaskCountWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskCountWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1543,13 +1600,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSignal: Task = {Task}")]
     public sealed class TaskInstanceSignal<T> : System.IObservable<T>
     {
         public TaskInstanceSignal(System.Threading.Tasks.Task<T> task) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSubscription: Stopped = {_stopped}")]
     public sealed class TaskInstanceSubscription : System.IDisposable
     {
         public TaskInstanceSubscription() { }
@@ -1557,13 +1614,22 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void Dispose() { }
         public bool TryStop() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Sequencer = {Sequencer}")]
+    [System.Diagnostics.DebuggerDisplay("ThrowSignal: Error = {_error}, Scheduler = {_scheduler}")]
+    public sealed class ThrowSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ThrowSignal(System.Exception error, System.Reactive.Concurrency.IScheduler scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalSignal: Source = {Source}, Sequencer = {Sequencer}")]
     public sealed class TimeIntervalSignal<T> : System.IObservable<ReactiveUI.Primitives.Core.TimeInterval<T>>
     {
         public TimeIntervalSignal(System.IObservable<T> source, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("First = {_first}, Last = {_last}")]
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalWitness: First = {_first}, Last = {_last}")]
     public sealed class TimeIntervalWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TimeIntervalWitness(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -1581,13 +1647,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
     {
         public static void Arm(ReactiveUI.Primitives.Disposables.SingleReplaceableDisposable slot, System.Reactive.Concurrency.IScheduler sequencer, System.TimeSpan delay, System.Action tick) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkSignal: Source = {Source}")]
     public sealed class UnsparkSignal<T> : System.IObservable<T>
     {
         public UnsparkSignal(System.IObservable<ReactiveUI.Primitives.Reactive.Core.Spark<T>> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class UnsparkWitness<T> : System.IDisposable, System.IObserver<ReactiveUI.Primitives.Reactive.Core.Spark<T>>
     {
         public UnsparkWitness(System.IObserver<T> observer) { }
@@ -1605,7 +1671,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
 }
 namespace ReactiveUI.Primitives.Reactive.Concurrency
 {
-    [System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
+    [System.Diagnostics.DebuggerDisplay("CoalescingDispatchScheduler: ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
     public abstract class CoalescingDispatchScheduler : System.Reactive.Concurrency.LocalScheduler
     {
         protected CoalescingDispatchScheduler() { }
@@ -1630,7 +1696,7 @@ namespace ReactiveUI.Primitives.Reactive.Concurrency
         public static ReactiveUI.Primitives.Concurrency.ScheduledItem<TAbsolute> Create<TAbsolute, TValue>(System.Reactive.Concurrency.IScheduler scheduler, TValue state, System.Func<System.Reactive.Concurrency.IScheduler, TValue, System.IDisposable> action, TAbsolute dueTime) where TAbsolute : System.IComparable<TAbsolute> { }
         public static ReactiveUI.Primitives.Concurrency.ScheduledItem<TAbsolute> Create<TAbsolute, TValue>(System.Reactive.Concurrency.IScheduler scheduler, TValue state, System.Func<System.Reactive.Concurrency.IScheduler, TValue, System.IDisposable> action, TAbsolute dueTime, System.Collections.Generic.IComparer<TAbsolute> comparer) where TAbsolute : System.IComparable<TAbsolute> { }
     }
-    [System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainState = {_drainState}, Disposed = {_isDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("WasmScheduler: ReadyCount = {_readyCount}, DrainState = {_drainState}, Disposed = {_isDisposed}")]
     public sealed class WasmScheduler : System.Reactive.Concurrency.LocalScheduler, System.IDisposable, System.Reactive.Concurrency.ISchedulerPeriodic
     {
         public static ReactiveUI.Primitives.Reactive.Concurrency.WasmScheduler Default { get; }
@@ -1672,7 +1738,7 @@ namespace ReactiveUI.Primitives.Reactive.Core
 }
 namespace ReactiveUI.Primitives.Reactive.Disposables
 {
-    [System.Diagnostics.DebuggerDisplay("Count = {Count}, IsDisposed = {IsDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ContainerDisposable: Count = {Count}, IsDisposed = {IsDisposed}")]
     public sealed class ContainerDisposable : ReactiveUI.Primitives.Disposables.MultipleDisposable
     {
         public ContainerDisposable() { }
@@ -1686,7 +1752,7 @@ namespace ReactiveUI.Primitives.Reactive.Disposables
 }
 namespace ReactiveUI.Primitives.Reactive.Signals
 {
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
+    [System.Diagnostics.DebuggerDisplay("PrioritySemaphoreSignal: Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
     public sealed class PrioritySemaphoreSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T> where T : System.IComparable<T>
     {
         public PrioritySemaphoreSignal(int maxCount) { }
@@ -1721,7 +1787,7 @@ namespace ReactiveUI.Primitives.Reactive.Signals
         public void OnNext(T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledSignal: Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
     public class ScheduledSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T>
     {
         public ScheduledSignal(System.Reactive.Concurrency.IScheduler scheduler) { }

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-maccatalyst/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-maccatalyst/PublicAPI.txt
@@ -845,7 +845,7 @@ namespace ReactiveUI.Primitives.Reactive
 }
 namespace ReactiveUI.Primitives.Reactive.Advanced
 {
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Period = {_period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSignal: DueTime = {_dueTime}, Period = {_period}")]
     public sealed class AfterSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
     {
         public AfterSignal(System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -853,7 +853,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<long> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSubscription: Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
     public sealed class AfterSubscription : System.IDisposable
     {
         public AfterSubscription(System.IObserver<long> observer, System.Reactive.Concurrency.IScheduler scheduler, System.TimeSpan dueTime, System.TimeSpan? period) { }
@@ -861,21 +861,21 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.AfterSubscription Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("SubscribeAsync = {SubscribeAsync}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncCreateSignal: SubscribeAsync = {SubscribeAsync}")]
     public sealed class AsyncCreateSignal<T> : System.IObservable<T>
     {
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ObservableFactory = {ObservableFactory}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncDeferSignal: ObservableFactory = {ObservableFactory}")]
     public sealed class AsyncDeferSignal<T> : System.IObservable<T>
     {
         public AsyncDeferSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public AsyncDeferSignal(System.Func<System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncSubscriptionLifetime: Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
     public sealed class AsyncSubscriptionLifetime : System.IDisposable
     {
         public AsyncSubscriptionLifetime() { }
@@ -886,33 +886,33 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable? disposable) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connected = {_connected}")]
+    [System.Diagnostics.DebuggerDisplay("AutoConnectSignal: Count = {_count}, Connected = {_connected}")]
     public sealed class AutoConnectSignal<T> : System.IObservable<T>
     {
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount) { }
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount, System.Action<System.IDisposable>? onConnect) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connection = {_connection}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSignal: Count = {_count}, Connection = {_connection}")]
     public sealed class AutoShareSignal<T> : System.IObservable<T>
     {
         public AutoShareSignal(ReactiveUI.Primitives.ConnectableSignal<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Owner = {_owner}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSubscription: Owner = {_owner}, Subscription = {Subscription}")]
     public sealed class AutoShareSubscription<T> : System.IDisposable
     {
         public AutoShareSubscription(ReactiveUI.Primitives.Reactive.Advanced.AutoShareSignal<T> owner, System.IDisposable subscription) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void Dispose() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("BlendSignal: Sources = {Sources}")]
     public sealed class BlendSignal<T> : System.IObservable<T>
     {
         public BlendSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("BlendWitness: ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
     public sealed class BlendWitness<T> : System.IDisposable
     {
         public BlendWitness(System.IObserver<T> observer) { }
@@ -921,7 +921,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.BlendWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.BlendWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("BufferEachWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class BufferEachWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public BufferEachWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -935,20 +935,20 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Window = {Window}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("BufferSignal: Window = {Window}, Source = {Source}")]
     public sealed class BufferSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public BufferSignal(System.IObservable<T> source, System.TimeSpan timeSpan, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("CastSignal: Source = {Source}")]
     public sealed class CastSignal<TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public CastSignal(System.IObservable<object?> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CastWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CastWitness<TResult> : System.IDisposable, System.IObserver<object?>
     {
         public CastWitness(System.IObserver<TResult> observer) { }
@@ -962,7 +962,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
+    [System.Diagnostics.DebuggerDisplay("ChainSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
     public sealed class ChainSignal<T> : System.IObservable<T>
     {
         public ChainSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -970,7 +970,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ChainSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("ChainWitness: IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
     public sealed class ChainWitness<T> : System.IDisposable
     {
         public ChainWitness(System.IObserver<T> observer) { }
@@ -980,13 +980,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.ChainWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.ChainWitness<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, TimeSpan = {TimeSpan}")]
+    [System.Diagnostics.DebuggerDisplay("CollectSignal: Source = {Source}, TimeSpan = {TimeSpan}")]
     public sealed class CollectSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public CollectSignal(System.IObservable<T> source, System.TimeSpan timeSpan, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Buffered = {Values.Count}")]
+    [System.Diagnostics.DebuggerDisplay("CollectWitness: Stopped = {_stopped}, Buffered = {Values.Count}")]
     public sealed class CollectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CollectWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -998,7 +998,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateSink: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class CreateSink<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateSink(System.IObserver<T> observer, bool disposeOnNextThrow) { }
@@ -1010,7 +1010,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CreateWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateWitness(System.IObserver<T> observer) { }
@@ -1024,13 +1024,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {DueTime}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietSignal: DueTime = {DueTime}, Source = {Source}")]
     public sealed class EmitIfQuietSignal<T> : System.IObservable<T>
     {
         public EmitIfQuietSignal(System.IObservable<T> source, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietWitness: HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
     public sealed class EmitIfQuietWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public EmitIfQuietWitness(System.IObserver<T> observer, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer) { }
@@ -1041,7 +1041,16 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("EmptySignal: Scheduler = {_scheduler}")]
+    public sealed class EmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public EmptySignal(System.Reactive.Concurrency.IScheduler scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("EnumerableBlendSignal: Sources = {Sources}")]
     public sealed class EnumerableBlendSignal<T> : System.IObservable<T>
     {
         public EnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -1051,7 +1060,14 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
     {
         public static System.IDisposable Attach<TEventHandler>(TEventHandler handler, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Reactive.Concurrency.IScheduler? scheduler) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
+    [System.Diagnostics.DebuggerDisplay("EverySignal: Period = {_period}, Scheduler = {_scheduler}")]
+    public sealed class EverySignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
+    {
+        public EverySignal(System.TimeSpan period, System.Reactive.Concurrency.IScheduler scheduler) { }
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<long> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ExpireCoordinator: Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
     public sealed class ExpireCoordinator<T> : System.IDisposable, System.IObserver<T>
     {
         public ExpireCoordinator(System.IObservable<T> source, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer, System.IObserver<T> observer) { }
@@ -1061,39 +1077,48 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnNext(T value) { }
         public ReactiveUI.Primitives.Reactive.Advanced.ExpireCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("ExpireSignal: DueTime = {_dueTime}, Source = {_source}")]
     public sealed class ExpireSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ExpireSignal(System.IObservable<T> source, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("FinallySignal: Source = {_source}")]
+    public sealed class FinallySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public FinallySignal(System.IObservable<T> source, System.Action finallyAction) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ForkJoinSignal: Left = {Left}, Right = {Right}")]
     public sealed class ForkJoinSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public ForkJoinSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("ForkJoinWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
     public sealed class ForkJoinWitness<TLeft, TRight, TResult>
     {
         public ForkJoinWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("CancellationRequested = {CancellationToken.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncExternalCancellationSignal: CancellationRequested = {CancellationToken.IsCancellationRequested}")]
     public sealed class FromAsyncExternalCancellationSignal<T> : System.IObservable<T>
     {
         public FromAsyncExternalCancellationSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSignal: TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
     public sealed class FromAsyncSignal<T> : System.IObservable<T>
     {
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSubscription: Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
     public sealed class FromAsyncSubscription<T> : System.IDisposable
     {
         public FromAsyncSubscription(System.IObserver<T> observer, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
@@ -1106,14 +1131,14 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public FromEventConversionSignal(System.Func<TCallback, TEventHandler> conversion, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Func<System.IObserver<TResult>, TCallback> callback, System.Reactive.Concurrency.IScheduler? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
+    [System.Diagnostics.DebuggerDisplay("FromEventPatternSignal: AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
     public sealed class FromEventPatternSignal<TEventHandler, TEventArgs> : System.IObservable<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> where TEventHandler : System.Delegate where TEventArgs : System.EventArgs
     {
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler) { }
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Reactive.Concurrency.IScheduler? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Disposed = {_disposed}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("GuardedWitness: Disposed = {_disposed}, Observer = {_observer}")]
     public sealed class GuardedWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public GuardedWitness(System.IObserver<T> observer, System.IDisposable cancel) { }
@@ -1123,7 +1148,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IgnoreValuesSignal: Source = {Source}")]
     public sealed class IgnoreValuesSignal<T> : System.IObservable<T>
     {
         public IgnoreValuesSignal(System.IObservable<T> source) { }
@@ -1137,14 +1162,14 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public System.IDisposable Subscribe(System.IObserver<System.Reactive.Unit> observer) { }
         public System.IDisposable Subscribe(System.Action<System.Reactive.Unit> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptySignal: Source = {Source}")]
     public sealed class IsEmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<bool>
     {
         public IsEmptySignal(System.IObservable<T> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<bool> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptyWitness: Stopped = {_stopped}, Subscription = {Subscription}")]
     public sealed class IsEmptyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public IsEmptyWitness(System.IObserver<bool> observer) { }
@@ -1157,14 +1182,23 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {Value}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("LeadSignal: Value = {Value}, Source = {Source}")]
     public sealed class LeadSignal<T> : ReactiveUI.Primitives.Advanced.IInlineSignal<T>
     {
         public LeadSignal(System.IObservable<T> source, T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
         public System.IDisposable Subscribe(System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("LoopSignal: Value = {Value}")]
+    public sealed class LoopSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public LoopSignal(T value) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("MapIndexedSignal: Source = {_source}")]
     public sealed class MapIndexedSignal<TSource, TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public MapIndexedSignal(System.IObservable<TSource> source, System.Func<TSource, int, TResult> selector) { }
@@ -1172,7 +1206,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Index = {_index}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("MapIndexedWitness: Index = {_index}, Stopped = {_stopped}")]
     public sealed class MapIndexedWitness<TSource, TResult> : System.IObserver<TSource>
     {
         public MapIndexedWitness(System.IObserver<TResult> observer, System.Func<TSource, int, TResult> selector) { }
@@ -1180,20 +1214,20 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(TSource value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentBlendCoordinator: Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
     public sealed class MaxConcurrentBlendCoordinator<T> : System.IDisposable
     {
         public MaxConcurrentBlendCoordinator(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.MaxConcurrentBlendCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentEnumerableBlendSignal: Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
     public sealed class MaxConcurrentEnumerableBlendSignal<T> : System.IObservable<T>
     {
         public MaxConcurrentEnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("MergeCoordinator: Active = {Active}, Done = {Done}")]
     public sealed class MergeCoordinator<T> : System.IDisposable
     {
         public MergeCoordinator(System.IObserver<T> observer) { }
@@ -1204,7 +1238,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.MergeCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.MergeCoordinator<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MergeSignal: Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
     public sealed class MergeSignal<T> : System.IObservable<T>
     {
         public MergeSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -1212,32 +1246,39 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public MergeSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("OnErrorResumeNextSignal: Sources = {_sources}")]
+    public sealed class OnErrorResumeNextSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("PairSignal: Left = {Left}, Right = {Right}")]
     public sealed class PairSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public PairSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
+    [System.Diagnostics.DebuggerDisplay("PairWitness: IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
     public sealed class PairWitness<TLeft, TRight, TResult>
     {
         public PairWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("PublishSelectorSignal: Source = {Source}, Selector = {Selector}")]
     public sealed class PublishSelectorSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public PublishSelectorSignal(System.IObservable<TSource> source, System.Func<System.IObservable<TSource>, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
+    [System.Diagnostics.DebuggerDisplay("RaceSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
     public sealed class RaceSignal<T> : System.IObservable<T>
     {
         public RaceSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public RaceSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Arms = {_arms}")]
+    [System.Diagnostics.DebuggerDisplay("RaceWitness: Arms = {_arms}")]
     public sealed class RaceWitness<T> : System.IDisposable
     {
         public RaceWitness(System.IObserver<T> observer) { }
@@ -1246,40 +1287,48 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.RaceWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.RaceWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeCombineLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeCombineLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeCombineLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
+    [System.Diagnostics.DebuggerDisplay("RangeForkJoinSignal: Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
     public sealed class RangeForkJoinSignal<TResult> : System.IObservable<TResult>
     {
         public RangeForkJoinSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeSyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeSyncLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeSyncLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeWithLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeWithLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeWithLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Remaining = {_remaining}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("RecoverSignal: Source = {_source}")]
+    public sealed class RecoverSignal<T, TException> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T> where TException : System.Exception
+    {
+        public RecoverSignal(System.IObservable<T> source, System.Func<TException, System.IObservable<T>> handler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceCoordinator: Remaining = {_remaining}, Disposed = {_disposed}")]
     public sealed class RepeatSourceCoordinator<T> : System.IDisposable
     {
         public RepeatSourceCoordinator(System.IObservable<T> source, int? repeatCount, System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.RepeatSourceCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, RepeatCount = {_repeatCount}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceSignal: Source = {_source}, RepeatCount = {_repeatCount}")]
     public sealed class RepeatSourceSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public RepeatSourceSignal(System.IObservable<T> source, int? repeatCount) { }
@@ -1287,7 +1336,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Generation = {_generation}, Terminated = {_terminated}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceWitness: Generation = {_generation}, Terminated = {_terminated}")]
     public sealed class RepeatSourceWitness<T> : System.IObserver<T>
     {
         public RepeatSourceWitness(ReactiveUI.Primitives.Reactive.Advanced.RepeatSourceCoordinator<T> parent, int generation) { }
@@ -1295,7 +1344,15 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_value}, Scheduler = {_scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ResumeSignal: Source = {_source}, Fallback = {_fallback}")]
+    public sealed class ResumeSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ResumeSignal(System.IObservable<T> source, System.IObservable<T> fallback) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ReturnSignal: Value = {_value}, Scheduler = {_scheduler}")]
     public sealed class ReturnSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ReturnSignal(T value, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -1304,13 +1361,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Values = {Values}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledEnumerableSignal: Values = {Values}, Scheduler = {Scheduler}")]
     public sealed class ScheduledEnumerableSignal<T> : System.IObservable<T>
     {
         public ScheduledEnumerableSignal(System.Collections.Generic.IEnumerable<T> values, System.Reactive.Concurrency.IScheduler scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyCoordinator<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TResult>> selector) { }
@@ -1324,13 +1381,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Reactive.Advanced.SelectManyCoordinator<TSource, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableSignal: Source = {_source}")]
     public sealed class SelectManyEnumerableSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManyEnumerableSignal(System.IObservable<TSource> source, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SelectManyEnumerableWitness<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyEnumerableWitness(System.IObserver<TResult> observer, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
@@ -1344,7 +1401,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyResultCoordinator<TSource, TCollection, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyResultCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
@@ -1357,20 +1414,20 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Reactive.Advanced.SelectManyResultCoordinator<TSource, TCollection, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, CollectionSelector = {CollectionSelector}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultSignal: Source = {Source}, CollectionSelector = {CollectionSelector}")]
     public sealed class SelectManyResultSignal<TSource, TCollection, TResult> : System.IObservable<TResult>
     {
         public SelectManyResultSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManySignal: Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
     public sealed class SelectManySignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManySignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public SelectManySignal(System.IObservable<TSource> source, System.IObservable<TResult> inner) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Start = {Start}, Count = {Count}")]
+    [System.Diagnostics.DebuggerDisplay("SequenceSignal: Start = {Start}, Count = {Count}")]
     public sealed class SequenceSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<int>
     {
         public SequenceSignal(int start, int count, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -1381,13 +1438,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
     {
         public static System.IDisposable Subscribe<T>(System.IObserver<T> observer, bool currentThreadRequired, System.Func<System.IObserver<T>, System.IDisposable, System.IDisposable> subscribeCore) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SparkSignal: Source = {Source}")]
     public sealed class SparkSignal<T> : System.IObservable<ReactiveUI.Primitives.Reactive.Core.Spark<T>>
     {
         public SparkSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Reactive.Core.Spark<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SparkWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SparkWitness(System.IObserver<ReactiveUI.Primitives.Reactive.Core.Spark<T>> observer) { }
@@ -1402,21 +1459,21 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Action = {Action}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Action = {Action}, Scheduler = {Scheduler}")]
     public sealed class StartSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<System.Reactive.Unit>
     {
         public StartSignal(System.Action action, System.Reactive.Concurrency.IScheduler scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<System.Reactive.Unit> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Function = {Function}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Function = {Function}, Scheduler = {Scheduler}")]
     public sealed class StartSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public StartSignal(System.Func<T> function, System.Reactive.Concurrency.IScheduler scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SubscribeSafeWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SubscribeSafeWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SubscribeSafeWitness(System.IObserver<T> observer) { }
@@ -1430,50 +1487,50 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, SkipNullSources = {_skipNullSources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchMapSignal: Source = {_source}, SkipNullSources = {_skipNullSources}")]
     public sealed class SwitchMapSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SwitchMapSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchSignal: Sources = {Sources}")]
     public sealed class SwitchSignal<T> : System.IObservable<T>
     {
         public SwitchSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Version = {_version}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchWitness: Version = {_version}, IsDone = {IsDone}")]
     public sealed class SwitchWitness<T> : System.IDisposable
     {
         public SwitchWitness(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.SwitchWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class SyncLatestSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public SyncLatestSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
     public sealed class SyncLatestWitness<TLeft, TRight, TResult>
     {
         public SyncLatestWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Gate = {Gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeGateSignal: Source = {Source}, Gate = {Gate}")]
     public sealed class SynchronizeGateSignal<T> : System.IObservable<T>
     {
         public SynchronizeGateSignal(System.IObservable<T> source, System.Threading.Lock gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, Gate = {_gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectSignal: Source = {_source}, Gate = {_gate}")]
     public sealed class SynchronizeObjectSignal<T> : System.IObservable<T>
     {
         public SynchronizeObjectSignal(System.IObservable<T> source, object gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SynchronizeObjectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SynchronizeObjectWitness(System.IObserver<T> observer, object gate) { }
@@ -1485,19 +1542,19 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeSignal: Source = {Source}")]
     public sealed class SynchronizeSignal<T> : System.IObservable<T>
     {
         public SynchronizeSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("TapSignal: Source = {Source}")]
     public sealed class TapSignal<T> : System.IObservable<T>
     {
         public TapSignal(System.IObservable<T> source, System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskAnyWitness: Stopped = {_stopped}, Task = {Task}")]
     public sealed class TaskAnyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskAnyWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1513,7 +1570,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainCoordinator: Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
     public sealed class TaskChainCoordinator<T> : System.IDisposable
     {
         public TaskChainCoordinator(System.IObserver<T> observer) { }
@@ -1521,13 +1578,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.TaskChainCoordinator<T> Run(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainSignal: Sources = {_sources}")]
     public sealed class TaskChainSignal<T> : System.IObservable<T>
     {
         public TaskChainSignal(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskCountWitness: Count = {_count}, Stopped = {_stopped}")]
     public sealed class TaskCountWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskCountWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1543,13 +1600,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSignal: Task = {Task}")]
     public sealed class TaskInstanceSignal<T> : System.IObservable<T>
     {
         public TaskInstanceSignal(System.Threading.Tasks.Task<T> task) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSubscription: Stopped = {_stopped}")]
     public sealed class TaskInstanceSubscription : System.IDisposable
     {
         public TaskInstanceSubscription() { }
@@ -1557,13 +1614,22 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void Dispose() { }
         public bool TryStop() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Sequencer = {Sequencer}")]
+    [System.Diagnostics.DebuggerDisplay("ThrowSignal: Error = {_error}, Scheduler = {_scheduler}")]
+    public sealed class ThrowSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ThrowSignal(System.Exception error, System.Reactive.Concurrency.IScheduler scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalSignal: Source = {Source}, Sequencer = {Sequencer}")]
     public sealed class TimeIntervalSignal<T> : System.IObservable<ReactiveUI.Primitives.Core.TimeInterval<T>>
     {
         public TimeIntervalSignal(System.IObservable<T> source, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("First = {_first}, Last = {_last}")]
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalWitness: First = {_first}, Last = {_last}")]
     public sealed class TimeIntervalWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TimeIntervalWitness(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -1581,13 +1647,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
     {
         public static void Arm(ReactiveUI.Primitives.Disposables.SingleReplaceableDisposable slot, System.Reactive.Concurrency.IScheduler sequencer, System.TimeSpan delay, System.Action tick) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkSignal: Source = {Source}")]
     public sealed class UnsparkSignal<T> : System.IObservable<T>
     {
         public UnsparkSignal(System.IObservable<ReactiveUI.Primitives.Reactive.Core.Spark<T>> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class UnsparkWitness<T> : System.IDisposable, System.IObserver<ReactiveUI.Primitives.Reactive.Core.Spark<T>>
     {
         public UnsparkWitness(System.IObserver<T> observer) { }
@@ -1605,7 +1671,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
 }
 namespace ReactiveUI.Primitives.Reactive.Concurrency
 {
-    [System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
+    [System.Diagnostics.DebuggerDisplay("CoalescingDispatchScheduler: ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
     public abstract class CoalescingDispatchScheduler : System.Reactive.Concurrency.LocalScheduler
     {
         protected CoalescingDispatchScheduler() { }
@@ -1630,7 +1696,7 @@ namespace ReactiveUI.Primitives.Reactive.Concurrency
         public static ReactiveUI.Primitives.Concurrency.ScheduledItem<TAbsolute> Create<TAbsolute, TValue>(System.Reactive.Concurrency.IScheduler scheduler, TValue state, System.Func<System.Reactive.Concurrency.IScheduler, TValue, System.IDisposable> action, TAbsolute dueTime) where TAbsolute : System.IComparable<TAbsolute> { }
         public static ReactiveUI.Primitives.Concurrency.ScheduledItem<TAbsolute> Create<TAbsolute, TValue>(System.Reactive.Concurrency.IScheduler scheduler, TValue state, System.Func<System.Reactive.Concurrency.IScheduler, TValue, System.IDisposable> action, TAbsolute dueTime, System.Collections.Generic.IComparer<TAbsolute> comparer) where TAbsolute : System.IComparable<TAbsolute> { }
     }
-    [System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainState = {_drainState}, Disposed = {_isDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("WasmScheduler: ReadyCount = {_readyCount}, DrainState = {_drainState}, Disposed = {_isDisposed}")]
     public sealed class WasmScheduler : System.Reactive.Concurrency.LocalScheduler, System.IDisposable, System.Reactive.Concurrency.ISchedulerPeriodic
     {
         public static ReactiveUI.Primitives.Reactive.Concurrency.WasmScheduler Default { get; }
@@ -1672,7 +1738,7 @@ namespace ReactiveUI.Primitives.Reactive.Core
 }
 namespace ReactiveUI.Primitives.Reactive.Disposables
 {
-    [System.Diagnostics.DebuggerDisplay("Count = {Count}, IsDisposed = {IsDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ContainerDisposable: Count = {Count}, IsDisposed = {IsDisposed}")]
     public sealed class ContainerDisposable : ReactiveUI.Primitives.Disposables.MultipleDisposable
     {
         public ContainerDisposable() { }
@@ -1686,7 +1752,7 @@ namespace ReactiveUI.Primitives.Reactive.Disposables
 }
 namespace ReactiveUI.Primitives.Reactive.Signals
 {
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
+    [System.Diagnostics.DebuggerDisplay("PrioritySemaphoreSignal: Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
     public sealed class PrioritySemaphoreSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T> where T : System.IComparable<T>
     {
         public PrioritySemaphoreSignal(int maxCount) { }
@@ -1721,7 +1787,7 @@ namespace ReactiveUI.Primitives.Reactive.Signals
         public void OnNext(T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledSignal: Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
     public class ScheduledSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T>
     {
         public ScheduledSignal(System.Reactive.Concurrency.IScheduler scheduler) { }

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-macos/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-macos/PublicAPI.txt
@@ -845,7 +845,7 @@ namespace ReactiveUI.Primitives.Reactive
 }
 namespace ReactiveUI.Primitives.Reactive.Advanced
 {
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Period = {_period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSignal: DueTime = {_dueTime}, Period = {_period}")]
     public sealed class AfterSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
     {
         public AfterSignal(System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -853,7 +853,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<long> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSubscription: Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
     public sealed class AfterSubscription : System.IDisposable
     {
         public AfterSubscription(System.IObserver<long> observer, System.Reactive.Concurrency.IScheduler scheduler, System.TimeSpan dueTime, System.TimeSpan? period) { }
@@ -861,21 +861,21 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.AfterSubscription Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("SubscribeAsync = {SubscribeAsync}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncCreateSignal: SubscribeAsync = {SubscribeAsync}")]
     public sealed class AsyncCreateSignal<T> : System.IObservable<T>
     {
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ObservableFactory = {ObservableFactory}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncDeferSignal: ObservableFactory = {ObservableFactory}")]
     public sealed class AsyncDeferSignal<T> : System.IObservable<T>
     {
         public AsyncDeferSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public AsyncDeferSignal(System.Func<System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncSubscriptionLifetime: Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
     public sealed class AsyncSubscriptionLifetime : System.IDisposable
     {
         public AsyncSubscriptionLifetime() { }
@@ -886,33 +886,33 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable? disposable) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connected = {_connected}")]
+    [System.Diagnostics.DebuggerDisplay("AutoConnectSignal: Count = {_count}, Connected = {_connected}")]
     public sealed class AutoConnectSignal<T> : System.IObservable<T>
     {
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount) { }
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount, System.Action<System.IDisposable>? onConnect) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connection = {_connection}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSignal: Count = {_count}, Connection = {_connection}")]
     public sealed class AutoShareSignal<T> : System.IObservable<T>
     {
         public AutoShareSignal(ReactiveUI.Primitives.ConnectableSignal<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Owner = {_owner}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSubscription: Owner = {_owner}, Subscription = {Subscription}")]
     public sealed class AutoShareSubscription<T> : System.IDisposable
     {
         public AutoShareSubscription(ReactiveUI.Primitives.Reactive.Advanced.AutoShareSignal<T> owner, System.IDisposable subscription) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void Dispose() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("BlendSignal: Sources = {Sources}")]
     public sealed class BlendSignal<T> : System.IObservable<T>
     {
         public BlendSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("BlendWitness: ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
     public sealed class BlendWitness<T> : System.IDisposable
     {
         public BlendWitness(System.IObserver<T> observer) { }
@@ -921,7 +921,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.BlendWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.BlendWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("BufferEachWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class BufferEachWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public BufferEachWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -935,20 +935,20 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Window = {Window}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("BufferSignal: Window = {Window}, Source = {Source}")]
     public sealed class BufferSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public BufferSignal(System.IObservable<T> source, System.TimeSpan timeSpan, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("CastSignal: Source = {Source}")]
     public sealed class CastSignal<TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public CastSignal(System.IObservable<object?> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CastWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CastWitness<TResult> : System.IDisposable, System.IObserver<object?>
     {
         public CastWitness(System.IObserver<TResult> observer) { }
@@ -962,7 +962,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
+    [System.Diagnostics.DebuggerDisplay("ChainSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
     public sealed class ChainSignal<T> : System.IObservable<T>
     {
         public ChainSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -970,7 +970,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ChainSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("ChainWitness: IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
     public sealed class ChainWitness<T> : System.IDisposable
     {
         public ChainWitness(System.IObserver<T> observer) { }
@@ -980,13 +980,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.ChainWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.ChainWitness<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, TimeSpan = {TimeSpan}")]
+    [System.Diagnostics.DebuggerDisplay("CollectSignal: Source = {Source}, TimeSpan = {TimeSpan}")]
     public sealed class CollectSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public CollectSignal(System.IObservable<T> source, System.TimeSpan timeSpan, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Buffered = {Values.Count}")]
+    [System.Diagnostics.DebuggerDisplay("CollectWitness: Stopped = {_stopped}, Buffered = {Values.Count}")]
     public sealed class CollectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CollectWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -998,7 +998,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateSink: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class CreateSink<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateSink(System.IObserver<T> observer, bool disposeOnNextThrow) { }
@@ -1010,7 +1010,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CreateWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateWitness(System.IObserver<T> observer) { }
@@ -1024,13 +1024,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {DueTime}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietSignal: DueTime = {DueTime}, Source = {Source}")]
     public sealed class EmitIfQuietSignal<T> : System.IObservable<T>
     {
         public EmitIfQuietSignal(System.IObservable<T> source, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietWitness: HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
     public sealed class EmitIfQuietWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public EmitIfQuietWitness(System.IObserver<T> observer, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer) { }
@@ -1041,7 +1041,16 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("EmptySignal: Scheduler = {_scheduler}")]
+    public sealed class EmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public EmptySignal(System.Reactive.Concurrency.IScheduler scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("EnumerableBlendSignal: Sources = {Sources}")]
     public sealed class EnumerableBlendSignal<T> : System.IObservable<T>
     {
         public EnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -1051,7 +1060,14 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
     {
         public static System.IDisposable Attach<TEventHandler>(TEventHandler handler, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Reactive.Concurrency.IScheduler? scheduler) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
+    [System.Diagnostics.DebuggerDisplay("EverySignal: Period = {_period}, Scheduler = {_scheduler}")]
+    public sealed class EverySignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
+    {
+        public EverySignal(System.TimeSpan period, System.Reactive.Concurrency.IScheduler scheduler) { }
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<long> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ExpireCoordinator: Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
     public sealed class ExpireCoordinator<T> : System.IDisposable, System.IObserver<T>
     {
         public ExpireCoordinator(System.IObservable<T> source, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer, System.IObserver<T> observer) { }
@@ -1061,39 +1077,48 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnNext(T value) { }
         public ReactiveUI.Primitives.Reactive.Advanced.ExpireCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("ExpireSignal: DueTime = {_dueTime}, Source = {_source}")]
     public sealed class ExpireSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ExpireSignal(System.IObservable<T> source, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("FinallySignal: Source = {_source}")]
+    public sealed class FinallySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public FinallySignal(System.IObservable<T> source, System.Action finallyAction) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ForkJoinSignal: Left = {Left}, Right = {Right}")]
     public sealed class ForkJoinSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public ForkJoinSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("ForkJoinWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
     public sealed class ForkJoinWitness<TLeft, TRight, TResult>
     {
         public ForkJoinWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("CancellationRequested = {CancellationToken.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncExternalCancellationSignal: CancellationRequested = {CancellationToken.IsCancellationRequested}")]
     public sealed class FromAsyncExternalCancellationSignal<T> : System.IObservable<T>
     {
         public FromAsyncExternalCancellationSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSignal: TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
     public sealed class FromAsyncSignal<T> : System.IObservable<T>
     {
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSubscription: Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
     public sealed class FromAsyncSubscription<T> : System.IDisposable
     {
         public FromAsyncSubscription(System.IObserver<T> observer, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
@@ -1106,14 +1131,14 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public FromEventConversionSignal(System.Func<TCallback, TEventHandler> conversion, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Func<System.IObserver<TResult>, TCallback> callback, System.Reactive.Concurrency.IScheduler? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
+    [System.Diagnostics.DebuggerDisplay("FromEventPatternSignal: AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
     public sealed class FromEventPatternSignal<TEventHandler, TEventArgs> : System.IObservable<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> where TEventHandler : System.Delegate where TEventArgs : System.EventArgs
     {
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler) { }
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Reactive.Concurrency.IScheduler? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Disposed = {_disposed}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("GuardedWitness: Disposed = {_disposed}, Observer = {_observer}")]
     public sealed class GuardedWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public GuardedWitness(System.IObserver<T> observer, System.IDisposable cancel) { }
@@ -1123,7 +1148,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IgnoreValuesSignal: Source = {Source}")]
     public sealed class IgnoreValuesSignal<T> : System.IObservable<T>
     {
         public IgnoreValuesSignal(System.IObservable<T> source) { }
@@ -1137,14 +1162,14 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public System.IDisposable Subscribe(System.IObserver<System.Reactive.Unit> observer) { }
         public System.IDisposable Subscribe(System.Action<System.Reactive.Unit> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptySignal: Source = {Source}")]
     public sealed class IsEmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<bool>
     {
         public IsEmptySignal(System.IObservable<T> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<bool> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptyWitness: Stopped = {_stopped}, Subscription = {Subscription}")]
     public sealed class IsEmptyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public IsEmptyWitness(System.IObserver<bool> observer) { }
@@ -1157,14 +1182,23 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {Value}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("LeadSignal: Value = {Value}, Source = {Source}")]
     public sealed class LeadSignal<T> : ReactiveUI.Primitives.Advanced.IInlineSignal<T>
     {
         public LeadSignal(System.IObservable<T> source, T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
         public System.IDisposable Subscribe(System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("LoopSignal: Value = {Value}")]
+    public sealed class LoopSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public LoopSignal(T value) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("MapIndexedSignal: Source = {_source}")]
     public sealed class MapIndexedSignal<TSource, TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public MapIndexedSignal(System.IObservable<TSource> source, System.Func<TSource, int, TResult> selector) { }
@@ -1172,7 +1206,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Index = {_index}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("MapIndexedWitness: Index = {_index}, Stopped = {_stopped}")]
     public sealed class MapIndexedWitness<TSource, TResult> : System.IObserver<TSource>
     {
         public MapIndexedWitness(System.IObserver<TResult> observer, System.Func<TSource, int, TResult> selector) { }
@@ -1180,20 +1214,20 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(TSource value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentBlendCoordinator: Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
     public sealed class MaxConcurrentBlendCoordinator<T> : System.IDisposable
     {
         public MaxConcurrentBlendCoordinator(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.MaxConcurrentBlendCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentEnumerableBlendSignal: Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
     public sealed class MaxConcurrentEnumerableBlendSignal<T> : System.IObservable<T>
     {
         public MaxConcurrentEnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("MergeCoordinator: Active = {Active}, Done = {Done}")]
     public sealed class MergeCoordinator<T> : System.IDisposable
     {
         public MergeCoordinator(System.IObserver<T> observer) { }
@@ -1204,7 +1238,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.MergeCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.MergeCoordinator<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MergeSignal: Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
     public sealed class MergeSignal<T> : System.IObservable<T>
     {
         public MergeSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -1212,32 +1246,39 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public MergeSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("OnErrorResumeNextSignal: Sources = {_sources}")]
+    public sealed class OnErrorResumeNextSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("PairSignal: Left = {Left}, Right = {Right}")]
     public sealed class PairSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public PairSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
+    [System.Diagnostics.DebuggerDisplay("PairWitness: IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
     public sealed class PairWitness<TLeft, TRight, TResult>
     {
         public PairWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("PublishSelectorSignal: Source = {Source}, Selector = {Selector}")]
     public sealed class PublishSelectorSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public PublishSelectorSignal(System.IObservable<TSource> source, System.Func<System.IObservable<TSource>, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
+    [System.Diagnostics.DebuggerDisplay("RaceSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
     public sealed class RaceSignal<T> : System.IObservable<T>
     {
         public RaceSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public RaceSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Arms = {_arms}")]
+    [System.Diagnostics.DebuggerDisplay("RaceWitness: Arms = {_arms}")]
     public sealed class RaceWitness<T> : System.IDisposable
     {
         public RaceWitness(System.IObserver<T> observer) { }
@@ -1246,40 +1287,48 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.RaceWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.RaceWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeCombineLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeCombineLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeCombineLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
+    [System.Diagnostics.DebuggerDisplay("RangeForkJoinSignal: Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
     public sealed class RangeForkJoinSignal<TResult> : System.IObservable<TResult>
     {
         public RangeForkJoinSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeSyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeSyncLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeSyncLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeWithLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeWithLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeWithLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Remaining = {_remaining}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("RecoverSignal: Source = {_source}")]
+    public sealed class RecoverSignal<T, TException> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T> where TException : System.Exception
+    {
+        public RecoverSignal(System.IObservable<T> source, System.Func<TException, System.IObservable<T>> handler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceCoordinator: Remaining = {_remaining}, Disposed = {_disposed}")]
     public sealed class RepeatSourceCoordinator<T> : System.IDisposable
     {
         public RepeatSourceCoordinator(System.IObservable<T> source, int? repeatCount, System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.RepeatSourceCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, RepeatCount = {_repeatCount}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceSignal: Source = {_source}, RepeatCount = {_repeatCount}")]
     public sealed class RepeatSourceSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public RepeatSourceSignal(System.IObservable<T> source, int? repeatCount) { }
@@ -1287,7 +1336,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Generation = {_generation}, Terminated = {_terminated}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceWitness: Generation = {_generation}, Terminated = {_terminated}")]
     public sealed class RepeatSourceWitness<T> : System.IObserver<T>
     {
         public RepeatSourceWitness(ReactiveUI.Primitives.Reactive.Advanced.RepeatSourceCoordinator<T> parent, int generation) { }
@@ -1295,7 +1344,15 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_value}, Scheduler = {_scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ResumeSignal: Source = {_source}, Fallback = {_fallback}")]
+    public sealed class ResumeSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ResumeSignal(System.IObservable<T> source, System.IObservable<T> fallback) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ReturnSignal: Value = {_value}, Scheduler = {_scheduler}")]
     public sealed class ReturnSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ReturnSignal(T value, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -1304,13 +1361,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Values = {Values}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledEnumerableSignal: Values = {Values}, Scheduler = {Scheduler}")]
     public sealed class ScheduledEnumerableSignal<T> : System.IObservable<T>
     {
         public ScheduledEnumerableSignal(System.Collections.Generic.IEnumerable<T> values, System.Reactive.Concurrency.IScheduler scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyCoordinator<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TResult>> selector) { }
@@ -1324,13 +1381,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Reactive.Advanced.SelectManyCoordinator<TSource, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableSignal: Source = {_source}")]
     public sealed class SelectManyEnumerableSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManyEnumerableSignal(System.IObservable<TSource> source, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SelectManyEnumerableWitness<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyEnumerableWitness(System.IObserver<TResult> observer, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
@@ -1344,7 +1401,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyResultCoordinator<TSource, TCollection, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyResultCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
@@ -1357,20 +1414,20 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Reactive.Advanced.SelectManyResultCoordinator<TSource, TCollection, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, CollectionSelector = {CollectionSelector}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultSignal: Source = {Source}, CollectionSelector = {CollectionSelector}")]
     public sealed class SelectManyResultSignal<TSource, TCollection, TResult> : System.IObservable<TResult>
     {
         public SelectManyResultSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManySignal: Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
     public sealed class SelectManySignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManySignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public SelectManySignal(System.IObservable<TSource> source, System.IObservable<TResult> inner) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Start = {Start}, Count = {Count}")]
+    [System.Diagnostics.DebuggerDisplay("SequenceSignal: Start = {Start}, Count = {Count}")]
     public sealed class SequenceSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<int>
     {
         public SequenceSignal(int start, int count, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -1381,13 +1438,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
     {
         public static System.IDisposable Subscribe<T>(System.IObserver<T> observer, bool currentThreadRequired, System.Func<System.IObserver<T>, System.IDisposable, System.IDisposable> subscribeCore) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SparkSignal: Source = {Source}")]
     public sealed class SparkSignal<T> : System.IObservable<ReactiveUI.Primitives.Reactive.Core.Spark<T>>
     {
         public SparkSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Reactive.Core.Spark<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SparkWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SparkWitness(System.IObserver<ReactiveUI.Primitives.Reactive.Core.Spark<T>> observer) { }
@@ -1402,21 +1459,21 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Action = {Action}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Action = {Action}, Scheduler = {Scheduler}")]
     public sealed class StartSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<System.Reactive.Unit>
     {
         public StartSignal(System.Action action, System.Reactive.Concurrency.IScheduler scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<System.Reactive.Unit> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Function = {Function}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Function = {Function}, Scheduler = {Scheduler}")]
     public sealed class StartSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public StartSignal(System.Func<T> function, System.Reactive.Concurrency.IScheduler scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SubscribeSafeWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SubscribeSafeWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SubscribeSafeWitness(System.IObserver<T> observer) { }
@@ -1430,50 +1487,50 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, SkipNullSources = {_skipNullSources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchMapSignal: Source = {_source}, SkipNullSources = {_skipNullSources}")]
     public sealed class SwitchMapSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SwitchMapSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchSignal: Sources = {Sources}")]
     public sealed class SwitchSignal<T> : System.IObservable<T>
     {
         public SwitchSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Version = {_version}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchWitness: Version = {_version}, IsDone = {IsDone}")]
     public sealed class SwitchWitness<T> : System.IDisposable
     {
         public SwitchWitness(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.SwitchWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class SyncLatestSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public SyncLatestSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
     public sealed class SyncLatestWitness<TLeft, TRight, TResult>
     {
         public SyncLatestWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Gate = {Gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeGateSignal: Source = {Source}, Gate = {Gate}")]
     public sealed class SynchronizeGateSignal<T> : System.IObservable<T>
     {
         public SynchronizeGateSignal(System.IObservable<T> source, System.Threading.Lock gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, Gate = {_gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectSignal: Source = {_source}, Gate = {_gate}")]
     public sealed class SynchronizeObjectSignal<T> : System.IObservable<T>
     {
         public SynchronizeObjectSignal(System.IObservable<T> source, object gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SynchronizeObjectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SynchronizeObjectWitness(System.IObserver<T> observer, object gate) { }
@@ -1485,19 +1542,19 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeSignal: Source = {Source}")]
     public sealed class SynchronizeSignal<T> : System.IObservable<T>
     {
         public SynchronizeSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("TapSignal: Source = {Source}")]
     public sealed class TapSignal<T> : System.IObservable<T>
     {
         public TapSignal(System.IObservable<T> source, System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskAnyWitness: Stopped = {_stopped}, Task = {Task}")]
     public sealed class TaskAnyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskAnyWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1513,7 +1570,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainCoordinator: Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
     public sealed class TaskChainCoordinator<T> : System.IDisposable
     {
         public TaskChainCoordinator(System.IObserver<T> observer) { }
@@ -1521,13 +1578,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.TaskChainCoordinator<T> Run(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainSignal: Sources = {_sources}")]
     public sealed class TaskChainSignal<T> : System.IObservable<T>
     {
         public TaskChainSignal(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskCountWitness: Count = {_count}, Stopped = {_stopped}")]
     public sealed class TaskCountWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskCountWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1543,13 +1600,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSignal: Task = {Task}")]
     public sealed class TaskInstanceSignal<T> : System.IObservable<T>
     {
         public TaskInstanceSignal(System.Threading.Tasks.Task<T> task) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSubscription: Stopped = {_stopped}")]
     public sealed class TaskInstanceSubscription : System.IDisposable
     {
         public TaskInstanceSubscription() { }
@@ -1557,13 +1614,22 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void Dispose() { }
         public bool TryStop() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Sequencer = {Sequencer}")]
+    [System.Diagnostics.DebuggerDisplay("ThrowSignal: Error = {_error}, Scheduler = {_scheduler}")]
+    public sealed class ThrowSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ThrowSignal(System.Exception error, System.Reactive.Concurrency.IScheduler scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalSignal: Source = {Source}, Sequencer = {Sequencer}")]
     public sealed class TimeIntervalSignal<T> : System.IObservable<ReactiveUI.Primitives.Core.TimeInterval<T>>
     {
         public TimeIntervalSignal(System.IObservable<T> source, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("First = {_first}, Last = {_last}")]
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalWitness: First = {_first}, Last = {_last}")]
     public sealed class TimeIntervalWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TimeIntervalWitness(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -1581,13 +1647,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
     {
         public static void Arm(ReactiveUI.Primitives.Disposables.SingleReplaceableDisposable slot, System.Reactive.Concurrency.IScheduler sequencer, System.TimeSpan delay, System.Action tick) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkSignal: Source = {Source}")]
     public sealed class UnsparkSignal<T> : System.IObservable<T>
     {
         public UnsparkSignal(System.IObservable<ReactiveUI.Primitives.Reactive.Core.Spark<T>> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class UnsparkWitness<T> : System.IDisposable, System.IObserver<ReactiveUI.Primitives.Reactive.Core.Spark<T>>
     {
         public UnsparkWitness(System.IObserver<T> observer) { }
@@ -1605,7 +1671,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
 }
 namespace ReactiveUI.Primitives.Reactive.Concurrency
 {
-    [System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
+    [System.Diagnostics.DebuggerDisplay("CoalescingDispatchScheduler: ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
     public abstract class CoalescingDispatchScheduler : System.Reactive.Concurrency.LocalScheduler
     {
         protected CoalescingDispatchScheduler() { }
@@ -1630,7 +1696,7 @@ namespace ReactiveUI.Primitives.Reactive.Concurrency
         public static ReactiveUI.Primitives.Concurrency.ScheduledItem<TAbsolute> Create<TAbsolute, TValue>(System.Reactive.Concurrency.IScheduler scheduler, TValue state, System.Func<System.Reactive.Concurrency.IScheduler, TValue, System.IDisposable> action, TAbsolute dueTime) where TAbsolute : System.IComparable<TAbsolute> { }
         public static ReactiveUI.Primitives.Concurrency.ScheduledItem<TAbsolute> Create<TAbsolute, TValue>(System.Reactive.Concurrency.IScheduler scheduler, TValue state, System.Func<System.Reactive.Concurrency.IScheduler, TValue, System.IDisposable> action, TAbsolute dueTime, System.Collections.Generic.IComparer<TAbsolute> comparer) where TAbsolute : System.IComparable<TAbsolute> { }
     }
-    [System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainState = {_drainState}, Disposed = {_isDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("WasmScheduler: ReadyCount = {_readyCount}, DrainState = {_drainState}, Disposed = {_isDisposed}")]
     public sealed class WasmScheduler : System.Reactive.Concurrency.LocalScheduler, System.IDisposable, System.Reactive.Concurrency.ISchedulerPeriodic
     {
         public static ReactiveUI.Primitives.Reactive.Concurrency.WasmScheduler Default { get; }
@@ -1672,7 +1738,7 @@ namespace ReactiveUI.Primitives.Reactive.Core
 }
 namespace ReactiveUI.Primitives.Reactive.Disposables
 {
-    [System.Diagnostics.DebuggerDisplay("Count = {Count}, IsDisposed = {IsDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ContainerDisposable: Count = {Count}, IsDisposed = {IsDisposed}")]
     public sealed class ContainerDisposable : ReactiveUI.Primitives.Disposables.MultipleDisposable
     {
         public ContainerDisposable() { }
@@ -1686,7 +1752,7 @@ namespace ReactiveUI.Primitives.Reactive.Disposables
 }
 namespace ReactiveUI.Primitives.Reactive.Signals
 {
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
+    [System.Diagnostics.DebuggerDisplay("PrioritySemaphoreSignal: Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
     public sealed class PrioritySemaphoreSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T> where T : System.IComparable<T>
     {
         public PrioritySemaphoreSignal(int maxCount) { }
@@ -1721,7 +1787,7 @@ namespace ReactiveUI.Primitives.Reactive.Signals
         public void OnNext(T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledSignal: Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
     public class ScheduledSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T>
     {
         public ScheduledSignal(System.Reactive.Concurrency.IScheduler scheduler) { }

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-tvos/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0-tvos/PublicAPI.txt
@@ -845,7 +845,7 @@ namespace ReactiveUI.Primitives.Reactive
 }
 namespace ReactiveUI.Primitives.Reactive.Advanced
 {
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Period = {_period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSignal: DueTime = {_dueTime}, Period = {_period}")]
     public sealed class AfterSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
     {
         public AfterSignal(System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -853,7 +853,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<long> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSubscription: Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
     public sealed class AfterSubscription : System.IDisposable
     {
         public AfterSubscription(System.IObserver<long> observer, System.Reactive.Concurrency.IScheduler scheduler, System.TimeSpan dueTime, System.TimeSpan? period) { }
@@ -861,21 +861,21 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.AfterSubscription Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("SubscribeAsync = {SubscribeAsync}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncCreateSignal: SubscribeAsync = {SubscribeAsync}")]
     public sealed class AsyncCreateSignal<T> : System.IObservable<T>
     {
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ObservableFactory = {ObservableFactory}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncDeferSignal: ObservableFactory = {ObservableFactory}")]
     public sealed class AsyncDeferSignal<T> : System.IObservable<T>
     {
         public AsyncDeferSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public AsyncDeferSignal(System.Func<System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncSubscriptionLifetime: Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
     public sealed class AsyncSubscriptionLifetime : System.IDisposable
     {
         public AsyncSubscriptionLifetime() { }
@@ -886,33 +886,33 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable? disposable) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connected = {_connected}")]
+    [System.Diagnostics.DebuggerDisplay("AutoConnectSignal: Count = {_count}, Connected = {_connected}")]
     public sealed class AutoConnectSignal<T> : System.IObservable<T>
     {
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount) { }
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount, System.Action<System.IDisposable>? onConnect) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connection = {_connection}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSignal: Count = {_count}, Connection = {_connection}")]
     public sealed class AutoShareSignal<T> : System.IObservable<T>
     {
         public AutoShareSignal(ReactiveUI.Primitives.ConnectableSignal<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Owner = {_owner}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSubscription: Owner = {_owner}, Subscription = {Subscription}")]
     public sealed class AutoShareSubscription<T> : System.IDisposable
     {
         public AutoShareSubscription(ReactiveUI.Primitives.Reactive.Advanced.AutoShareSignal<T> owner, System.IDisposable subscription) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void Dispose() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("BlendSignal: Sources = {Sources}")]
     public sealed class BlendSignal<T> : System.IObservable<T>
     {
         public BlendSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("BlendWitness: ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
     public sealed class BlendWitness<T> : System.IDisposable
     {
         public BlendWitness(System.IObserver<T> observer) { }
@@ -921,7 +921,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.BlendWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.BlendWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("BufferEachWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class BufferEachWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public BufferEachWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -935,20 +935,20 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Window = {Window}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("BufferSignal: Window = {Window}, Source = {Source}")]
     public sealed class BufferSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public BufferSignal(System.IObservable<T> source, System.TimeSpan timeSpan, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("CastSignal: Source = {Source}")]
     public sealed class CastSignal<TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public CastSignal(System.IObservable<object?> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CastWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CastWitness<TResult> : System.IDisposable, System.IObserver<object?>
     {
         public CastWitness(System.IObserver<TResult> observer) { }
@@ -962,7 +962,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
+    [System.Diagnostics.DebuggerDisplay("ChainSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
     public sealed class ChainSignal<T> : System.IObservable<T>
     {
         public ChainSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -970,7 +970,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ChainSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("ChainWitness: IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
     public sealed class ChainWitness<T> : System.IDisposable
     {
         public ChainWitness(System.IObserver<T> observer) { }
@@ -980,13 +980,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.ChainWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.ChainWitness<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, TimeSpan = {TimeSpan}")]
+    [System.Diagnostics.DebuggerDisplay("CollectSignal: Source = {Source}, TimeSpan = {TimeSpan}")]
     public sealed class CollectSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public CollectSignal(System.IObservable<T> source, System.TimeSpan timeSpan, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Buffered = {Values.Count}")]
+    [System.Diagnostics.DebuggerDisplay("CollectWitness: Stopped = {_stopped}, Buffered = {Values.Count}")]
     public sealed class CollectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CollectWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -998,7 +998,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateSink: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class CreateSink<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateSink(System.IObserver<T> observer, bool disposeOnNextThrow) { }
@@ -1010,7 +1010,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CreateWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateWitness(System.IObserver<T> observer) { }
@@ -1024,13 +1024,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {DueTime}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietSignal: DueTime = {DueTime}, Source = {Source}")]
     public sealed class EmitIfQuietSignal<T> : System.IObservable<T>
     {
         public EmitIfQuietSignal(System.IObservable<T> source, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietWitness: HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
     public sealed class EmitIfQuietWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public EmitIfQuietWitness(System.IObserver<T> observer, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer) { }
@@ -1041,7 +1041,16 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("EmptySignal: Scheduler = {_scheduler}")]
+    public sealed class EmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public EmptySignal(System.Reactive.Concurrency.IScheduler scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("EnumerableBlendSignal: Sources = {Sources}")]
     public sealed class EnumerableBlendSignal<T> : System.IObservable<T>
     {
         public EnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -1051,7 +1060,14 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
     {
         public static System.IDisposable Attach<TEventHandler>(TEventHandler handler, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Reactive.Concurrency.IScheduler? scheduler) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
+    [System.Diagnostics.DebuggerDisplay("EverySignal: Period = {_period}, Scheduler = {_scheduler}")]
+    public sealed class EverySignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
+    {
+        public EverySignal(System.TimeSpan period, System.Reactive.Concurrency.IScheduler scheduler) { }
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<long> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ExpireCoordinator: Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
     public sealed class ExpireCoordinator<T> : System.IDisposable, System.IObserver<T>
     {
         public ExpireCoordinator(System.IObservable<T> source, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer, System.IObserver<T> observer) { }
@@ -1061,39 +1077,48 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnNext(T value) { }
         public ReactiveUI.Primitives.Reactive.Advanced.ExpireCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("ExpireSignal: DueTime = {_dueTime}, Source = {_source}")]
     public sealed class ExpireSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ExpireSignal(System.IObservable<T> source, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("FinallySignal: Source = {_source}")]
+    public sealed class FinallySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public FinallySignal(System.IObservable<T> source, System.Action finallyAction) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ForkJoinSignal: Left = {Left}, Right = {Right}")]
     public sealed class ForkJoinSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public ForkJoinSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("ForkJoinWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
     public sealed class ForkJoinWitness<TLeft, TRight, TResult>
     {
         public ForkJoinWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("CancellationRequested = {CancellationToken.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncExternalCancellationSignal: CancellationRequested = {CancellationToken.IsCancellationRequested}")]
     public sealed class FromAsyncExternalCancellationSignal<T> : System.IObservable<T>
     {
         public FromAsyncExternalCancellationSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSignal: TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
     public sealed class FromAsyncSignal<T> : System.IObservable<T>
     {
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSubscription: Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
     public sealed class FromAsyncSubscription<T> : System.IDisposable
     {
         public FromAsyncSubscription(System.IObserver<T> observer, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
@@ -1106,14 +1131,14 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public FromEventConversionSignal(System.Func<TCallback, TEventHandler> conversion, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Func<System.IObserver<TResult>, TCallback> callback, System.Reactive.Concurrency.IScheduler? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
+    [System.Diagnostics.DebuggerDisplay("FromEventPatternSignal: AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
     public sealed class FromEventPatternSignal<TEventHandler, TEventArgs> : System.IObservable<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> where TEventHandler : System.Delegate where TEventArgs : System.EventArgs
     {
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler) { }
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Reactive.Concurrency.IScheduler? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Disposed = {_disposed}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("GuardedWitness: Disposed = {_disposed}, Observer = {_observer}")]
     public sealed class GuardedWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public GuardedWitness(System.IObserver<T> observer, System.IDisposable cancel) { }
@@ -1123,7 +1148,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IgnoreValuesSignal: Source = {Source}")]
     public sealed class IgnoreValuesSignal<T> : System.IObservable<T>
     {
         public IgnoreValuesSignal(System.IObservable<T> source) { }
@@ -1137,14 +1162,14 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public System.IDisposable Subscribe(System.IObserver<System.Reactive.Unit> observer) { }
         public System.IDisposable Subscribe(System.Action<System.Reactive.Unit> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptySignal: Source = {Source}")]
     public sealed class IsEmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<bool>
     {
         public IsEmptySignal(System.IObservable<T> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<bool> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptyWitness: Stopped = {_stopped}, Subscription = {Subscription}")]
     public sealed class IsEmptyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public IsEmptyWitness(System.IObserver<bool> observer) { }
@@ -1157,14 +1182,23 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {Value}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("LeadSignal: Value = {Value}, Source = {Source}")]
     public sealed class LeadSignal<T> : ReactiveUI.Primitives.Advanced.IInlineSignal<T>
     {
         public LeadSignal(System.IObservable<T> source, T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
         public System.IDisposable Subscribe(System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("LoopSignal: Value = {Value}")]
+    public sealed class LoopSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public LoopSignal(T value) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("MapIndexedSignal: Source = {_source}")]
     public sealed class MapIndexedSignal<TSource, TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public MapIndexedSignal(System.IObservable<TSource> source, System.Func<TSource, int, TResult> selector) { }
@@ -1172,7 +1206,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Index = {_index}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("MapIndexedWitness: Index = {_index}, Stopped = {_stopped}")]
     public sealed class MapIndexedWitness<TSource, TResult> : System.IObserver<TSource>
     {
         public MapIndexedWitness(System.IObserver<TResult> observer, System.Func<TSource, int, TResult> selector) { }
@@ -1180,20 +1214,20 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(TSource value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentBlendCoordinator: Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
     public sealed class MaxConcurrentBlendCoordinator<T> : System.IDisposable
     {
         public MaxConcurrentBlendCoordinator(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.MaxConcurrentBlendCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentEnumerableBlendSignal: Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
     public sealed class MaxConcurrentEnumerableBlendSignal<T> : System.IObservable<T>
     {
         public MaxConcurrentEnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("MergeCoordinator: Active = {Active}, Done = {Done}")]
     public sealed class MergeCoordinator<T> : System.IDisposable
     {
         public MergeCoordinator(System.IObserver<T> observer) { }
@@ -1204,7 +1238,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.MergeCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.MergeCoordinator<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MergeSignal: Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
     public sealed class MergeSignal<T> : System.IObservable<T>
     {
         public MergeSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -1212,32 +1246,39 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public MergeSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("OnErrorResumeNextSignal: Sources = {_sources}")]
+    public sealed class OnErrorResumeNextSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("PairSignal: Left = {Left}, Right = {Right}")]
     public sealed class PairSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public PairSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
+    [System.Diagnostics.DebuggerDisplay("PairWitness: IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
     public sealed class PairWitness<TLeft, TRight, TResult>
     {
         public PairWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("PublishSelectorSignal: Source = {Source}, Selector = {Selector}")]
     public sealed class PublishSelectorSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public PublishSelectorSignal(System.IObservable<TSource> source, System.Func<System.IObservable<TSource>, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
+    [System.Diagnostics.DebuggerDisplay("RaceSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
     public sealed class RaceSignal<T> : System.IObservable<T>
     {
         public RaceSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public RaceSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Arms = {_arms}")]
+    [System.Diagnostics.DebuggerDisplay("RaceWitness: Arms = {_arms}")]
     public sealed class RaceWitness<T> : System.IDisposable
     {
         public RaceWitness(System.IObserver<T> observer) { }
@@ -1246,40 +1287,48 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.RaceWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.RaceWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeCombineLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeCombineLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeCombineLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
+    [System.Diagnostics.DebuggerDisplay("RangeForkJoinSignal: Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
     public sealed class RangeForkJoinSignal<TResult> : System.IObservable<TResult>
     {
         public RangeForkJoinSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeSyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeSyncLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeSyncLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeWithLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeWithLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeWithLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Remaining = {_remaining}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("RecoverSignal: Source = {_source}")]
+    public sealed class RecoverSignal<T, TException> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T> where TException : System.Exception
+    {
+        public RecoverSignal(System.IObservable<T> source, System.Func<TException, System.IObservable<T>> handler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceCoordinator: Remaining = {_remaining}, Disposed = {_disposed}")]
     public sealed class RepeatSourceCoordinator<T> : System.IDisposable
     {
         public RepeatSourceCoordinator(System.IObservable<T> source, int? repeatCount, System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.RepeatSourceCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, RepeatCount = {_repeatCount}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceSignal: Source = {_source}, RepeatCount = {_repeatCount}")]
     public sealed class RepeatSourceSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public RepeatSourceSignal(System.IObservable<T> source, int? repeatCount) { }
@@ -1287,7 +1336,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Generation = {_generation}, Terminated = {_terminated}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceWitness: Generation = {_generation}, Terminated = {_terminated}")]
     public sealed class RepeatSourceWitness<T> : System.IObserver<T>
     {
         public RepeatSourceWitness(ReactiveUI.Primitives.Reactive.Advanced.RepeatSourceCoordinator<T> parent, int generation) { }
@@ -1295,7 +1344,15 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_value}, Scheduler = {_scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ResumeSignal: Source = {_source}, Fallback = {_fallback}")]
+    public sealed class ResumeSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ResumeSignal(System.IObservable<T> source, System.IObservable<T> fallback) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ReturnSignal: Value = {_value}, Scheduler = {_scheduler}")]
     public sealed class ReturnSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ReturnSignal(T value, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -1304,13 +1361,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Values = {Values}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledEnumerableSignal: Values = {Values}, Scheduler = {Scheduler}")]
     public sealed class ScheduledEnumerableSignal<T> : System.IObservable<T>
     {
         public ScheduledEnumerableSignal(System.Collections.Generic.IEnumerable<T> values, System.Reactive.Concurrency.IScheduler scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyCoordinator<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TResult>> selector) { }
@@ -1324,13 +1381,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Reactive.Advanced.SelectManyCoordinator<TSource, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableSignal: Source = {_source}")]
     public sealed class SelectManyEnumerableSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManyEnumerableSignal(System.IObservable<TSource> source, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SelectManyEnumerableWitness<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyEnumerableWitness(System.IObserver<TResult> observer, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
@@ -1344,7 +1401,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyResultCoordinator<TSource, TCollection, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyResultCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
@@ -1357,20 +1414,20 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Reactive.Advanced.SelectManyResultCoordinator<TSource, TCollection, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, CollectionSelector = {CollectionSelector}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultSignal: Source = {Source}, CollectionSelector = {CollectionSelector}")]
     public sealed class SelectManyResultSignal<TSource, TCollection, TResult> : System.IObservable<TResult>
     {
         public SelectManyResultSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManySignal: Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
     public sealed class SelectManySignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManySignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public SelectManySignal(System.IObservable<TSource> source, System.IObservable<TResult> inner) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Start = {Start}, Count = {Count}")]
+    [System.Diagnostics.DebuggerDisplay("SequenceSignal: Start = {Start}, Count = {Count}")]
     public sealed class SequenceSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<int>
     {
         public SequenceSignal(int start, int count, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -1381,13 +1438,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
     {
         public static System.IDisposable Subscribe<T>(System.IObserver<T> observer, bool currentThreadRequired, System.Func<System.IObserver<T>, System.IDisposable, System.IDisposable> subscribeCore) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SparkSignal: Source = {Source}")]
     public sealed class SparkSignal<T> : System.IObservable<ReactiveUI.Primitives.Reactive.Core.Spark<T>>
     {
         public SparkSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Reactive.Core.Spark<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SparkWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SparkWitness(System.IObserver<ReactiveUI.Primitives.Reactive.Core.Spark<T>> observer) { }
@@ -1402,21 +1459,21 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Action = {Action}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Action = {Action}, Scheduler = {Scheduler}")]
     public sealed class StartSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<System.Reactive.Unit>
     {
         public StartSignal(System.Action action, System.Reactive.Concurrency.IScheduler scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<System.Reactive.Unit> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Function = {Function}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Function = {Function}, Scheduler = {Scheduler}")]
     public sealed class StartSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public StartSignal(System.Func<T> function, System.Reactive.Concurrency.IScheduler scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SubscribeSafeWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SubscribeSafeWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SubscribeSafeWitness(System.IObserver<T> observer) { }
@@ -1430,50 +1487,50 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, SkipNullSources = {_skipNullSources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchMapSignal: Source = {_source}, SkipNullSources = {_skipNullSources}")]
     public sealed class SwitchMapSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SwitchMapSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchSignal: Sources = {Sources}")]
     public sealed class SwitchSignal<T> : System.IObservable<T>
     {
         public SwitchSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Version = {_version}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchWitness: Version = {_version}, IsDone = {IsDone}")]
     public sealed class SwitchWitness<T> : System.IDisposable
     {
         public SwitchWitness(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.SwitchWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class SyncLatestSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public SyncLatestSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
     public sealed class SyncLatestWitness<TLeft, TRight, TResult>
     {
         public SyncLatestWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Gate = {Gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeGateSignal: Source = {Source}, Gate = {Gate}")]
     public sealed class SynchronizeGateSignal<T> : System.IObservable<T>
     {
         public SynchronizeGateSignal(System.IObservable<T> source, System.Threading.Lock gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, Gate = {_gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectSignal: Source = {_source}, Gate = {_gate}")]
     public sealed class SynchronizeObjectSignal<T> : System.IObservable<T>
     {
         public SynchronizeObjectSignal(System.IObservable<T> source, object gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SynchronizeObjectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SynchronizeObjectWitness(System.IObserver<T> observer, object gate) { }
@@ -1485,19 +1542,19 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeSignal: Source = {Source}")]
     public sealed class SynchronizeSignal<T> : System.IObservable<T>
     {
         public SynchronizeSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("TapSignal: Source = {Source}")]
     public sealed class TapSignal<T> : System.IObservable<T>
     {
         public TapSignal(System.IObservable<T> source, System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskAnyWitness: Stopped = {_stopped}, Task = {Task}")]
     public sealed class TaskAnyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskAnyWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1513,7 +1570,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainCoordinator: Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
     public sealed class TaskChainCoordinator<T> : System.IDisposable
     {
         public TaskChainCoordinator(System.IObserver<T> observer) { }
@@ -1521,13 +1578,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.TaskChainCoordinator<T> Run(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainSignal: Sources = {_sources}")]
     public sealed class TaskChainSignal<T> : System.IObservable<T>
     {
         public TaskChainSignal(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskCountWitness: Count = {_count}, Stopped = {_stopped}")]
     public sealed class TaskCountWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskCountWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1543,13 +1600,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSignal: Task = {Task}")]
     public sealed class TaskInstanceSignal<T> : System.IObservable<T>
     {
         public TaskInstanceSignal(System.Threading.Tasks.Task<T> task) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSubscription: Stopped = {_stopped}")]
     public sealed class TaskInstanceSubscription : System.IDisposable
     {
         public TaskInstanceSubscription() { }
@@ -1557,13 +1614,22 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void Dispose() { }
         public bool TryStop() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Sequencer = {Sequencer}")]
+    [System.Diagnostics.DebuggerDisplay("ThrowSignal: Error = {_error}, Scheduler = {_scheduler}")]
+    public sealed class ThrowSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ThrowSignal(System.Exception error, System.Reactive.Concurrency.IScheduler scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalSignal: Source = {Source}, Sequencer = {Sequencer}")]
     public sealed class TimeIntervalSignal<T> : System.IObservable<ReactiveUI.Primitives.Core.TimeInterval<T>>
     {
         public TimeIntervalSignal(System.IObservable<T> source, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("First = {_first}, Last = {_last}")]
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalWitness: First = {_first}, Last = {_last}")]
     public sealed class TimeIntervalWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TimeIntervalWitness(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -1581,13 +1647,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
     {
         public static void Arm(ReactiveUI.Primitives.Disposables.SingleReplaceableDisposable slot, System.Reactive.Concurrency.IScheduler sequencer, System.TimeSpan delay, System.Action tick) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkSignal: Source = {Source}")]
     public sealed class UnsparkSignal<T> : System.IObservable<T>
     {
         public UnsparkSignal(System.IObservable<ReactiveUI.Primitives.Reactive.Core.Spark<T>> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class UnsparkWitness<T> : System.IDisposable, System.IObserver<ReactiveUI.Primitives.Reactive.Core.Spark<T>>
     {
         public UnsparkWitness(System.IObserver<T> observer) { }
@@ -1605,7 +1671,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
 }
 namespace ReactiveUI.Primitives.Reactive.Concurrency
 {
-    [System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
+    [System.Diagnostics.DebuggerDisplay("CoalescingDispatchScheduler: ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
     public abstract class CoalescingDispatchScheduler : System.Reactive.Concurrency.LocalScheduler
     {
         protected CoalescingDispatchScheduler() { }
@@ -1630,7 +1696,7 @@ namespace ReactiveUI.Primitives.Reactive.Concurrency
         public static ReactiveUI.Primitives.Concurrency.ScheduledItem<TAbsolute> Create<TAbsolute, TValue>(System.Reactive.Concurrency.IScheduler scheduler, TValue state, System.Func<System.Reactive.Concurrency.IScheduler, TValue, System.IDisposable> action, TAbsolute dueTime) where TAbsolute : System.IComparable<TAbsolute> { }
         public static ReactiveUI.Primitives.Concurrency.ScheduledItem<TAbsolute> Create<TAbsolute, TValue>(System.Reactive.Concurrency.IScheduler scheduler, TValue state, System.Func<System.Reactive.Concurrency.IScheduler, TValue, System.IDisposable> action, TAbsolute dueTime, System.Collections.Generic.IComparer<TAbsolute> comparer) where TAbsolute : System.IComparable<TAbsolute> { }
     }
-    [System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainState = {_drainState}, Disposed = {_isDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("WasmScheduler: ReadyCount = {_readyCount}, DrainState = {_drainState}, Disposed = {_isDisposed}")]
     public sealed class WasmScheduler : System.Reactive.Concurrency.LocalScheduler, System.IDisposable, System.Reactive.Concurrency.ISchedulerPeriodic
     {
         public static ReactiveUI.Primitives.Reactive.Concurrency.WasmScheduler Default { get; }
@@ -1672,7 +1738,7 @@ namespace ReactiveUI.Primitives.Reactive.Core
 }
 namespace ReactiveUI.Primitives.Reactive.Disposables
 {
-    [System.Diagnostics.DebuggerDisplay("Count = {Count}, IsDisposed = {IsDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ContainerDisposable: Count = {Count}, IsDisposed = {IsDisposed}")]
     public sealed class ContainerDisposable : ReactiveUI.Primitives.Disposables.MultipleDisposable
     {
         public ContainerDisposable() { }
@@ -1686,7 +1752,7 @@ namespace ReactiveUI.Primitives.Reactive.Disposables
 }
 namespace ReactiveUI.Primitives.Reactive.Signals
 {
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
+    [System.Diagnostics.DebuggerDisplay("PrioritySemaphoreSignal: Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
     public sealed class PrioritySemaphoreSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T> where T : System.IComparable<T>
     {
         public PrioritySemaphoreSignal(int maxCount) { }
@@ -1721,7 +1787,7 @@ namespace ReactiveUI.Primitives.Reactive.Signals
         public void OnNext(T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledSignal: Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
     public class ScheduledSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T>
     {
         public ScheduledSignal(System.Reactive.Concurrency.IScheduler scheduler) { }

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net11.0/PublicAPI.txt
@@ -844,7 +844,7 @@ namespace ReactiveUI.Primitives.Reactive
 }
 namespace ReactiveUI.Primitives.Reactive.Advanced
 {
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Period = {_period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSignal: DueTime = {_dueTime}, Period = {_period}")]
     public sealed class AfterSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
     {
         public AfterSignal(System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -852,7 +852,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<long> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSubscription: Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
     public sealed class AfterSubscription : System.IDisposable
     {
         public AfterSubscription(System.IObserver<long> observer, System.Reactive.Concurrency.IScheduler scheduler, System.TimeSpan dueTime, System.TimeSpan? period) { }
@@ -860,21 +860,21 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.AfterSubscription Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("SubscribeAsync = {SubscribeAsync}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncCreateSignal: SubscribeAsync = {SubscribeAsync}")]
     public sealed class AsyncCreateSignal<T> : System.IObservable<T>
     {
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ObservableFactory = {ObservableFactory}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncDeferSignal: ObservableFactory = {ObservableFactory}")]
     public sealed class AsyncDeferSignal<T> : System.IObservable<T>
     {
         public AsyncDeferSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public AsyncDeferSignal(System.Func<System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncSubscriptionLifetime: Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
     public sealed class AsyncSubscriptionLifetime : System.IDisposable
     {
         public AsyncSubscriptionLifetime() { }
@@ -885,33 +885,33 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable? disposable) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connected = {_connected}")]
+    [System.Diagnostics.DebuggerDisplay("AutoConnectSignal: Count = {_count}, Connected = {_connected}")]
     public sealed class AutoConnectSignal<T> : System.IObservable<T>
     {
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount) { }
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount, System.Action<System.IDisposable>? onConnect) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connection = {_connection}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSignal: Count = {_count}, Connection = {_connection}")]
     public sealed class AutoShareSignal<T> : System.IObservable<T>
     {
         public AutoShareSignal(ReactiveUI.Primitives.ConnectableSignal<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Owner = {_owner}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSubscription: Owner = {_owner}, Subscription = {Subscription}")]
     public sealed class AutoShareSubscription<T> : System.IDisposable
     {
         public AutoShareSubscription(ReactiveUI.Primitives.Reactive.Advanced.AutoShareSignal<T> owner, System.IDisposable subscription) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void Dispose() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("BlendSignal: Sources = {Sources}")]
     public sealed class BlendSignal<T> : System.IObservable<T>
     {
         public BlendSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("BlendWitness: ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
     public sealed class BlendWitness<T> : System.IDisposable
     {
         public BlendWitness(System.IObserver<T> observer) { }
@@ -920,7 +920,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.BlendWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.BlendWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("BufferEachWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class BufferEachWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public BufferEachWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -934,20 +934,20 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Window = {Window}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("BufferSignal: Window = {Window}, Source = {Source}")]
     public sealed class BufferSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public BufferSignal(System.IObservable<T> source, System.TimeSpan timeSpan, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("CastSignal: Source = {Source}")]
     public sealed class CastSignal<TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public CastSignal(System.IObservable<object?> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CastWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CastWitness<TResult> : System.IDisposable, System.IObserver<object?>
     {
         public CastWitness(System.IObserver<TResult> observer) { }
@@ -961,7 +961,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
+    [System.Diagnostics.DebuggerDisplay("ChainSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
     public sealed class ChainSignal<T> : System.IObservable<T>
     {
         public ChainSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -969,7 +969,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ChainSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("ChainWitness: IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
     public sealed class ChainWitness<T> : System.IDisposable
     {
         public ChainWitness(System.IObserver<T> observer) { }
@@ -979,13 +979,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.ChainWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.ChainWitness<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, TimeSpan = {TimeSpan}")]
+    [System.Diagnostics.DebuggerDisplay("CollectSignal: Source = {Source}, TimeSpan = {TimeSpan}")]
     public sealed class CollectSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public CollectSignal(System.IObservable<T> source, System.TimeSpan timeSpan, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Buffered = {Values.Count}")]
+    [System.Diagnostics.DebuggerDisplay("CollectWitness: Stopped = {_stopped}, Buffered = {Values.Count}")]
     public sealed class CollectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CollectWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -997,7 +997,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateSink: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class CreateSink<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateSink(System.IObserver<T> observer, bool disposeOnNextThrow) { }
@@ -1009,7 +1009,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CreateWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateWitness(System.IObserver<T> observer) { }
@@ -1023,13 +1023,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {DueTime}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietSignal: DueTime = {DueTime}, Source = {Source}")]
     public sealed class EmitIfQuietSignal<T> : System.IObservable<T>
     {
         public EmitIfQuietSignal(System.IObservable<T> source, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietWitness: HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
     public sealed class EmitIfQuietWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public EmitIfQuietWitness(System.IObserver<T> observer, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer) { }
@@ -1040,7 +1040,16 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("EmptySignal: Scheduler = {_scheduler}")]
+    public sealed class EmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public EmptySignal(System.Reactive.Concurrency.IScheduler scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("EnumerableBlendSignal: Sources = {Sources}")]
     public sealed class EnumerableBlendSignal<T> : System.IObservable<T>
     {
         public EnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -1050,7 +1059,14 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
     {
         public static System.IDisposable Attach<TEventHandler>(TEventHandler handler, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Reactive.Concurrency.IScheduler? scheduler) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
+    [System.Diagnostics.DebuggerDisplay("EverySignal: Period = {_period}, Scheduler = {_scheduler}")]
+    public sealed class EverySignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
+    {
+        public EverySignal(System.TimeSpan period, System.Reactive.Concurrency.IScheduler scheduler) { }
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<long> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ExpireCoordinator: Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
     public sealed class ExpireCoordinator<T> : System.IDisposable, System.IObserver<T>
     {
         public ExpireCoordinator(System.IObservable<T> source, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer, System.IObserver<T> observer) { }
@@ -1060,39 +1076,48 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnNext(T value) { }
         public ReactiveUI.Primitives.Reactive.Advanced.ExpireCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("ExpireSignal: DueTime = {_dueTime}, Source = {_source}")]
     public sealed class ExpireSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ExpireSignal(System.IObservable<T> source, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("FinallySignal: Source = {_source}")]
+    public sealed class FinallySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public FinallySignal(System.IObservable<T> source, System.Action finallyAction) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ForkJoinSignal: Left = {Left}, Right = {Right}")]
     public sealed class ForkJoinSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public ForkJoinSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("ForkJoinWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
     public sealed class ForkJoinWitness<TLeft, TRight, TResult>
     {
         public ForkJoinWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("CancellationRequested = {CancellationToken.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncExternalCancellationSignal: CancellationRequested = {CancellationToken.IsCancellationRequested}")]
     public sealed class FromAsyncExternalCancellationSignal<T> : System.IObservable<T>
     {
         public FromAsyncExternalCancellationSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSignal: TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
     public sealed class FromAsyncSignal<T> : System.IObservable<T>
     {
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSubscription: Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
     public sealed class FromAsyncSubscription<T> : System.IDisposable
     {
         public FromAsyncSubscription(System.IObserver<T> observer, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
@@ -1105,14 +1130,14 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public FromEventConversionSignal(System.Func<TCallback, TEventHandler> conversion, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Func<System.IObserver<TResult>, TCallback> callback, System.Reactive.Concurrency.IScheduler? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
+    [System.Diagnostics.DebuggerDisplay("FromEventPatternSignal: AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
     public sealed class FromEventPatternSignal<TEventHandler, TEventArgs> : System.IObservable<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> where TEventHandler : System.Delegate where TEventArgs : System.EventArgs
     {
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler) { }
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Reactive.Concurrency.IScheduler? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Disposed = {_disposed}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("GuardedWitness: Disposed = {_disposed}, Observer = {_observer}")]
     public sealed class GuardedWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public GuardedWitness(System.IObserver<T> observer, System.IDisposable cancel) { }
@@ -1122,7 +1147,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IgnoreValuesSignal: Source = {Source}")]
     public sealed class IgnoreValuesSignal<T> : System.IObservable<T>
     {
         public IgnoreValuesSignal(System.IObservable<T> source) { }
@@ -1136,14 +1161,14 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public System.IDisposable Subscribe(System.IObserver<System.Reactive.Unit> observer) { }
         public System.IDisposable Subscribe(System.Action<System.Reactive.Unit> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptySignal: Source = {Source}")]
     public sealed class IsEmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<bool>
     {
         public IsEmptySignal(System.IObservable<T> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<bool> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptyWitness: Stopped = {_stopped}, Subscription = {Subscription}")]
     public sealed class IsEmptyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public IsEmptyWitness(System.IObserver<bool> observer) { }
@@ -1156,14 +1181,23 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {Value}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("LeadSignal: Value = {Value}, Source = {Source}")]
     public sealed class LeadSignal<T> : ReactiveUI.Primitives.Advanced.IInlineSignal<T>
     {
         public LeadSignal(System.IObservable<T> source, T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
         public System.IDisposable Subscribe(System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("LoopSignal: Value = {Value}")]
+    public sealed class LoopSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public LoopSignal(T value) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("MapIndexedSignal: Source = {_source}")]
     public sealed class MapIndexedSignal<TSource, TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public MapIndexedSignal(System.IObservable<TSource> source, System.Func<TSource, int, TResult> selector) { }
@@ -1171,7 +1205,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Index = {_index}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("MapIndexedWitness: Index = {_index}, Stopped = {_stopped}")]
     public sealed class MapIndexedWitness<TSource, TResult> : System.IObserver<TSource>
     {
         public MapIndexedWitness(System.IObserver<TResult> observer, System.Func<TSource, int, TResult> selector) { }
@@ -1179,20 +1213,20 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(TSource value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentBlendCoordinator: Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
     public sealed class MaxConcurrentBlendCoordinator<T> : System.IDisposable
     {
         public MaxConcurrentBlendCoordinator(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.MaxConcurrentBlendCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentEnumerableBlendSignal: Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
     public sealed class MaxConcurrentEnumerableBlendSignal<T> : System.IObservable<T>
     {
         public MaxConcurrentEnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("MergeCoordinator: Active = {Active}, Done = {Done}")]
     public sealed class MergeCoordinator<T> : System.IDisposable
     {
         public MergeCoordinator(System.IObserver<T> observer) { }
@@ -1203,7 +1237,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.MergeCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.MergeCoordinator<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MergeSignal: Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
     public sealed class MergeSignal<T> : System.IObservable<T>
     {
         public MergeSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -1211,32 +1245,39 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public MergeSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("OnErrorResumeNextSignal: Sources = {_sources}")]
+    public sealed class OnErrorResumeNextSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("PairSignal: Left = {Left}, Right = {Right}")]
     public sealed class PairSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public PairSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
+    [System.Diagnostics.DebuggerDisplay("PairWitness: IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
     public sealed class PairWitness<TLeft, TRight, TResult>
     {
         public PairWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("PublishSelectorSignal: Source = {Source}, Selector = {Selector}")]
     public sealed class PublishSelectorSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public PublishSelectorSignal(System.IObservable<TSource> source, System.Func<System.IObservable<TSource>, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
+    [System.Diagnostics.DebuggerDisplay("RaceSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
     public sealed class RaceSignal<T> : System.IObservable<T>
     {
         public RaceSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public RaceSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Arms = {_arms}")]
+    [System.Diagnostics.DebuggerDisplay("RaceWitness: Arms = {_arms}")]
     public sealed class RaceWitness<T> : System.IDisposable
     {
         public RaceWitness(System.IObserver<T> observer) { }
@@ -1245,40 +1286,48 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.RaceWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.RaceWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeCombineLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeCombineLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeCombineLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
+    [System.Diagnostics.DebuggerDisplay("RangeForkJoinSignal: Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
     public sealed class RangeForkJoinSignal<TResult> : System.IObservable<TResult>
     {
         public RangeForkJoinSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeSyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeSyncLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeSyncLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeWithLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeWithLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeWithLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Remaining = {_remaining}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("RecoverSignal: Source = {_source}")]
+    public sealed class RecoverSignal<T, TException> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T> where TException : System.Exception
+    {
+        public RecoverSignal(System.IObservable<T> source, System.Func<TException, System.IObservable<T>> handler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceCoordinator: Remaining = {_remaining}, Disposed = {_disposed}")]
     public sealed class RepeatSourceCoordinator<T> : System.IDisposable
     {
         public RepeatSourceCoordinator(System.IObservable<T> source, int? repeatCount, System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.RepeatSourceCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, RepeatCount = {_repeatCount}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceSignal: Source = {_source}, RepeatCount = {_repeatCount}")]
     public sealed class RepeatSourceSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public RepeatSourceSignal(System.IObservable<T> source, int? repeatCount) { }
@@ -1286,7 +1335,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Generation = {_generation}, Terminated = {_terminated}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceWitness: Generation = {_generation}, Terminated = {_terminated}")]
     public sealed class RepeatSourceWitness<T> : System.IObserver<T>
     {
         public RepeatSourceWitness(ReactiveUI.Primitives.Reactive.Advanced.RepeatSourceCoordinator<T> parent, int generation) { }
@@ -1294,7 +1343,15 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_value}, Scheduler = {_scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ResumeSignal: Source = {_source}, Fallback = {_fallback}")]
+    public sealed class ResumeSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ResumeSignal(System.IObservable<T> source, System.IObservable<T> fallback) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ReturnSignal: Value = {_value}, Scheduler = {_scheduler}")]
     public sealed class ReturnSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ReturnSignal(T value, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -1303,13 +1360,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Values = {Values}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledEnumerableSignal: Values = {Values}, Scheduler = {Scheduler}")]
     public sealed class ScheduledEnumerableSignal<T> : System.IObservable<T>
     {
         public ScheduledEnumerableSignal(System.Collections.Generic.IEnumerable<T> values, System.Reactive.Concurrency.IScheduler scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyCoordinator<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TResult>> selector) { }
@@ -1323,13 +1380,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Reactive.Advanced.SelectManyCoordinator<TSource, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableSignal: Source = {_source}")]
     public sealed class SelectManyEnumerableSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManyEnumerableSignal(System.IObservable<TSource> source, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SelectManyEnumerableWitness<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyEnumerableWitness(System.IObserver<TResult> observer, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
@@ -1343,7 +1400,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyResultCoordinator<TSource, TCollection, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyResultCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
@@ -1356,20 +1413,20 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Reactive.Advanced.SelectManyResultCoordinator<TSource, TCollection, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, CollectionSelector = {CollectionSelector}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultSignal: Source = {Source}, CollectionSelector = {CollectionSelector}")]
     public sealed class SelectManyResultSignal<TSource, TCollection, TResult> : System.IObservable<TResult>
     {
         public SelectManyResultSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManySignal: Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
     public sealed class SelectManySignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManySignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public SelectManySignal(System.IObservable<TSource> source, System.IObservable<TResult> inner) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Start = {Start}, Count = {Count}")]
+    [System.Diagnostics.DebuggerDisplay("SequenceSignal: Start = {Start}, Count = {Count}")]
     public sealed class SequenceSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<int>
     {
         public SequenceSignal(int start, int count, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -1380,13 +1437,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
     {
         public static System.IDisposable Subscribe<T>(System.IObserver<T> observer, bool currentThreadRequired, System.Func<System.IObserver<T>, System.IDisposable, System.IDisposable> subscribeCore) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SparkSignal: Source = {Source}")]
     public sealed class SparkSignal<T> : System.IObservable<ReactiveUI.Primitives.Reactive.Core.Spark<T>>
     {
         public SparkSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Reactive.Core.Spark<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SparkWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SparkWitness(System.IObserver<ReactiveUI.Primitives.Reactive.Core.Spark<T>> observer) { }
@@ -1401,21 +1458,21 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Action = {Action}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Action = {Action}, Scheduler = {Scheduler}")]
     public sealed class StartSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<System.Reactive.Unit>
     {
         public StartSignal(System.Action action, System.Reactive.Concurrency.IScheduler scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<System.Reactive.Unit> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Function = {Function}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Function = {Function}, Scheduler = {Scheduler}")]
     public sealed class StartSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public StartSignal(System.Func<T> function, System.Reactive.Concurrency.IScheduler scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SubscribeSafeWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SubscribeSafeWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SubscribeSafeWitness(System.IObserver<T> observer) { }
@@ -1429,50 +1486,50 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, SkipNullSources = {_skipNullSources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchMapSignal: Source = {_source}, SkipNullSources = {_skipNullSources}")]
     public sealed class SwitchMapSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SwitchMapSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchSignal: Sources = {Sources}")]
     public sealed class SwitchSignal<T> : System.IObservable<T>
     {
         public SwitchSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Version = {_version}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchWitness: Version = {_version}, IsDone = {IsDone}")]
     public sealed class SwitchWitness<T> : System.IDisposable
     {
         public SwitchWitness(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.SwitchWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class SyncLatestSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public SyncLatestSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
     public sealed class SyncLatestWitness<TLeft, TRight, TResult>
     {
         public SyncLatestWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Gate = {Gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeGateSignal: Source = {Source}, Gate = {Gate}")]
     public sealed class SynchronizeGateSignal<T> : System.IObservable<T>
     {
         public SynchronizeGateSignal(System.IObservable<T> source, System.Threading.Lock gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, Gate = {_gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectSignal: Source = {_source}, Gate = {_gate}")]
     public sealed class SynchronizeObjectSignal<T> : System.IObservable<T>
     {
         public SynchronizeObjectSignal(System.IObservable<T> source, object gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SynchronizeObjectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SynchronizeObjectWitness(System.IObserver<T> observer, object gate) { }
@@ -1484,19 +1541,19 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeSignal: Source = {Source}")]
     public sealed class SynchronizeSignal<T> : System.IObservable<T>
     {
         public SynchronizeSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("TapSignal: Source = {Source}")]
     public sealed class TapSignal<T> : System.IObservable<T>
     {
         public TapSignal(System.IObservable<T> source, System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskAnyWitness: Stopped = {_stopped}, Task = {Task}")]
     public sealed class TaskAnyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskAnyWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1512,7 +1569,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainCoordinator: Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
     public sealed class TaskChainCoordinator<T> : System.IDisposable
     {
         public TaskChainCoordinator(System.IObserver<T> observer) { }
@@ -1520,13 +1577,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.TaskChainCoordinator<T> Run(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainSignal: Sources = {_sources}")]
     public sealed class TaskChainSignal<T> : System.IObservable<T>
     {
         public TaskChainSignal(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskCountWitness: Count = {_count}, Stopped = {_stopped}")]
     public sealed class TaskCountWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskCountWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1542,13 +1599,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSignal: Task = {Task}")]
     public sealed class TaskInstanceSignal<T> : System.IObservable<T>
     {
         public TaskInstanceSignal(System.Threading.Tasks.Task<T> task) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSubscription: Stopped = {_stopped}")]
     public sealed class TaskInstanceSubscription : System.IDisposable
     {
         public TaskInstanceSubscription() { }
@@ -1556,13 +1613,22 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void Dispose() { }
         public bool TryStop() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Sequencer = {Sequencer}")]
+    [System.Diagnostics.DebuggerDisplay("ThrowSignal: Error = {_error}, Scheduler = {_scheduler}")]
+    public sealed class ThrowSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ThrowSignal(System.Exception error, System.Reactive.Concurrency.IScheduler scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalSignal: Source = {Source}, Sequencer = {Sequencer}")]
     public sealed class TimeIntervalSignal<T> : System.IObservable<ReactiveUI.Primitives.Core.TimeInterval<T>>
     {
         public TimeIntervalSignal(System.IObservable<T> source, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("First = {_first}, Last = {_last}")]
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalWitness: First = {_first}, Last = {_last}")]
     public sealed class TimeIntervalWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TimeIntervalWitness(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -1580,13 +1646,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
     {
         public static void Arm(ReactiveUI.Primitives.Disposables.SingleReplaceableDisposable slot, System.Reactive.Concurrency.IScheduler sequencer, System.TimeSpan delay, System.Action tick) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkSignal: Source = {Source}")]
     public sealed class UnsparkSignal<T> : System.IObservable<T>
     {
         public UnsparkSignal(System.IObservable<ReactiveUI.Primitives.Reactive.Core.Spark<T>> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class UnsparkWitness<T> : System.IDisposable, System.IObserver<ReactiveUI.Primitives.Reactive.Core.Spark<T>>
     {
         public UnsparkWitness(System.IObserver<T> observer) { }
@@ -1610,7 +1676,7 @@ namespace ReactiveUI.Primitives.Reactive.Concurrency
         public static ReactiveUI.Primitives.Concurrency.ScheduledItem<TAbsolute> Create<TAbsolute, TValue>(System.Reactive.Concurrency.IScheduler scheduler, TValue state, System.Func<System.Reactive.Concurrency.IScheduler, TValue, System.IDisposable> action, TAbsolute dueTime) where TAbsolute : System.IComparable<TAbsolute> { }
         public static ReactiveUI.Primitives.Concurrency.ScheduledItem<TAbsolute> Create<TAbsolute, TValue>(System.Reactive.Concurrency.IScheduler scheduler, TValue state, System.Func<System.Reactive.Concurrency.IScheduler, TValue, System.IDisposable> action, TAbsolute dueTime, System.Collections.Generic.IComparer<TAbsolute> comparer) where TAbsolute : System.IComparable<TAbsolute> { }
     }
-    [System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainState = {_drainState}, Disposed = {_isDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("WasmScheduler: ReadyCount = {_readyCount}, DrainState = {_drainState}, Disposed = {_isDisposed}")]
     public sealed class WasmScheduler : System.Reactive.Concurrency.LocalScheduler, System.IDisposable, System.Reactive.Concurrency.ISchedulerPeriodic
     {
         public static ReactiveUI.Primitives.Reactive.Concurrency.WasmScheduler Default { get; }
@@ -1652,7 +1718,7 @@ namespace ReactiveUI.Primitives.Reactive.Core
 }
 namespace ReactiveUI.Primitives.Reactive.Disposables
 {
-    [System.Diagnostics.DebuggerDisplay("Count = {Count}, IsDisposed = {IsDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ContainerDisposable: Count = {Count}, IsDisposed = {IsDisposed}")]
     public sealed class ContainerDisposable : ReactiveUI.Primitives.Disposables.MultipleDisposable
     {
         public ContainerDisposable() { }
@@ -1666,7 +1732,7 @@ namespace ReactiveUI.Primitives.Reactive.Disposables
 }
 namespace ReactiveUI.Primitives.Reactive.Signals
 {
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
+    [System.Diagnostics.DebuggerDisplay("PrioritySemaphoreSignal: Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
     public sealed class PrioritySemaphoreSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T> where T : System.IComparable<T>
     {
         public PrioritySemaphoreSignal(int maxCount) { }
@@ -1701,7 +1767,7 @@ namespace ReactiveUI.Primitives.Reactive.Signals
         public void OnNext(T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledSignal: Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
     public class ScheduledSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T>
     {
         public ScheduledSignal(System.Reactive.Concurrency.IScheduler scheduler) { }

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net462/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net462/PublicAPI.txt
@@ -810,7 +810,7 @@ namespace ReactiveUI.Primitives.Reactive
 }
 namespace ReactiveUI.Primitives.Reactive.Advanced
 {
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Period = {_period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSignal: DueTime = {_dueTime}, Period = {_period}")]
     public sealed class AfterSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
     {
         public AfterSignal(System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -818,7 +818,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<long> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSubscription: Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
     public sealed class AfterSubscription : System.IDisposable
     {
         public AfterSubscription(System.IObserver<long> observer, System.Reactive.Concurrency.IScheduler scheduler, System.TimeSpan dueTime, System.TimeSpan? period) { }
@@ -826,21 +826,21 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.AfterSubscription Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("SubscribeAsync = {SubscribeAsync}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncCreateSignal: SubscribeAsync = {SubscribeAsync}")]
     public sealed class AsyncCreateSignal<T> : System.IObservable<T>
     {
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ObservableFactory = {ObservableFactory}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncDeferSignal: ObservableFactory = {ObservableFactory}")]
     public sealed class AsyncDeferSignal<T> : System.IObservable<T>
     {
         public AsyncDeferSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public AsyncDeferSignal(System.Func<System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncSubscriptionLifetime: Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
     public sealed class AsyncSubscriptionLifetime : System.IDisposable
     {
         public AsyncSubscriptionLifetime() { }
@@ -851,33 +851,33 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable? disposable) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connected = {_connected}")]
+    [System.Diagnostics.DebuggerDisplay("AutoConnectSignal: Count = {_count}, Connected = {_connected}")]
     public sealed class AutoConnectSignal<T> : System.IObservable<T>
     {
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount) { }
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount, System.Action<System.IDisposable>? onConnect) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connection = {_connection}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSignal: Count = {_count}, Connection = {_connection}")]
     public sealed class AutoShareSignal<T> : System.IObservable<T>
     {
         public AutoShareSignal(ReactiveUI.Primitives.ConnectableSignal<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Owner = {_owner}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSubscription: Owner = {_owner}, Subscription = {Subscription}")]
     public sealed class AutoShareSubscription<T> : System.IDisposable
     {
         public AutoShareSubscription(ReactiveUI.Primitives.Reactive.Advanced.AutoShareSignal<T> owner, System.IDisposable subscription) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void Dispose() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("BlendSignal: Sources = {Sources}")]
     public sealed class BlendSignal<T> : System.IObservable<T>
     {
         public BlendSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("BlendWitness: ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
     public sealed class BlendWitness<T> : System.IDisposable
     {
         public BlendWitness(System.IObserver<T> observer) { }
@@ -886,7 +886,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.BlendWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.BlendWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("BufferEachWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class BufferEachWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public BufferEachWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -900,20 +900,20 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Window = {Window}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("BufferSignal: Window = {Window}, Source = {Source}")]
     public sealed class BufferSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public BufferSignal(System.IObservable<T> source, System.TimeSpan timeSpan, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("CastSignal: Source = {Source}")]
     public sealed class CastSignal<TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public CastSignal(System.IObservable<object?> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CastWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CastWitness<TResult> : System.IDisposable, System.IObserver<object?>
     {
         public CastWitness(System.IObserver<TResult> observer) { }
@@ -927,7 +927,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
+    [System.Diagnostics.DebuggerDisplay("ChainSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
     public sealed class ChainSignal<T> : System.IObservable<T>
     {
         public ChainSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -935,7 +935,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ChainSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("ChainWitness: IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
     public sealed class ChainWitness<T> : System.IDisposable
     {
         public ChainWitness(System.IObserver<T> observer) { }
@@ -945,13 +945,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.ChainWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.ChainWitness<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, TimeSpan = {TimeSpan}")]
+    [System.Diagnostics.DebuggerDisplay("CollectSignal: Source = {Source}, TimeSpan = {TimeSpan}")]
     public sealed class CollectSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public CollectSignal(System.IObservable<T> source, System.TimeSpan timeSpan, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Buffered = {Values.Count}")]
+    [System.Diagnostics.DebuggerDisplay("CollectWitness: Stopped = {_stopped}, Buffered = {Values.Count}")]
     public sealed class CollectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CollectWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -963,7 +963,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateSink: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class CreateSink<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateSink(System.IObserver<T> observer, bool disposeOnNextThrow) { }
@@ -975,7 +975,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CreateWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateWitness(System.IObserver<T> observer) { }
@@ -989,13 +989,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {DueTime}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietSignal: DueTime = {DueTime}, Source = {Source}")]
     public sealed class EmitIfQuietSignal<T> : System.IObservable<T>
     {
         public EmitIfQuietSignal(System.IObservable<T> source, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietWitness: HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
     public sealed class EmitIfQuietWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public EmitIfQuietWitness(System.IObserver<T> observer, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer) { }
@@ -1006,7 +1006,16 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("EmptySignal: Scheduler = {_scheduler}")]
+    public sealed class EmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public EmptySignal(System.Reactive.Concurrency.IScheduler scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("EnumerableBlendSignal: Sources = {Sources}")]
     public sealed class EnumerableBlendSignal<T> : System.IObservable<T>
     {
         public EnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -1016,7 +1025,14 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
     {
         public static System.IDisposable Attach<TEventHandler>(TEventHandler handler, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Reactive.Concurrency.IScheduler? scheduler) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
+    [System.Diagnostics.DebuggerDisplay("EverySignal: Period = {_period}, Scheduler = {_scheduler}")]
+    public sealed class EverySignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
+    {
+        public EverySignal(System.TimeSpan period, System.Reactive.Concurrency.IScheduler scheduler) { }
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<long> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ExpireCoordinator: Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
     public sealed class ExpireCoordinator<T> : System.IDisposable, System.IObserver<T>
     {
         public ExpireCoordinator(System.IObservable<T> source, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer, System.IObserver<T> observer) { }
@@ -1026,39 +1042,48 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnNext(T value) { }
         public ReactiveUI.Primitives.Reactive.Advanced.ExpireCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("ExpireSignal: DueTime = {_dueTime}, Source = {_source}")]
     public sealed class ExpireSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ExpireSignal(System.IObservable<T> source, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("FinallySignal: Source = {_source}")]
+    public sealed class FinallySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public FinallySignal(System.IObservable<T> source, System.Action finallyAction) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ForkJoinSignal: Left = {Left}, Right = {Right}")]
     public sealed class ForkJoinSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public ForkJoinSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("ForkJoinWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
     public sealed class ForkJoinWitness<TLeft, TRight, TResult>
     {
         public ForkJoinWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("CancellationRequested = {CancellationToken.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncExternalCancellationSignal: CancellationRequested = {CancellationToken.IsCancellationRequested}")]
     public sealed class FromAsyncExternalCancellationSignal<T> : System.IObservable<T>
     {
         public FromAsyncExternalCancellationSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSignal: TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
     public sealed class FromAsyncSignal<T> : System.IObservable<T>
     {
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSubscription: Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
     public sealed class FromAsyncSubscription<T> : System.IDisposable
     {
         public FromAsyncSubscription(System.IObserver<T> observer, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
@@ -1071,14 +1096,14 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public FromEventConversionSignal(System.Func<TCallback, TEventHandler> conversion, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Func<System.IObserver<TResult>, TCallback> callback, System.Reactive.Concurrency.IScheduler? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
+    [System.Diagnostics.DebuggerDisplay("FromEventPatternSignal: AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
     public sealed class FromEventPatternSignal<TEventHandler, TEventArgs> : System.IObservable<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> where TEventHandler : System.Delegate where TEventArgs : System.EventArgs
     {
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler) { }
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Reactive.Concurrency.IScheduler? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Disposed = {_disposed}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("GuardedWitness: Disposed = {_disposed}, Observer = {_observer}")]
     public sealed class GuardedWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public GuardedWitness(System.IObserver<T> observer, System.IDisposable cancel) { }
@@ -1088,7 +1113,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IgnoreValuesSignal: Source = {Source}")]
     public sealed class IgnoreValuesSignal<T> : System.IObservable<T>
     {
         public IgnoreValuesSignal(System.IObservable<T> source) { }
@@ -1102,14 +1127,14 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public System.IDisposable Subscribe(System.IObserver<System.Reactive.Unit> observer) { }
         public System.IDisposable Subscribe(System.Action<System.Reactive.Unit> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptySignal: Source = {Source}")]
     public sealed class IsEmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<bool>
     {
         public IsEmptySignal(System.IObservable<T> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<bool> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptyWitness: Stopped = {_stopped}, Subscription = {Subscription}")]
     public sealed class IsEmptyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public IsEmptyWitness(System.IObserver<bool> observer) { }
@@ -1122,14 +1147,23 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {Value}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("LeadSignal: Value = {Value}, Source = {Source}")]
     public sealed class LeadSignal<T> : ReactiveUI.Primitives.Advanced.IInlineSignal<T>
     {
         public LeadSignal(System.IObservable<T> source, T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
         public System.IDisposable Subscribe(System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("LoopSignal: Value = {Value}")]
+    public sealed class LoopSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public LoopSignal(T value) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("MapIndexedSignal: Source = {_source}")]
     public sealed class MapIndexedSignal<TSource, TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public MapIndexedSignal(System.IObservable<TSource> source, System.Func<TSource, int, TResult> selector) { }
@@ -1137,7 +1171,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Index = {_index}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("MapIndexedWitness: Index = {_index}, Stopped = {_stopped}")]
     public sealed class MapIndexedWitness<TSource, TResult> : System.IObserver<TSource>
     {
         public MapIndexedWitness(System.IObserver<TResult> observer, System.Func<TSource, int, TResult> selector) { }
@@ -1145,20 +1179,20 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(TSource value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentBlendCoordinator: Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
     public sealed class MaxConcurrentBlendCoordinator<T> : System.IDisposable
     {
         public MaxConcurrentBlendCoordinator(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.MaxConcurrentBlendCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentEnumerableBlendSignal: Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
     public sealed class MaxConcurrentEnumerableBlendSignal<T> : System.IObservable<T>
     {
         public MaxConcurrentEnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("MergeCoordinator: Active = {Active}, Done = {Done}")]
     public sealed class MergeCoordinator<T> : System.IDisposable
     {
         public MergeCoordinator(System.IObserver<T> observer) { }
@@ -1169,7 +1203,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.MergeCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.MergeCoordinator<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MergeSignal: Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
     public sealed class MergeSignal<T> : System.IObservable<T>
     {
         public MergeSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -1177,32 +1211,39 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public MergeSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("OnErrorResumeNextSignal: Sources = {_sources}")]
+    public sealed class OnErrorResumeNextSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("PairSignal: Left = {Left}, Right = {Right}")]
     public sealed class PairSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public PairSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
+    [System.Diagnostics.DebuggerDisplay("PairWitness: IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
     public sealed class PairWitness<TLeft, TRight, TResult>
     {
         public PairWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("PublishSelectorSignal: Source = {Source}, Selector = {Selector}")]
     public sealed class PublishSelectorSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public PublishSelectorSignal(System.IObservable<TSource> source, System.Func<System.IObservable<TSource>, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
+    [System.Diagnostics.DebuggerDisplay("RaceSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
     public sealed class RaceSignal<T> : System.IObservable<T>
     {
         public RaceSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public RaceSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Arms = {_arms}")]
+    [System.Diagnostics.DebuggerDisplay("RaceWitness: Arms = {_arms}")]
     public sealed class RaceWitness<T> : System.IDisposable
     {
         public RaceWitness(System.IObserver<T> observer) { }
@@ -1211,40 +1252,48 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.RaceWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.RaceWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeCombineLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeCombineLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeCombineLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
+    [System.Diagnostics.DebuggerDisplay("RangeForkJoinSignal: Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
     public sealed class RangeForkJoinSignal<TResult> : System.IObservable<TResult>
     {
         public RangeForkJoinSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeSyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeSyncLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeSyncLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeWithLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeWithLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeWithLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Remaining = {_remaining}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("RecoverSignal: Source = {_source}")]
+    public sealed class RecoverSignal<T, TException> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T> where TException : System.Exception
+    {
+        public RecoverSignal(System.IObservable<T> source, System.Func<TException, System.IObservable<T>> handler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceCoordinator: Remaining = {_remaining}, Disposed = {_disposed}")]
     public sealed class RepeatSourceCoordinator<T> : System.IDisposable
     {
         public RepeatSourceCoordinator(System.IObservable<T> source, int? repeatCount, System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.RepeatSourceCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, RepeatCount = {_repeatCount}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceSignal: Source = {_source}, RepeatCount = {_repeatCount}")]
     public sealed class RepeatSourceSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public RepeatSourceSignal(System.IObservable<T> source, int? repeatCount) { }
@@ -1252,7 +1301,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Generation = {_generation}, Terminated = {_terminated}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceWitness: Generation = {_generation}, Terminated = {_terminated}")]
     public sealed class RepeatSourceWitness<T> : System.IObserver<T>
     {
         public RepeatSourceWitness(ReactiveUI.Primitives.Reactive.Advanced.RepeatSourceCoordinator<T> parent, int generation) { }
@@ -1260,7 +1309,15 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_value}, Scheduler = {_scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ResumeSignal: Source = {_source}, Fallback = {_fallback}")]
+    public sealed class ResumeSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ResumeSignal(System.IObservable<T> source, System.IObservable<T> fallback) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ReturnSignal: Value = {_value}, Scheduler = {_scheduler}")]
     public sealed class ReturnSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ReturnSignal(T value, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -1269,13 +1326,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Values = {Values}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledEnumerableSignal: Values = {Values}, Scheduler = {Scheduler}")]
     public sealed class ScheduledEnumerableSignal<T> : System.IObservable<T>
     {
         public ScheduledEnumerableSignal(System.Collections.Generic.IEnumerable<T> values, System.Reactive.Concurrency.IScheduler scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyCoordinator<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TResult>> selector) { }
@@ -1289,13 +1346,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Reactive.Advanced.SelectManyCoordinator<TSource, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableSignal: Source = {_source}")]
     public sealed class SelectManyEnumerableSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManyEnumerableSignal(System.IObservable<TSource> source, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SelectManyEnumerableWitness<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyEnumerableWitness(System.IObserver<TResult> observer, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
@@ -1309,7 +1366,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyResultCoordinator<TSource, TCollection, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyResultCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
@@ -1322,20 +1379,20 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Reactive.Advanced.SelectManyResultCoordinator<TSource, TCollection, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, CollectionSelector = {CollectionSelector}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultSignal: Source = {Source}, CollectionSelector = {CollectionSelector}")]
     public sealed class SelectManyResultSignal<TSource, TCollection, TResult> : System.IObservable<TResult>
     {
         public SelectManyResultSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManySignal: Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
     public sealed class SelectManySignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManySignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public SelectManySignal(System.IObservable<TSource> source, System.IObservable<TResult> inner) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Start = {Start}, Count = {Count}")]
+    [System.Diagnostics.DebuggerDisplay("SequenceSignal: Start = {Start}, Count = {Count}")]
     public sealed class SequenceSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<int>
     {
         public SequenceSignal(int start, int count, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -1346,13 +1403,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
     {
         public static System.IDisposable Subscribe<T>(System.IObserver<T> observer, bool currentThreadRequired, System.Func<System.IObserver<T>, System.IDisposable, System.IDisposable> subscribeCore) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SparkSignal: Source = {Source}")]
     public sealed class SparkSignal<T> : System.IObservable<ReactiveUI.Primitives.Reactive.Core.Spark<T>>
     {
         public SparkSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Reactive.Core.Spark<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SparkWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SparkWitness(System.IObserver<ReactiveUI.Primitives.Reactive.Core.Spark<T>> observer) { }
@@ -1367,21 +1424,21 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Action = {Action}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Action = {Action}, Scheduler = {Scheduler}")]
     public sealed class StartSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<System.Reactive.Unit>
     {
         public StartSignal(System.Action action, System.Reactive.Concurrency.IScheduler scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<System.Reactive.Unit> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Function = {Function}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Function = {Function}, Scheduler = {Scheduler}")]
     public sealed class StartSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public StartSignal(System.Func<T> function, System.Reactive.Concurrency.IScheduler scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SubscribeSafeWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SubscribeSafeWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SubscribeSafeWitness(System.IObserver<T> observer) { }
@@ -1395,50 +1452,50 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, SkipNullSources = {_skipNullSources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchMapSignal: Source = {_source}, SkipNullSources = {_skipNullSources}")]
     public sealed class SwitchMapSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SwitchMapSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchSignal: Sources = {Sources}")]
     public sealed class SwitchSignal<T> : System.IObservable<T>
     {
         public SwitchSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Version = {_version}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchWitness: Version = {_version}, IsDone = {IsDone}")]
     public sealed class SwitchWitness<T> : System.IDisposable
     {
         public SwitchWitness(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.SwitchWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class SyncLatestSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public SyncLatestSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
     public sealed class SyncLatestWitness<TLeft, TRight, TResult>
     {
         public SyncLatestWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Gate = {Gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeGateSignal: Source = {Source}, Gate = {Gate}")]
     public sealed class SynchronizeGateSignal<T> : System.IObservable<T>
     {
         public SynchronizeGateSignal(System.IObservable<T> source, object gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, Gate = {_gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectSignal: Source = {_source}, Gate = {_gate}")]
     public sealed class SynchronizeObjectSignal<T> : System.IObservable<T>
     {
         public SynchronizeObjectSignal(System.IObservable<T> source, object gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SynchronizeObjectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SynchronizeObjectWitness(System.IObserver<T> observer, object gate) { }
@@ -1450,19 +1507,19 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeSignal: Source = {Source}")]
     public sealed class SynchronizeSignal<T> : System.IObservable<T>
     {
         public SynchronizeSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("TapSignal: Source = {Source}")]
     public sealed class TapSignal<T> : System.IObservable<T>
     {
         public TapSignal(System.IObservable<T> source, System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskAnyWitness: Stopped = {_stopped}, Task = {Task}")]
     public sealed class TaskAnyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskAnyWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1478,7 +1535,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainCoordinator: Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
     public sealed class TaskChainCoordinator<T> : System.IDisposable
     {
         public TaskChainCoordinator(System.IObserver<T> observer) { }
@@ -1486,13 +1543,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.TaskChainCoordinator<T> Run(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainSignal: Sources = {_sources}")]
     public sealed class TaskChainSignal<T> : System.IObservable<T>
     {
         public TaskChainSignal(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskCountWitness: Count = {_count}, Stopped = {_stopped}")]
     public sealed class TaskCountWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskCountWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1508,13 +1565,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSignal: Task = {Task}")]
     public sealed class TaskInstanceSignal<T> : System.IObservable<T>
     {
         public TaskInstanceSignal(System.Threading.Tasks.Task<T> task) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSubscription: Stopped = {_stopped}")]
     public sealed class TaskInstanceSubscription : System.IDisposable
     {
         public TaskInstanceSubscription() { }
@@ -1522,13 +1579,22 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void Dispose() { }
         public bool TryStop() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Sequencer = {Sequencer}")]
+    [System.Diagnostics.DebuggerDisplay("ThrowSignal: Error = {_error}, Scheduler = {_scheduler}")]
+    public sealed class ThrowSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ThrowSignal(System.Exception error, System.Reactive.Concurrency.IScheduler scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalSignal: Source = {Source}, Sequencer = {Sequencer}")]
     public sealed class TimeIntervalSignal<T> : System.IObservable<ReactiveUI.Primitives.Core.TimeInterval<T>>
     {
         public TimeIntervalSignal(System.IObservable<T> source, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("First = {_first}, Last = {_last}")]
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalWitness: First = {_first}, Last = {_last}")]
     public sealed class TimeIntervalWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TimeIntervalWitness(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -1546,13 +1612,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
     {
         public static void Arm(ReactiveUI.Primitives.Disposables.SingleReplaceableDisposable slot, System.Reactive.Concurrency.IScheduler sequencer, System.TimeSpan delay, System.Action tick) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkSignal: Source = {Source}")]
     public sealed class UnsparkSignal<T> : System.IObservable<T>
     {
         public UnsparkSignal(System.IObservable<ReactiveUI.Primitives.Reactive.Core.Spark<T>> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class UnsparkWitness<T> : System.IDisposable, System.IObserver<ReactiveUI.Primitives.Reactive.Core.Spark<T>>
     {
         public UnsparkWitness(System.IObserver<T> observer) { }
@@ -1576,7 +1642,7 @@ namespace ReactiveUI.Primitives.Reactive.Concurrency
         public static ReactiveUI.Primitives.Concurrency.ScheduledItem<TAbsolute> Create<TAbsolute, TValue>(System.Reactive.Concurrency.IScheduler scheduler, TValue state, System.Func<System.Reactive.Concurrency.IScheduler, TValue, System.IDisposable> action, TAbsolute dueTime) where TAbsolute : System.IComparable<TAbsolute> { }
         public static ReactiveUI.Primitives.Concurrency.ScheduledItem<TAbsolute> Create<TAbsolute, TValue>(System.Reactive.Concurrency.IScheduler scheduler, TValue state, System.Func<System.Reactive.Concurrency.IScheduler, TValue, System.IDisposable> action, TAbsolute dueTime, System.Collections.Generic.IComparer<TAbsolute> comparer) where TAbsolute : System.IComparable<TAbsolute> { }
     }
-    [System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainState = {_drainState}, Disposed = {_isDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("WasmScheduler: ReadyCount = {_readyCount}, DrainState = {_drainState}, Disposed = {_isDisposed}")]
     public sealed class WasmScheduler : System.Reactive.Concurrency.LocalScheduler, System.IDisposable, System.Reactive.Concurrency.ISchedulerPeriodic
     {
         public static ReactiveUI.Primitives.Reactive.Concurrency.WasmScheduler Default { get; }
@@ -1618,7 +1684,7 @@ namespace ReactiveUI.Primitives.Reactive.Core
 }
 namespace ReactiveUI.Primitives.Reactive.Disposables
 {
-    [System.Diagnostics.DebuggerDisplay("Count = {Count}, IsDisposed = {IsDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ContainerDisposable: Count = {Count}, IsDisposed = {IsDisposed}")]
     public sealed class ContainerDisposable : ReactiveUI.Primitives.Disposables.MultipleDisposable
     {
         public ContainerDisposable() { }
@@ -1632,7 +1698,7 @@ namespace ReactiveUI.Primitives.Reactive.Disposables
 }
 namespace ReactiveUI.Primitives.Reactive.Signals
 {
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
+    [System.Diagnostics.DebuggerDisplay("PrioritySemaphoreSignal: Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
     public sealed class PrioritySemaphoreSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T> where T : System.IComparable<T>
     {
         public PrioritySemaphoreSignal(int maxCount) { }
@@ -1667,7 +1733,7 @@ namespace ReactiveUI.Primitives.Reactive.Signals
         public void OnNext(T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledSignal: Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
     public class ScheduledSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T>
     {
         public ScheduledSignal(System.Reactive.Concurrency.IScheduler scheduler) { }

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net472/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net472/PublicAPI.txt
@@ -810,7 +810,7 @@ namespace ReactiveUI.Primitives.Reactive
 }
 namespace ReactiveUI.Primitives.Reactive.Advanced
 {
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Period = {_period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSignal: DueTime = {_dueTime}, Period = {_period}")]
     public sealed class AfterSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
     {
         public AfterSignal(System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -818,7 +818,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<long> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSubscription: Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
     public sealed class AfterSubscription : System.IDisposable
     {
         public AfterSubscription(System.IObserver<long> observer, System.Reactive.Concurrency.IScheduler scheduler, System.TimeSpan dueTime, System.TimeSpan? period) { }
@@ -826,21 +826,21 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.AfterSubscription Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("SubscribeAsync = {SubscribeAsync}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncCreateSignal: SubscribeAsync = {SubscribeAsync}")]
     public sealed class AsyncCreateSignal<T> : System.IObservable<T>
     {
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ObservableFactory = {ObservableFactory}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncDeferSignal: ObservableFactory = {ObservableFactory}")]
     public sealed class AsyncDeferSignal<T> : System.IObservable<T>
     {
         public AsyncDeferSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public AsyncDeferSignal(System.Func<System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncSubscriptionLifetime: Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
     public sealed class AsyncSubscriptionLifetime : System.IDisposable
     {
         public AsyncSubscriptionLifetime() { }
@@ -851,33 +851,33 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable? disposable) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connected = {_connected}")]
+    [System.Diagnostics.DebuggerDisplay("AutoConnectSignal: Count = {_count}, Connected = {_connected}")]
     public sealed class AutoConnectSignal<T> : System.IObservable<T>
     {
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount) { }
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount, System.Action<System.IDisposable>? onConnect) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connection = {_connection}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSignal: Count = {_count}, Connection = {_connection}")]
     public sealed class AutoShareSignal<T> : System.IObservable<T>
     {
         public AutoShareSignal(ReactiveUI.Primitives.ConnectableSignal<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Owner = {_owner}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSubscription: Owner = {_owner}, Subscription = {Subscription}")]
     public sealed class AutoShareSubscription<T> : System.IDisposable
     {
         public AutoShareSubscription(ReactiveUI.Primitives.Reactive.Advanced.AutoShareSignal<T> owner, System.IDisposable subscription) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void Dispose() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("BlendSignal: Sources = {Sources}")]
     public sealed class BlendSignal<T> : System.IObservable<T>
     {
         public BlendSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("BlendWitness: ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
     public sealed class BlendWitness<T> : System.IDisposable
     {
         public BlendWitness(System.IObserver<T> observer) { }
@@ -886,7 +886,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.BlendWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.BlendWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("BufferEachWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class BufferEachWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public BufferEachWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -900,20 +900,20 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Window = {Window}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("BufferSignal: Window = {Window}, Source = {Source}")]
     public sealed class BufferSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public BufferSignal(System.IObservable<T> source, System.TimeSpan timeSpan, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("CastSignal: Source = {Source}")]
     public sealed class CastSignal<TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public CastSignal(System.IObservable<object?> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CastWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CastWitness<TResult> : System.IDisposable, System.IObserver<object?>
     {
         public CastWitness(System.IObserver<TResult> observer) { }
@@ -927,7 +927,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
+    [System.Diagnostics.DebuggerDisplay("ChainSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
     public sealed class ChainSignal<T> : System.IObservable<T>
     {
         public ChainSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -935,7 +935,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ChainSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("ChainWitness: IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
     public sealed class ChainWitness<T> : System.IDisposable
     {
         public ChainWitness(System.IObserver<T> observer) { }
@@ -945,13 +945,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.ChainWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.ChainWitness<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, TimeSpan = {TimeSpan}")]
+    [System.Diagnostics.DebuggerDisplay("CollectSignal: Source = {Source}, TimeSpan = {TimeSpan}")]
     public sealed class CollectSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public CollectSignal(System.IObservable<T> source, System.TimeSpan timeSpan, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Buffered = {Values.Count}")]
+    [System.Diagnostics.DebuggerDisplay("CollectWitness: Stopped = {_stopped}, Buffered = {Values.Count}")]
     public sealed class CollectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CollectWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -963,7 +963,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateSink: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class CreateSink<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateSink(System.IObserver<T> observer, bool disposeOnNextThrow) { }
@@ -975,7 +975,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CreateWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateWitness(System.IObserver<T> observer) { }
@@ -989,13 +989,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {DueTime}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietSignal: DueTime = {DueTime}, Source = {Source}")]
     public sealed class EmitIfQuietSignal<T> : System.IObservable<T>
     {
         public EmitIfQuietSignal(System.IObservable<T> source, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietWitness: HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
     public sealed class EmitIfQuietWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public EmitIfQuietWitness(System.IObserver<T> observer, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer) { }
@@ -1006,7 +1006,16 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("EmptySignal: Scheduler = {_scheduler}")]
+    public sealed class EmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public EmptySignal(System.Reactive.Concurrency.IScheduler scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("EnumerableBlendSignal: Sources = {Sources}")]
     public sealed class EnumerableBlendSignal<T> : System.IObservable<T>
     {
         public EnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -1016,7 +1025,14 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
     {
         public static System.IDisposable Attach<TEventHandler>(TEventHandler handler, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Reactive.Concurrency.IScheduler? scheduler) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
+    [System.Diagnostics.DebuggerDisplay("EverySignal: Period = {_period}, Scheduler = {_scheduler}")]
+    public sealed class EverySignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
+    {
+        public EverySignal(System.TimeSpan period, System.Reactive.Concurrency.IScheduler scheduler) { }
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<long> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ExpireCoordinator: Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
     public sealed class ExpireCoordinator<T> : System.IDisposable, System.IObserver<T>
     {
         public ExpireCoordinator(System.IObservable<T> source, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer, System.IObserver<T> observer) { }
@@ -1026,39 +1042,48 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnNext(T value) { }
         public ReactiveUI.Primitives.Reactive.Advanced.ExpireCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("ExpireSignal: DueTime = {_dueTime}, Source = {_source}")]
     public sealed class ExpireSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ExpireSignal(System.IObservable<T> source, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("FinallySignal: Source = {_source}")]
+    public sealed class FinallySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public FinallySignal(System.IObservable<T> source, System.Action finallyAction) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ForkJoinSignal: Left = {Left}, Right = {Right}")]
     public sealed class ForkJoinSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public ForkJoinSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("ForkJoinWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
     public sealed class ForkJoinWitness<TLeft, TRight, TResult>
     {
         public ForkJoinWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("CancellationRequested = {CancellationToken.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncExternalCancellationSignal: CancellationRequested = {CancellationToken.IsCancellationRequested}")]
     public sealed class FromAsyncExternalCancellationSignal<T> : System.IObservable<T>
     {
         public FromAsyncExternalCancellationSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSignal: TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
     public sealed class FromAsyncSignal<T> : System.IObservable<T>
     {
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSubscription: Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
     public sealed class FromAsyncSubscription<T> : System.IDisposable
     {
         public FromAsyncSubscription(System.IObserver<T> observer, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
@@ -1071,14 +1096,14 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public FromEventConversionSignal(System.Func<TCallback, TEventHandler> conversion, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Func<System.IObserver<TResult>, TCallback> callback, System.Reactive.Concurrency.IScheduler? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
+    [System.Diagnostics.DebuggerDisplay("FromEventPatternSignal: AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
     public sealed class FromEventPatternSignal<TEventHandler, TEventArgs> : System.IObservable<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> where TEventHandler : System.Delegate where TEventArgs : System.EventArgs
     {
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler) { }
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Reactive.Concurrency.IScheduler? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Disposed = {_disposed}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("GuardedWitness: Disposed = {_disposed}, Observer = {_observer}")]
     public sealed class GuardedWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public GuardedWitness(System.IObserver<T> observer, System.IDisposable cancel) { }
@@ -1088,7 +1113,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IgnoreValuesSignal: Source = {Source}")]
     public sealed class IgnoreValuesSignal<T> : System.IObservable<T>
     {
         public IgnoreValuesSignal(System.IObservable<T> source) { }
@@ -1102,14 +1127,14 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public System.IDisposable Subscribe(System.IObserver<System.Reactive.Unit> observer) { }
         public System.IDisposable Subscribe(System.Action<System.Reactive.Unit> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptySignal: Source = {Source}")]
     public sealed class IsEmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<bool>
     {
         public IsEmptySignal(System.IObservable<T> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<bool> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptyWitness: Stopped = {_stopped}, Subscription = {Subscription}")]
     public sealed class IsEmptyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public IsEmptyWitness(System.IObserver<bool> observer) { }
@@ -1122,14 +1147,23 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {Value}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("LeadSignal: Value = {Value}, Source = {Source}")]
     public sealed class LeadSignal<T> : ReactiveUI.Primitives.Advanced.IInlineSignal<T>
     {
         public LeadSignal(System.IObservable<T> source, T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
         public System.IDisposable Subscribe(System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("LoopSignal: Value = {Value}")]
+    public sealed class LoopSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public LoopSignal(T value) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("MapIndexedSignal: Source = {_source}")]
     public sealed class MapIndexedSignal<TSource, TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public MapIndexedSignal(System.IObservable<TSource> source, System.Func<TSource, int, TResult> selector) { }
@@ -1137,7 +1171,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Index = {_index}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("MapIndexedWitness: Index = {_index}, Stopped = {_stopped}")]
     public sealed class MapIndexedWitness<TSource, TResult> : System.IObserver<TSource>
     {
         public MapIndexedWitness(System.IObserver<TResult> observer, System.Func<TSource, int, TResult> selector) { }
@@ -1145,20 +1179,20 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(TSource value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentBlendCoordinator: Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
     public sealed class MaxConcurrentBlendCoordinator<T> : System.IDisposable
     {
         public MaxConcurrentBlendCoordinator(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.MaxConcurrentBlendCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentEnumerableBlendSignal: Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
     public sealed class MaxConcurrentEnumerableBlendSignal<T> : System.IObservable<T>
     {
         public MaxConcurrentEnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("MergeCoordinator: Active = {Active}, Done = {Done}")]
     public sealed class MergeCoordinator<T> : System.IDisposable
     {
         public MergeCoordinator(System.IObserver<T> observer) { }
@@ -1169,7 +1203,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.MergeCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.MergeCoordinator<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MergeSignal: Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
     public sealed class MergeSignal<T> : System.IObservable<T>
     {
         public MergeSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -1177,32 +1211,39 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public MergeSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("OnErrorResumeNextSignal: Sources = {_sources}")]
+    public sealed class OnErrorResumeNextSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("PairSignal: Left = {Left}, Right = {Right}")]
     public sealed class PairSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public PairSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
+    [System.Diagnostics.DebuggerDisplay("PairWitness: IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
     public sealed class PairWitness<TLeft, TRight, TResult>
     {
         public PairWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("PublishSelectorSignal: Source = {Source}, Selector = {Selector}")]
     public sealed class PublishSelectorSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public PublishSelectorSignal(System.IObservable<TSource> source, System.Func<System.IObservable<TSource>, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
+    [System.Diagnostics.DebuggerDisplay("RaceSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
     public sealed class RaceSignal<T> : System.IObservable<T>
     {
         public RaceSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public RaceSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Arms = {_arms}")]
+    [System.Diagnostics.DebuggerDisplay("RaceWitness: Arms = {_arms}")]
     public sealed class RaceWitness<T> : System.IDisposable
     {
         public RaceWitness(System.IObserver<T> observer) { }
@@ -1211,40 +1252,48 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.RaceWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.RaceWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeCombineLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeCombineLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeCombineLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
+    [System.Diagnostics.DebuggerDisplay("RangeForkJoinSignal: Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
     public sealed class RangeForkJoinSignal<TResult> : System.IObservable<TResult>
     {
         public RangeForkJoinSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeSyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeSyncLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeSyncLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeWithLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeWithLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeWithLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Remaining = {_remaining}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("RecoverSignal: Source = {_source}")]
+    public sealed class RecoverSignal<T, TException> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T> where TException : System.Exception
+    {
+        public RecoverSignal(System.IObservable<T> source, System.Func<TException, System.IObservable<T>> handler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceCoordinator: Remaining = {_remaining}, Disposed = {_disposed}")]
     public sealed class RepeatSourceCoordinator<T> : System.IDisposable
     {
         public RepeatSourceCoordinator(System.IObservable<T> source, int? repeatCount, System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.RepeatSourceCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, RepeatCount = {_repeatCount}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceSignal: Source = {_source}, RepeatCount = {_repeatCount}")]
     public sealed class RepeatSourceSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public RepeatSourceSignal(System.IObservable<T> source, int? repeatCount) { }
@@ -1252,7 +1301,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Generation = {_generation}, Terminated = {_terminated}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceWitness: Generation = {_generation}, Terminated = {_terminated}")]
     public sealed class RepeatSourceWitness<T> : System.IObserver<T>
     {
         public RepeatSourceWitness(ReactiveUI.Primitives.Reactive.Advanced.RepeatSourceCoordinator<T> parent, int generation) { }
@@ -1260,7 +1309,15 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_value}, Scheduler = {_scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ResumeSignal: Source = {_source}, Fallback = {_fallback}")]
+    public sealed class ResumeSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ResumeSignal(System.IObservable<T> source, System.IObservable<T> fallback) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ReturnSignal: Value = {_value}, Scheduler = {_scheduler}")]
     public sealed class ReturnSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ReturnSignal(T value, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -1269,13 +1326,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Values = {Values}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledEnumerableSignal: Values = {Values}, Scheduler = {Scheduler}")]
     public sealed class ScheduledEnumerableSignal<T> : System.IObservable<T>
     {
         public ScheduledEnumerableSignal(System.Collections.Generic.IEnumerable<T> values, System.Reactive.Concurrency.IScheduler scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyCoordinator<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TResult>> selector) { }
@@ -1289,13 +1346,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Reactive.Advanced.SelectManyCoordinator<TSource, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableSignal: Source = {_source}")]
     public sealed class SelectManyEnumerableSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManyEnumerableSignal(System.IObservable<TSource> source, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SelectManyEnumerableWitness<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyEnumerableWitness(System.IObserver<TResult> observer, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
@@ -1309,7 +1366,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyResultCoordinator<TSource, TCollection, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyResultCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
@@ -1322,20 +1379,20 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Reactive.Advanced.SelectManyResultCoordinator<TSource, TCollection, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, CollectionSelector = {CollectionSelector}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultSignal: Source = {Source}, CollectionSelector = {CollectionSelector}")]
     public sealed class SelectManyResultSignal<TSource, TCollection, TResult> : System.IObservable<TResult>
     {
         public SelectManyResultSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManySignal: Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
     public sealed class SelectManySignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManySignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public SelectManySignal(System.IObservable<TSource> source, System.IObservable<TResult> inner) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Start = {Start}, Count = {Count}")]
+    [System.Diagnostics.DebuggerDisplay("SequenceSignal: Start = {Start}, Count = {Count}")]
     public sealed class SequenceSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<int>
     {
         public SequenceSignal(int start, int count, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -1346,13 +1403,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
     {
         public static System.IDisposable Subscribe<T>(System.IObserver<T> observer, bool currentThreadRequired, System.Func<System.IObserver<T>, System.IDisposable, System.IDisposable> subscribeCore) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SparkSignal: Source = {Source}")]
     public sealed class SparkSignal<T> : System.IObservable<ReactiveUI.Primitives.Reactive.Core.Spark<T>>
     {
         public SparkSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Reactive.Core.Spark<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SparkWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SparkWitness(System.IObserver<ReactiveUI.Primitives.Reactive.Core.Spark<T>> observer) { }
@@ -1367,21 +1424,21 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Action = {Action}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Action = {Action}, Scheduler = {Scheduler}")]
     public sealed class StartSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<System.Reactive.Unit>
     {
         public StartSignal(System.Action action, System.Reactive.Concurrency.IScheduler scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<System.Reactive.Unit> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Function = {Function}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Function = {Function}, Scheduler = {Scheduler}")]
     public sealed class StartSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public StartSignal(System.Func<T> function, System.Reactive.Concurrency.IScheduler scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SubscribeSafeWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SubscribeSafeWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SubscribeSafeWitness(System.IObserver<T> observer) { }
@@ -1395,50 +1452,50 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, SkipNullSources = {_skipNullSources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchMapSignal: Source = {_source}, SkipNullSources = {_skipNullSources}")]
     public sealed class SwitchMapSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SwitchMapSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchSignal: Sources = {Sources}")]
     public sealed class SwitchSignal<T> : System.IObservable<T>
     {
         public SwitchSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Version = {_version}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchWitness: Version = {_version}, IsDone = {IsDone}")]
     public sealed class SwitchWitness<T> : System.IDisposable
     {
         public SwitchWitness(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.SwitchWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class SyncLatestSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public SyncLatestSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
     public sealed class SyncLatestWitness<TLeft, TRight, TResult>
     {
         public SyncLatestWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Gate = {Gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeGateSignal: Source = {Source}, Gate = {Gate}")]
     public sealed class SynchronizeGateSignal<T> : System.IObservable<T>
     {
         public SynchronizeGateSignal(System.IObservable<T> source, object gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, Gate = {_gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectSignal: Source = {_source}, Gate = {_gate}")]
     public sealed class SynchronizeObjectSignal<T> : System.IObservable<T>
     {
         public SynchronizeObjectSignal(System.IObservable<T> source, object gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SynchronizeObjectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SynchronizeObjectWitness(System.IObserver<T> observer, object gate) { }
@@ -1450,19 +1507,19 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeSignal: Source = {Source}")]
     public sealed class SynchronizeSignal<T> : System.IObservable<T>
     {
         public SynchronizeSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("TapSignal: Source = {Source}")]
     public sealed class TapSignal<T> : System.IObservable<T>
     {
         public TapSignal(System.IObservable<T> source, System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskAnyWitness: Stopped = {_stopped}, Task = {Task}")]
     public sealed class TaskAnyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskAnyWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1478,7 +1535,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainCoordinator: Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
     public sealed class TaskChainCoordinator<T> : System.IDisposable
     {
         public TaskChainCoordinator(System.IObserver<T> observer) { }
@@ -1486,13 +1543,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.TaskChainCoordinator<T> Run(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainSignal: Sources = {_sources}")]
     public sealed class TaskChainSignal<T> : System.IObservable<T>
     {
         public TaskChainSignal(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskCountWitness: Count = {_count}, Stopped = {_stopped}")]
     public sealed class TaskCountWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskCountWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1508,13 +1565,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSignal: Task = {Task}")]
     public sealed class TaskInstanceSignal<T> : System.IObservable<T>
     {
         public TaskInstanceSignal(System.Threading.Tasks.Task<T> task) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSubscription: Stopped = {_stopped}")]
     public sealed class TaskInstanceSubscription : System.IDisposable
     {
         public TaskInstanceSubscription() { }
@@ -1522,13 +1579,22 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void Dispose() { }
         public bool TryStop() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Sequencer = {Sequencer}")]
+    [System.Diagnostics.DebuggerDisplay("ThrowSignal: Error = {_error}, Scheduler = {_scheduler}")]
+    public sealed class ThrowSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ThrowSignal(System.Exception error, System.Reactive.Concurrency.IScheduler scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalSignal: Source = {Source}, Sequencer = {Sequencer}")]
     public sealed class TimeIntervalSignal<T> : System.IObservable<ReactiveUI.Primitives.Core.TimeInterval<T>>
     {
         public TimeIntervalSignal(System.IObservable<T> source, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("First = {_first}, Last = {_last}")]
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalWitness: First = {_first}, Last = {_last}")]
     public sealed class TimeIntervalWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TimeIntervalWitness(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -1546,13 +1612,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
     {
         public static void Arm(ReactiveUI.Primitives.Disposables.SingleReplaceableDisposable slot, System.Reactive.Concurrency.IScheduler sequencer, System.TimeSpan delay, System.Action tick) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkSignal: Source = {Source}")]
     public sealed class UnsparkSignal<T> : System.IObservable<T>
     {
         public UnsparkSignal(System.IObservable<ReactiveUI.Primitives.Reactive.Core.Spark<T>> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class UnsparkWitness<T> : System.IDisposable, System.IObserver<ReactiveUI.Primitives.Reactive.Core.Spark<T>>
     {
         public UnsparkWitness(System.IObserver<T> observer) { }
@@ -1576,7 +1642,7 @@ namespace ReactiveUI.Primitives.Reactive.Concurrency
         public static ReactiveUI.Primitives.Concurrency.ScheduledItem<TAbsolute> Create<TAbsolute, TValue>(System.Reactive.Concurrency.IScheduler scheduler, TValue state, System.Func<System.Reactive.Concurrency.IScheduler, TValue, System.IDisposable> action, TAbsolute dueTime) where TAbsolute : System.IComparable<TAbsolute> { }
         public static ReactiveUI.Primitives.Concurrency.ScheduledItem<TAbsolute> Create<TAbsolute, TValue>(System.Reactive.Concurrency.IScheduler scheduler, TValue state, System.Func<System.Reactive.Concurrency.IScheduler, TValue, System.IDisposable> action, TAbsolute dueTime, System.Collections.Generic.IComparer<TAbsolute> comparer) where TAbsolute : System.IComparable<TAbsolute> { }
     }
-    [System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainState = {_drainState}, Disposed = {_isDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("WasmScheduler: ReadyCount = {_readyCount}, DrainState = {_drainState}, Disposed = {_isDisposed}")]
     public sealed class WasmScheduler : System.Reactive.Concurrency.LocalScheduler, System.IDisposable, System.Reactive.Concurrency.ISchedulerPeriodic
     {
         public static ReactiveUI.Primitives.Reactive.Concurrency.WasmScheduler Default { get; }
@@ -1618,7 +1684,7 @@ namespace ReactiveUI.Primitives.Reactive.Core
 }
 namespace ReactiveUI.Primitives.Reactive.Disposables
 {
-    [System.Diagnostics.DebuggerDisplay("Count = {Count}, IsDisposed = {IsDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ContainerDisposable: Count = {Count}, IsDisposed = {IsDisposed}")]
     public sealed class ContainerDisposable : ReactiveUI.Primitives.Disposables.MultipleDisposable
     {
         public ContainerDisposable() { }
@@ -1632,7 +1698,7 @@ namespace ReactiveUI.Primitives.Reactive.Disposables
 }
 namespace ReactiveUI.Primitives.Reactive.Signals
 {
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
+    [System.Diagnostics.DebuggerDisplay("PrioritySemaphoreSignal: Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
     public sealed class PrioritySemaphoreSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T> where T : System.IComparable<T>
     {
         public PrioritySemaphoreSignal(int maxCount) { }
@@ -1667,7 +1733,7 @@ namespace ReactiveUI.Primitives.Reactive.Signals
         public void OnNext(T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledSignal: Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
     public class ScheduledSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T>
     {
         public ScheduledSignal(System.Reactive.Concurrency.IScheduler scheduler) { }

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net48/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net48/PublicAPI.txt
@@ -810,7 +810,7 @@ namespace ReactiveUI.Primitives.Reactive
 }
 namespace ReactiveUI.Primitives.Reactive.Advanced
 {
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Period = {_period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSignal: DueTime = {_dueTime}, Period = {_period}")]
     public sealed class AfterSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
     {
         public AfterSignal(System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -818,7 +818,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<long> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSubscription: Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
     public sealed class AfterSubscription : System.IDisposable
     {
         public AfterSubscription(System.IObserver<long> observer, System.Reactive.Concurrency.IScheduler scheduler, System.TimeSpan dueTime, System.TimeSpan? period) { }
@@ -826,21 +826,21 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.AfterSubscription Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("SubscribeAsync = {SubscribeAsync}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncCreateSignal: SubscribeAsync = {SubscribeAsync}")]
     public sealed class AsyncCreateSignal<T> : System.IObservable<T>
     {
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ObservableFactory = {ObservableFactory}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncDeferSignal: ObservableFactory = {ObservableFactory}")]
     public sealed class AsyncDeferSignal<T> : System.IObservable<T>
     {
         public AsyncDeferSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public AsyncDeferSignal(System.Func<System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncSubscriptionLifetime: Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
     public sealed class AsyncSubscriptionLifetime : System.IDisposable
     {
         public AsyncSubscriptionLifetime() { }
@@ -851,33 +851,33 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable? disposable) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connected = {_connected}")]
+    [System.Diagnostics.DebuggerDisplay("AutoConnectSignal: Count = {_count}, Connected = {_connected}")]
     public sealed class AutoConnectSignal<T> : System.IObservable<T>
     {
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount) { }
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount, System.Action<System.IDisposable>? onConnect) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connection = {_connection}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSignal: Count = {_count}, Connection = {_connection}")]
     public sealed class AutoShareSignal<T> : System.IObservable<T>
     {
         public AutoShareSignal(ReactiveUI.Primitives.ConnectableSignal<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Owner = {_owner}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSubscription: Owner = {_owner}, Subscription = {Subscription}")]
     public sealed class AutoShareSubscription<T> : System.IDisposable
     {
         public AutoShareSubscription(ReactiveUI.Primitives.Reactive.Advanced.AutoShareSignal<T> owner, System.IDisposable subscription) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void Dispose() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("BlendSignal: Sources = {Sources}")]
     public sealed class BlendSignal<T> : System.IObservable<T>
     {
         public BlendSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("BlendWitness: ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
     public sealed class BlendWitness<T> : System.IDisposable
     {
         public BlendWitness(System.IObserver<T> observer) { }
@@ -886,7 +886,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.BlendWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.BlendWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("BufferEachWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class BufferEachWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public BufferEachWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -900,20 +900,20 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Window = {Window}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("BufferSignal: Window = {Window}, Source = {Source}")]
     public sealed class BufferSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public BufferSignal(System.IObservable<T> source, System.TimeSpan timeSpan, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("CastSignal: Source = {Source}")]
     public sealed class CastSignal<TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public CastSignal(System.IObservable<object?> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CastWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CastWitness<TResult> : System.IDisposable, System.IObserver<object?>
     {
         public CastWitness(System.IObserver<TResult> observer) { }
@@ -927,7 +927,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
+    [System.Diagnostics.DebuggerDisplay("ChainSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
     public sealed class ChainSignal<T> : System.IObservable<T>
     {
         public ChainSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -935,7 +935,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ChainSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("ChainWitness: IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
     public sealed class ChainWitness<T> : System.IDisposable
     {
         public ChainWitness(System.IObserver<T> observer) { }
@@ -945,13 +945,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.ChainWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.ChainWitness<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, TimeSpan = {TimeSpan}")]
+    [System.Diagnostics.DebuggerDisplay("CollectSignal: Source = {Source}, TimeSpan = {TimeSpan}")]
     public sealed class CollectSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public CollectSignal(System.IObservable<T> source, System.TimeSpan timeSpan, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Buffered = {Values.Count}")]
+    [System.Diagnostics.DebuggerDisplay("CollectWitness: Stopped = {_stopped}, Buffered = {Values.Count}")]
     public sealed class CollectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CollectWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -963,7 +963,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateSink: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class CreateSink<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateSink(System.IObserver<T> observer, bool disposeOnNextThrow) { }
@@ -975,7 +975,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CreateWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateWitness(System.IObserver<T> observer) { }
@@ -989,13 +989,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {DueTime}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietSignal: DueTime = {DueTime}, Source = {Source}")]
     public sealed class EmitIfQuietSignal<T> : System.IObservable<T>
     {
         public EmitIfQuietSignal(System.IObservable<T> source, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietWitness: HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
     public sealed class EmitIfQuietWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public EmitIfQuietWitness(System.IObserver<T> observer, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer) { }
@@ -1006,7 +1006,16 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("EmptySignal: Scheduler = {_scheduler}")]
+    public sealed class EmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public EmptySignal(System.Reactive.Concurrency.IScheduler scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("EnumerableBlendSignal: Sources = {Sources}")]
     public sealed class EnumerableBlendSignal<T> : System.IObservable<T>
     {
         public EnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -1016,7 +1025,14 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
     {
         public static System.IDisposable Attach<TEventHandler>(TEventHandler handler, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Reactive.Concurrency.IScheduler? scheduler) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
+    [System.Diagnostics.DebuggerDisplay("EverySignal: Period = {_period}, Scheduler = {_scheduler}")]
+    public sealed class EverySignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
+    {
+        public EverySignal(System.TimeSpan period, System.Reactive.Concurrency.IScheduler scheduler) { }
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<long> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ExpireCoordinator: Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
     public sealed class ExpireCoordinator<T> : System.IDisposable, System.IObserver<T>
     {
         public ExpireCoordinator(System.IObservable<T> source, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer, System.IObserver<T> observer) { }
@@ -1026,39 +1042,48 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnNext(T value) { }
         public ReactiveUI.Primitives.Reactive.Advanced.ExpireCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("ExpireSignal: DueTime = {_dueTime}, Source = {_source}")]
     public sealed class ExpireSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ExpireSignal(System.IObservable<T> source, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("FinallySignal: Source = {_source}")]
+    public sealed class FinallySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public FinallySignal(System.IObservable<T> source, System.Action finallyAction) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ForkJoinSignal: Left = {Left}, Right = {Right}")]
     public sealed class ForkJoinSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public ForkJoinSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("ForkJoinWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
     public sealed class ForkJoinWitness<TLeft, TRight, TResult>
     {
         public ForkJoinWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("CancellationRequested = {CancellationToken.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncExternalCancellationSignal: CancellationRequested = {CancellationToken.IsCancellationRequested}")]
     public sealed class FromAsyncExternalCancellationSignal<T> : System.IObservable<T>
     {
         public FromAsyncExternalCancellationSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSignal: TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
     public sealed class FromAsyncSignal<T> : System.IObservable<T>
     {
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSubscription: Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
     public sealed class FromAsyncSubscription<T> : System.IDisposable
     {
         public FromAsyncSubscription(System.IObserver<T> observer, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
@@ -1071,14 +1096,14 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public FromEventConversionSignal(System.Func<TCallback, TEventHandler> conversion, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Func<System.IObserver<TResult>, TCallback> callback, System.Reactive.Concurrency.IScheduler? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
+    [System.Diagnostics.DebuggerDisplay("FromEventPatternSignal: AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
     public sealed class FromEventPatternSignal<TEventHandler, TEventArgs> : System.IObservable<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> where TEventHandler : System.Delegate where TEventArgs : System.EventArgs
     {
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler) { }
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Reactive.Concurrency.IScheduler? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Disposed = {_disposed}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("GuardedWitness: Disposed = {_disposed}, Observer = {_observer}")]
     public sealed class GuardedWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public GuardedWitness(System.IObserver<T> observer, System.IDisposable cancel) { }
@@ -1088,7 +1113,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IgnoreValuesSignal: Source = {Source}")]
     public sealed class IgnoreValuesSignal<T> : System.IObservable<T>
     {
         public IgnoreValuesSignal(System.IObservable<T> source) { }
@@ -1102,14 +1127,14 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public System.IDisposable Subscribe(System.IObserver<System.Reactive.Unit> observer) { }
         public System.IDisposable Subscribe(System.Action<System.Reactive.Unit> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptySignal: Source = {Source}")]
     public sealed class IsEmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<bool>
     {
         public IsEmptySignal(System.IObservable<T> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<bool> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptyWitness: Stopped = {_stopped}, Subscription = {Subscription}")]
     public sealed class IsEmptyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public IsEmptyWitness(System.IObserver<bool> observer) { }
@@ -1122,14 +1147,23 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {Value}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("LeadSignal: Value = {Value}, Source = {Source}")]
     public sealed class LeadSignal<T> : ReactiveUI.Primitives.Advanced.IInlineSignal<T>
     {
         public LeadSignal(System.IObservable<T> source, T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
         public System.IDisposable Subscribe(System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("LoopSignal: Value = {Value}")]
+    public sealed class LoopSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public LoopSignal(T value) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("MapIndexedSignal: Source = {_source}")]
     public sealed class MapIndexedSignal<TSource, TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public MapIndexedSignal(System.IObservable<TSource> source, System.Func<TSource, int, TResult> selector) { }
@@ -1137,7 +1171,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Index = {_index}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("MapIndexedWitness: Index = {_index}, Stopped = {_stopped}")]
     public sealed class MapIndexedWitness<TSource, TResult> : System.IObserver<TSource>
     {
         public MapIndexedWitness(System.IObserver<TResult> observer, System.Func<TSource, int, TResult> selector) { }
@@ -1145,20 +1179,20 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(TSource value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentBlendCoordinator: Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
     public sealed class MaxConcurrentBlendCoordinator<T> : System.IDisposable
     {
         public MaxConcurrentBlendCoordinator(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.MaxConcurrentBlendCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentEnumerableBlendSignal: Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
     public sealed class MaxConcurrentEnumerableBlendSignal<T> : System.IObservable<T>
     {
         public MaxConcurrentEnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("MergeCoordinator: Active = {Active}, Done = {Done}")]
     public sealed class MergeCoordinator<T> : System.IDisposable
     {
         public MergeCoordinator(System.IObserver<T> observer) { }
@@ -1169,7 +1203,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.MergeCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.MergeCoordinator<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MergeSignal: Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
     public sealed class MergeSignal<T> : System.IObservable<T>
     {
         public MergeSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -1177,32 +1211,39 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public MergeSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("OnErrorResumeNextSignal: Sources = {_sources}")]
+    public sealed class OnErrorResumeNextSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("PairSignal: Left = {Left}, Right = {Right}")]
     public sealed class PairSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public PairSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
+    [System.Diagnostics.DebuggerDisplay("PairWitness: IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
     public sealed class PairWitness<TLeft, TRight, TResult>
     {
         public PairWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("PublishSelectorSignal: Source = {Source}, Selector = {Selector}")]
     public sealed class PublishSelectorSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public PublishSelectorSignal(System.IObservable<TSource> source, System.Func<System.IObservable<TSource>, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
+    [System.Diagnostics.DebuggerDisplay("RaceSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
     public sealed class RaceSignal<T> : System.IObservable<T>
     {
         public RaceSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public RaceSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Arms = {_arms}")]
+    [System.Diagnostics.DebuggerDisplay("RaceWitness: Arms = {_arms}")]
     public sealed class RaceWitness<T> : System.IDisposable
     {
         public RaceWitness(System.IObserver<T> observer) { }
@@ -1211,40 +1252,48 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.RaceWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.RaceWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeCombineLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeCombineLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeCombineLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
+    [System.Diagnostics.DebuggerDisplay("RangeForkJoinSignal: Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
     public sealed class RangeForkJoinSignal<TResult> : System.IObservable<TResult>
     {
         public RangeForkJoinSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeSyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeSyncLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeSyncLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeWithLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeWithLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeWithLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Remaining = {_remaining}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("RecoverSignal: Source = {_source}")]
+    public sealed class RecoverSignal<T, TException> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T> where TException : System.Exception
+    {
+        public RecoverSignal(System.IObservable<T> source, System.Func<TException, System.IObservable<T>> handler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceCoordinator: Remaining = {_remaining}, Disposed = {_disposed}")]
     public sealed class RepeatSourceCoordinator<T> : System.IDisposable
     {
         public RepeatSourceCoordinator(System.IObservable<T> source, int? repeatCount, System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.RepeatSourceCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, RepeatCount = {_repeatCount}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceSignal: Source = {_source}, RepeatCount = {_repeatCount}")]
     public sealed class RepeatSourceSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public RepeatSourceSignal(System.IObservable<T> source, int? repeatCount) { }
@@ -1252,7 +1301,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Generation = {_generation}, Terminated = {_terminated}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceWitness: Generation = {_generation}, Terminated = {_terminated}")]
     public sealed class RepeatSourceWitness<T> : System.IObserver<T>
     {
         public RepeatSourceWitness(ReactiveUI.Primitives.Reactive.Advanced.RepeatSourceCoordinator<T> parent, int generation) { }
@@ -1260,7 +1309,15 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_value}, Scheduler = {_scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ResumeSignal: Source = {_source}, Fallback = {_fallback}")]
+    public sealed class ResumeSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ResumeSignal(System.IObservable<T> source, System.IObservable<T> fallback) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ReturnSignal: Value = {_value}, Scheduler = {_scheduler}")]
     public sealed class ReturnSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ReturnSignal(T value, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -1269,13 +1326,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Values = {Values}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledEnumerableSignal: Values = {Values}, Scheduler = {Scheduler}")]
     public sealed class ScheduledEnumerableSignal<T> : System.IObservable<T>
     {
         public ScheduledEnumerableSignal(System.Collections.Generic.IEnumerable<T> values, System.Reactive.Concurrency.IScheduler scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyCoordinator<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TResult>> selector) { }
@@ -1289,13 +1346,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Reactive.Advanced.SelectManyCoordinator<TSource, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableSignal: Source = {_source}")]
     public sealed class SelectManyEnumerableSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManyEnumerableSignal(System.IObservable<TSource> source, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SelectManyEnumerableWitness<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyEnumerableWitness(System.IObserver<TResult> observer, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
@@ -1309,7 +1366,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyResultCoordinator<TSource, TCollection, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyResultCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
@@ -1322,20 +1379,20 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Reactive.Advanced.SelectManyResultCoordinator<TSource, TCollection, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, CollectionSelector = {CollectionSelector}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultSignal: Source = {Source}, CollectionSelector = {CollectionSelector}")]
     public sealed class SelectManyResultSignal<TSource, TCollection, TResult> : System.IObservable<TResult>
     {
         public SelectManyResultSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManySignal: Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
     public sealed class SelectManySignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManySignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public SelectManySignal(System.IObservable<TSource> source, System.IObservable<TResult> inner) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Start = {Start}, Count = {Count}")]
+    [System.Diagnostics.DebuggerDisplay("SequenceSignal: Start = {Start}, Count = {Count}")]
     public sealed class SequenceSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<int>
     {
         public SequenceSignal(int start, int count, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -1346,13 +1403,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
     {
         public static System.IDisposable Subscribe<T>(System.IObserver<T> observer, bool currentThreadRequired, System.Func<System.IObserver<T>, System.IDisposable, System.IDisposable> subscribeCore) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SparkSignal: Source = {Source}")]
     public sealed class SparkSignal<T> : System.IObservable<ReactiveUI.Primitives.Reactive.Core.Spark<T>>
     {
         public SparkSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Reactive.Core.Spark<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SparkWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SparkWitness(System.IObserver<ReactiveUI.Primitives.Reactive.Core.Spark<T>> observer) { }
@@ -1367,21 +1424,21 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Action = {Action}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Action = {Action}, Scheduler = {Scheduler}")]
     public sealed class StartSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<System.Reactive.Unit>
     {
         public StartSignal(System.Action action, System.Reactive.Concurrency.IScheduler scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<System.Reactive.Unit> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Function = {Function}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Function = {Function}, Scheduler = {Scheduler}")]
     public sealed class StartSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public StartSignal(System.Func<T> function, System.Reactive.Concurrency.IScheduler scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SubscribeSafeWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SubscribeSafeWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SubscribeSafeWitness(System.IObserver<T> observer) { }
@@ -1395,50 +1452,50 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, SkipNullSources = {_skipNullSources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchMapSignal: Source = {_source}, SkipNullSources = {_skipNullSources}")]
     public sealed class SwitchMapSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SwitchMapSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchSignal: Sources = {Sources}")]
     public sealed class SwitchSignal<T> : System.IObservable<T>
     {
         public SwitchSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Version = {_version}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchWitness: Version = {_version}, IsDone = {IsDone}")]
     public sealed class SwitchWitness<T> : System.IDisposable
     {
         public SwitchWitness(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.SwitchWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class SyncLatestSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public SyncLatestSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
     public sealed class SyncLatestWitness<TLeft, TRight, TResult>
     {
         public SyncLatestWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Gate = {Gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeGateSignal: Source = {Source}, Gate = {Gate}")]
     public sealed class SynchronizeGateSignal<T> : System.IObservable<T>
     {
         public SynchronizeGateSignal(System.IObservable<T> source, object gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, Gate = {_gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectSignal: Source = {_source}, Gate = {_gate}")]
     public sealed class SynchronizeObjectSignal<T> : System.IObservable<T>
     {
         public SynchronizeObjectSignal(System.IObservable<T> source, object gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SynchronizeObjectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SynchronizeObjectWitness(System.IObserver<T> observer, object gate) { }
@@ -1450,19 +1507,19 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeSignal: Source = {Source}")]
     public sealed class SynchronizeSignal<T> : System.IObservable<T>
     {
         public SynchronizeSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("TapSignal: Source = {Source}")]
     public sealed class TapSignal<T> : System.IObservable<T>
     {
         public TapSignal(System.IObservable<T> source, System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskAnyWitness: Stopped = {_stopped}, Task = {Task}")]
     public sealed class TaskAnyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskAnyWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1478,7 +1535,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainCoordinator: Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
     public sealed class TaskChainCoordinator<T> : System.IDisposable
     {
         public TaskChainCoordinator(System.IObserver<T> observer) { }
@@ -1486,13 +1543,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.TaskChainCoordinator<T> Run(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainSignal: Sources = {_sources}")]
     public sealed class TaskChainSignal<T> : System.IObservable<T>
     {
         public TaskChainSignal(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskCountWitness: Count = {_count}, Stopped = {_stopped}")]
     public sealed class TaskCountWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskCountWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1508,13 +1565,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSignal: Task = {Task}")]
     public sealed class TaskInstanceSignal<T> : System.IObservable<T>
     {
         public TaskInstanceSignal(System.Threading.Tasks.Task<T> task) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSubscription: Stopped = {_stopped}")]
     public sealed class TaskInstanceSubscription : System.IDisposable
     {
         public TaskInstanceSubscription() { }
@@ -1522,13 +1579,22 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void Dispose() { }
         public bool TryStop() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Sequencer = {Sequencer}")]
+    [System.Diagnostics.DebuggerDisplay("ThrowSignal: Error = {_error}, Scheduler = {_scheduler}")]
+    public sealed class ThrowSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ThrowSignal(System.Exception error, System.Reactive.Concurrency.IScheduler scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalSignal: Source = {Source}, Sequencer = {Sequencer}")]
     public sealed class TimeIntervalSignal<T> : System.IObservable<ReactiveUI.Primitives.Core.TimeInterval<T>>
     {
         public TimeIntervalSignal(System.IObservable<T> source, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("First = {_first}, Last = {_last}")]
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalWitness: First = {_first}, Last = {_last}")]
     public sealed class TimeIntervalWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TimeIntervalWitness(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -1546,13 +1612,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
     {
         public static void Arm(ReactiveUI.Primitives.Disposables.SingleReplaceableDisposable slot, System.Reactive.Concurrency.IScheduler sequencer, System.TimeSpan delay, System.Action tick) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkSignal: Source = {Source}")]
     public sealed class UnsparkSignal<T> : System.IObservable<T>
     {
         public UnsparkSignal(System.IObservable<ReactiveUI.Primitives.Reactive.Core.Spark<T>> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class UnsparkWitness<T> : System.IDisposable, System.IObserver<ReactiveUI.Primitives.Reactive.Core.Spark<T>>
     {
         public UnsparkWitness(System.IObserver<T> observer) { }
@@ -1576,7 +1642,7 @@ namespace ReactiveUI.Primitives.Reactive.Concurrency
         public static ReactiveUI.Primitives.Concurrency.ScheduledItem<TAbsolute> Create<TAbsolute, TValue>(System.Reactive.Concurrency.IScheduler scheduler, TValue state, System.Func<System.Reactive.Concurrency.IScheduler, TValue, System.IDisposable> action, TAbsolute dueTime) where TAbsolute : System.IComparable<TAbsolute> { }
         public static ReactiveUI.Primitives.Concurrency.ScheduledItem<TAbsolute> Create<TAbsolute, TValue>(System.Reactive.Concurrency.IScheduler scheduler, TValue state, System.Func<System.Reactive.Concurrency.IScheduler, TValue, System.IDisposable> action, TAbsolute dueTime, System.Collections.Generic.IComparer<TAbsolute> comparer) where TAbsolute : System.IComparable<TAbsolute> { }
     }
-    [System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainState = {_drainState}, Disposed = {_isDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("WasmScheduler: ReadyCount = {_readyCount}, DrainState = {_drainState}, Disposed = {_isDisposed}")]
     public sealed class WasmScheduler : System.Reactive.Concurrency.LocalScheduler, System.IDisposable, System.Reactive.Concurrency.ISchedulerPeriodic
     {
         public static ReactiveUI.Primitives.Reactive.Concurrency.WasmScheduler Default { get; }
@@ -1618,7 +1684,7 @@ namespace ReactiveUI.Primitives.Reactive.Core
 }
 namespace ReactiveUI.Primitives.Reactive.Disposables
 {
-    [System.Diagnostics.DebuggerDisplay("Count = {Count}, IsDisposed = {IsDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ContainerDisposable: Count = {Count}, IsDisposed = {IsDisposed}")]
     public sealed class ContainerDisposable : ReactiveUI.Primitives.Disposables.MultipleDisposable
     {
         public ContainerDisposable() { }
@@ -1632,7 +1698,7 @@ namespace ReactiveUI.Primitives.Reactive.Disposables
 }
 namespace ReactiveUI.Primitives.Reactive.Signals
 {
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
+    [System.Diagnostics.DebuggerDisplay("PrioritySemaphoreSignal: Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
     public sealed class PrioritySemaphoreSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T> where T : System.IComparable<T>
     {
         public PrioritySemaphoreSignal(int maxCount) { }
@@ -1667,7 +1733,7 @@ namespace ReactiveUI.Primitives.Reactive.Signals
         public void OnNext(T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledSignal: Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
     public class ScheduledSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T>
     {
         public ScheduledSignal(System.Reactive.Concurrency.IScheduler scheduler) { }

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net481/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net481/PublicAPI.txt
@@ -810,7 +810,7 @@ namespace ReactiveUI.Primitives.Reactive
 }
 namespace ReactiveUI.Primitives.Reactive.Advanced
 {
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Period = {_period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSignal: DueTime = {_dueTime}, Period = {_period}")]
     public sealed class AfterSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
     {
         public AfterSignal(System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -818,7 +818,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<long> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSubscription: Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
     public sealed class AfterSubscription : System.IDisposable
     {
         public AfterSubscription(System.IObserver<long> observer, System.Reactive.Concurrency.IScheduler scheduler, System.TimeSpan dueTime, System.TimeSpan? period) { }
@@ -826,21 +826,21 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.AfterSubscription Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("SubscribeAsync = {SubscribeAsync}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncCreateSignal: SubscribeAsync = {SubscribeAsync}")]
     public sealed class AsyncCreateSignal<T> : System.IObservable<T>
     {
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ObservableFactory = {ObservableFactory}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncDeferSignal: ObservableFactory = {ObservableFactory}")]
     public sealed class AsyncDeferSignal<T> : System.IObservable<T>
     {
         public AsyncDeferSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public AsyncDeferSignal(System.Func<System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncSubscriptionLifetime: Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
     public sealed class AsyncSubscriptionLifetime : System.IDisposable
     {
         public AsyncSubscriptionLifetime() { }
@@ -851,33 +851,33 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable? disposable) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connected = {_connected}")]
+    [System.Diagnostics.DebuggerDisplay("AutoConnectSignal: Count = {_count}, Connected = {_connected}")]
     public sealed class AutoConnectSignal<T> : System.IObservable<T>
     {
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount) { }
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount, System.Action<System.IDisposable>? onConnect) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connection = {_connection}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSignal: Count = {_count}, Connection = {_connection}")]
     public sealed class AutoShareSignal<T> : System.IObservable<T>
     {
         public AutoShareSignal(ReactiveUI.Primitives.ConnectableSignal<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Owner = {_owner}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSubscription: Owner = {_owner}, Subscription = {Subscription}")]
     public sealed class AutoShareSubscription<T> : System.IDisposable
     {
         public AutoShareSubscription(ReactiveUI.Primitives.Reactive.Advanced.AutoShareSignal<T> owner, System.IDisposable subscription) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void Dispose() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("BlendSignal: Sources = {Sources}")]
     public sealed class BlendSignal<T> : System.IObservable<T>
     {
         public BlendSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("BlendWitness: ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
     public sealed class BlendWitness<T> : System.IDisposable
     {
         public BlendWitness(System.IObserver<T> observer) { }
@@ -886,7 +886,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.BlendWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.BlendWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("BufferEachWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class BufferEachWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public BufferEachWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -900,20 +900,20 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Window = {Window}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("BufferSignal: Window = {Window}, Source = {Source}")]
     public sealed class BufferSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public BufferSignal(System.IObservable<T> source, System.TimeSpan timeSpan, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("CastSignal: Source = {Source}")]
     public sealed class CastSignal<TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public CastSignal(System.IObservable<object?> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CastWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CastWitness<TResult> : System.IDisposable, System.IObserver<object?>
     {
         public CastWitness(System.IObserver<TResult> observer) { }
@@ -927,7 +927,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
+    [System.Diagnostics.DebuggerDisplay("ChainSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
     public sealed class ChainSignal<T> : System.IObservable<T>
     {
         public ChainSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -935,7 +935,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ChainSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("ChainWitness: IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
     public sealed class ChainWitness<T> : System.IDisposable
     {
         public ChainWitness(System.IObserver<T> observer) { }
@@ -945,13 +945,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.ChainWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.ChainWitness<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, TimeSpan = {TimeSpan}")]
+    [System.Diagnostics.DebuggerDisplay("CollectSignal: Source = {Source}, TimeSpan = {TimeSpan}")]
     public sealed class CollectSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public CollectSignal(System.IObservable<T> source, System.TimeSpan timeSpan, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Buffered = {Values.Count}")]
+    [System.Diagnostics.DebuggerDisplay("CollectWitness: Stopped = {_stopped}, Buffered = {Values.Count}")]
     public sealed class CollectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CollectWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -963,7 +963,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateSink: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class CreateSink<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateSink(System.IObserver<T> observer, bool disposeOnNextThrow) { }
@@ -975,7 +975,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CreateWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateWitness(System.IObserver<T> observer) { }
@@ -989,13 +989,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {DueTime}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietSignal: DueTime = {DueTime}, Source = {Source}")]
     public sealed class EmitIfQuietSignal<T> : System.IObservable<T>
     {
         public EmitIfQuietSignal(System.IObservable<T> source, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietWitness: HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
     public sealed class EmitIfQuietWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public EmitIfQuietWitness(System.IObserver<T> observer, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer) { }
@@ -1006,7 +1006,16 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("EmptySignal: Scheduler = {_scheduler}")]
+    public sealed class EmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public EmptySignal(System.Reactive.Concurrency.IScheduler scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("EnumerableBlendSignal: Sources = {Sources}")]
     public sealed class EnumerableBlendSignal<T> : System.IObservable<T>
     {
         public EnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -1016,7 +1025,14 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
     {
         public static System.IDisposable Attach<TEventHandler>(TEventHandler handler, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Reactive.Concurrency.IScheduler? scheduler) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
+    [System.Diagnostics.DebuggerDisplay("EverySignal: Period = {_period}, Scheduler = {_scheduler}")]
+    public sealed class EverySignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
+    {
+        public EverySignal(System.TimeSpan period, System.Reactive.Concurrency.IScheduler scheduler) { }
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<long> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ExpireCoordinator: Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
     public sealed class ExpireCoordinator<T> : System.IDisposable, System.IObserver<T>
     {
         public ExpireCoordinator(System.IObservable<T> source, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer, System.IObserver<T> observer) { }
@@ -1026,39 +1042,48 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnNext(T value) { }
         public ReactiveUI.Primitives.Reactive.Advanced.ExpireCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("ExpireSignal: DueTime = {_dueTime}, Source = {_source}")]
     public sealed class ExpireSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ExpireSignal(System.IObservable<T> source, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("FinallySignal: Source = {_source}")]
+    public sealed class FinallySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public FinallySignal(System.IObservable<T> source, System.Action finallyAction) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ForkJoinSignal: Left = {Left}, Right = {Right}")]
     public sealed class ForkJoinSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public ForkJoinSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("ForkJoinWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
     public sealed class ForkJoinWitness<TLeft, TRight, TResult>
     {
         public ForkJoinWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("CancellationRequested = {CancellationToken.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncExternalCancellationSignal: CancellationRequested = {CancellationToken.IsCancellationRequested}")]
     public sealed class FromAsyncExternalCancellationSignal<T> : System.IObservable<T>
     {
         public FromAsyncExternalCancellationSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSignal: TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
     public sealed class FromAsyncSignal<T> : System.IObservable<T>
     {
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSubscription: Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
     public sealed class FromAsyncSubscription<T> : System.IDisposable
     {
         public FromAsyncSubscription(System.IObserver<T> observer, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
@@ -1071,14 +1096,14 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public FromEventConversionSignal(System.Func<TCallback, TEventHandler> conversion, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Func<System.IObserver<TResult>, TCallback> callback, System.Reactive.Concurrency.IScheduler? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
+    [System.Diagnostics.DebuggerDisplay("FromEventPatternSignal: AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
     public sealed class FromEventPatternSignal<TEventHandler, TEventArgs> : System.IObservable<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> where TEventHandler : System.Delegate where TEventArgs : System.EventArgs
     {
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler) { }
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Reactive.Concurrency.IScheduler? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Disposed = {_disposed}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("GuardedWitness: Disposed = {_disposed}, Observer = {_observer}")]
     public sealed class GuardedWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public GuardedWitness(System.IObserver<T> observer, System.IDisposable cancel) { }
@@ -1088,7 +1113,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IgnoreValuesSignal: Source = {Source}")]
     public sealed class IgnoreValuesSignal<T> : System.IObservable<T>
     {
         public IgnoreValuesSignal(System.IObservable<T> source) { }
@@ -1102,14 +1127,14 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public System.IDisposable Subscribe(System.IObserver<System.Reactive.Unit> observer) { }
         public System.IDisposable Subscribe(System.Action<System.Reactive.Unit> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptySignal: Source = {Source}")]
     public sealed class IsEmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<bool>
     {
         public IsEmptySignal(System.IObservable<T> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<bool> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptyWitness: Stopped = {_stopped}, Subscription = {Subscription}")]
     public sealed class IsEmptyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public IsEmptyWitness(System.IObserver<bool> observer) { }
@@ -1122,14 +1147,23 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {Value}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("LeadSignal: Value = {Value}, Source = {Source}")]
     public sealed class LeadSignal<T> : ReactiveUI.Primitives.Advanced.IInlineSignal<T>
     {
         public LeadSignal(System.IObservable<T> source, T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
         public System.IDisposable Subscribe(System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("LoopSignal: Value = {Value}")]
+    public sealed class LoopSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public LoopSignal(T value) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("MapIndexedSignal: Source = {_source}")]
     public sealed class MapIndexedSignal<TSource, TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public MapIndexedSignal(System.IObservable<TSource> source, System.Func<TSource, int, TResult> selector) { }
@@ -1137,7 +1171,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Index = {_index}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("MapIndexedWitness: Index = {_index}, Stopped = {_stopped}")]
     public sealed class MapIndexedWitness<TSource, TResult> : System.IObserver<TSource>
     {
         public MapIndexedWitness(System.IObserver<TResult> observer, System.Func<TSource, int, TResult> selector) { }
@@ -1145,20 +1179,20 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(TSource value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentBlendCoordinator: Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
     public sealed class MaxConcurrentBlendCoordinator<T> : System.IDisposable
     {
         public MaxConcurrentBlendCoordinator(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.MaxConcurrentBlendCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentEnumerableBlendSignal: Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
     public sealed class MaxConcurrentEnumerableBlendSignal<T> : System.IObservable<T>
     {
         public MaxConcurrentEnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("MergeCoordinator: Active = {Active}, Done = {Done}")]
     public sealed class MergeCoordinator<T> : System.IDisposable
     {
         public MergeCoordinator(System.IObserver<T> observer) { }
@@ -1169,7 +1203,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.MergeCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.MergeCoordinator<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MergeSignal: Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
     public sealed class MergeSignal<T> : System.IObservable<T>
     {
         public MergeSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -1177,32 +1211,39 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public MergeSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("OnErrorResumeNextSignal: Sources = {_sources}")]
+    public sealed class OnErrorResumeNextSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("PairSignal: Left = {Left}, Right = {Right}")]
     public sealed class PairSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public PairSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
+    [System.Diagnostics.DebuggerDisplay("PairWitness: IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
     public sealed class PairWitness<TLeft, TRight, TResult>
     {
         public PairWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("PublishSelectorSignal: Source = {Source}, Selector = {Selector}")]
     public sealed class PublishSelectorSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public PublishSelectorSignal(System.IObservable<TSource> source, System.Func<System.IObservable<TSource>, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
+    [System.Diagnostics.DebuggerDisplay("RaceSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
     public sealed class RaceSignal<T> : System.IObservable<T>
     {
         public RaceSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public RaceSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Arms = {_arms}")]
+    [System.Diagnostics.DebuggerDisplay("RaceWitness: Arms = {_arms}")]
     public sealed class RaceWitness<T> : System.IDisposable
     {
         public RaceWitness(System.IObserver<T> observer) { }
@@ -1211,40 +1252,48 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.RaceWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.RaceWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeCombineLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeCombineLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeCombineLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
+    [System.Diagnostics.DebuggerDisplay("RangeForkJoinSignal: Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
     public sealed class RangeForkJoinSignal<TResult> : System.IObservable<TResult>
     {
         public RangeForkJoinSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeSyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeSyncLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeSyncLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeWithLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeWithLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeWithLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Remaining = {_remaining}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("RecoverSignal: Source = {_source}")]
+    public sealed class RecoverSignal<T, TException> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T> where TException : System.Exception
+    {
+        public RecoverSignal(System.IObservable<T> source, System.Func<TException, System.IObservable<T>> handler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceCoordinator: Remaining = {_remaining}, Disposed = {_disposed}")]
     public sealed class RepeatSourceCoordinator<T> : System.IDisposable
     {
         public RepeatSourceCoordinator(System.IObservable<T> source, int? repeatCount, System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.RepeatSourceCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, RepeatCount = {_repeatCount}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceSignal: Source = {_source}, RepeatCount = {_repeatCount}")]
     public sealed class RepeatSourceSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public RepeatSourceSignal(System.IObservable<T> source, int? repeatCount) { }
@@ -1252,7 +1301,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Generation = {_generation}, Terminated = {_terminated}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceWitness: Generation = {_generation}, Terminated = {_terminated}")]
     public sealed class RepeatSourceWitness<T> : System.IObserver<T>
     {
         public RepeatSourceWitness(ReactiveUI.Primitives.Reactive.Advanced.RepeatSourceCoordinator<T> parent, int generation) { }
@@ -1260,7 +1309,15 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_value}, Scheduler = {_scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ResumeSignal: Source = {_source}, Fallback = {_fallback}")]
+    public sealed class ResumeSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ResumeSignal(System.IObservable<T> source, System.IObservable<T> fallback) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ReturnSignal: Value = {_value}, Scheduler = {_scheduler}")]
     public sealed class ReturnSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ReturnSignal(T value, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -1269,13 +1326,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Values = {Values}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledEnumerableSignal: Values = {Values}, Scheduler = {Scheduler}")]
     public sealed class ScheduledEnumerableSignal<T> : System.IObservable<T>
     {
         public ScheduledEnumerableSignal(System.Collections.Generic.IEnumerable<T> values, System.Reactive.Concurrency.IScheduler scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyCoordinator<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TResult>> selector) { }
@@ -1289,13 +1346,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Reactive.Advanced.SelectManyCoordinator<TSource, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableSignal: Source = {_source}")]
     public sealed class SelectManyEnumerableSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManyEnumerableSignal(System.IObservable<TSource> source, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SelectManyEnumerableWitness<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyEnumerableWitness(System.IObserver<TResult> observer, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
@@ -1309,7 +1366,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyResultCoordinator<TSource, TCollection, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyResultCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
@@ -1322,20 +1379,20 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Reactive.Advanced.SelectManyResultCoordinator<TSource, TCollection, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, CollectionSelector = {CollectionSelector}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultSignal: Source = {Source}, CollectionSelector = {CollectionSelector}")]
     public sealed class SelectManyResultSignal<TSource, TCollection, TResult> : System.IObservable<TResult>
     {
         public SelectManyResultSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManySignal: Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
     public sealed class SelectManySignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManySignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public SelectManySignal(System.IObservable<TSource> source, System.IObservable<TResult> inner) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Start = {Start}, Count = {Count}")]
+    [System.Diagnostics.DebuggerDisplay("SequenceSignal: Start = {Start}, Count = {Count}")]
     public sealed class SequenceSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<int>
     {
         public SequenceSignal(int start, int count, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -1346,13 +1403,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
     {
         public static System.IDisposable Subscribe<T>(System.IObserver<T> observer, bool currentThreadRequired, System.Func<System.IObserver<T>, System.IDisposable, System.IDisposable> subscribeCore) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SparkSignal: Source = {Source}")]
     public sealed class SparkSignal<T> : System.IObservable<ReactiveUI.Primitives.Reactive.Core.Spark<T>>
     {
         public SparkSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Reactive.Core.Spark<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SparkWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SparkWitness(System.IObserver<ReactiveUI.Primitives.Reactive.Core.Spark<T>> observer) { }
@@ -1367,21 +1424,21 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Action = {Action}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Action = {Action}, Scheduler = {Scheduler}")]
     public sealed class StartSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<System.Reactive.Unit>
     {
         public StartSignal(System.Action action, System.Reactive.Concurrency.IScheduler scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<System.Reactive.Unit> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Function = {Function}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Function = {Function}, Scheduler = {Scheduler}")]
     public sealed class StartSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public StartSignal(System.Func<T> function, System.Reactive.Concurrency.IScheduler scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SubscribeSafeWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SubscribeSafeWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SubscribeSafeWitness(System.IObserver<T> observer) { }
@@ -1395,50 +1452,50 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, SkipNullSources = {_skipNullSources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchMapSignal: Source = {_source}, SkipNullSources = {_skipNullSources}")]
     public sealed class SwitchMapSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SwitchMapSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchSignal: Sources = {Sources}")]
     public sealed class SwitchSignal<T> : System.IObservable<T>
     {
         public SwitchSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Version = {_version}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchWitness: Version = {_version}, IsDone = {IsDone}")]
     public sealed class SwitchWitness<T> : System.IDisposable
     {
         public SwitchWitness(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.SwitchWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class SyncLatestSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public SyncLatestSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
     public sealed class SyncLatestWitness<TLeft, TRight, TResult>
     {
         public SyncLatestWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Gate = {Gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeGateSignal: Source = {Source}, Gate = {Gate}")]
     public sealed class SynchronizeGateSignal<T> : System.IObservable<T>
     {
         public SynchronizeGateSignal(System.IObservable<T> source, object gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, Gate = {_gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectSignal: Source = {_source}, Gate = {_gate}")]
     public sealed class SynchronizeObjectSignal<T> : System.IObservable<T>
     {
         public SynchronizeObjectSignal(System.IObservable<T> source, object gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SynchronizeObjectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SynchronizeObjectWitness(System.IObserver<T> observer, object gate) { }
@@ -1450,19 +1507,19 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeSignal: Source = {Source}")]
     public sealed class SynchronizeSignal<T> : System.IObservable<T>
     {
         public SynchronizeSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("TapSignal: Source = {Source}")]
     public sealed class TapSignal<T> : System.IObservable<T>
     {
         public TapSignal(System.IObservable<T> source, System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskAnyWitness: Stopped = {_stopped}, Task = {Task}")]
     public sealed class TaskAnyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskAnyWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1478,7 +1535,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainCoordinator: Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
     public sealed class TaskChainCoordinator<T> : System.IDisposable
     {
         public TaskChainCoordinator(System.IObserver<T> observer) { }
@@ -1486,13 +1543,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.TaskChainCoordinator<T> Run(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainSignal: Sources = {_sources}")]
     public sealed class TaskChainSignal<T> : System.IObservable<T>
     {
         public TaskChainSignal(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskCountWitness: Count = {_count}, Stopped = {_stopped}")]
     public sealed class TaskCountWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskCountWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1508,13 +1565,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSignal: Task = {Task}")]
     public sealed class TaskInstanceSignal<T> : System.IObservable<T>
     {
         public TaskInstanceSignal(System.Threading.Tasks.Task<T> task) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSubscription: Stopped = {_stopped}")]
     public sealed class TaskInstanceSubscription : System.IDisposable
     {
         public TaskInstanceSubscription() { }
@@ -1522,13 +1579,22 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void Dispose() { }
         public bool TryStop() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Sequencer = {Sequencer}")]
+    [System.Diagnostics.DebuggerDisplay("ThrowSignal: Error = {_error}, Scheduler = {_scheduler}")]
+    public sealed class ThrowSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ThrowSignal(System.Exception error, System.Reactive.Concurrency.IScheduler scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalSignal: Source = {Source}, Sequencer = {Sequencer}")]
     public sealed class TimeIntervalSignal<T> : System.IObservable<ReactiveUI.Primitives.Core.TimeInterval<T>>
     {
         public TimeIntervalSignal(System.IObservable<T> source, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("First = {_first}, Last = {_last}")]
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalWitness: First = {_first}, Last = {_last}")]
     public sealed class TimeIntervalWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TimeIntervalWitness(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -1546,13 +1612,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
     {
         public static void Arm(ReactiveUI.Primitives.Disposables.SingleReplaceableDisposable slot, System.Reactive.Concurrency.IScheduler sequencer, System.TimeSpan delay, System.Action tick) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkSignal: Source = {Source}")]
     public sealed class UnsparkSignal<T> : System.IObservable<T>
     {
         public UnsparkSignal(System.IObservable<ReactiveUI.Primitives.Reactive.Core.Spark<T>> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class UnsparkWitness<T> : System.IDisposable, System.IObserver<ReactiveUI.Primitives.Reactive.Core.Spark<T>>
     {
         public UnsparkWitness(System.IObserver<T> observer) { }
@@ -1576,7 +1642,7 @@ namespace ReactiveUI.Primitives.Reactive.Concurrency
         public static ReactiveUI.Primitives.Concurrency.ScheduledItem<TAbsolute> Create<TAbsolute, TValue>(System.Reactive.Concurrency.IScheduler scheduler, TValue state, System.Func<System.Reactive.Concurrency.IScheduler, TValue, System.IDisposable> action, TAbsolute dueTime) where TAbsolute : System.IComparable<TAbsolute> { }
         public static ReactiveUI.Primitives.Concurrency.ScheduledItem<TAbsolute> Create<TAbsolute, TValue>(System.Reactive.Concurrency.IScheduler scheduler, TValue state, System.Func<System.Reactive.Concurrency.IScheduler, TValue, System.IDisposable> action, TAbsolute dueTime, System.Collections.Generic.IComparer<TAbsolute> comparer) where TAbsolute : System.IComparable<TAbsolute> { }
     }
-    [System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainState = {_drainState}, Disposed = {_isDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("WasmScheduler: ReadyCount = {_readyCount}, DrainState = {_drainState}, Disposed = {_isDisposed}")]
     public sealed class WasmScheduler : System.Reactive.Concurrency.LocalScheduler, System.IDisposable, System.Reactive.Concurrency.ISchedulerPeriodic
     {
         public static ReactiveUI.Primitives.Reactive.Concurrency.WasmScheduler Default { get; }
@@ -1618,7 +1684,7 @@ namespace ReactiveUI.Primitives.Reactive.Core
 }
 namespace ReactiveUI.Primitives.Reactive.Disposables
 {
-    [System.Diagnostics.DebuggerDisplay("Count = {Count}, IsDisposed = {IsDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ContainerDisposable: Count = {Count}, IsDisposed = {IsDisposed}")]
     public sealed class ContainerDisposable : ReactiveUI.Primitives.Disposables.MultipleDisposable
     {
         public ContainerDisposable() { }
@@ -1632,7 +1698,7 @@ namespace ReactiveUI.Primitives.Reactive.Disposables
 }
 namespace ReactiveUI.Primitives.Reactive.Signals
 {
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
+    [System.Diagnostics.DebuggerDisplay("PrioritySemaphoreSignal: Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
     public sealed class PrioritySemaphoreSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T> where T : System.IComparable<T>
     {
         public PrioritySemaphoreSignal(int maxCount) { }
@@ -1667,7 +1733,7 @@ namespace ReactiveUI.Primitives.Reactive.Signals
         public void OnNext(T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledSignal: Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
     public class ScheduledSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T>
     {
         public ScheduledSignal(System.Reactive.Concurrency.IScheduler scheduler) { }

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net8.0/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net8.0/PublicAPI.txt
@@ -810,7 +810,7 @@ namespace ReactiveUI.Primitives.Reactive
 }
 namespace ReactiveUI.Primitives.Reactive.Advanced
 {
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Period = {_period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSignal: DueTime = {_dueTime}, Period = {_period}")]
     public sealed class AfterSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
     {
         public AfterSignal(System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -818,7 +818,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<long> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSubscription: Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
     public sealed class AfterSubscription : System.IDisposable
     {
         public AfterSubscription(System.IObserver<long> observer, System.Reactive.Concurrency.IScheduler scheduler, System.TimeSpan dueTime, System.TimeSpan? period) { }
@@ -826,21 +826,21 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.AfterSubscription Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("SubscribeAsync = {SubscribeAsync}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncCreateSignal: SubscribeAsync = {SubscribeAsync}")]
     public sealed class AsyncCreateSignal<T> : System.IObservable<T>
     {
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ObservableFactory = {ObservableFactory}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncDeferSignal: ObservableFactory = {ObservableFactory}")]
     public sealed class AsyncDeferSignal<T> : System.IObservable<T>
     {
         public AsyncDeferSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public AsyncDeferSignal(System.Func<System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncSubscriptionLifetime: Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
     public sealed class AsyncSubscriptionLifetime : System.IDisposable
     {
         public AsyncSubscriptionLifetime() { }
@@ -851,33 +851,33 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable? disposable) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connected = {_connected}")]
+    [System.Diagnostics.DebuggerDisplay("AutoConnectSignal: Count = {_count}, Connected = {_connected}")]
     public sealed class AutoConnectSignal<T> : System.IObservable<T>
     {
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount) { }
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount, System.Action<System.IDisposable>? onConnect) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connection = {_connection}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSignal: Count = {_count}, Connection = {_connection}")]
     public sealed class AutoShareSignal<T> : System.IObservable<T>
     {
         public AutoShareSignal(ReactiveUI.Primitives.ConnectableSignal<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Owner = {_owner}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSubscription: Owner = {_owner}, Subscription = {Subscription}")]
     public sealed class AutoShareSubscription<T> : System.IDisposable
     {
         public AutoShareSubscription(ReactiveUI.Primitives.Reactive.Advanced.AutoShareSignal<T> owner, System.IDisposable subscription) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void Dispose() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("BlendSignal: Sources = {Sources}")]
     public sealed class BlendSignal<T> : System.IObservable<T>
     {
         public BlendSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("BlendWitness: ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
     public sealed class BlendWitness<T> : System.IDisposable
     {
         public BlendWitness(System.IObserver<T> observer) { }
@@ -886,7 +886,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.BlendWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.BlendWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("BufferEachWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class BufferEachWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public BufferEachWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -900,20 +900,20 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Window = {Window}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("BufferSignal: Window = {Window}, Source = {Source}")]
     public sealed class BufferSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public BufferSignal(System.IObservable<T> source, System.TimeSpan timeSpan, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("CastSignal: Source = {Source}")]
     public sealed class CastSignal<TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public CastSignal(System.IObservable<object?> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CastWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CastWitness<TResult> : System.IDisposable, System.IObserver<object?>
     {
         public CastWitness(System.IObserver<TResult> observer) { }
@@ -927,7 +927,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
+    [System.Diagnostics.DebuggerDisplay("ChainSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
     public sealed class ChainSignal<T> : System.IObservable<T>
     {
         public ChainSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -935,7 +935,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ChainSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("ChainWitness: IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
     public sealed class ChainWitness<T> : System.IDisposable
     {
         public ChainWitness(System.IObserver<T> observer) { }
@@ -945,13 +945,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.ChainWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.ChainWitness<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, TimeSpan = {TimeSpan}")]
+    [System.Diagnostics.DebuggerDisplay("CollectSignal: Source = {Source}, TimeSpan = {TimeSpan}")]
     public sealed class CollectSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public CollectSignal(System.IObservable<T> source, System.TimeSpan timeSpan, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Buffered = {Values.Count}")]
+    [System.Diagnostics.DebuggerDisplay("CollectWitness: Stopped = {_stopped}, Buffered = {Values.Count}")]
     public sealed class CollectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CollectWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -963,7 +963,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateSink: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class CreateSink<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateSink(System.IObserver<T> observer, bool disposeOnNextThrow) { }
@@ -975,7 +975,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CreateWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateWitness(System.IObserver<T> observer) { }
@@ -989,13 +989,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {DueTime}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietSignal: DueTime = {DueTime}, Source = {Source}")]
     public sealed class EmitIfQuietSignal<T> : System.IObservable<T>
     {
         public EmitIfQuietSignal(System.IObservable<T> source, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietWitness: HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
     public sealed class EmitIfQuietWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public EmitIfQuietWitness(System.IObserver<T> observer, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer) { }
@@ -1006,7 +1006,16 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("EmptySignal: Scheduler = {_scheduler}")]
+    public sealed class EmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public EmptySignal(System.Reactive.Concurrency.IScheduler scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("EnumerableBlendSignal: Sources = {Sources}")]
     public sealed class EnumerableBlendSignal<T> : System.IObservable<T>
     {
         public EnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -1016,7 +1025,14 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
     {
         public static System.IDisposable Attach<TEventHandler>(TEventHandler handler, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Reactive.Concurrency.IScheduler? scheduler) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
+    [System.Diagnostics.DebuggerDisplay("EverySignal: Period = {_period}, Scheduler = {_scheduler}")]
+    public sealed class EverySignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
+    {
+        public EverySignal(System.TimeSpan period, System.Reactive.Concurrency.IScheduler scheduler) { }
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<long> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ExpireCoordinator: Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
     public sealed class ExpireCoordinator<T> : System.IDisposable, System.IObserver<T>
     {
         public ExpireCoordinator(System.IObservable<T> source, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer, System.IObserver<T> observer) { }
@@ -1026,39 +1042,48 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnNext(T value) { }
         public ReactiveUI.Primitives.Reactive.Advanced.ExpireCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("ExpireSignal: DueTime = {_dueTime}, Source = {_source}")]
     public sealed class ExpireSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ExpireSignal(System.IObservable<T> source, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("FinallySignal: Source = {_source}")]
+    public sealed class FinallySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public FinallySignal(System.IObservable<T> source, System.Action finallyAction) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ForkJoinSignal: Left = {Left}, Right = {Right}")]
     public sealed class ForkJoinSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public ForkJoinSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("ForkJoinWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
     public sealed class ForkJoinWitness<TLeft, TRight, TResult>
     {
         public ForkJoinWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("CancellationRequested = {CancellationToken.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncExternalCancellationSignal: CancellationRequested = {CancellationToken.IsCancellationRequested}")]
     public sealed class FromAsyncExternalCancellationSignal<T> : System.IObservable<T>
     {
         public FromAsyncExternalCancellationSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSignal: TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
     public sealed class FromAsyncSignal<T> : System.IObservable<T>
     {
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSubscription: Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
     public sealed class FromAsyncSubscription<T> : System.IDisposable
     {
         public FromAsyncSubscription(System.IObserver<T> observer, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
@@ -1071,14 +1096,14 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public FromEventConversionSignal(System.Func<TCallback, TEventHandler> conversion, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Func<System.IObserver<TResult>, TCallback> callback, System.Reactive.Concurrency.IScheduler? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
+    [System.Diagnostics.DebuggerDisplay("FromEventPatternSignal: AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
     public sealed class FromEventPatternSignal<TEventHandler, TEventArgs> : System.IObservable<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> where TEventHandler : System.Delegate where TEventArgs : System.EventArgs
     {
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler) { }
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Reactive.Concurrency.IScheduler? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Disposed = {_disposed}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("GuardedWitness: Disposed = {_disposed}, Observer = {_observer}")]
     public sealed class GuardedWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public GuardedWitness(System.IObserver<T> observer, System.IDisposable cancel) { }
@@ -1088,7 +1113,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IgnoreValuesSignal: Source = {Source}")]
     public sealed class IgnoreValuesSignal<T> : System.IObservable<T>
     {
         public IgnoreValuesSignal(System.IObservable<T> source) { }
@@ -1102,14 +1127,14 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public System.IDisposable Subscribe(System.IObserver<System.Reactive.Unit> observer) { }
         public System.IDisposable Subscribe(System.Action<System.Reactive.Unit> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptySignal: Source = {Source}")]
     public sealed class IsEmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<bool>
     {
         public IsEmptySignal(System.IObservable<T> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<bool> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptyWitness: Stopped = {_stopped}, Subscription = {Subscription}")]
     public sealed class IsEmptyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public IsEmptyWitness(System.IObserver<bool> observer) { }
@@ -1122,14 +1147,23 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {Value}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("LeadSignal: Value = {Value}, Source = {Source}")]
     public sealed class LeadSignal<T> : ReactiveUI.Primitives.Advanced.IInlineSignal<T>
     {
         public LeadSignal(System.IObservable<T> source, T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
         public System.IDisposable Subscribe(System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("LoopSignal: Value = {Value}")]
+    public sealed class LoopSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public LoopSignal(T value) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("MapIndexedSignal: Source = {_source}")]
     public sealed class MapIndexedSignal<TSource, TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public MapIndexedSignal(System.IObservable<TSource> source, System.Func<TSource, int, TResult> selector) { }
@@ -1137,7 +1171,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Index = {_index}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("MapIndexedWitness: Index = {_index}, Stopped = {_stopped}")]
     public sealed class MapIndexedWitness<TSource, TResult> : System.IObserver<TSource>
     {
         public MapIndexedWitness(System.IObserver<TResult> observer, System.Func<TSource, int, TResult> selector) { }
@@ -1145,20 +1179,20 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(TSource value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentBlendCoordinator: Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
     public sealed class MaxConcurrentBlendCoordinator<T> : System.IDisposable
     {
         public MaxConcurrentBlendCoordinator(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.MaxConcurrentBlendCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentEnumerableBlendSignal: Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
     public sealed class MaxConcurrentEnumerableBlendSignal<T> : System.IObservable<T>
     {
         public MaxConcurrentEnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("MergeCoordinator: Active = {Active}, Done = {Done}")]
     public sealed class MergeCoordinator<T> : System.IDisposable
     {
         public MergeCoordinator(System.IObserver<T> observer) { }
@@ -1169,7 +1203,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.MergeCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.MergeCoordinator<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MergeSignal: Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
     public sealed class MergeSignal<T> : System.IObservable<T>
     {
         public MergeSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -1177,32 +1211,39 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public MergeSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("OnErrorResumeNextSignal: Sources = {_sources}")]
+    public sealed class OnErrorResumeNextSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("PairSignal: Left = {Left}, Right = {Right}")]
     public sealed class PairSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public PairSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
+    [System.Diagnostics.DebuggerDisplay("PairWitness: IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
     public sealed class PairWitness<TLeft, TRight, TResult>
     {
         public PairWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("PublishSelectorSignal: Source = {Source}, Selector = {Selector}")]
     public sealed class PublishSelectorSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public PublishSelectorSignal(System.IObservable<TSource> source, System.Func<System.IObservable<TSource>, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
+    [System.Diagnostics.DebuggerDisplay("RaceSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
     public sealed class RaceSignal<T> : System.IObservable<T>
     {
         public RaceSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public RaceSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Arms = {_arms}")]
+    [System.Diagnostics.DebuggerDisplay("RaceWitness: Arms = {_arms}")]
     public sealed class RaceWitness<T> : System.IDisposable
     {
         public RaceWitness(System.IObserver<T> observer) { }
@@ -1211,40 +1252,48 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.RaceWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.RaceWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeCombineLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeCombineLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeCombineLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
+    [System.Diagnostics.DebuggerDisplay("RangeForkJoinSignal: Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
     public sealed class RangeForkJoinSignal<TResult> : System.IObservable<TResult>
     {
         public RangeForkJoinSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeSyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeSyncLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeSyncLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeWithLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeWithLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeWithLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Remaining = {_remaining}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("RecoverSignal: Source = {_source}")]
+    public sealed class RecoverSignal<T, TException> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T> where TException : System.Exception
+    {
+        public RecoverSignal(System.IObservable<T> source, System.Func<TException, System.IObservable<T>> handler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceCoordinator: Remaining = {_remaining}, Disposed = {_disposed}")]
     public sealed class RepeatSourceCoordinator<T> : System.IDisposable
     {
         public RepeatSourceCoordinator(System.IObservable<T> source, int? repeatCount, System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.RepeatSourceCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, RepeatCount = {_repeatCount}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceSignal: Source = {_source}, RepeatCount = {_repeatCount}")]
     public sealed class RepeatSourceSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public RepeatSourceSignal(System.IObservable<T> source, int? repeatCount) { }
@@ -1252,7 +1301,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Generation = {_generation}, Terminated = {_terminated}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceWitness: Generation = {_generation}, Terminated = {_terminated}")]
     public sealed class RepeatSourceWitness<T> : System.IObserver<T>
     {
         public RepeatSourceWitness(ReactiveUI.Primitives.Reactive.Advanced.RepeatSourceCoordinator<T> parent, int generation) { }
@@ -1260,7 +1309,15 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_value}, Scheduler = {_scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ResumeSignal: Source = {_source}, Fallback = {_fallback}")]
+    public sealed class ResumeSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ResumeSignal(System.IObservable<T> source, System.IObservable<T> fallback) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ReturnSignal: Value = {_value}, Scheduler = {_scheduler}")]
     public sealed class ReturnSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ReturnSignal(T value, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -1269,13 +1326,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Values = {Values}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledEnumerableSignal: Values = {Values}, Scheduler = {Scheduler}")]
     public sealed class ScheduledEnumerableSignal<T> : System.IObservable<T>
     {
         public ScheduledEnumerableSignal(System.Collections.Generic.IEnumerable<T> values, System.Reactive.Concurrency.IScheduler scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyCoordinator<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TResult>> selector) { }
@@ -1289,13 +1346,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Reactive.Advanced.SelectManyCoordinator<TSource, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableSignal: Source = {_source}")]
     public sealed class SelectManyEnumerableSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManyEnumerableSignal(System.IObservable<TSource> source, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SelectManyEnumerableWitness<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyEnumerableWitness(System.IObserver<TResult> observer, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
@@ -1309,7 +1366,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyResultCoordinator<TSource, TCollection, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyResultCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
@@ -1322,20 +1379,20 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Reactive.Advanced.SelectManyResultCoordinator<TSource, TCollection, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, CollectionSelector = {CollectionSelector}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultSignal: Source = {Source}, CollectionSelector = {CollectionSelector}")]
     public sealed class SelectManyResultSignal<TSource, TCollection, TResult> : System.IObservable<TResult>
     {
         public SelectManyResultSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManySignal: Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
     public sealed class SelectManySignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManySignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public SelectManySignal(System.IObservable<TSource> source, System.IObservable<TResult> inner) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Start = {Start}, Count = {Count}")]
+    [System.Diagnostics.DebuggerDisplay("SequenceSignal: Start = {Start}, Count = {Count}")]
     public sealed class SequenceSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<int>
     {
         public SequenceSignal(int start, int count, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -1346,13 +1403,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
     {
         public static System.IDisposable Subscribe<T>(System.IObserver<T> observer, bool currentThreadRequired, System.Func<System.IObserver<T>, System.IDisposable, System.IDisposable> subscribeCore) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SparkSignal: Source = {Source}")]
     public sealed class SparkSignal<T> : System.IObservable<ReactiveUI.Primitives.Reactive.Core.Spark<T>>
     {
         public SparkSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Reactive.Core.Spark<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SparkWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SparkWitness(System.IObserver<ReactiveUI.Primitives.Reactive.Core.Spark<T>> observer) { }
@@ -1367,21 +1424,21 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Action = {Action}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Action = {Action}, Scheduler = {Scheduler}")]
     public sealed class StartSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<System.Reactive.Unit>
     {
         public StartSignal(System.Action action, System.Reactive.Concurrency.IScheduler scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<System.Reactive.Unit> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Function = {Function}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Function = {Function}, Scheduler = {Scheduler}")]
     public sealed class StartSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public StartSignal(System.Func<T> function, System.Reactive.Concurrency.IScheduler scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SubscribeSafeWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SubscribeSafeWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SubscribeSafeWitness(System.IObserver<T> observer) { }
@@ -1395,50 +1452,50 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, SkipNullSources = {_skipNullSources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchMapSignal: Source = {_source}, SkipNullSources = {_skipNullSources}")]
     public sealed class SwitchMapSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SwitchMapSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchSignal: Sources = {Sources}")]
     public sealed class SwitchSignal<T> : System.IObservable<T>
     {
         public SwitchSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Version = {_version}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchWitness: Version = {_version}, IsDone = {IsDone}")]
     public sealed class SwitchWitness<T> : System.IDisposable
     {
         public SwitchWitness(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.SwitchWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class SyncLatestSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public SyncLatestSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
     public sealed class SyncLatestWitness<TLeft, TRight, TResult>
     {
         public SyncLatestWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Gate = {Gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeGateSignal: Source = {Source}, Gate = {Gate}")]
     public sealed class SynchronizeGateSignal<T> : System.IObservable<T>
     {
         public SynchronizeGateSignal(System.IObservable<T> source, object gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, Gate = {_gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectSignal: Source = {_source}, Gate = {_gate}")]
     public sealed class SynchronizeObjectSignal<T> : System.IObservable<T>
     {
         public SynchronizeObjectSignal(System.IObservable<T> source, object gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SynchronizeObjectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SynchronizeObjectWitness(System.IObserver<T> observer, object gate) { }
@@ -1450,19 +1507,19 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeSignal: Source = {Source}")]
     public sealed class SynchronizeSignal<T> : System.IObservable<T>
     {
         public SynchronizeSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("TapSignal: Source = {Source}")]
     public sealed class TapSignal<T> : System.IObservable<T>
     {
         public TapSignal(System.IObservable<T> source, System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskAnyWitness: Stopped = {_stopped}, Task = {Task}")]
     public sealed class TaskAnyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskAnyWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1478,7 +1535,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainCoordinator: Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
     public sealed class TaskChainCoordinator<T> : System.IDisposable
     {
         public TaskChainCoordinator(System.IObserver<T> observer) { }
@@ -1486,13 +1543,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.TaskChainCoordinator<T> Run(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainSignal: Sources = {_sources}")]
     public sealed class TaskChainSignal<T> : System.IObservable<T>
     {
         public TaskChainSignal(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskCountWitness: Count = {_count}, Stopped = {_stopped}")]
     public sealed class TaskCountWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskCountWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1508,13 +1565,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSignal: Task = {Task}")]
     public sealed class TaskInstanceSignal<T> : System.IObservable<T>
     {
         public TaskInstanceSignal(System.Threading.Tasks.Task<T> task) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSubscription: Stopped = {_stopped}")]
     public sealed class TaskInstanceSubscription : System.IDisposable
     {
         public TaskInstanceSubscription() { }
@@ -1522,13 +1579,22 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void Dispose() { }
         public bool TryStop() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Sequencer = {Sequencer}")]
+    [System.Diagnostics.DebuggerDisplay("ThrowSignal: Error = {_error}, Scheduler = {_scheduler}")]
+    public sealed class ThrowSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ThrowSignal(System.Exception error, System.Reactive.Concurrency.IScheduler scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalSignal: Source = {Source}, Sequencer = {Sequencer}")]
     public sealed class TimeIntervalSignal<T> : System.IObservable<ReactiveUI.Primitives.Core.TimeInterval<T>>
     {
         public TimeIntervalSignal(System.IObservable<T> source, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("First = {_first}, Last = {_last}")]
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalWitness: First = {_first}, Last = {_last}")]
     public sealed class TimeIntervalWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TimeIntervalWitness(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -1546,13 +1612,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
     {
         public static void Arm(ReactiveUI.Primitives.Disposables.SingleReplaceableDisposable slot, System.Reactive.Concurrency.IScheduler sequencer, System.TimeSpan delay, System.Action tick) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkSignal: Source = {Source}")]
     public sealed class UnsparkSignal<T> : System.IObservable<T>
     {
         public UnsparkSignal(System.IObservable<ReactiveUI.Primitives.Reactive.Core.Spark<T>> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class UnsparkWitness<T> : System.IDisposable, System.IObserver<ReactiveUI.Primitives.Reactive.Core.Spark<T>>
     {
         public UnsparkWitness(System.IObserver<T> observer) { }
@@ -1576,7 +1642,7 @@ namespace ReactiveUI.Primitives.Reactive.Concurrency
         public static ReactiveUI.Primitives.Concurrency.ScheduledItem<TAbsolute> Create<TAbsolute, TValue>(System.Reactive.Concurrency.IScheduler scheduler, TValue state, System.Func<System.Reactive.Concurrency.IScheduler, TValue, System.IDisposable> action, TAbsolute dueTime) where TAbsolute : System.IComparable<TAbsolute> { }
         public static ReactiveUI.Primitives.Concurrency.ScheduledItem<TAbsolute> Create<TAbsolute, TValue>(System.Reactive.Concurrency.IScheduler scheduler, TValue state, System.Func<System.Reactive.Concurrency.IScheduler, TValue, System.IDisposable> action, TAbsolute dueTime, System.Collections.Generic.IComparer<TAbsolute> comparer) where TAbsolute : System.IComparable<TAbsolute> { }
     }
-    [System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainState = {_drainState}, Disposed = {_isDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("WasmScheduler: ReadyCount = {_readyCount}, DrainState = {_drainState}, Disposed = {_isDisposed}")]
     public sealed class WasmScheduler : System.Reactive.Concurrency.LocalScheduler, System.IDisposable, System.Reactive.Concurrency.ISchedulerPeriodic
     {
         public static ReactiveUI.Primitives.Reactive.Concurrency.WasmScheduler Default { get; }
@@ -1618,7 +1684,7 @@ namespace ReactiveUI.Primitives.Reactive.Core
 }
 namespace ReactiveUI.Primitives.Reactive.Disposables
 {
-    [System.Diagnostics.DebuggerDisplay("Count = {Count}, IsDisposed = {IsDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ContainerDisposable: Count = {Count}, IsDisposed = {IsDisposed}")]
     public sealed class ContainerDisposable : ReactiveUI.Primitives.Disposables.MultipleDisposable
     {
         public ContainerDisposable() { }
@@ -1632,7 +1698,7 @@ namespace ReactiveUI.Primitives.Reactive.Disposables
 }
 namespace ReactiveUI.Primitives.Reactive.Signals
 {
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
+    [System.Diagnostics.DebuggerDisplay("PrioritySemaphoreSignal: Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
     public sealed class PrioritySemaphoreSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T> where T : System.IComparable<T>
     {
         public PrioritySemaphoreSignal(int maxCount) { }
@@ -1667,7 +1733,7 @@ namespace ReactiveUI.Primitives.Reactive.Signals
         public void OnNext(T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledSignal: Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
     public class ScheduledSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T>
     {
         public ScheduledSignal(System.Reactive.Concurrency.IScheduler scheduler) { }

--- a/src/ReactiveUI.Primitives.Reactive/PublicAPI/net9.0/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Reactive/PublicAPI/net9.0/PublicAPI.txt
@@ -844,7 +844,7 @@ namespace ReactiveUI.Primitives.Reactive
 }
 namespace ReactiveUI.Primitives.Reactive.Advanced
 {
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Period = {_period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSignal: DueTime = {_dueTime}, Period = {_period}")]
     public sealed class AfterSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
     {
         public AfterSignal(System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -852,7 +852,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<long> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSubscription: Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
     public sealed class AfterSubscription : System.IDisposable
     {
         public AfterSubscription(System.IObserver<long> observer, System.Reactive.Concurrency.IScheduler scheduler, System.TimeSpan dueTime, System.TimeSpan? period) { }
@@ -860,21 +860,21 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.AfterSubscription Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("SubscribeAsync = {SubscribeAsync}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncCreateSignal: SubscribeAsync = {SubscribeAsync}")]
     public sealed class AsyncCreateSignal<T> : System.IObservable<T>
     {
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ObservableFactory = {ObservableFactory}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncDeferSignal: ObservableFactory = {ObservableFactory}")]
     public sealed class AsyncDeferSignal<T> : System.IObservable<T>
     {
         public AsyncDeferSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public AsyncDeferSignal(System.Func<System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncSubscriptionLifetime: Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
     public sealed class AsyncSubscriptionLifetime : System.IDisposable
     {
         public AsyncSubscriptionLifetime() { }
@@ -885,33 +885,33 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable? disposable) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connected = {_connected}")]
+    [System.Diagnostics.DebuggerDisplay("AutoConnectSignal: Count = {_count}, Connected = {_connected}")]
     public sealed class AutoConnectSignal<T> : System.IObservable<T>
     {
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount) { }
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount, System.Action<System.IDisposable>? onConnect) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connection = {_connection}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSignal: Count = {_count}, Connection = {_connection}")]
     public sealed class AutoShareSignal<T> : System.IObservable<T>
     {
         public AutoShareSignal(ReactiveUI.Primitives.ConnectableSignal<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Owner = {_owner}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSubscription: Owner = {_owner}, Subscription = {Subscription}")]
     public sealed class AutoShareSubscription<T> : System.IDisposable
     {
         public AutoShareSubscription(ReactiveUI.Primitives.Reactive.Advanced.AutoShareSignal<T> owner, System.IDisposable subscription) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void Dispose() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("BlendSignal: Sources = {Sources}")]
     public sealed class BlendSignal<T> : System.IObservable<T>
     {
         public BlendSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("BlendWitness: ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
     public sealed class BlendWitness<T> : System.IDisposable
     {
         public BlendWitness(System.IObserver<T> observer) { }
@@ -920,7 +920,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.BlendWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.BlendWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("BufferEachWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class BufferEachWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public BufferEachWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -934,20 +934,20 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Window = {Window}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("BufferSignal: Window = {Window}, Source = {Source}")]
     public sealed class BufferSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public BufferSignal(System.IObservable<T> source, System.TimeSpan timeSpan, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("CastSignal: Source = {Source}")]
     public sealed class CastSignal<TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public CastSignal(System.IObservable<object?> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CastWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CastWitness<TResult> : System.IDisposable, System.IObserver<object?>
     {
         public CastWitness(System.IObserver<TResult> observer) { }
@@ -961,7 +961,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
+    [System.Diagnostics.DebuggerDisplay("ChainSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
     public sealed class ChainSignal<T> : System.IObservable<T>
     {
         public ChainSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -969,7 +969,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ChainSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("ChainWitness: IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
     public sealed class ChainWitness<T> : System.IDisposable
     {
         public ChainWitness(System.IObserver<T> observer) { }
@@ -979,13 +979,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.ChainWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.ChainWitness<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, TimeSpan = {TimeSpan}")]
+    [System.Diagnostics.DebuggerDisplay("CollectSignal: Source = {Source}, TimeSpan = {TimeSpan}")]
     public sealed class CollectSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public CollectSignal(System.IObservable<T> source, System.TimeSpan timeSpan, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Buffered = {Values.Count}")]
+    [System.Diagnostics.DebuggerDisplay("CollectWitness: Stopped = {_stopped}, Buffered = {Values.Count}")]
     public sealed class CollectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CollectWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -997,7 +997,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateSink: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class CreateSink<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateSink(System.IObserver<T> observer, bool disposeOnNextThrow) { }
@@ -1009,7 +1009,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CreateWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateWitness(System.IObserver<T> observer) { }
@@ -1023,13 +1023,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {DueTime}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietSignal: DueTime = {DueTime}, Source = {Source}")]
     public sealed class EmitIfQuietSignal<T> : System.IObservable<T>
     {
         public EmitIfQuietSignal(System.IObservable<T> source, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietWitness: HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
     public sealed class EmitIfQuietWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public EmitIfQuietWitness(System.IObserver<T> observer, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer) { }
@@ -1040,7 +1040,16 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("EmptySignal: Scheduler = {_scheduler}")]
+    public sealed class EmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public EmptySignal(System.Reactive.Concurrency.IScheduler scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("EnumerableBlendSignal: Sources = {Sources}")]
     public sealed class EnumerableBlendSignal<T> : System.IObservable<T>
     {
         public EnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -1050,7 +1059,14 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
     {
         public static System.IDisposable Attach<TEventHandler>(TEventHandler handler, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Reactive.Concurrency.IScheduler? scheduler) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
+    [System.Diagnostics.DebuggerDisplay("EverySignal: Period = {_period}, Scheduler = {_scheduler}")]
+    public sealed class EverySignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
+    {
+        public EverySignal(System.TimeSpan period, System.Reactive.Concurrency.IScheduler scheduler) { }
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<long> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ExpireCoordinator: Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
     public sealed class ExpireCoordinator<T> : System.IDisposable, System.IObserver<T>
     {
         public ExpireCoordinator(System.IObservable<T> source, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer, System.IObserver<T> observer) { }
@@ -1060,39 +1076,48 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnNext(T value) { }
         public ReactiveUI.Primitives.Reactive.Advanced.ExpireCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("ExpireSignal: DueTime = {_dueTime}, Source = {_source}")]
     public sealed class ExpireSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ExpireSignal(System.IObservable<T> source, System.TimeSpan dueTime, System.Reactive.Concurrency.IScheduler sequencer) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("FinallySignal: Source = {_source}")]
+    public sealed class FinallySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public FinallySignal(System.IObservable<T> source, System.Action finallyAction) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ForkJoinSignal: Left = {Left}, Right = {Right}")]
     public sealed class ForkJoinSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public ForkJoinSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("ForkJoinWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
     public sealed class ForkJoinWitness<TLeft, TRight, TResult>
     {
         public ForkJoinWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("CancellationRequested = {CancellationToken.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncExternalCancellationSignal: CancellationRequested = {CancellationToken.IsCancellationRequested}")]
     public sealed class FromAsyncExternalCancellationSignal<T> : System.IObservable<T>
     {
         public FromAsyncExternalCancellationSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSignal: TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
     public sealed class FromAsyncSignal<T> : System.IObservable<T>
     {
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSubscription: Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
     public sealed class FromAsyncSubscription<T> : System.IDisposable
     {
         public FromAsyncSubscription(System.IObserver<T> observer, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
@@ -1105,14 +1130,14 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public FromEventConversionSignal(System.Func<TCallback, TEventHandler> conversion, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Func<System.IObserver<TResult>, TCallback> callback, System.Reactive.Concurrency.IScheduler? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
+    [System.Diagnostics.DebuggerDisplay("FromEventPatternSignal: AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
     public sealed class FromEventPatternSignal<TEventHandler, TEventArgs> : System.IObservable<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> where TEventHandler : System.Delegate where TEventArgs : System.EventArgs
     {
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler) { }
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Reactive.Concurrency.IScheduler? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Disposed = {_disposed}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("GuardedWitness: Disposed = {_disposed}, Observer = {_observer}")]
     public sealed class GuardedWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public GuardedWitness(System.IObserver<T> observer, System.IDisposable cancel) { }
@@ -1122,7 +1147,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IgnoreValuesSignal: Source = {Source}")]
     public sealed class IgnoreValuesSignal<T> : System.IObservable<T>
     {
         public IgnoreValuesSignal(System.IObservable<T> source) { }
@@ -1136,14 +1161,14 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public System.IDisposable Subscribe(System.IObserver<System.Reactive.Unit> observer) { }
         public System.IDisposable Subscribe(System.Action<System.Reactive.Unit> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptySignal: Source = {Source}")]
     public sealed class IsEmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<bool>
     {
         public IsEmptySignal(System.IObservable<T> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<bool> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptyWitness: Stopped = {_stopped}, Subscription = {Subscription}")]
     public sealed class IsEmptyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public IsEmptyWitness(System.IObserver<bool> observer) { }
@@ -1156,14 +1181,23 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {Value}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("LeadSignal: Value = {Value}, Source = {Source}")]
     public sealed class LeadSignal<T> : ReactiveUI.Primitives.Advanced.IInlineSignal<T>
     {
         public LeadSignal(System.IObservable<T> source, T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
         public System.IDisposable Subscribe(System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("LoopSignal: Value = {Value}")]
+    public sealed class LoopSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public LoopSignal(T value) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("MapIndexedSignal: Source = {_source}")]
     public sealed class MapIndexedSignal<TSource, TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public MapIndexedSignal(System.IObservable<TSource> source, System.Func<TSource, int, TResult> selector) { }
@@ -1171,7 +1205,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Index = {_index}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("MapIndexedWitness: Index = {_index}, Stopped = {_stopped}")]
     public sealed class MapIndexedWitness<TSource, TResult> : System.IObserver<TSource>
     {
         public MapIndexedWitness(System.IObserver<TResult> observer, System.Func<TSource, int, TResult> selector) { }
@@ -1179,20 +1213,20 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(TSource value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentBlendCoordinator: Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
     public sealed class MaxConcurrentBlendCoordinator<T> : System.IDisposable
     {
         public MaxConcurrentBlendCoordinator(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.MaxConcurrentBlendCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentEnumerableBlendSignal: Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
     public sealed class MaxConcurrentEnumerableBlendSignal<T> : System.IObservable<T>
     {
         public MaxConcurrentEnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("MergeCoordinator: Active = {Active}, Done = {Done}")]
     public sealed class MergeCoordinator<T> : System.IDisposable
     {
         public MergeCoordinator(System.IObserver<T> observer) { }
@@ -1203,7 +1237,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.MergeCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.MergeCoordinator<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MergeSignal: Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
     public sealed class MergeSignal<T> : System.IObservable<T>
     {
         public MergeSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -1211,32 +1245,39 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public MergeSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("OnErrorResumeNextSignal: Sources = {_sources}")]
+    public sealed class OnErrorResumeNextSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("PairSignal: Left = {Left}, Right = {Right}")]
     public sealed class PairSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public PairSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
+    [System.Diagnostics.DebuggerDisplay("PairWitness: IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
     public sealed class PairWitness<TLeft, TRight, TResult>
     {
         public PairWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("PublishSelectorSignal: Source = {Source}, Selector = {Selector}")]
     public sealed class PublishSelectorSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public PublishSelectorSignal(System.IObservable<TSource> source, System.Func<System.IObservable<TSource>, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
+    [System.Diagnostics.DebuggerDisplay("RaceSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
     public sealed class RaceSignal<T> : System.IObservable<T>
     {
         public RaceSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public RaceSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Arms = {_arms}")]
+    [System.Diagnostics.DebuggerDisplay("RaceWitness: Arms = {_arms}")]
     public sealed class RaceWitness<T> : System.IDisposable
     {
         public RaceWitness(System.IObserver<T> observer) { }
@@ -1245,40 +1286,48 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public ReactiveUI.Primitives.Reactive.Advanced.RaceWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Reactive.Advanced.RaceWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeCombineLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeCombineLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeCombineLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
+    [System.Diagnostics.DebuggerDisplay("RangeForkJoinSignal: Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
     public sealed class RangeForkJoinSignal<TResult> : System.IObservable<TResult>
     {
         public RangeForkJoinSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeSyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeSyncLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeSyncLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeWithLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeWithLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeWithLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Remaining = {_remaining}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("RecoverSignal: Source = {_source}")]
+    public sealed class RecoverSignal<T, TException> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T> where TException : System.Exception
+    {
+        public RecoverSignal(System.IObservable<T> source, System.Func<TException, System.IObservable<T>> handler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceCoordinator: Remaining = {_remaining}, Disposed = {_disposed}")]
     public sealed class RepeatSourceCoordinator<T> : System.IDisposable
     {
         public RepeatSourceCoordinator(System.IObservable<T> source, int? repeatCount, System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.RepeatSourceCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, RepeatCount = {_repeatCount}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceSignal: Source = {_source}, RepeatCount = {_repeatCount}")]
     public sealed class RepeatSourceSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public RepeatSourceSignal(System.IObservable<T> source, int? repeatCount) { }
@@ -1286,7 +1335,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Generation = {_generation}, Terminated = {_terminated}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceWitness: Generation = {_generation}, Terminated = {_terminated}")]
     public sealed class RepeatSourceWitness<T> : System.IObserver<T>
     {
         public RepeatSourceWitness(ReactiveUI.Primitives.Reactive.Advanced.RepeatSourceCoordinator<T> parent, int generation) { }
@@ -1294,7 +1343,15 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_value}, Scheduler = {_scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ResumeSignal: Source = {_source}, Fallback = {_fallback}")]
+    public sealed class ResumeSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ResumeSignal(System.IObservable<T> source, System.IObservable<T> fallback) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ReturnSignal: Value = {_value}, Scheduler = {_scheduler}")]
     public sealed class ReturnSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ReturnSignal(T value, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -1303,13 +1360,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Values = {Values}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledEnumerableSignal: Values = {Values}, Scheduler = {Scheduler}")]
     public sealed class ScheduledEnumerableSignal<T> : System.IObservable<T>
     {
         public ScheduledEnumerableSignal(System.Collections.Generic.IEnumerable<T> values, System.Reactive.Concurrency.IScheduler scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyCoordinator<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TResult>> selector) { }
@@ -1323,13 +1380,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Reactive.Advanced.SelectManyCoordinator<TSource, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableSignal: Source = {_source}")]
     public sealed class SelectManyEnumerableSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManyEnumerableSignal(System.IObservable<TSource> source, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SelectManyEnumerableWitness<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyEnumerableWitness(System.IObserver<TResult> observer, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
@@ -1343,7 +1400,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyResultCoordinator<TSource, TCollection, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyResultCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
@@ -1356,20 +1413,20 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Reactive.Advanced.SelectManyResultCoordinator<TSource, TCollection, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, CollectionSelector = {CollectionSelector}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultSignal: Source = {Source}, CollectionSelector = {CollectionSelector}")]
     public sealed class SelectManyResultSignal<TSource, TCollection, TResult> : System.IObservable<TResult>
     {
         public SelectManyResultSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManySignal: Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
     public sealed class SelectManySignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManySignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public SelectManySignal(System.IObservable<TSource> source, System.IObservable<TResult> inner) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Start = {Start}, Count = {Count}")]
+    [System.Diagnostics.DebuggerDisplay("SequenceSignal: Start = {Start}, Count = {Count}")]
     public sealed class SequenceSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<int>
     {
         public SequenceSignal(int start, int count, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -1380,13 +1437,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
     {
         public static System.IDisposable Subscribe<T>(System.IObserver<T> observer, bool currentThreadRequired, System.Func<System.IObserver<T>, System.IDisposable, System.IDisposable> subscribeCore) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SparkSignal: Source = {Source}")]
     public sealed class SparkSignal<T> : System.IObservable<ReactiveUI.Primitives.Reactive.Core.Spark<T>>
     {
         public SparkSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Reactive.Core.Spark<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SparkWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SparkWitness(System.IObserver<ReactiveUI.Primitives.Reactive.Core.Spark<T>> observer) { }
@@ -1401,21 +1458,21 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Action = {Action}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Action = {Action}, Scheduler = {Scheduler}")]
     public sealed class StartSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<System.Reactive.Unit>
     {
         public StartSignal(System.Action action, System.Reactive.Concurrency.IScheduler scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<System.Reactive.Unit> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Function = {Function}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Function = {Function}, Scheduler = {Scheduler}")]
     public sealed class StartSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public StartSignal(System.Func<T> function, System.Reactive.Concurrency.IScheduler scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SubscribeSafeWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SubscribeSafeWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SubscribeSafeWitness(System.IObserver<T> observer) { }
@@ -1429,50 +1486,50 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, SkipNullSources = {_skipNullSources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchMapSignal: Source = {_source}, SkipNullSources = {_skipNullSources}")]
     public sealed class SwitchMapSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SwitchMapSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchSignal: Sources = {Sources}")]
     public sealed class SwitchSignal<T> : System.IObservable<T>
     {
         public SwitchSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Version = {_version}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchWitness: Version = {_version}, IsDone = {IsDone}")]
     public sealed class SwitchWitness<T> : System.IDisposable
     {
         public SwitchWitness(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.SwitchWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class SyncLatestSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public SyncLatestSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
     public sealed class SyncLatestWitness<TLeft, TRight, TResult>
     {
         public SyncLatestWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Gate = {Gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeGateSignal: Source = {Source}, Gate = {Gate}")]
     public sealed class SynchronizeGateSignal<T> : System.IObservable<T>
     {
         public SynchronizeGateSignal(System.IObservable<T> source, System.Threading.Lock gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, Gate = {_gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectSignal: Source = {_source}, Gate = {_gate}")]
     public sealed class SynchronizeObjectSignal<T> : System.IObservable<T>
     {
         public SynchronizeObjectSignal(System.IObservable<T> source, object gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SynchronizeObjectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SynchronizeObjectWitness(System.IObserver<T> observer, object gate) { }
@@ -1484,19 +1541,19 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeSignal: Source = {Source}")]
     public sealed class SynchronizeSignal<T> : System.IObservable<T>
     {
         public SynchronizeSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("TapSignal: Source = {Source}")]
     public sealed class TapSignal<T> : System.IObservable<T>
     {
         public TapSignal(System.IObservable<T> source, System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskAnyWitness: Stopped = {_stopped}, Task = {Task}")]
     public sealed class TaskAnyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskAnyWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1512,7 +1569,7 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainCoordinator: Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
     public sealed class TaskChainCoordinator<T> : System.IDisposable
     {
         public TaskChainCoordinator(System.IObserver<T> observer) { }
@@ -1520,13 +1577,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Reactive.Advanced.TaskChainCoordinator<T> Run(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainSignal: Sources = {_sources}")]
     public sealed class TaskChainSignal<T> : System.IObservable<T>
     {
         public TaskChainSignal(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskCountWitness: Count = {_count}, Stopped = {_stopped}")]
     public sealed class TaskCountWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskCountWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1542,13 +1599,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSignal: Task = {Task}")]
     public sealed class TaskInstanceSignal<T> : System.IObservable<T>
     {
         public TaskInstanceSignal(System.Threading.Tasks.Task<T> task) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSubscription: Stopped = {_stopped}")]
     public sealed class TaskInstanceSubscription : System.IDisposable
     {
         public TaskInstanceSubscription() { }
@@ -1556,13 +1613,22 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
         public void Dispose() { }
         public bool TryStop() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Sequencer = {Sequencer}")]
+    [System.Diagnostics.DebuggerDisplay("ThrowSignal: Error = {_error}, Scheduler = {_scheduler}")]
+    public sealed class ThrowSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ThrowSignal(System.Exception error, System.Reactive.Concurrency.IScheduler scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalSignal: Source = {Source}, Sequencer = {Sequencer}")]
     public sealed class TimeIntervalSignal<T> : System.IObservable<ReactiveUI.Primitives.Core.TimeInterval<T>>
     {
         public TimeIntervalSignal(System.IObservable<T> source, System.Reactive.Concurrency.IScheduler sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("First = {_first}, Last = {_last}")]
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalWitness: First = {_first}, Last = {_last}")]
     public sealed class TimeIntervalWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TimeIntervalWitness(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -1580,13 +1646,13 @@ namespace ReactiveUI.Primitives.Reactive.Advanced
     {
         public static void Arm(ReactiveUI.Primitives.Disposables.SingleReplaceableDisposable slot, System.Reactive.Concurrency.IScheduler sequencer, System.TimeSpan delay, System.Action tick) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkSignal: Source = {Source}")]
     public sealed class UnsparkSignal<T> : System.IObservable<T>
     {
         public UnsparkSignal(System.IObservable<ReactiveUI.Primitives.Reactive.Core.Spark<T>> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class UnsparkWitness<T> : System.IDisposable, System.IObserver<ReactiveUI.Primitives.Reactive.Core.Spark<T>>
     {
         public UnsparkWitness(System.IObserver<T> observer) { }
@@ -1610,7 +1676,7 @@ namespace ReactiveUI.Primitives.Reactive.Concurrency
         public static ReactiveUI.Primitives.Concurrency.ScheduledItem<TAbsolute> Create<TAbsolute, TValue>(System.Reactive.Concurrency.IScheduler scheduler, TValue state, System.Func<System.Reactive.Concurrency.IScheduler, TValue, System.IDisposable> action, TAbsolute dueTime) where TAbsolute : System.IComparable<TAbsolute> { }
         public static ReactiveUI.Primitives.Concurrency.ScheduledItem<TAbsolute> Create<TAbsolute, TValue>(System.Reactive.Concurrency.IScheduler scheduler, TValue state, System.Func<System.Reactive.Concurrency.IScheduler, TValue, System.IDisposable> action, TAbsolute dueTime, System.Collections.Generic.IComparer<TAbsolute> comparer) where TAbsolute : System.IComparable<TAbsolute> { }
     }
-    [System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainState = {_drainState}, Disposed = {_isDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("WasmScheduler: ReadyCount = {_readyCount}, DrainState = {_drainState}, Disposed = {_isDisposed}")]
     public sealed class WasmScheduler : System.Reactive.Concurrency.LocalScheduler, System.IDisposable, System.Reactive.Concurrency.ISchedulerPeriodic
     {
         public static ReactiveUI.Primitives.Reactive.Concurrency.WasmScheduler Default { get; }
@@ -1652,7 +1718,7 @@ namespace ReactiveUI.Primitives.Reactive.Core
 }
 namespace ReactiveUI.Primitives.Reactive.Disposables
 {
-    [System.Diagnostics.DebuggerDisplay("Count = {Count}, IsDisposed = {IsDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ContainerDisposable: Count = {Count}, IsDisposed = {IsDisposed}")]
     public sealed class ContainerDisposable : ReactiveUI.Primitives.Disposables.MultipleDisposable
     {
         public ContainerDisposable() { }
@@ -1666,7 +1732,7 @@ namespace ReactiveUI.Primitives.Reactive.Disposables
 }
 namespace ReactiveUI.Primitives.Reactive.Signals
 {
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
+    [System.Diagnostics.DebuggerDisplay("PrioritySemaphoreSignal: Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
     public sealed class PrioritySemaphoreSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T> where T : System.IComparable<T>
     {
         public PrioritySemaphoreSignal(int maxCount) { }
@@ -1701,7 +1767,7 @@ namespace ReactiveUI.Primitives.Reactive.Signals
         public void OnNext(T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledSignal: Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
     public class ScheduledSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T>
     {
         public ScheduledSignal(System.Reactive.Concurrency.IScheduler scheduler) { }

--- a/src/ReactiveUI.Primitives.WinForms.Reactive/Concurrency/ControlSequencer.cs
+++ b/src/ReactiveUI.Primitives.WinForms.Reactive/Concurrency/ControlSequencer.cs
@@ -8,7 +8,7 @@ namespace ReactiveUI.Primitives.Reactive.Concurrency;
 
 /// <summary>Windows Forms scheduler that coalesces scheduled work through a UI control.</summary>
 /// <seealso cref="System.Reactive.Concurrency.IScheduler" />
-[System.Diagnostics.DebuggerDisplay("Control = {Control}")]
+[System.Diagnostics.DebuggerDisplay("ControlSequencer: Control = {Control}")]
 public sealed class ControlSequencer : CoalescingDispatchScheduler
 {
     /// <summary>Initializes a new instance of the <see cref="ControlSequencer"/> class.</summary>

--- a/src/ReactiveUI.Primitives.WinForms.Reactive/PublicAPI/net10.0-windows/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.WinForms.Reactive/PublicAPI/net10.0-windows/PublicAPI.txt
@@ -2,7 +2,7 @@
 [assembly: System.Runtime.Versioning.SupportedOSPlatform("Windows7.0")]
 namespace ReactiveUI.Primitives.Reactive.Concurrency;
 
-[System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
+[System.Diagnostics.DebuggerDisplay("CoalescingDispatchScheduler: ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
 public abstract class CoalescingDispatchScheduler : System.Reactive.Concurrency.LocalScheduler
 {
     protected CoalescingDispatchScheduler() { }
@@ -13,7 +13,7 @@ public abstract class CoalescingDispatchScheduler : System.Reactive.Concurrency.
     public override System.IDisposable Schedule<TState>(TState state, System.TimeSpan dueTime, System.Func<System.Reactive.Concurrency.IScheduler, TState, System.IDisposable> action) { }
     protected virtual System.IDisposable ScheduleOnDispatcher(System.Action work, System.TimeSpan dueTime) { }
 }
-[System.Diagnostics.DebuggerDisplay("Control = {Control}")]
+[System.Diagnostics.DebuggerDisplay("ControlSequencer: Control = {Control}")]
 public sealed class ControlSequencer : ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler
 {
     public ControlSequencer(System.Windows.Forms.Control control) { }

--- a/src/ReactiveUI.Primitives.WinForms.Reactive/PublicAPI/net11.0-windows/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.WinForms.Reactive/PublicAPI/net11.0-windows/PublicAPI.txt
@@ -2,7 +2,7 @@
 [assembly: System.Runtime.Versioning.SupportedOSPlatform("Windows7.0")]
 namespace ReactiveUI.Primitives.Reactive.Concurrency;
 
-[System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
+[System.Diagnostics.DebuggerDisplay("CoalescingDispatchScheduler: ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
 public abstract class CoalescingDispatchScheduler : System.Reactive.Concurrency.LocalScheduler
 {
     protected CoalescingDispatchScheduler() { }
@@ -13,7 +13,7 @@ public abstract class CoalescingDispatchScheduler : System.Reactive.Concurrency.
     public override System.IDisposable Schedule<TState>(TState state, System.TimeSpan dueTime, System.Func<System.Reactive.Concurrency.IScheduler, TState, System.IDisposable> action) { }
     protected virtual System.IDisposable ScheduleOnDispatcher(System.Action work, System.TimeSpan dueTime) { }
 }
-[System.Diagnostics.DebuggerDisplay("Control = {Control}")]
+[System.Diagnostics.DebuggerDisplay("ControlSequencer: Control = {Control}")]
 public sealed class ControlSequencer : ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler
 {
     public ControlSequencer(System.Windows.Forms.Control control) { }

--- a/src/ReactiveUI.Primitives.WinForms.Reactive/PublicAPI/net462/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.WinForms.Reactive/PublicAPI/net462/PublicAPI.txt
@@ -1,7 +1,7 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Primitives.WinForms.Reactive.Tests")]
 namespace ReactiveUI.Primitives.Reactive.Concurrency;
 
-[System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
+[System.Diagnostics.DebuggerDisplay("CoalescingDispatchScheduler: ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
 public abstract class CoalescingDispatchScheduler : System.Reactive.Concurrency.LocalScheduler
 {
     protected CoalescingDispatchScheduler() { }
@@ -12,7 +12,7 @@ public abstract class CoalescingDispatchScheduler : System.Reactive.Concurrency.
     public override System.IDisposable Schedule<TState>(TState state, System.TimeSpan dueTime, System.Func<System.Reactive.Concurrency.IScheduler, TState, System.IDisposable> action) { }
     protected virtual System.IDisposable ScheduleOnDispatcher(System.Action work, System.TimeSpan dueTime) { }
 }
-[System.Diagnostics.DebuggerDisplay("Control = {Control}")]
+[System.Diagnostics.DebuggerDisplay("ControlSequencer: Control = {Control}")]
 public sealed class ControlSequencer : ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler
 {
     public ControlSequencer(System.Windows.Forms.Control control) { }

--- a/src/ReactiveUI.Primitives.WinForms.Reactive/PublicAPI/net472/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.WinForms.Reactive/PublicAPI/net472/PublicAPI.txt
@@ -1,7 +1,7 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Primitives.WinForms.Reactive.Tests")]
 namespace ReactiveUI.Primitives.Reactive.Concurrency;
 
-[System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
+[System.Diagnostics.DebuggerDisplay("CoalescingDispatchScheduler: ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
 public abstract class CoalescingDispatchScheduler : System.Reactive.Concurrency.LocalScheduler
 {
     protected CoalescingDispatchScheduler() { }
@@ -12,7 +12,7 @@ public abstract class CoalescingDispatchScheduler : System.Reactive.Concurrency.
     public override System.IDisposable Schedule<TState>(TState state, System.TimeSpan dueTime, System.Func<System.Reactive.Concurrency.IScheduler, TState, System.IDisposable> action) { }
     protected virtual System.IDisposable ScheduleOnDispatcher(System.Action work, System.TimeSpan dueTime) { }
 }
-[System.Diagnostics.DebuggerDisplay("Control = {Control}")]
+[System.Diagnostics.DebuggerDisplay("ControlSequencer: Control = {Control}")]
 public sealed class ControlSequencer : ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler
 {
     public ControlSequencer(System.Windows.Forms.Control control) { }

--- a/src/ReactiveUI.Primitives.WinForms.Reactive/PublicAPI/net48/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.WinForms.Reactive/PublicAPI/net48/PublicAPI.txt
@@ -1,7 +1,7 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Primitives.WinForms.Reactive.Tests")]
 namespace ReactiveUI.Primitives.Reactive.Concurrency;
 
-[System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
+[System.Diagnostics.DebuggerDisplay("CoalescingDispatchScheduler: ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
 public abstract class CoalescingDispatchScheduler : System.Reactive.Concurrency.LocalScheduler
 {
     protected CoalescingDispatchScheduler() { }
@@ -12,7 +12,7 @@ public abstract class CoalescingDispatchScheduler : System.Reactive.Concurrency.
     public override System.IDisposable Schedule<TState>(TState state, System.TimeSpan dueTime, System.Func<System.Reactive.Concurrency.IScheduler, TState, System.IDisposable> action) { }
     protected virtual System.IDisposable ScheduleOnDispatcher(System.Action work, System.TimeSpan dueTime) { }
 }
-[System.Diagnostics.DebuggerDisplay("Control = {Control}")]
+[System.Diagnostics.DebuggerDisplay("ControlSequencer: Control = {Control}")]
 public sealed class ControlSequencer : ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler
 {
     public ControlSequencer(System.Windows.Forms.Control control) { }

--- a/src/ReactiveUI.Primitives.WinForms.Reactive/PublicAPI/net481/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.WinForms.Reactive/PublicAPI/net481/PublicAPI.txt
@@ -1,7 +1,7 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Primitives.WinForms.Reactive.Tests")]
 namespace ReactiveUI.Primitives.Reactive.Concurrency;
 
-[System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
+[System.Diagnostics.DebuggerDisplay("CoalescingDispatchScheduler: ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
 public abstract class CoalescingDispatchScheduler : System.Reactive.Concurrency.LocalScheduler
 {
     protected CoalescingDispatchScheduler() { }
@@ -12,7 +12,7 @@ public abstract class CoalescingDispatchScheduler : System.Reactive.Concurrency.
     public override System.IDisposable Schedule<TState>(TState state, System.TimeSpan dueTime, System.Func<System.Reactive.Concurrency.IScheduler, TState, System.IDisposable> action) { }
     protected virtual System.IDisposable ScheduleOnDispatcher(System.Action work, System.TimeSpan dueTime) { }
 }
-[System.Diagnostics.DebuggerDisplay("Control = {Control}")]
+[System.Diagnostics.DebuggerDisplay("ControlSequencer: Control = {Control}")]
 public sealed class ControlSequencer : ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler
 {
     public ControlSequencer(System.Windows.Forms.Control control) { }

--- a/src/ReactiveUI.Primitives.WinForms.Reactive/PublicAPI/net8.0-windows/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.WinForms.Reactive/PublicAPI/net8.0-windows/PublicAPI.txt
@@ -2,7 +2,7 @@
 [assembly: System.Runtime.Versioning.SupportedOSPlatform("Windows7.0")]
 namespace ReactiveUI.Primitives.Reactive.Concurrency;
 
-[System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
+[System.Diagnostics.DebuggerDisplay("CoalescingDispatchScheduler: ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
 public abstract class CoalescingDispatchScheduler : System.Reactive.Concurrency.LocalScheduler
 {
     protected CoalescingDispatchScheduler() { }
@@ -13,7 +13,7 @@ public abstract class CoalescingDispatchScheduler : System.Reactive.Concurrency.
     public override System.IDisposable Schedule<TState>(TState state, System.TimeSpan dueTime, System.Func<System.Reactive.Concurrency.IScheduler, TState, System.IDisposable> action) { }
     protected virtual System.IDisposable ScheduleOnDispatcher(System.Action work, System.TimeSpan dueTime) { }
 }
-[System.Diagnostics.DebuggerDisplay("Control = {Control}")]
+[System.Diagnostics.DebuggerDisplay("ControlSequencer: Control = {Control}")]
 public sealed class ControlSequencer : ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler
 {
     public ControlSequencer(System.Windows.Forms.Control control) { }

--- a/src/ReactiveUI.Primitives.WinForms.Reactive/PublicAPI/net9.0-windows/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.WinForms.Reactive/PublicAPI/net9.0-windows/PublicAPI.txt
@@ -2,7 +2,7 @@
 [assembly: System.Runtime.Versioning.SupportedOSPlatform("Windows7.0")]
 namespace ReactiveUI.Primitives.Reactive.Concurrency;
 
-[System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
+[System.Diagnostics.DebuggerDisplay("CoalescingDispatchScheduler: ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
 public abstract class CoalescingDispatchScheduler : System.Reactive.Concurrency.LocalScheduler
 {
     protected CoalescingDispatchScheduler() { }
@@ -13,7 +13,7 @@ public abstract class CoalescingDispatchScheduler : System.Reactive.Concurrency.
     public override System.IDisposable Schedule<TState>(TState state, System.TimeSpan dueTime, System.Func<System.Reactive.Concurrency.IScheduler, TState, System.IDisposable> action) { }
     protected virtual System.IDisposable ScheduleOnDispatcher(System.Action work, System.TimeSpan dueTime) { }
 }
-[System.Diagnostics.DebuggerDisplay("Control = {Control}")]
+[System.Diagnostics.DebuggerDisplay("ControlSequencer: Control = {Control}")]
 public sealed class ControlSequencer : ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler
 {
     public ControlSequencer(System.Windows.Forms.Control control) { }

--- a/src/ReactiveUI.Primitives.WinUI.Reactive/Concurrency/DispatcherQueueSequencer.cs
+++ b/src/ReactiveUI.Primitives.WinUI.Reactive/Concurrency/DispatcherQueueSequencer.cs
@@ -9,7 +9,7 @@ namespace ReactiveUI.Primitives.Reactive.Concurrency;
 
 /// <summary>WinUI dispatcher queue scheduler that coalesces scheduled work through a <see cref="DispatcherQueue"/>.</summary>
 /// <seealso cref="System.Reactive.Concurrency.IScheduler" />
-[System.Diagnostics.DebuggerDisplay("DispatcherQueue = {DispatcherQueue}, Priority = {Priority}")]
+[System.Diagnostics.DebuggerDisplay("DispatcherQueueSequencer: DispatcherQueue = {DispatcherQueue}, Priority = {Priority}")]
 public sealed class DispatcherQueueSequencer : CoalescingDispatchScheduler
 {
     /// <summary>Cached dispatcher queue handler used for the drain.</summary>

--- a/src/ReactiveUI.Primitives.WinUI.Reactive/PublicAPI/net10.0-windows10.0.19041.0/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.WinUI.Reactive/PublicAPI/net10.0-windows10.0.19041.0/PublicAPI.txt
@@ -2,7 +2,7 @@
 [assembly: System.Runtime.Versioning.SupportedOSPlatform("Windows10.0.19041.0")]
 namespace ReactiveUI.Primitives.Reactive.Concurrency;
 
-[System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
+[System.Diagnostics.DebuggerDisplay("CoalescingDispatchScheduler: ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
 public abstract class CoalescingDispatchScheduler : System.Reactive.Concurrency.LocalScheduler
 {
     protected CoalescingDispatchScheduler() { }
@@ -13,7 +13,7 @@ public abstract class CoalescingDispatchScheduler : System.Reactive.Concurrency.
     public override System.IDisposable Schedule<TState>(TState state, System.TimeSpan dueTime, System.Func<System.Reactive.Concurrency.IScheduler, TState, System.IDisposable> action) { }
     protected virtual System.IDisposable ScheduleOnDispatcher(System.Action work, System.TimeSpan dueTime) { }
 }
-[System.Diagnostics.DebuggerDisplay("DispatcherQueue = {DispatcherQueue}, Priority = {Priority}")]
+[System.Diagnostics.DebuggerDisplay("DispatcherQueueSequencer: DispatcherQueue = {DispatcherQueue}, Priority = {Priority}")]
 public sealed class DispatcherQueueSequencer : ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler
 {
     public DispatcherQueueSequencer(Microsoft.UI.Dispatching.DispatcherQueue dispatcherQueue) { }

--- a/src/ReactiveUI.Primitives.WinUI.Reactive/PublicAPI/net11.0-windows10.0.19041.0/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.WinUI.Reactive/PublicAPI/net11.0-windows10.0.19041.0/PublicAPI.txt
@@ -2,7 +2,7 @@
 [assembly: System.Runtime.Versioning.SupportedOSPlatform("Windows10.0.19041.0")]
 namespace ReactiveUI.Primitives.Reactive.Concurrency;
 
-[System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
+[System.Diagnostics.DebuggerDisplay("CoalescingDispatchScheduler: ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
 public abstract class CoalescingDispatchScheduler : System.Reactive.Concurrency.LocalScheduler
 {
     protected CoalescingDispatchScheduler() { }
@@ -13,7 +13,7 @@ public abstract class CoalescingDispatchScheduler : System.Reactive.Concurrency.
     public override System.IDisposable Schedule<TState>(TState state, System.TimeSpan dueTime, System.Func<System.Reactive.Concurrency.IScheduler, TState, System.IDisposable> action) { }
     protected virtual System.IDisposable ScheduleOnDispatcher(System.Action work, System.TimeSpan dueTime) { }
 }
-[System.Diagnostics.DebuggerDisplay("DispatcherQueue = {DispatcherQueue}, Priority = {Priority}")]
+[System.Diagnostics.DebuggerDisplay("DispatcherQueueSequencer: DispatcherQueue = {DispatcherQueue}, Priority = {Priority}")]
 public sealed class DispatcherQueueSequencer : ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler
 {
     public DispatcherQueueSequencer(Microsoft.UI.Dispatching.DispatcherQueue dispatcherQueue) { }

--- a/src/ReactiveUI.Primitives.WinUI.Reactive/PublicAPI/net8.0-windows10.0.19041.0/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.WinUI.Reactive/PublicAPI/net8.0-windows10.0.19041.0/PublicAPI.txt
@@ -2,7 +2,7 @@
 [assembly: System.Runtime.Versioning.SupportedOSPlatform("Windows10.0.19041.0")]
 namespace ReactiveUI.Primitives.Reactive.Concurrency;
 
-[System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
+[System.Diagnostics.DebuggerDisplay("CoalescingDispatchScheduler: ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
 public abstract class CoalescingDispatchScheduler : System.Reactive.Concurrency.LocalScheduler
 {
     protected CoalescingDispatchScheduler() { }
@@ -13,7 +13,7 @@ public abstract class CoalescingDispatchScheduler : System.Reactive.Concurrency.
     public override System.IDisposable Schedule<TState>(TState state, System.TimeSpan dueTime, System.Func<System.Reactive.Concurrency.IScheduler, TState, System.IDisposable> action) { }
     protected virtual System.IDisposable ScheduleOnDispatcher(System.Action work, System.TimeSpan dueTime) { }
 }
-[System.Diagnostics.DebuggerDisplay("DispatcherQueue = {DispatcherQueue}, Priority = {Priority}")]
+[System.Diagnostics.DebuggerDisplay("DispatcherQueueSequencer: DispatcherQueue = {DispatcherQueue}, Priority = {Priority}")]
 public sealed class DispatcherQueueSequencer : ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler
 {
     public DispatcherQueueSequencer(Microsoft.UI.Dispatching.DispatcherQueue dispatcherQueue) { }

--- a/src/ReactiveUI.Primitives.WinUI.Reactive/PublicAPI/net9.0-windows10.0.19041.0/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.WinUI.Reactive/PublicAPI/net9.0-windows10.0.19041.0/PublicAPI.txt
@@ -2,7 +2,7 @@
 [assembly: System.Runtime.Versioning.SupportedOSPlatform("Windows10.0.19041.0")]
 namespace ReactiveUI.Primitives.Reactive.Concurrency;
 
-[System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
+[System.Diagnostics.DebuggerDisplay("CoalescingDispatchScheduler: ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
 public abstract class CoalescingDispatchScheduler : System.Reactive.Concurrency.LocalScheduler
 {
     protected CoalescingDispatchScheduler() { }
@@ -13,7 +13,7 @@ public abstract class CoalescingDispatchScheduler : System.Reactive.Concurrency.
     public override System.IDisposable Schedule<TState>(TState state, System.TimeSpan dueTime, System.Func<System.Reactive.Concurrency.IScheduler, TState, System.IDisposable> action) { }
     protected virtual System.IDisposable ScheduleOnDispatcher(System.Action work, System.TimeSpan dueTime) { }
 }
-[System.Diagnostics.DebuggerDisplay("DispatcherQueue = {DispatcherQueue}, Priority = {Priority}")]
+[System.Diagnostics.DebuggerDisplay("DispatcherQueueSequencer: DispatcherQueue = {DispatcherQueue}, Priority = {Priority}")]
 public sealed class DispatcherQueueSequencer : ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler
 {
     public DispatcherQueueSequencer(Microsoft.UI.Dispatching.DispatcherQueue dispatcherQueue) { }

--- a/src/ReactiveUI.Primitives.Wpf.Reactive/Concurrency/DispatcherSequencer.cs
+++ b/src/ReactiveUI.Primitives.Wpf.Reactive/Concurrency/DispatcherSequencer.cs
@@ -9,7 +9,7 @@ namespace ReactiveUI.Primitives.Reactive.Concurrency;
 
 /// <summary>WPF dispatcher scheduler that coalesces scheduled work onto a dispatcher drain.</summary>
 /// <seealso cref="System.Reactive.Concurrency.IScheduler" />
-[System.Diagnostics.DebuggerDisplay("Dispatcher = {Dispatcher}, Priority = {Priority}")]
+[System.Diagnostics.DebuggerDisplay("DispatcherSequencer: Dispatcher = {Dispatcher}, Priority = {Priority}")]
 public sealed class DispatcherSequencer : CoalescingDispatchScheduler
 {
     /// <summary>Initializes a new instance of the <see cref="DispatcherSequencer"/> class.</summary>

--- a/src/ReactiveUI.Primitives.Wpf.Reactive/PublicAPI/net10.0-windows/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Wpf.Reactive/PublicAPI/net10.0-windows/PublicAPI.txt
@@ -2,7 +2,7 @@
 [assembly: System.Runtime.Versioning.SupportedOSPlatform("Windows7.0")]
 namespace ReactiveUI.Primitives.Reactive.Concurrency;
 
-[System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
+[System.Diagnostics.DebuggerDisplay("CoalescingDispatchScheduler: ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
 public abstract class CoalescingDispatchScheduler : System.Reactive.Concurrency.LocalScheduler
 {
     protected CoalescingDispatchScheduler() { }
@@ -13,7 +13,7 @@ public abstract class CoalescingDispatchScheduler : System.Reactive.Concurrency.
     public override System.IDisposable Schedule<TState>(TState state, System.TimeSpan dueTime, System.Func<System.Reactive.Concurrency.IScheduler, TState, System.IDisposable> action) { }
     protected virtual System.IDisposable ScheduleOnDispatcher(System.Action work, System.TimeSpan dueTime) { }
 }
-[System.Diagnostics.DebuggerDisplay("Dispatcher = {Dispatcher}, Priority = {Priority}")]
+[System.Diagnostics.DebuggerDisplay("DispatcherSequencer: Dispatcher = {Dispatcher}, Priority = {Priority}")]
 public sealed class DispatcherSequencer : ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler
 {
     public DispatcherSequencer(System.Windows.Threading.Dispatcher dispatcher) { }

--- a/src/ReactiveUI.Primitives.Wpf.Reactive/PublicAPI/net11.0-windows/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Wpf.Reactive/PublicAPI/net11.0-windows/PublicAPI.txt
@@ -2,7 +2,7 @@
 [assembly: System.Runtime.Versioning.SupportedOSPlatform("Windows7.0")]
 namespace ReactiveUI.Primitives.Reactive.Concurrency;
 
-[System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
+[System.Diagnostics.DebuggerDisplay("CoalescingDispatchScheduler: ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
 public abstract class CoalescingDispatchScheduler : System.Reactive.Concurrency.LocalScheduler
 {
     protected CoalescingDispatchScheduler() { }
@@ -13,7 +13,7 @@ public abstract class CoalescingDispatchScheduler : System.Reactive.Concurrency.
     public override System.IDisposable Schedule<TState>(TState state, System.TimeSpan dueTime, System.Func<System.Reactive.Concurrency.IScheduler, TState, System.IDisposable> action) { }
     protected virtual System.IDisposable ScheduleOnDispatcher(System.Action work, System.TimeSpan dueTime) { }
 }
-[System.Diagnostics.DebuggerDisplay("Dispatcher = {Dispatcher}, Priority = {Priority}")]
+[System.Diagnostics.DebuggerDisplay("DispatcherSequencer: Dispatcher = {Dispatcher}, Priority = {Priority}")]
 public sealed class DispatcherSequencer : ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler
 {
     public DispatcherSequencer(System.Windows.Threading.Dispatcher dispatcher) { }

--- a/src/ReactiveUI.Primitives.Wpf.Reactive/PublicAPI/net462/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Wpf.Reactive/PublicAPI/net462/PublicAPI.txt
@@ -1,7 +1,7 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Primitives.Wpf.Reactive.Tests")]
 namespace ReactiveUI.Primitives.Reactive.Concurrency;
 
-[System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
+[System.Diagnostics.DebuggerDisplay("CoalescingDispatchScheduler: ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
 public abstract class CoalescingDispatchScheduler : System.Reactive.Concurrency.LocalScheduler
 {
     protected CoalescingDispatchScheduler() { }
@@ -12,7 +12,7 @@ public abstract class CoalescingDispatchScheduler : System.Reactive.Concurrency.
     public override System.IDisposable Schedule<TState>(TState state, System.TimeSpan dueTime, System.Func<System.Reactive.Concurrency.IScheduler, TState, System.IDisposable> action) { }
     protected virtual System.IDisposable ScheduleOnDispatcher(System.Action work, System.TimeSpan dueTime) { }
 }
-[System.Diagnostics.DebuggerDisplay("Dispatcher = {Dispatcher}, Priority = {Priority}")]
+[System.Diagnostics.DebuggerDisplay("DispatcherSequencer: Dispatcher = {Dispatcher}, Priority = {Priority}")]
 public sealed class DispatcherSequencer : ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler
 {
     public DispatcherSequencer(System.Windows.Threading.Dispatcher dispatcher) { }

--- a/src/ReactiveUI.Primitives.Wpf.Reactive/PublicAPI/net472/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Wpf.Reactive/PublicAPI/net472/PublicAPI.txt
@@ -1,7 +1,7 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Primitives.Wpf.Reactive.Tests")]
 namespace ReactiveUI.Primitives.Reactive.Concurrency;
 
-[System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
+[System.Diagnostics.DebuggerDisplay("CoalescingDispatchScheduler: ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
 public abstract class CoalescingDispatchScheduler : System.Reactive.Concurrency.LocalScheduler
 {
     protected CoalescingDispatchScheduler() { }
@@ -12,7 +12,7 @@ public abstract class CoalescingDispatchScheduler : System.Reactive.Concurrency.
     public override System.IDisposable Schedule<TState>(TState state, System.TimeSpan dueTime, System.Func<System.Reactive.Concurrency.IScheduler, TState, System.IDisposable> action) { }
     protected virtual System.IDisposable ScheduleOnDispatcher(System.Action work, System.TimeSpan dueTime) { }
 }
-[System.Diagnostics.DebuggerDisplay("Dispatcher = {Dispatcher}, Priority = {Priority}")]
+[System.Diagnostics.DebuggerDisplay("DispatcherSequencer: Dispatcher = {Dispatcher}, Priority = {Priority}")]
 public sealed class DispatcherSequencer : ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler
 {
     public DispatcherSequencer(System.Windows.Threading.Dispatcher dispatcher) { }

--- a/src/ReactiveUI.Primitives.Wpf.Reactive/PublicAPI/net48/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Wpf.Reactive/PublicAPI/net48/PublicAPI.txt
@@ -1,7 +1,7 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Primitives.Wpf.Reactive.Tests")]
 namespace ReactiveUI.Primitives.Reactive.Concurrency;
 
-[System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
+[System.Diagnostics.DebuggerDisplay("CoalescingDispatchScheduler: ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
 public abstract class CoalescingDispatchScheduler : System.Reactive.Concurrency.LocalScheduler
 {
     protected CoalescingDispatchScheduler() { }
@@ -12,7 +12,7 @@ public abstract class CoalescingDispatchScheduler : System.Reactive.Concurrency.
     public override System.IDisposable Schedule<TState>(TState state, System.TimeSpan dueTime, System.Func<System.Reactive.Concurrency.IScheduler, TState, System.IDisposable> action) { }
     protected virtual System.IDisposable ScheduleOnDispatcher(System.Action work, System.TimeSpan dueTime) { }
 }
-[System.Diagnostics.DebuggerDisplay("Dispatcher = {Dispatcher}, Priority = {Priority}")]
+[System.Diagnostics.DebuggerDisplay("DispatcherSequencer: Dispatcher = {Dispatcher}, Priority = {Priority}")]
 public sealed class DispatcherSequencer : ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler
 {
     public DispatcherSequencer(System.Windows.Threading.Dispatcher dispatcher) { }

--- a/src/ReactiveUI.Primitives.Wpf.Reactive/PublicAPI/net481/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Wpf.Reactive/PublicAPI/net481/PublicAPI.txt
@@ -1,7 +1,7 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Primitives.Wpf.Reactive.Tests")]
 namespace ReactiveUI.Primitives.Reactive.Concurrency;
 
-[System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
+[System.Diagnostics.DebuggerDisplay("CoalescingDispatchScheduler: ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
 public abstract class CoalescingDispatchScheduler : System.Reactive.Concurrency.LocalScheduler
 {
     protected CoalescingDispatchScheduler() { }
@@ -12,7 +12,7 @@ public abstract class CoalescingDispatchScheduler : System.Reactive.Concurrency.
     public override System.IDisposable Schedule<TState>(TState state, System.TimeSpan dueTime, System.Func<System.Reactive.Concurrency.IScheduler, TState, System.IDisposable> action) { }
     protected virtual System.IDisposable ScheduleOnDispatcher(System.Action work, System.TimeSpan dueTime) { }
 }
-[System.Diagnostics.DebuggerDisplay("Dispatcher = {Dispatcher}, Priority = {Priority}")]
+[System.Diagnostics.DebuggerDisplay("DispatcherSequencer: Dispatcher = {Dispatcher}, Priority = {Priority}")]
 public sealed class DispatcherSequencer : ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler
 {
     public DispatcherSequencer(System.Windows.Threading.Dispatcher dispatcher) { }

--- a/src/ReactiveUI.Primitives.Wpf.Reactive/PublicAPI/net8.0-windows/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Wpf.Reactive/PublicAPI/net8.0-windows/PublicAPI.txt
@@ -2,7 +2,7 @@
 [assembly: System.Runtime.Versioning.SupportedOSPlatform("Windows7.0")]
 namespace ReactiveUI.Primitives.Reactive.Concurrency;
 
-[System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
+[System.Diagnostics.DebuggerDisplay("CoalescingDispatchScheduler: ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
 public abstract class CoalescingDispatchScheduler : System.Reactive.Concurrency.LocalScheduler
 {
     protected CoalescingDispatchScheduler() { }
@@ -13,7 +13,7 @@ public abstract class CoalescingDispatchScheduler : System.Reactive.Concurrency.
     public override System.IDisposable Schedule<TState>(TState state, System.TimeSpan dueTime, System.Func<System.Reactive.Concurrency.IScheduler, TState, System.IDisposable> action) { }
     protected virtual System.IDisposable ScheduleOnDispatcher(System.Action work, System.TimeSpan dueTime) { }
 }
-[System.Diagnostics.DebuggerDisplay("Dispatcher = {Dispatcher}, Priority = {Priority}")]
+[System.Diagnostics.DebuggerDisplay("DispatcherSequencer: Dispatcher = {Dispatcher}, Priority = {Priority}")]
 public sealed class DispatcherSequencer : ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler
 {
     public DispatcherSequencer(System.Windows.Threading.Dispatcher dispatcher) { }

--- a/src/ReactiveUI.Primitives.Wpf.Reactive/PublicAPI/net9.0-windows/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives.Wpf.Reactive/PublicAPI/net9.0-windows/PublicAPI.txt
@@ -2,7 +2,7 @@
 [assembly: System.Runtime.Versioning.SupportedOSPlatform("Windows7.0")]
 namespace ReactiveUI.Primitives.Reactive.Concurrency;
 
-[System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
+[System.Diagnostics.DebuggerDisplay("CoalescingDispatchScheduler: ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
 public abstract class CoalescingDispatchScheduler : System.Reactive.Concurrency.LocalScheduler
 {
     protected CoalescingDispatchScheduler() { }
@@ -13,7 +13,7 @@ public abstract class CoalescingDispatchScheduler : System.Reactive.Concurrency.
     public override System.IDisposable Schedule<TState>(TState state, System.TimeSpan dueTime, System.Func<System.Reactive.Concurrency.IScheduler, TState, System.IDisposable> action) { }
     protected virtual System.IDisposable ScheduleOnDispatcher(System.Action work, System.TimeSpan dueTime) { }
 }
-[System.Diagnostics.DebuggerDisplay("Dispatcher = {Dispatcher}, Priority = {Priority}")]
+[System.Diagnostics.DebuggerDisplay("DispatcherSequencer: Dispatcher = {Dispatcher}, Priority = {Priority}")]
 public sealed class DispatcherSequencer : ReactiveUI.Primitives.Reactive.Concurrency.CoalescingDispatchScheduler
 {
     public DispatcherSequencer(System.Windows.Threading.Dispatcher dispatcher) { }

--- a/src/ReactiveUI.Primitives/Advanced/DispatchSequencerState.cs
+++ b/src/ReactiveUI.Primitives/Advanced/DispatchSequencerState.cs
@@ -19,7 +19,7 @@ namespace ReactiveUI.Primitives.Advanced;
     "SST1803:Make record struct readonly",
     Justification =
         "Mutable dispatch-coalescing engine: holds the ready queue plus drain/post latches that mutate in place.")]
-[System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
+[System.Diagnostics.DebuggerDisplay("DispatchSequencerState: ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
 public record struct DispatchSequencerState
 {
     /// <summary>Ready work items awaiting a UI-thread drain.</summary>

--- a/src/ReactiveUI.Primitives/PublicAPI/net10.0-android/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net10.0-android/PublicAPI.txt
@@ -518,7 +518,7 @@ namespace ReactiveUI.Primitives
 }
 namespace ReactiveUI.Primitives.Advanced
 {
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Period = {_period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSignal: DueTime = {_dueTime}, Period = {_period}")]
     public sealed class AfterSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
     {
         public AfterSignal(System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -526,7 +526,7 @@ namespace ReactiveUI.Primitives.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<long> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSubscription: Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
     public sealed class AfterSubscription : System.IDisposable
     {
         public AfterSubscription(System.IObserver<long> observer, ReactiveUI.Primitives.Concurrency.ISequencer scheduler, System.TimeSpan dueTime, System.TimeSpan? period) { }
@@ -534,21 +534,21 @@ namespace ReactiveUI.Primitives.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.AfterSubscription Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("SubscribeAsync = {SubscribeAsync}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncCreateSignal: SubscribeAsync = {SubscribeAsync}")]
     public sealed class AsyncCreateSignal<T> : System.IObservable<T>
     {
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ObservableFactory = {ObservableFactory}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncDeferSignal: ObservableFactory = {ObservableFactory}")]
     public sealed class AsyncDeferSignal<T> : System.IObservable<T>
     {
         public AsyncDeferSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public AsyncDeferSignal(System.Func<System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncSubscriptionLifetime: Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
     public sealed class AsyncSubscriptionLifetime : System.IDisposable
     {
         public AsyncSubscriptionLifetime() { }
@@ -559,33 +559,33 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable? disposable) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connected = {_connected}")]
+    [System.Diagnostics.DebuggerDisplay("AutoConnectSignal: Count = {_count}, Connected = {_connected}")]
     public sealed class AutoConnectSignal<T> : System.IObservable<T>
     {
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount) { }
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount, System.Action<System.IDisposable>? onConnect) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connection = {_connection}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSignal: Count = {_count}, Connection = {_connection}")]
     public sealed class AutoShareSignal<T> : System.IObservable<T>
     {
         public AutoShareSignal(ReactiveUI.Primitives.ConnectableSignal<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Owner = {_owner}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSubscription: Owner = {_owner}, Subscription = {Subscription}")]
     public sealed class AutoShareSubscription<T> : System.IDisposable
     {
         public AutoShareSubscription(ReactiveUI.Primitives.Advanced.AutoShareSignal<T> owner, System.IDisposable subscription) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void Dispose() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("BlendSignal: Sources = {Sources}")]
     public sealed class BlendSignal<T> : System.IObservable<T>
     {
         public BlendSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("BlendWitness: ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
     public sealed class BlendWitness<T> : System.IDisposable
     {
         public BlendWitness(System.IObserver<T> observer) { }
@@ -594,7 +594,7 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.BlendWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.BlendWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("BufferEachWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class BufferEachWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public BufferEachWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -608,20 +608,20 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Window = {Window}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("BufferSignal: Window = {Window}, Source = {Source}")]
     public sealed class BufferSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public BufferSignal(System.IObservable<T> source, System.TimeSpan timeSpan, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("CastSignal: Source = {Source}")]
     public sealed class CastSignal<TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public CastSignal(System.IObservable<object?> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CastWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CastWitness<TResult> : System.IDisposable, System.IObserver<object?>
     {
         public CastWitness(System.IObserver<TResult> observer) { }
@@ -635,7 +635,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
+    [System.Diagnostics.DebuggerDisplay("ChainSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
     public sealed class ChainSignal<T> : System.IObservable<T>
     {
         public ChainSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -643,7 +643,7 @@ namespace ReactiveUI.Primitives.Advanced
         public ChainSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("ChainWitness: IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
     public sealed class ChainWitness<T> : System.IDisposable
     {
         public ChainWitness(System.IObserver<T> observer) { }
@@ -653,13 +653,13 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.ChainWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.ChainWitness<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, TimeSpan = {TimeSpan}")]
+    [System.Diagnostics.DebuggerDisplay("CollectSignal: Source = {Source}, TimeSpan = {TimeSpan}")]
     public sealed class CollectSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public CollectSignal(System.IObservable<T> source, System.TimeSpan timeSpan, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Buffered = {Values.Count}")]
+    [System.Diagnostics.DebuggerDisplay("CollectWitness: Stopped = {_stopped}, Buffered = {Values.Count}")]
     public sealed class CollectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CollectWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -671,7 +671,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateSink: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class CreateSink<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateSink(System.IObserver<T> observer, bool disposeOnNextThrow) { }
@@ -683,7 +683,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CreateWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateWitness(System.IObserver<T> observer) { }
@@ -697,7 +697,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
+    [System.Diagnostics.DebuggerDisplay("DispatchSequencerState: ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
     public record struct DispatchSequencerState : System.IEquatable<ReactiveUI.Primitives.Advanced.DispatchSequencerState>
     {
         public DispatchSequencerState(ReactiveUI.Primitives.Concurrency.ISequencer owner, System.Func<System.Action, bool> post, System.Action drain) { }
@@ -712,13 +712,13 @@ namespace ReactiveUI.Primitives.Advanced
         public static System.TimeSpan DelayUntil(long dueTimestamp) { }
         public static void RunIfActive(ReactiveUI.Primitives.Concurrency.IWorkItem item) { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {DueTime}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietSignal: DueTime = {DueTime}, Source = {Source}")]
     public sealed class EmitIfQuietSignal<T> : System.IObservable<T>
     {
         public EmitIfQuietSignal(System.IObservable<T> source, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietWitness: HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
     public sealed class EmitIfQuietWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public EmitIfQuietWitness(System.IObserver<T> observer, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
@@ -729,7 +729,16 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("EmptySignal: Scheduler = {_scheduler}")]
+    public sealed class EmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public EmptySignal(ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("EnumerableBlendSignal: Sources = {Sources}")]
     public sealed class EnumerableBlendSignal<T> : System.IObservable<T>
     {
         public EnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -739,7 +748,14 @@ namespace ReactiveUI.Primitives.Advanced
     {
         public static System.IDisposable Attach<TEventHandler>(TEventHandler handler, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
+    [System.Diagnostics.DebuggerDisplay("EverySignal: Period = {_period}, Scheduler = {_scheduler}")]
+    public sealed class EverySignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
+    {
+        public EverySignal(System.TimeSpan period, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<long> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ExpireCoordinator: Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
     public sealed class ExpireCoordinator<T> : System.IDisposable, System.IObserver<T>
     {
         public ExpireCoordinator(System.IObservable<T> source, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer, System.IObserver<T> observer) { }
@@ -749,39 +765,48 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnNext(T value) { }
         public ReactiveUI.Primitives.Advanced.ExpireCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("ExpireSignal: DueTime = {_dueTime}, Source = {_source}")]
     public sealed class ExpireSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ExpireSignal(System.IObservable<T> source, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("FinallySignal: Source = {_source}")]
+    public sealed class FinallySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public FinallySignal(System.IObservable<T> source, System.Action finallyAction) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ForkJoinSignal: Left = {Left}, Right = {Right}")]
     public sealed class ForkJoinSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public ForkJoinSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("ForkJoinWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
     public sealed class ForkJoinWitness<TLeft, TRight, TResult>
     {
         public ForkJoinWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("CancellationRequested = {CancellationToken.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncExternalCancellationSignal: CancellationRequested = {CancellationToken.IsCancellationRequested}")]
     public sealed class FromAsyncExternalCancellationSignal<T> : System.IObservable<T>
     {
         public FromAsyncExternalCancellationSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSignal: TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
     public sealed class FromAsyncSignal<T> : System.IObservable<T>
     {
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSubscription: Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
     public sealed class FromAsyncSubscription<T> : System.IDisposable
     {
         public FromAsyncSubscription(System.IObserver<T> observer, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
@@ -794,14 +819,14 @@ namespace ReactiveUI.Primitives.Advanced
         public FromEventConversionSignal(System.Func<TCallback, TEventHandler> conversion, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Func<System.IObserver<TResult>, TCallback> callback, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
+    [System.Diagnostics.DebuggerDisplay("FromEventPatternSignal: AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
     public sealed class FromEventPatternSignal<TEventHandler, TEventArgs> : System.IObservable<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> where TEventHandler : System.Delegate where TEventArgs : System.EventArgs
     {
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler) { }
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Disposed = {_disposed}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("GuardedWitness: Disposed = {_disposed}, Observer = {_observer}")]
     public sealed class GuardedWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public GuardedWitness(System.IObserver<T> observer, System.IDisposable cancel) { }
@@ -811,7 +836,7 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IgnoreValuesSignal: Source = {Source}")]
     public sealed class IgnoreValuesSignal<T> : System.IObservable<T>
     {
         public IgnoreValuesSignal(System.IObservable<T> source) { }
@@ -825,14 +850,14 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.RxVoid> observer) { }
         public System.IDisposable Subscribe(System.Action<ReactiveUI.Primitives.RxVoid> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptySignal: Source = {Source}")]
     public sealed class IsEmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<bool>
     {
         public IsEmptySignal(System.IObservable<T> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<bool> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptyWitness: Stopped = {_stopped}, Subscription = {Subscription}")]
     public sealed class IsEmptyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public IsEmptyWitness(System.IObserver<bool> observer) { }
@@ -845,14 +870,23 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {Value}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("LeadSignal: Value = {Value}, Source = {Source}")]
     public sealed class LeadSignal<T> : ReactiveUI.Primitives.Advanced.IInlineSignal<T>
     {
         public LeadSignal(System.IObservable<T> source, T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
         public System.IDisposable Subscribe(System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("LoopSignal: Value = {Value}")]
+    public sealed class LoopSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public LoopSignal(T value) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("MapIndexedSignal: Source = {_source}")]
     public sealed class MapIndexedSignal<TSource, TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public MapIndexedSignal(System.IObservable<TSource> source, System.Func<TSource, int, TResult> selector) { }
@@ -860,7 +894,7 @@ namespace ReactiveUI.Primitives.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Index = {_index}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("MapIndexedWitness: Index = {_index}, Stopped = {_stopped}")]
     public sealed class MapIndexedWitness<TSource, TResult> : System.IObserver<TSource>
     {
         public MapIndexedWitness(System.IObserver<TResult> observer, System.Func<TSource, int, TResult> selector) { }
@@ -868,20 +902,20 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(TSource value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentBlendCoordinator: Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
     public sealed class MaxConcurrentBlendCoordinator<T> : System.IDisposable
     {
         public MaxConcurrentBlendCoordinator(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.MaxConcurrentBlendCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentEnumerableBlendSignal: Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
     public sealed class MaxConcurrentEnumerableBlendSignal<T> : System.IObservable<T>
     {
         public MaxConcurrentEnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("MergeCoordinator: Active = {Active}, Done = {Done}")]
     public sealed class MergeCoordinator<T> : System.IDisposable
     {
         public MergeCoordinator(System.IObserver<T> observer) { }
@@ -892,7 +926,7 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.MergeCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.MergeCoordinator<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MergeSignal: Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
     public sealed class MergeSignal<T> : System.IObservable<T>
     {
         public MergeSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -900,32 +934,39 @@ namespace ReactiveUI.Primitives.Advanced
         public MergeSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("OnErrorResumeNextSignal: Sources = {_sources}")]
+    public sealed class OnErrorResumeNextSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("PairSignal: Left = {Left}, Right = {Right}")]
     public sealed class PairSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public PairSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
+    [System.Diagnostics.DebuggerDisplay("PairWitness: IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
     public sealed class PairWitness<TLeft, TRight, TResult>
     {
         public PairWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("PublishSelectorSignal: Source = {Source}, Selector = {Selector}")]
     public sealed class PublishSelectorSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public PublishSelectorSignal(System.IObservable<TSource> source, System.Func<System.IObservable<TSource>, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
+    [System.Diagnostics.DebuggerDisplay("RaceSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
     public sealed class RaceSignal<T> : System.IObservable<T>
     {
         public RaceSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public RaceSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Arms = {_arms}")]
+    [System.Diagnostics.DebuggerDisplay("RaceWitness: Arms = {_arms}")]
     public sealed class RaceWitness<T> : System.IDisposable
     {
         public RaceWitness(System.IObserver<T> observer) { }
@@ -934,40 +975,48 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.RaceWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.RaceWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeCombineLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeCombineLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeCombineLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
+    [System.Diagnostics.DebuggerDisplay("RangeForkJoinSignal: Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
     public sealed class RangeForkJoinSignal<TResult> : System.IObservable<TResult>
     {
         public RangeForkJoinSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeSyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeSyncLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeSyncLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeWithLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeWithLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeWithLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Remaining = {_remaining}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("RecoverSignal: Source = {_source}")]
+    public sealed class RecoverSignal<T, TException> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T> where TException : System.Exception
+    {
+        public RecoverSignal(System.IObservable<T> source, System.Func<TException, System.IObservable<T>> handler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceCoordinator: Remaining = {_remaining}, Disposed = {_disposed}")]
     public sealed class RepeatSourceCoordinator<T> : System.IDisposable
     {
         public RepeatSourceCoordinator(System.IObservable<T> source, int? repeatCount, System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.RepeatSourceCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, RepeatCount = {_repeatCount}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceSignal: Source = {_source}, RepeatCount = {_repeatCount}")]
     public sealed class RepeatSourceSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public RepeatSourceSignal(System.IObservable<T> source, int? repeatCount) { }
@@ -975,7 +1024,7 @@ namespace ReactiveUI.Primitives.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Generation = {_generation}, Terminated = {_terminated}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceWitness: Generation = {_generation}, Terminated = {_terminated}")]
     public sealed class RepeatSourceWitness<T> : System.IObserver<T>
     {
         public RepeatSourceWitness(ReactiveUI.Primitives.Advanced.RepeatSourceCoordinator<T> parent, int generation) { }
@@ -983,7 +1032,15 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_value}, Scheduler = {_scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ResumeSignal: Source = {_source}, Fallback = {_fallback}")]
+    public sealed class ResumeSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ResumeSignal(System.IObservable<T> source, System.IObservable<T> fallback) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ReturnSignal: Value = {_value}, Scheduler = {_scheduler}")]
     public sealed class ReturnSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ReturnSignal(T value, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -992,13 +1049,13 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Values = {Values}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledEnumerableSignal: Values = {Values}, Scheduler = {Scheduler}")]
     public sealed class ScheduledEnumerableSignal<T> : System.IObservable<T>
     {
         public ScheduledEnumerableSignal(System.Collections.Generic.IEnumerable<T> values, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyCoordinator<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TResult>> selector) { }
@@ -1012,13 +1069,13 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Advanced.SelectManyCoordinator<TSource, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableSignal: Source = {_source}")]
     public sealed class SelectManyEnumerableSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManyEnumerableSignal(System.IObservable<TSource> source, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SelectManyEnumerableWitness<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyEnumerableWitness(System.IObserver<TResult> observer, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
@@ -1032,7 +1089,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyResultCoordinator<TSource, TCollection, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyResultCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
@@ -1045,20 +1102,20 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Advanced.SelectManyResultCoordinator<TSource, TCollection, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, CollectionSelector = {CollectionSelector}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultSignal: Source = {Source}, CollectionSelector = {CollectionSelector}")]
     public sealed class SelectManyResultSignal<TSource, TCollection, TResult> : System.IObservable<TResult>
     {
         public SelectManyResultSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManySignal: Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
     public sealed class SelectManySignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManySignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public SelectManySignal(System.IObservable<TSource> source, System.IObservable<TResult> inner) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Start = {Start}, Count = {Count}")]
+    [System.Diagnostics.DebuggerDisplay("SequenceSignal: Start = {Start}, Count = {Count}")]
     public sealed class SequenceSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<int>
     {
         public SequenceSignal(int start, int count, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -1069,13 +1126,13 @@ namespace ReactiveUI.Primitives.Advanced
     {
         public static System.IDisposable Subscribe<T>(System.IObserver<T> observer, bool currentThreadRequired, System.Func<System.IObserver<T>, System.IDisposable, System.IDisposable> subscribeCore) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SparkSignal: Source = {Source}")]
     public sealed class SparkSignal<T> : System.IObservable<ReactiveUI.Primitives.Core.Spark<T>>
     {
         public SparkSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.Spark<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SparkWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SparkWitness(System.IObserver<ReactiveUI.Primitives.Core.Spark<T>> observer) { }
@@ -1090,21 +1147,21 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Action = {Action}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Action = {Action}, Scheduler = {Scheduler}")]
     public sealed class StartSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<ReactiveUI.Primitives.RxVoid>
     {
         public StartSignal(System.Action action, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.RxVoid> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Function = {Function}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Function = {Function}, Scheduler = {Scheduler}")]
     public sealed class StartSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public StartSignal(System.Func<T> function, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SubscribeSafeWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SubscribeSafeWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SubscribeSafeWitness(System.IObserver<T> observer) { }
@@ -1118,50 +1175,50 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, SkipNullSources = {_skipNullSources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchMapSignal: Source = {_source}, SkipNullSources = {_skipNullSources}")]
     public sealed class SwitchMapSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SwitchMapSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchSignal: Sources = {Sources}")]
     public sealed class SwitchSignal<T> : System.IObservable<T>
     {
         public SwitchSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Version = {_version}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchWitness: Version = {_version}, IsDone = {IsDone}")]
     public sealed class SwitchWitness<T> : System.IDisposable
     {
         public SwitchWitness(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.SwitchWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class SyncLatestSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public SyncLatestSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
     public sealed class SyncLatestWitness<TLeft, TRight, TResult>
     {
         public SyncLatestWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Gate = {Gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeGateSignal: Source = {Source}, Gate = {Gate}")]
     public sealed class SynchronizeGateSignal<T> : System.IObservable<T>
     {
         public SynchronizeGateSignal(System.IObservable<T> source, System.Threading.Lock gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, Gate = {_gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectSignal: Source = {_source}, Gate = {_gate}")]
     public sealed class SynchronizeObjectSignal<T> : System.IObservable<T>
     {
         public SynchronizeObjectSignal(System.IObservable<T> source, object gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SynchronizeObjectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SynchronizeObjectWitness(System.IObserver<T> observer, object gate) { }
@@ -1173,19 +1230,19 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeSignal: Source = {Source}")]
     public sealed class SynchronizeSignal<T> : System.IObservable<T>
     {
         public SynchronizeSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("TapSignal: Source = {Source}")]
     public sealed class TapSignal<T> : System.IObservable<T>
     {
         public TapSignal(System.IObservable<T> source, System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskAnyWitness: Stopped = {_stopped}, Task = {Task}")]
     public sealed class TaskAnyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskAnyWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1201,7 +1258,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainCoordinator: Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
     public sealed class TaskChainCoordinator<T> : System.IDisposable
     {
         public TaskChainCoordinator(System.IObserver<T> observer) { }
@@ -1209,13 +1266,13 @@ namespace ReactiveUI.Primitives.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.TaskChainCoordinator<T> Run(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainSignal: Sources = {_sources}")]
     public sealed class TaskChainSignal<T> : System.IObservable<T>
     {
         public TaskChainSignal(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskCountWitness: Count = {_count}, Stopped = {_stopped}")]
     public sealed class TaskCountWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskCountWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1231,13 +1288,13 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSignal: Task = {Task}")]
     public sealed class TaskInstanceSignal<T> : System.IObservable<T>
     {
         public TaskInstanceSignal(System.Threading.Tasks.Task<T> task) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSubscription: Stopped = {_stopped}")]
     public sealed class TaskInstanceSubscription : System.IDisposable
     {
         public TaskInstanceSubscription() { }
@@ -1245,13 +1302,22 @@ namespace ReactiveUI.Primitives.Advanced
         public void Dispose() { }
         public bool TryStop() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Sequencer = {Sequencer}")]
+    [System.Diagnostics.DebuggerDisplay("ThrowSignal: Error = {_error}, Scheduler = {_scheduler}")]
+    public sealed class ThrowSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ThrowSignal(System.Exception error, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalSignal: Source = {Source}, Sequencer = {Sequencer}")]
     public sealed class TimeIntervalSignal<T> : System.IObservable<ReactiveUI.Primitives.Core.TimeInterval<T>>
     {
         public TimeIntervalSignal(System.IObservable<T> source, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("First = {_first}, Last = {_last}")]
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalWitness: First = {_first}, Last = {_last}")]
     public sealed class TimeIntervalWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TimeIntervalWitness(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -1269,13 +1335,13 @@ namespace ReactiveUI.Primitives.Advanced
     {
         public static void Arm(ReactiveUI.Primitives.Disposables.SingleReplaceableDisposable slot, ReactiveUI.Primitives.Concurrency.ISequencer sequencer, System.TimeSpan delay, System.Action tick) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkSignal: Source = {Source}")]
     public sealed class UnsparkSignal<T> : System.IObservable<T>
     {
         public UnsparkSignal(System.IObservable<ReactiveUI.Primitives.Core.Spark<T>> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class UnsparkWitness<T> : System.IDisposable, System.IObserver<ReactiveUI.Primitives.Core.Spark<T>>
     {
         public UnsparkWitness(System.IObserver<T> observer) { }
@@ -1872,7 +1938,7 @@ namespace ReactiveUI.Primitives.Extensions.Operators
 }
 namespace ReactiveUI.Primitives.Signals
 {
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
+    [System.Diagnostics.DebuggerDisplay("PrioritySemaphoreSignal: Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
     public sealed class PrioritySemaphoreSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T> where T : System.IComparable<T>
     {
         public PrioritySemaphoreSignal(int maxCount) { }
@@ -1907,7 +1973,7 @@ namespace ReactiveUI.Primitives.Signals
         public void OnNext(T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledSignal: Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
     public class ScheduledSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T>
     {
         public ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }

--- a/src/ReactiveUI.Primitives/PublicAPI/net10.0-ios/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net10.0-ios/PublicAPI.txt
@@ -514,7 +514,7 @@ namespace ReactiveUI.Primitives
 }
 namespace ReactiveUI.Primitives.Advanced
 {
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Period = {_period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSignal: DueTime = {_dueTime}, Period = {_period}")]
     public sealed class AfterSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
     {
         public AfterSignal(System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -522,7 +522,7 @@ namespace ReactiveUI.Primitives.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<long> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSubscription: Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
     public sealed class AfterSubscription : System.IDisposable
     {
         public AfterSubscription(System.IObserver<long> observer, ReactiveUI.Primitives.Concurrency.ISequencer scheduler, System.TimeSpan dueTime, System.TimeSpan? period) { }
@@ -530,21 +530,21 @@ namespace ReactiveUI.Primitives.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.AfterSubscription Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("SubscribeAsync = {SubscribeAsync}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncCreateSignal: SubscribeAsync = {SubscribeAsync}")]
     public sealed class AsyncCreateSignal<T> : System.IObservable<T>
     {
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ObservableFactory = {ObservableFactory}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncDeferSignal: ObservableFactory = {ObservableFactory}")]
     public sealed class AsyncDeferSignal<T> : System.IObservable<T>
     {
         public AsyncDeferSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public AsyncDeferSignal(System.Func<System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncSubscriptionLifetime: Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
     public sealed class AsyncSubscriptionLifetime : System.IDisposable
     {
         public AsyncSubscriptionLifetime() { }
@@ -555,33 +555,33 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable? disposable) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connected = {_connected}")]
+    [System.Diagnostics.DebuggerDisplay("AutoConnectSignal: Count = {_count}, Connected = {_connected}")]
     public sealed class AutoConnectSignal<T> : System.IObservable<T>
     {
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount) { }
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount, System.Action<System.IDisposable>? onConnect) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connection = {_connection}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSignal: Count = {_count}, Connection = {_connection}")]
     public sealed class AutoShareSignal<T> : System.IObservable<T>
     {
         public AutoShareSignal(ReactiveUI.Primitives.ConnectableSignal<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Owner = {_owner}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSubscription: Owner = {_owner}, Subscription = {Subscription}")]
     public sealed class AutoShareSubscription<T> : System.IDisposable
     {
         public AutoShareSubscription(ReactiveUI.Primitives.Advanced.AutoShareSignal<T> owner, System.IDisposable subscription) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void Dispose() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("BlendSignal: Sources = {Sources}")]
     public sealed class BlendSignal<T> : System.IObservable<T>
     {
         public BlendSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("BlendWitness: ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
     public sealed class BlendWitness<T> : System.IDisposable
     {
         public BlendWitness(System.IObserver<T> observer) { }
@@ -590,7 +590,7 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.BlendWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.BlendWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("BufferEachWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class BufferEachWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public BufferEachWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -604,20 +604,20 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Window = {Window}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("BufferSignal: Window = {Window}, Source = {Source}")]
     public sealed class BufferSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public BufferSignal(System.IObservable<T> source, System.TimeSpan timeSpan, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("CastSignal: Source = {Source}")]
     public sealed class CastSignal<TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public CastSignal(System.IObservable<object?> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CastWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CastWitness<TResult> : System.IDisposable, System.IObserver<object?>
     {
         public CastWitness(System.IObserver<TResult> observer) { }
@@ -631,7 +631,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
+    [System.Diagnostics.DebuggerDisplay("ChainSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
     public sealed class ChainSignal<T> : System.IObservable<T>
     {
         public ChainSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -639,7 +639,7 @@ namespace ReactiveUI.Primitives.Advanced
         public ChainSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("ChainWitness: IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
     public sealed class ChainWitness<T> : System.IDisposable
     {
         public ChainWitness(System.IObserver<T> observer) { }
@@ -649,13 +649,13 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.ChainWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.ChainWitness<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, TimeSpan = {TimeSpan}")]
+    [System.Diagnostics.DebuggerDisplay("CollectSignal: Source = {Source}, TimeSpan = {TimeSpan}")]
     public sealed class CollectSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public CollectSignal(System.IObservable<T> source, System.TimeSpan timeSpan, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Buffered = {Values.Count}")]
+    [System.Diagnostics.DebuggerDisplay("CollectWitness: Stopped = {_stopped}, Buffered = {Values.Count}")]
     public sealed class CollectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CollectWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -667,7 +667,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateSink: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class CreateSink<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateSink(System.IObserver<T> observer, bool disposeOnNextThrow) { }
@@ -679,7 +679,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CreateWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateWitness(System.IObserver<T> observer) { }
@@ -693,7 +693,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
+    [System.Diagnostics.DebuggerDisplay("DispatchSequencerState: ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
     public record struct DispatchSequencerState : System.IEquatable<ReactiveUI.Primitives.Advanced.DispatchSequencerState>
     {
         public DispatchSequencerState(ReactiveUI.Primitives.Concurrency.ISequencer owner, System.Func<System.Action, bool> post, System.Action drain) { }
@@ -708,13 +708,13 @@ namespace ReactiveUI.Primitives.Advanced
         public static System.TimeSpan DelayUntil(long dueTimestamp) { }
         public static void RunIfActive(ReactiveUI.Primitives.Concurrency.IWorkItem item) { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {DueTime}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietSignal: DueTime = {DueTime}, Source = {Source}")]
     public sealed class EmitIfQuietSignal<T> : System.IObservable<T>
     {
         public EmitIfQuietSignal(System.IObservable<T> source, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietWitness: HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
     public sealed class EmitIfQuietWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public EmitIfQuietWitness(System.IObserver<T> observer, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
@@ -725,7 +725,16 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("EmptySignal: Scheduler = {_scheduler}")]
+    public sealed class EmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public EmptySignal(ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("EnumerableBlendSignal: Sources = {Sources}")]
     public sealed class EnumerableBlendSignal<T> : System.IObservable<T>
     {
         public EnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -735,7 +744,14 @@ namespace ReactiveUI.Primitives.Advanced
     {
         public static System.IDisposable Attach<TEventHandler>(TEventHandler handler, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
+    [System.Diagnostics.DebuggerDisplay("EverySignal: Period = {_period}, Scheduler = {_scheduler}")]
+    public sealed class EverySignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
+    {
+        public EverySignal(System.TimeSpan period, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<long> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ExpireCoordinator: Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
     public sealed class ExpireCoordinator<T> : System.IDisposable, System.IObserver<T>
     {
         public ExpireCoordinator(System.IObservable<T> source, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer, System.IObserver<T> observer) { }
@@ -745,39 +761,48 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnNext(T value) { }
         public ReactiveUI.Primitives.Advanced.ExpireCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("ExpireSignal: DueTime = {_dueTime}, Source = {_source}")]
     public sealed class ExpireSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ExpireSignal(System.IObservable<T> source, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("FinallySignal: Source = {_source}")]
+    public sealed class FinallySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public FinallySignal(System.IObservable<T> source, System.Action finallyAction) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ForkJoinSignal: Left = {Left}, Right = {Right}")]
     public sealed class ForkJoinSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public ForkJoinSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("ForkJoinWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
     public sealed class ForkJoinWitness<TLeft, TRight, TResult>
     {
         public ForkJoinWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("CancellationRequested = {CancellationToken.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncExternalCancellationSignal: CancellationRequested = {CancellationToken.IsCancellationRequested}")]
     public sealed class FromAsyncExternalCancellationSignal<T> : System.IObservable<T>
     {
         public FromAsyncExternalCancellationSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSignal: TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
     public sealed class FromAsyncSignal<T> : System.IObservable<T>
     {
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSubscription: Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
     public sealed class FromAsyncSubscription<T> : System.IDisposable
     {
         public FromAsyncSubscription(System.IObserver<T> observer, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
@@ -790,14 +815,14 @@ namespace ReactiveUI.Primitives.Advanced
         public FromEventConversionSignal(System.Func<TCallback, TEventHandler> conversion, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Func<System.IObserver<TResult>, TCallback> callback, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
+    [System.Diagnostics.DebuggerDisplay("FromEventPatternSignal: AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
     public sealed class FromEventPatternSignal<TEventHandler, TEventArgs> : System.IObservable<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> where TEventHandler : System.Delegate where TEventArgs : System.EventArgs
     {
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler) { }
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Disposed = {_disposed}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("GuardedWitness: Disposed = {_disposed}, Observer = {_observer}")]
     public sealed class GuardedWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public GuardedWitness(System.IObserver<T> observer, System.IDisposable cancel) { }
@@ -807,7 +832,7 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IgnoreValuesSignal: Source = {Source}")]
     public sealed class IgnoreValuesSignal<T> : System.IObservable<T>
     {
         public IgnoreValuesSignal(System.IObservable<T> source) { }
@@ -821,14 +846,14 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.RxVoid> observer) { }
         public System.IDisposable Subscribe(System.Action<ReactiveUI.Primitives.RxVoid> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptySignal: Source = {Source}")]
     public sealed class IsEmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<bool>
     {
         public IsEmptySignal(System.IObservable<T> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<bool> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptyWitness: Stopped = {_stopped}, Subscription = {Subscription}")]
     public sealed class IsEmptyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public IsEmptyWitness(System.IObserver<bool> observer) { }
@@ -841,14 +866,23 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {Value}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("LeadSignal: Value = {Value}, Source = {Source}")]
     public sealed class LeadSignal<T> : ReactiveUI.Primitives.Advanced.IInlineSignal<T>
     {
         public LeadSignal(System.IObservable<T> source, T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
         public System.IDisposable Subscribe(System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("LoopSignal: Value = {Value}")]
+    public sealed class LoopSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public LoopSignal(T value) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("MapIndexedSignal: Source = {_source}")]
     public sealed class MapIndexedSignal<TSource, TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public MapIndexedSignal(System.IObservable<TSource> source, System.Func<TSource, int, TResult> selector) { }
@@ -856,7 +890,7 @@ namespace ReactiveUI.Primitives.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Index = {_index}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("MapIndexedWitness: Index = {_index}, Stopped = {_stopped}")]
     public sealed class MapIndexedWitness<TSource, TResult> : System.IObserver<TSource>
     {
         public MapIndexedWitness(System.IObserver<TResult> observer, System.Func<TSource, int, TResult> selector) { }
@@ -864,20 +898,20 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(TSource value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentBlendCoordinator: Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
     public sealed class MaxConcurrentBlendCoordinator<T> : System.IDisposable
     {
         public MaxConcurrentBlendCoordinator(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.MaxConcurrentBlendCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentEnumerableBlendSignal: Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
     public sealed class MaxConcurrentEnumerableBlendSignal<T> : System.IObservable<T>
     {
         public MaxConcurrentEnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("MergeCoordinator: Active = {Active}, Done = {Done}")]
     public sealed class MergeCoordinator<T> : System.IDisposable
     {
         public MergeCoordinator(System.IObserver<T> observer) { }
@@ -888,7 +922,7 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.MergeCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.MergeCoordinator<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MergeSignal: Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
     public sealed class MergeSignal<T> : System.IObservable<T>
     {
         public MergeSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -896,32 +930,39 @@ namespace ReactiveUI.Primitives.Advanced
         public MergeSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("OnErrorResumeNextSignal: Sources = {_sources}")]
+    public sealed class OnErrorResumeNextSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("PairSignal: Left = {Left}, Right = {Right}")]
     public sealed class PairSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public PairSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
+    [System.Diagnostics.DebuggerDisplay("PairWitness: IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
     public sealed class PairWitness<TLeft, TRight, TResult>
     {
         public PairWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("PublishSelectorSignal: Source = {Source}, Selector = {Selector}")]
     public sealed class PublishSelectorSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public PublishSelectorSignal(System.IObservable<TSource> source, System.Func<System.IObservable<TSource>, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
+    [System.Diagnostics.DebuggerDisplay("RaceSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
     public sealed class RaceSignal<T> : System.IObservable<T>
     {
         public RaceSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public RaceSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Arms = {_arms}")]
+    [System.Diagnostics.DebuggerDisplay("RaceWitness: Arms = {_arms}")]
     public sealed class RaceWitness<T> : System.IDisposable
     {
         public RaceWitness(System.IObserver<T> observer) { }
@@ -930,40 +971,48 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.RaceWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.RaceWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeCombineLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeCombineLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeCombineLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
+    [System.Diagnostics.DebuggerDisplay("RangeForkJoinSignal: Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
     public sealed class RangeForkJoinSignal<TResult> : System.IObservable<TResult>
     {
         public RangeForkJoinSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeSyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeSyncLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeSyncLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeWithLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeWithLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeWithLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Remaining = {_remaining}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("RecoverSignal: Source = {_source}")]
+    public sealed class RecoverSignal<T, TException> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T> where TException : System.Exception
+    {
+        public RecoverSignal(System.IObservable<T> source, System.Func<TException, System.IObservable<T>> handler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceCoordinator: Remaining = {_remaining}, Disposed = {_disposed}")]
     public sealed class RepeatSourceCoordinator<T> : System.IDisposable
     {
         public RepeatSourceCoordinator(System.IObservable<T> source, int? repeatCount, System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.RepeatSourceCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, RepeatCount = {_repeatCount}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceSignal: Source = {_source}, RepeatCount = {_repeatCount}")]
     public sealed class RepeatSourceSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public RepeatSourceSignal(System.IObservable<T> source, int? repeatCount) { }
@@ -971,7 +1020,7 @@ namespace ReactiveUI.Primitives.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Generation = {_generation}, Terminated = {_terminated}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceWitness: Generation = {_generation}, Terminated = {_terminated}")]
     public sealed class RepeatSourceWitness<T> : System.IObserver<T>
     {
         public RepeatSourceWitness(ReactiveUI.Primitives.Advanced.RepeatSourceCoordinator<T> parent, int generation) { }
@@ -979,7 +1028,15 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_value}, Scheduler = {_scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ResumeSignal: Source = {_source}, Fallback = {_fallback}")]
+    public sealed class ResumeSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ResumeSignal(System.IObservable<T> source, System.IObservable<T> fallback) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ReturnSignal: Value = {_value}, Scheduler = {_scheduler}")]
     public sealed class ReturnSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ReturnSignal(T value, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -988,13 +1045,13 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Values = {Values}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledEnumerableSignal: Values = {Values}, Scheduler = {Scheduler}")]
     public sealed class ScheduledEnumerableSignal<T> : System.IObservable<T>
     {
         public ScheduledEnumerableSignal(System.Collections.Generic.IEnumerable<T> values, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyCoordinator<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TResult>> selector) { }
@@ -1008,13 +1065,13 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Advanced.SelectManyCoordinator<TSource, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableSignal: Source = {_source}")]
     public sealed class SelectManyEnumerableSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManyEnumerableSignal(System.IObservable<TSource> source, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SelectManyEnumerableWitness<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyEnumerableWitness(System.IObserver<TResult> observer, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
@@ -1028,7 +1085,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyResultCoordinator<TSource, TCollection, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyResultCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
@@ -1041,20 +1098,20 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Advanced.SelectManyResultCoordinator<TSource, TCollection, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, CollectionSelector = {CollectionSelector}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultSignal: Source = {Source}, CollectionSelector = {CollectionSelector}")]
     public sealed class SelectManyResultSignal<TSource, TCollection, TResult> : System.IObservable<TResult>
     {
         public SelectManyResultSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManySignal: Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
     public sealed class SelectManySignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManySignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public SelectManySignal(System.IObservable<TSource> source, System.IObservable<TResult> inner) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Start = {Start}, Count = {Count}")]
+    [System.Diagnostics.DebuggerDisplay("SequenceSignal: Start = {Start}, Count = {Count}")]
     public sealed class SequenceSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<int>
     {
         public SequenceSignal(int start, int count, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -1065,13 +1122,13 @@ namespace ReactiveUI.Primitives.Advanced
     {
         public static System.IDisposable Subscribe<T>(System.IObserver<T> observer, bool currentThreadRequired, System.Func<System.IObserver<T>, System.IDisposable, System.IDisposable> subscribeCore) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SparkSignal: Source = {Source}")]
     public sealed class SparkSignal<T> : System.IObservable<ReactiveUI.Primitives.Core.Spark<T>>
     {
         public SparkSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.Spark<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SparkWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SparkWitness(System.IObserver<ReactiveUI.Primitives.Core.Spark<T>> observer) { }
@@ -1086,21 +1143,21 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Action = {Action}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Action = {Action}, Scheduler = {Scheduler}")]
     public sealed class StartSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<ReactiveUI.Primitives.RxVoid>
     {
         public StartSignal(System.Action action, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.RxVoid> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Function = {Function}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Function = {Function}, Scheduler = {Scheduler}")]
     public sealed class StartSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public StartSignal(System.Func<T> function, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SubscribeSafeWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SubscribeSafeWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SubscribeSafeWitness(System.IObserver<T> observer) { }
@@ -1114,50 +1171,50 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, SkipNullSources = {_skipNullSources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchMapSignal: Source = {_source}, SkipNullSources = {_skipNullSources}")]
     public sealed class SwitchMapSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SwitchMapSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchSignal: Sources = {Sources}")]
     public sealed class SwitchSignal<T> : System.IObservable<T>
     {
         public SwitchSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Version = {_version}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchWitness: Version = {_version}, IsDone = {IsDone}")]
     public sealed class SwitchWitness<T> : System.IDisposable
     {
         public SwitchWitness(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.SwitchWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class SyncLatestSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public SyncLatestSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
     public sealed class SyncLatestWitness<TLeft, TRight, TResult>
     {
         public SyncLatestWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Gate = {Gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeGateSignal: Source = {Source}, Gate = {Gate}")]
     public sealed class SynchronizeGateSignal<T> : System.IObservable<T>
     {
         public SynchronizeGateSignal(System.IObservable<T> source, System.Threading.Lock gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, Gate = {_gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectSignal: Source = {_source}, Gate = {_gate}")]
     public sealed class SynchronizeObjectSignal<T> : System.IObservable<T>
     {
         public SynchronizeObjectSignal(System.IObservable<T> source, object gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SynchronizeObjectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SynchronizeObjectWitness(System.IObserver<T> observer, object gate) { }
@@ -1169,19 +1226,19 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeSignal: Source = {Source}")]
     public sealed class SynchronizeSignal<T> : System.IObservable<T>
     {
         public SynchronizeSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("TapSignal: Source = {Source}")]
     public sealed class TapSignal<T> : System.IObservable<T>
     {
         public TapSignal(System.IObservable<T> source, System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskAnyWitness: Stopped = {_stopped}, Task = {Task}")]
     public sealed class TaskAnyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskAnyWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1197,7 +1254,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainCoordinator: Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
     public sealed class TaskChainCoordinator<T> : System.IDisposable
     {
         public TaskChainCoordinator(System.IObserver<T> observer) { }
@@ -1205,13 +1262,13 @@ namespace ReactiveUI.Primitives.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.TaskChainCoordinator<T> Run(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainSignal: Sources = {_sources}")]
     public sealed class TaskChainSignal<T> : System.IObservable<T>
     {
         public TaskChainSignal(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskCountWitness: Count = {_count}, Stopped = {_stopped}")]
     public sealed class TaskCountWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskCountWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1227,13 +1284,13 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSignal: Task = {Task}")]
     public sealed class TaskInstanceSignal<T> : System.IObservable<T>
     {
         public TaskInstanceSignal(System.Threading.Tasks.Task<T> task) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSubscription: Stopped = {_stopped}")]
     public sealed class TaskInstanceSubscription : System.IDisposable
     {
         public TaskInstanceSubscription() { }
@@ -1241,13 +1298,22 @@ namespace ReactiveUI.Primitives.Advanced
         public void Dispose() { }
         public bool TryStop() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Sequencer = {Sequencer}")]
+    [System.Diagnostics.DebuggerDisplay("ThrowSignal: Error = {_error}, Scheduler = {_scheduler}")]
+    public sealed class ThrowSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ThrowSignal(System.Exception error, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalSignal: Source = {Source}, Sequencer = {Sequencer}")]
     public sealed class TimeIntervalSignal<T> : System.IObservable<ReactiveUI.Primitives.Core.TimeInterval<T>>
     {
         public TimeIntervalSignal(System.IObservable<T> source, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("First = {_first}, Last = {_last}")]
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalWitness: First = {_first}, Last = {_last}")]
     public sealed class TimeIntervalWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TimeIntervalWitness(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -1265,13 +1331,13 @@ namespace ReactiveUI.Primitives.Advanced
     {
         public static void Arm(ReactiveUI.Primitives.Disposables.SingleReplaceableDisposable slot, ReactiveUI.Primitives.Concurrency.ISequencer sequencer, System.TimeSpan delay, System.Action tick) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkSignal: Source = {Source}")]
     public sealed class UnsparkSignal<T> : System.IObservable<T>
     {
         public UnsparkSignal(System.IObservable<ReactiveUI.Primitives.Core.Spark<T>> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class UnsparkWitness<T> : System.IDisposable, System.IObserver<ReactiveUI.Primitives.Core.Spark<T>>
     {
         public UnsparkWitness(System.IObserver<T> observer) { }
@@ -1866,7 +1932,7 @@ namespace ReactiveUI.Primitives.Extensions.Operators
 }
 namespace ReactiveUI.Primitives.Signals
 {
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
+    [System.Diagnostics.DebuggerDisplay("PrioritySemaphoreSignal: Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
     public sealed class PrioritySemaphoreSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T> where T : System.IComparable<T>
     {
         public PrioritySemaphoreSignal(int maxCount) { }
@@ -1901,7 +1967,7 @@ namespace ReactiveUI.Primitives.Signals
         public void OnNext(T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledSignal: Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
     public class ScheduledSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T>
     {
         public ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }

--- a/src/ReactiveUI.Primitives/PublicAPI/net10.0-maccatalyst/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net10.0-maccatalyst/PublicAPI.txt
@@ -514,7 +514,7 @@ namespace ReactiveUI.Primitives
 }
 namespace ReactiveUI.Primitives.Advanced
 {
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Period = {_period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSignal: DueTime = {_dueTime}, Period = {_period}")]
     public sealed class AfterSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
     {
         public AfterSignal(System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -522,7 +522,7 @@ namespace ReactiveUI.Primitives.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<long> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSubscription: Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
     public sealed class AfterSubscription : System.IDisposable
     {
         public AfterSubscription(System.IObserver<long> observer, ReactiveUI.Primitives.Concurrency.ISequencer scheduler, System.TimeSpan dueTime, System.TimeSpan? period) { }
@@ -530,21 +530,21 @@ namespace ReactiveUI.Primitives.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.AfterSubscription Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("SubscribeAsync = {SubscribeAsync}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncCreateSignal: SubscribeAsync = {SubscribeAsync}")]
     public sealed class AsyncCreateSignal<T> : System.IObservable<T>
     {
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ObservableFactory = {ObservableFactory}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncDeferSignal: ObservableFactory = {ObservableFactory}")]
     public sealed class AsyncDeferSignal<T> : System.IObservable<T>
     {
         public AsyncDeferSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public AsyncDeferSignal(System.Func<System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncSubscriptionLifetime: Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
     public sealed class AsyncSubscriptionLifetime : System.IDisposable
     {
         public AsyncSubscriptionLifetime() { }
@@ -555,33 +555,33 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable? disposable) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connected = {_connected}")]
+    [System.Diagnostics.DebuggerDisplay("AutoConnectSignal: Count = {_count}, Connected = {_connected}")]
     public sealed class AutoConnectSignal<T> : System.IObservable<T>
     {
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount) { }
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount, System.Action<System.IDisposable>? onConnect) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connection = {_connection}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSignal: Count = {_count}, Connection = {_connection}")]
     public sealed class AutoShareSignal<T> : System.IObservable<T>
     {
         public AutoShareSignal(ReactiveUI.Primitives.ConnectableSignal<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Owner = {_owner}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSubscription: Owner = {_owner}, Subscription = {Subscription}")]
     public sealed class AutoShareSubscription<T> : System.IDisposable
     {
         public AutoShareSubscription(ReactiveUI.Primitives.Advanced.AutoShareSignal<T> owner, System.IDisposable subscription) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void Dispose() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("BlendSignal: Sources = {Sources}")]
     public sealed class BlendSignal<T> : System.IObservable<T>
     {
         public BlendSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("BlendWitness: ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
     public sealed class BlendWitness<T> : System.IDisposable
     {
         public BlendWitness(System.IObserver<T> observer) { }
@@ -590,7 +590,7 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.BlendWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.BlendWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("BufferEachWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class BufferEachWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public BufferEachWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -604,20 +604,20 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Window = {Window}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("BufferSignal: Window = {Window}, Source = {Source}")]
     public sealed class BufferSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public BufferSignal(System.IObservable<T> source, System.TimeSpan timeSpan, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("CastSignal: Source = {Source}")]
     public sealed class CastSignal<TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public CastSignal(System.IObservable<object?> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CastWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CastWitness<TResult> : System.IDisposable, System.IObserver<object?>
     {
         public CastWitness(System.IObserver<TResult> observer) { }
@@ -631,7 +631,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
+    [System.Diagnostics.DebuggerDisplay("ChainSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
     public sealed class ChainSignal<T> : System.IObservable<T>
     {
         public ChainSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -639,7 +639,7 @@ namespace ReactiveUI.Primitives.Advanced
         public ChainSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("ChainWitness: IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
     public sealed class ChainWitness<T> : System.IDisposable
     {
         public ChainWitness(System.IObserver<T> observer) { }
@@ -649,13 +649,13 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.ChainWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.ChainWitness<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, TimeSpan = {TimeSpan}")]
+    [System.Diagnostics.DebuggerDisplay("CollectSignal: Source = {Source}, TimeSpan = {TimeSpan}")]
     public sealed class CollectSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public CollectSignal(System.IObservable<T> source, System.TimeSpan timeSpan, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Buffered = {Values.Count}")]
+    [System.Diagnostics.DebuggerDisplay("CollectWitness: Stopped = {_stopped}, Buffered = {Values.Count}")]
     public sealed class CollectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CollectWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -667,7 +667,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateSink: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class CreateSink<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateSink(System.IObserver<T> observer, bool disposeOnNextThrow) { }
@@ -679,7 +679,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CreateWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateWitness(System.IObserver<T> observer) { }
@@ -693,7 +693,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
+    [System.Diagnostics.DebuggerDisplay("DispatchSequencerState: ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
     public record struct DispatchSequencerState : System.IEquatable<ReactiveUI.Primitives.Advanced.DispatchSequencerState>
     {
         public DispatchSequencerState(ReactiveUI.Primitives.Concurrency.ISequencer owner, System.Func<System.Action, bool> post, System.Action drain) { }
@@ -708,13 +708,13 @@ namespace ReactiveUI.Primitives.Advanced
         public static System.TimeSpan DelayUntil(long dueTimestamp) { }
         public static void RunIfActive(ReactiveUI.Primitives.Concurrency.IWorkItem item) { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {DueTime}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietSignal: DueTime = {DueTime}, Source = {Source}")]
     public sealed class EmitIfQuietSignal<T> : System.IObservable<T>
     {
         public EmitIfQuietSignal(System.IObservable<T> source, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietWitness: HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
     public sealed class EmitIfQuietWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public EmitIfQuietWitness(System.IObserver<T> observer, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
@@ -725,7 +725,16 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("EmptySignal: Scheduler = {_scheduler}")]
+    public sealed class EmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public EmptySignal(ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("EnumerableBlendSignal: Sources = {Sources}")]
     public sealed class EnumerableBlendSignal<T> : System.IObservable<T>
     {
         public EnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -735,7 +744,14 @@ namespace ReactiveUI.Primitives.Advanced
     {
         public static System.IDisposable Attach<TEventHandler>(TEventHandler handler, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
+    [System.Diagnostics.DebuggerDisplay("EverySignal: Period = {_period}, Scheduler = {_scheduler}")]
+    public sealed class EverySignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
+    {
+        public EverySignal(System.TimeSpan period, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<long> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ExpireCoordinator: Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
     public sealed class ExpireCoordinator<T> : System.IDisposable, System.IObserver<T>
     {
         public ExpireCoordinator(System.IObservable<T> source, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer, System.IObserver<T> observer) { }
@@ -745,39 +761,48 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnNext(T value) { }
         public ReactiveUI.Primitives.Advanced.ExpireCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("ExpireSignal: DueTime = {_dueTime}, Source = {_source}")]
     public sealed class ExpireSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ExpireSignal(System.IObservable<T> source, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("FinallySignal: Source = {_source}")]
+    public sealed class FinallySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public FinallySignal(System.IObservable<T> source, System.Action finallyAction) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ForkJoinSignal: Left = {Left}, Right = {Right}")]
     public sealed class ForkJoinSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public ForkJoinSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("ForkJoinWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
     public sealed class ForkJoinWitness<TLeft, TRight, TResult>
     {
         public ForkJoinWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("CancellationRequested = {CancellationToken.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncExternalCancellationSignal: CancellationRequested = {CancellationToken.IsCancellationRequested}")]
     public sealed class FromAsyncExternalCancellationSignal<T> : System.IObservable<T>
     {
         public FromAsyncExternalCancellationSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSignal: TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
     public sealed class FromAsyncSignal<T> : System.IObservable<T>
     {
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSubscription: Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
     public sealed class FromAsyncSubscription<T> : System.IDisposable
     {
         public FromAsyncSubscription(System.IObserver<T> observer, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
@@ -790,14 +815,14 @@ namespace ReactiveUI.Primitives.Advanced
         public FromEventConversionSignal(System.Func<TCallback, TEventHandler> conversion, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Func<System.IObserver<TResult>, TCallback> callback, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
+    [System.Diagnostics.DebuggerDisplay("FromEventPatternSignal: AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
     public sealed class FromEventPatternSignal<TEventHandler, TEventArgs> : System.IObservable<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> where TEventHandler : System.Delegate where TEventArgs : System.EventArgs
     {
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler) { }
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Disposed = {_disposed}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("GuardedWitness: Disposed = {_disposed}, Observer = {_observer}")]
     public sealed class GuardedWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public GuardedWitness(System.IObserver<T> observer, System.IDisposable cancel) { }
@@ -807,7 +832,7 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IgnoreValuesSignal: Source = {Source}")]
     public sealed class IgnoreValuesSignal<T> : System.IObservable<T>
     {
         public IgnoreValuesSignal(System.IObservable<T> source) { }
@@ -821,14 +846,14 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.RxVoid> observer) { }
         public System.IDisposable Subscribe(System.Action<ReactiveUI.Primitives.RxVoid> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptySignal: Source = {Source}")]
     public sealed class IsEmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<bool>
     {
         public IsEmptySignal(System.IObservable<T> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<bool> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptyWitness: Stopped = {_stopped}, Subscription = {Subscription}")]
     public sealed class IsEmptyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public IsEmptyWitness(System.IObserver<bool> observer) { }
@@ -841,14 +866,23 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {Value}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("LeadSignal: Value = {Value}, Source = {Source}")]
     public sealed class LeadSignal<T> : ReactiveUI.Primitives.Advanced.IInlineSignal<T>
     {
         public LeadSignal(System.IObservable<T> source, T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
         public System.IDisposable Subscribe(System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("LoopSignal: Value = {Value}")]
+    public sealed class LoopSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public LoopSignal(T value) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("MapIndexedSignal: Source = {_source}")]
     public sealed class MapIndexedSignal<TSource, TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public MapIndexedSignal(System.IObservable<TSource> source, System.Func<TSource, int, TResult> selector) { }
@@ -856,7 +890,7 @@ namespace ReactiveUI.Primitives.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Index = {_index}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("MapIndexedWitness: Index = {_index}, Stopped = {_stopped}")]
     public sealed class MapIndexedWitness<TSource, TResult> : System.IObserver<TSource>
     {
         public MapIndexedWitness(System.IObserver<TResult> observer, System.Func<TSource, int, TResult> selector) { }
@@ -864,20 +898,20 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(TSource value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentBlendCoordinator: Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
     public sealed class MaxConcurrentBlendCoordinator<T> : System.IDisposable
     {
         public MaxConcurrentBlendCoordinator(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.MaxConcurrentBlendCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentEnumerableBlendSignal: Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
     public sealed class MaxConcurrentEnumerableBlendSignal<T> : System.IObservable<T>
     {
         public MaxConcurrentEnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("MergeCoordinator: Active = {Active}, Done = {Done}")]
     public sealed class MergeCoordinator<T> : System.IDisposable
     {
         public MergeCoordinator(System.IObserver<T> observer) { }
@@ -888,7 +922,7 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.MergeCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.MergeCoordinator<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MergeSignal: Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
     public sealed class MergeSignal<T> : System.IObservable<T>
     {
         public MergeSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -896,32 +930,39 @@ namespace ReactiveUI.Primitives.Advanced
         public MergeSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("OnErrorResumeNextSignal: Sources = {_sources}")]
+    public sealed class OnErrorResumeNextSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("PairSignal: Left = {Left}, Right = {Right}")]
     public sealed class PairSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public PairSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
+    [System.Diagnostics.DebuggerDisplay("PairWitness: IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
     public sealed class PairWitness<TLeft, TRight, TResult>
     {
         public PairWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("PublishSelectorSignal: Source = {Source}, Selector = {Selector}")]
     public sealed class PublishSelectorSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public PublishSelectorSignal(System.IObservable<TSource> source, System.Func<System.IObservable<TSource>, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
+    [System.Diagnostics.DebuggerDisplay("RaceSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
     public sealed class RaceSignal<T> : System.IObservable<T>
     {
         public RaceSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public RaceSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Arms = {_arms}")]
+    [System.Diagnostics.DebuggerDisplay("RaceWitness: Arms = {_arms}")]
     public sealed class RaceWitness<T> : System.IDisposable
     {
         public RaceWitness(System.IObserver<T> observer) { }
@@ -930,40 +971,48 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.RaceWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.RaceWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeCombineLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeCombineLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeCombineLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
+    [System.Diagnostics.DebuggerDisplay("RangeForkJoinSignal: Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
     public sealed class RangeForkJoinSignal<TResult> : System.IObservable<TResult>
     {
         public RangeForkJoinSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeSyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeSyncLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeSyncLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeWithLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeWithLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeWithLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Remaining = {_remaining}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("RecoverSignal: Source = {_source}")]
+    public sealed class RecoverSignal<T, TException> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T> where TException : System.Exception
+    {
+        public RecoverSignal(System.IObservable<T> source, System.Func<TException, System.IObservable<T>> handler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceCoordinator: Remaining = {_remaining}, Disposed = {_disposed}")]
     public sealed class RepeatSourceCoordinator<T> : System.IDisposable
     {
         public RepeatSourceCoordinator(System.IObservable<T> source, int? repeatCount, System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.RepeatSourceCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, RepeatCount = {_repeatCount}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceSignal: Source = {_source}, RepeatCount = {_repeatCount}")]
     public sealed class RepeatSourceSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public RepeatSourceSignal(System.IObservable<T> source, int? repeatCount) { }
@@ -971,7 +1020,7 @@ namespace ReactiveUI.Primitives.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Generation = {_generation}, Terminated = {_terminated}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceWitness: Generation = {_generation}, Terminated = {_terminated}")]
     public sealed class RepeatSourceWitness<T> : System.IObserver<T>
     {
         public RepeatSourceWitness(ReactiveUI.Primitives.Advanced.RepeatSourceCoordinator<T> parent, int generation) { }
@@ -979,7 +1028,15 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_value}, Scheduler = {_scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ResumeSignal: Source = {_source}, Fallback = {_fallback}")]
+    public sealed class ResumeSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ResumeSignal(System.IObservable<T> source, System.IObservable<T> fallback) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ReturnSignal: Value = {_value}, Scheduler = {_scheduler}")]
     public sealed class ReturnSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ReturnSignal(T value, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -988,13 +1045,13 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Values = {Values}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledEnumerableSignal: Values = {Values}, Scheduler = {Scheduler}")]
     public sealed class ScheduledEnumerableSignal<T> : System.IObservable<T>
     {
         public ScheduledEnumerableSignal(System.Collections.Generic.IEnumerable<T> values, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyCoordinator<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TResult>> selector) { }
@@ -1008,13 +1065,13 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Advanced.SelectManyCoordinator<TSource, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableSignal: Source = {_source}")]
     public sealed class SelectManyEnumerableSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManyEnumerableSignal(System.IObservable<TSource> source, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SelectManyEnumerableWitness<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyEnumerableWitness(System.IObserver<TResult> observer, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
@@ -1028,7 +1085,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyResultCoordinator<TSource, TCollection, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyResultCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
@@ -1041,20 +1098,20 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Advanced.SelectManyResultCoordinator<TSource, TCollection, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, CollectionSelector = {CollectionSelector}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultSignal: Source = {Source}, CollectionSelector = {CollectionSelector}")]
     public sealed class SelectManyResultSignal<TSource, TCollection, TResult> : System.IObservable<TResult>
     {
         public SelectManyResultSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManySignal: Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
     public sealed class SelectManySignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManySignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public SelectManySignal(System.IObservable<TSource> source, System.IObservable<TResult> inner) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Start = {Start}, Count = {Count}")]
+    [System.Diagnostics.DebuggerDisplay("SequenceSignal: Start = {Start}, Count = {Count}")]
     public sealed class SequenceSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<int>
     {
         public SequenceSignal(int start, int count, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -1065,13 +1122,13 @@ namespace ReactiveUI.Primitives.Advanced
     {
         public static System.IDisposable Subscribe<T>(System.IObserver<T> observer, bool currentThreadRequired, System.Func<System.IObserver<T>, System.IDisposable, System.IDisposable> subscribeCore) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SparkSignal: Source = {Source}")]
     public sealed class SparkSignal<T> : System.IObservable<ReactiveUI.Primitives.Core.Spark<T>>
     {
         public SparkSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.Spark<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SparkWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SparkWitness(System.IObserver<ReactiveUI.Primitives.Core.Spark<T>> observer) { }
@@ -1086,21 +1143,21 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Action = {Action}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Action = {Action}, Scheduler = {Scheduler}")]
     public sealed class StartSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<ReactiveUI.Primitives.RxVoid>
     {
         public StartSignal(System.Action action, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.RxVoid> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Function = {Function}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Function = {Function}, Scheduler = {Scheduler}")]
     public sealed class StartSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public StartSignal(System.Func<T> function, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SubscribeSafeWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SubscribeSafeWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SubscribeSafeWitness(System.IObserver<T> observer) { }
@@ -1114,50 +1171,50 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, SkipNullSources = {_skipNullSources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchMapSignal: Source = {_source}, SkipNullSources = {_skipNullSources}")]
     public sealed class SwitchMapSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SwitchMapSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchSignal: Sources = {Sources}")]
     public sealed class SwitchSignal<T> : System.IObservable<T>
     {
         public SwitchSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Version = {_version}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchWitness: Version = {_version}, IsDone = {IsDone}")]
     public sealed class SwitchWitness<T> : System.IDisposable
     {
         public SwitchWitness(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.SwitchWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class SyncLatestSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public SyncLatestSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
     public sealed class SyncLatestWitness<TLeft, TRight, TResult>
     {
         public SyncLatestWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Gate = {Gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeGateSignal: Source = {Source}, Gate = {Gate}")]
     public sealed class SynchronizeGateSignal<T> : System.IObservable<T>
     {
         public SynchronizeGateSignal(System.IObservable<T> source, System.Threading.Lock gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, Gate = {_gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectSignal: Source = {_source}, Gate = {_gate}")]
     public sealed class SynchronizeObjectSignal<T> : System.IObservable<T>
     {
         public SynchronizeObjectSignal(System.IObservable<T> source, object gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SynchronizeObjectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SynchronizeObjectWitness(System.IObserver<T> observer, object gate) { }
@@ -1169,19 +1226,19 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeSignal: Source = {Source}")]
     public sealed class SynchronizeSignal<T> : System.IObservable<T>
     {
         public SynchronizeSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("TapSignal: Source = {Source}")]
     public sealed class TapSignal<T> : System.IObservable<T>
     {
         public TapSignal(System.IObservable<T> source, System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskAnyWitness: Stopped = {_stopped}, Task = {Task}")]
     public sealed class TaskAnyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskAnyWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1197,7 +1254,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainCoordinator: Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
     public sealed class TaskChainCoordinator<T> : System.IDisposable
     {
         public TaskChainCoordinator(System.IObserver<T> observer) { }
@@ -1205,13 +1262,13 @@ namespace ReactiveUI.Primitives.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.TaskChainCoordinator<T> Run(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainSignal: Sources = {_sources}")]
     public sealed class TaskChainSignal<T> : System.IObservable<T>
     {
         public TaskChainSignal(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskCountWitness: Count = {_count}, Stopped = {_stopped}")]
     public sealed class TaskCountWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskCountWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1227,13 +1284,13 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSignal: Task = {Task}")]
     public sealed class TaskInstanceSignal<T> : System.IObservable<T>
     {
         public TaskInstanceSignal(System.Threading.Tasks.Task<T> task) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSubscription: Stopped = {_stopped}")]
     public sealed class TaskInstanceSubscription : System.IDisposable
     {
         public TaskInstanceSubscription() { }
@@ -1241,13 +1298,22 @@ namespace ReactiveUI.Primitives.Advanced
         public void Dispose() { }
         public bool TryStop() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Sequencer = {Sequencer}")]
+    [System.Diagnostics.DebuggerDisplay("ThrowSignal: Error = {_error}, Scheduler = {_scheduler}")]
+    public sealed class ThrowSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ThrowSignal(System.Exception error, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalSignal: Source = {Source}, Sequencer = {Sequencer}")]
     public sealed class TimeIntervalSignal<T> : System.IObservable<ReactiveUI.Primitives.Core.TimeInterval<T>>
     {
         public TimeIntervalSignal(System.IObservable<T> source, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("First = {_first}, Last = {_last}")]
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalWitness: First = {_first}, Last = {_last}")]
     public sealed class TimeIntervalWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TimeIntervalWitness(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -1265,13 +1331,13 @@ namespace ReactiveUI.Primitives.Advanced
     {
         public static void Arm(ReactiveUI.Primitives.Disposables.SingleReplaceableDisposable slot, ReactiveUI.Primitives.Concurrency.ISequencer sequencer, System.TimeSpan delay, System.Action tick) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkSignal: Source = {Source}")]
     public sealed class UnsparkSignal<T> : System.IObservable<T>
     {
         public UnsparkSignal(System.IObservable<ReactiveUI.Primitives.Core.Spark<T>> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class UnsparkWitness<T> : System.IDisposable, System.IObserver<ReactiveUI.Primitives.Core.Spark<T>>
     {
         public UnsparkWitness(System.IObserver<T> observer) { }
@@ -1866,7 +1932,7 @@ namespace ReactiveUI.Primitives.Extensions.Operators
 }
 namespace ReactiveUI.Primitives.Signals
 {
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
+    [System.Diagnostics.DebuggerDisplay("PrioritySemaphoreSignal: Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
     public sealed class PrioritySemaphoreSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T> where T : System.IComparable<T>
     {
         public PrioritySemaphoreSignal(int maxCount) { }
@@ -1901,7 +1967,7 @@ namespace ReactiveUI.Primitives.Signals
         public void OnNext(T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledSignal: Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
     public class ScheduledSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T>
     {
         public ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }

--- a/src/ReactiveUI.Primitives/PublicAPI/net10.0-macos/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net10.0-macos/PublicAPI.txt
@@ -514,7 +514,7 @@ namespace ReactiveUI.Primitives
 }
 namespace ReactiveUI.Primitives.Advanced
 {
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Period = {_period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSignal: DueTime = {_dueTime}, Period = {_period}")]
     public sealed class AfterSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
     {
         public AfterSignal(System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -522,7 +522,7 @@ namespace ReactiveUI.Primitives.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<long> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSubscription: Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
     public sealed class AfterSubscription : System.IDisposable
     {
         public AfterSubscription(System.IObserver<long> observer, ReactiveUI.Primitives.Concurrency.ISequencer scheduler, System.TimeSpan dueTime, System.TimeSpan? period) { }
@@ -530,21 +530,21 @@ namespace ReactiveUI.Primitives.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.AfterSubscription Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("SubscribeAsync = {SubscribeAsync}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncCreateSignal: SubscribeAsync = {SubscribeAsync}")]
     public sealed class AsyncCreateSignal<T> : System.IObservable<T>
     {
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ObservableFactory = {ObservableFactory}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncDeferSignal: ObservableFactory = {ObservableFactory}")]
     public sealed class AsyncDeferSignal<T> : System.IObservable<T>
     {
         public AsyncDeferSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public AsyncDeferSignal(System.Func<System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncSubscriptionLifetime: Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
     public sealed class AsyncSubscriptionLifetime : System.IDisposable
     {
         public AsyncSubscriptionLifetime() { }
@@ -555,33 +555,33 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable? disposable) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connected = {_connected}")]
+    [System.Diagnostics.DebuggerDisplay("AutoConnectSignal: Count = {_count}, Connected = {_connected}")]
     public sealed class AutoConnectSignal<T> : System.IObservable<T>
     {
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount) { }
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount, System.Action<System.IDisposable>? onConnect) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connection = {_connection}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSignal: Count = {_count}, Connection = {_connection}")]
     public sealed class AutoShareSignal<T> : System.IObservable<T>
     {
         public AutoShareSignal(ReactiveUI.Primitives.ConnectableSignal<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Owner = {_owner}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSubscription: Owner = {_owner}, Subscription = {Subscription}")]
     public sealed class AutoShareSubscription<T> : System.IDisposable
     {
         public AutoShareSubscription(ReactiveUI.Primitives.Advanced.AutoShareSignal<T> owner, System.IDisposable subscription) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void Dispose() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("BlendSignal: Sources = {Sources}")]
     public sealed class BlendSignal<T> : System.IObservable<T>
     {
         public BlendSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("BlendWitness: ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
     public sealed class BlendWitness<T> : System.IDisposable
     {
         public BlendWitness(System.IObserver<T> observer) { }
@@ -590,7 +590,7 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.BlendWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.BlendWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("BufferEachWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class BufferEachWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public BufferEachWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -604,20 +604,20 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Window = {Window}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("BufferSignal: Window = {Window}, Source = {Source}")]
     public sealed class BufferSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public BufferSignal(System.IObservable<T> source, System.TimeSpan timeSpan, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("CastSignal: Source = {Source}")]
     public sealed class CastSignal<TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public CastSignal(System.IObservable<object?> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CastWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CastWitness<TResult> : System.IDisposable, System.IObserver<object?>
     {
         public CastWitness(System.IObserver<TResult> observer) { }
@@ -631,7 +631,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
+    [System.Diagnostics.DebuggerDisplay("ChainSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
     public sealed class ChainSignal<T> : System.IObservable<T>
     {
         public ChainSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -639,7 +639,7 @@ namespace ReactiveUI.Primitives.Advanced
         public ChainSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("ChainWitness: IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
     public sealed class ChainWitness<T> : System.IDisposable
     {
         public ChainWitness(System.IObserver<T> observer) { }
@@ -649,13 +649,13 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.ChainWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.ChainWitness<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, TimeSpan = {TimeSpan}")]
+    [System.Diagnostics.DebuggerDisplay("CollectSignal: Source = {Source}, TimeSpan = {TimeSpan}")]
     public sealed class CollectSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public CollectSignal(System.IObservable<T> source, System.TimeSpan timeSpan, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Buffered = {Values.Count}")]
+    [System.Diagnostics.DebuggerDisplay("CollectWitness: Stopped = {_stopped}, Buffered = {Values.Count}")]
     public sealed class CollectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CollectWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -667,7 +667,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateSink: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class CreateSink<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateSink(System.IObserver<T> observer, bool disposeOnNextThrow) { }
@@ -679,7 +679,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CreateWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateWitness(System.IObserver<T> observer) { }
@@ -693,7 +693,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
+    [System.Diagnostics.DebuggerDisplay("DispatchSequencerState: ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
     public record struct DispatchSequencerState : System.IEquatable<ReactiveUI.Primitives.Advanced.DispatchSequencerState>
     {
         public DispatchSequencerState(ReactiveUI.Primitives.Concurrency.ISequencer owner, System.Func<System.Action, bool> post, System.Action drain) { }
@@ -708,13 +708,13 @@ namespace ReactiveUI.Primitives.Advanced
         public static System.TimeSpan DelayUntil(long dueTimestamp) { }
         public static void RunIfActive(ReactiveUI.Primitives.Concurrency.IWorkItem item) { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {DueTime}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietSignal: DueTime = {DueTime}, Source = {Source}")]
     public sealed class EmitIfQuietSignal<T> : System.IObservable<T>
     {
         public EmitIfQuietSignal(System.IObservable<T> source, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietWitness: HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
     public sealed class EmitIfQuietWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public EmitIfQuietWitness(System.IObserver<T> observer, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
@@ -725,7 +725,16 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("EmptySignal: Scheduler = {_scheduler}")]
+    public sealed class EmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public EmptySignal(ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("EnumerableBlendSignal: Sources = {Sources}")]
     public sealed class EnumerableBlendSignal<T> : System.IObservable<T>
     {
         public EnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -735,7 +744,14 @@ namespace ReactiveUI.Primitives.Advanced
     {
         public static System.IDisposable Attach<TEventHandler>(TEventHandler handler, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
+    [System.Diagnostics.DebuggerDisplay("EverySignal: Period = {_period}, Scheduler = {_scheduler}")]
+    public sealed class EverySignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
+    {
+        public EverySignal(System.TimeSpan period, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<long> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ExpireCoordinator: Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
     public sealed class ExpireCoordinator<T> : System.IDisposable, System.IObserver<T>
     {
         public ExpireCoordinator(System.IObservable<T> source, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer, System.IObserver<T> observer) { }
@@ -745,39 +761,48 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnNext(T value) { }
         public ReactiveUI.Primitives.Advanced.ExpireCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("ExpireSignal: DueTime = {_dueTime}, Source = {_source}")]
     public sealed class ExpireSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ExpireSignal(System.IObservable<T> source, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("FinallySignal: Source = {_source}")]
+    public sealed class FinallySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public FinallySignal(System.IObservable<T> source, System.Action finallyAction) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ForkJoinSignal: Left = {Left}, Right = {Right}")]
     public sealed class ForkJoinSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public ForkJoinSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("ForkJoinWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
     public sealed class ForkJoinWitness<TLeft, TRight, TResult>
     {
         public ForkJoinWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("CancellationRequested = {CancellationToken.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncExternalCancellationSignal: CancellationRequested = {CancellationToken.IsCancellationRequested}")]
     public sealed class FromAsyncExternalCancellationSignal<T> : System.IObservable<T>
     {
         public FromAsyncExternalCancellationSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSignal: TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
     public sealed class FromAsyncSignal<T> : System.IObservable<T>
     {
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSubscription: Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
     public sealed class FromAsyncSubscription<T> : System.IDisposable
     {
         public FromAsyncSubscription(System.IObserver<T> observer, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
@@ -790,14 +815,14 @@ namespace ReactiveUI.Primitives.Advanced
         public FromEventConversionSignal(System.Func<TCallback, TEventHandler> conversion, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Func<System.IObserver<TResult>, TCallback> callback, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
+    [System.Diagnostics.DebuggerDisplay("FromEventPatternSignal: AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
     public sealed class FromEventPatternSignal<TEventHandler, TEventArgs> : System.IObservable<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> where TEventHandler : System.Delegate where TEventArgs : System.EventArgs
     {
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler) { }
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Disposed = {_disposed}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("GuardedWitness: Disposed = {_disposed}, Observer = {_observer}")]
     public sealed class GuardedWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public GuardedWitness(System.IObserver<T> observer, System.IDisposable cancel) { }
@@ -807,7 +832,7 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IgnoreValuesSignal: Source = {Source}")]
     public sealed class IgnoreValuesSignal<T> : System.IObservable<T>
     {
         public IgnoreValuesSignal(System.IObservable<T> source) { }
@@ -821,14 +846,14 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.RxVoid> observer) { }
         public System.IDisposable Subscribe(System.Action<ReactiveUI.Primitives.RxVoid> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptySignal: Source = {Source}")]
     public sealed class IsEmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<bool>
     {
         public IsEmptySignal(System.IObservable<T> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<bool> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptyWitness: Stopped = {_stopped}, Subscription = {Subscription}")]
     public sealed class IsEmptyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public IsEmptyWitness(System.IObserver<bool> observer) { }
@@ -841,14 +866,23 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {Value}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("LeadSignal: Value = {Value}, Source = {Source}")]
     public sealed class LeadSignal<T> : ReactiveUI.Primitives.Advanced.IInlineSignal<T>
     {
         public LeadSignal(System.IObservable<T> source, T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
         public System.IDisposable Subscribe(System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("LoopSignal: Value = {Value}")]
+    public sealed class LoopSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public LoopSignal(T value) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("MapIndexedSignal: Source = {_source}")]
     public sealed class MapIndexedSignal<TSource, TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public MapIndexedSignal(System.IObservable<TSource> source, System.Func<TSource, int, TResult> selector) { }
@@ -856,7 +890,7 @@ namespace ReactiveUI.Primitives.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Index = {_index}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("MapIndexedWitness: Index = {_index}, Stopped = {_stopped}")]
     public sealed class MapIndexedWitness<TSource, TResult> : System.IObserver<TSource>
     {
         public MapIndexedWitness(System.IObserver<TResult> observer, System.Func<TSource, int, TResult> selector) { }
@@ -864,20 +898,20 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(TSource value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentBlendCoordinator: Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
     public sealed class MaxConcurrentBlendCoordinator<T> : System.IDisposable
     {
         public MaxConcurrentBlendCoordinator(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.MaxConcurrentBlendCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentEnumerableBlendSignal: Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
     public sealed class MaxConcurrentEnumerableBlendSignal<T> : System.IObservable<T>
     {
         public MaxConcurrentEnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("MergeCoordinator: Active = {Active}, Done = {Done}")]
     public sealed class MergeCoordinator<T> : System.IDisposable
     {
         public MergeCoordinator(System.IObserver<T> observer) { }
@@ -888,7 +922,7 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.MergeCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.MergeCoordinator<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MergeSignal: Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
     public sealed class MergeSignal<T> : System.IObservable<T>
     {
         public MergeSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -896,32 +930,39 @@ namespace ReactiveUI.Primitives.Advanced
         public MergeSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("OnErrorResumeNextSignal: Sources = {_sources}")]
+    public sealed class OnErrorResumeNextSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("PairSignal: Left = {Left}, Right = {Right}")]
     public sealed class PairSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public PairSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
+    [System.Diagnostics.DebuggerDisplay("PairWitness: IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
     public sealed class PairWitness<TLeft, TRight, TResult>
     {
         public PairWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("PublishSelectorSignal: Source = {Source}, Selector = {Selector}")]
     public sealed class PublishSelectorSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public PublishSelectorSignal(System.IObservable<TSource> source, System.Func<System.IObservable<TSource>, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
+    [System.Diagnostics.DebuggerDisplay("RaceSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
     public sealed class RaceSignal<T> : System.IObservable<T>
     {
         public RaceSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public RaceSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Arms = {_arms}")]
+    [System.Diagnostics.DebuggerDisplay("RaceWitness: Arms = {_arms}")]
     public sealed class RaceWitness<T> : System.IDisposable
     {
         public RaceWitness(System.IObserver<T> observer) { }
@@ -930,40 +971,48 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.RaceWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.RaceWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeCombineLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeCombineLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeCombineLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
+    [System.Diagnostics.DebuggerDisplay("RangeForkJoinSignal: Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
     public sealed class RangeForkJoinSignal<TResult> : System.IObservable<TResult>
     {
         public RangeForkJoinSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeSyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeSyncLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeSyncLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeWithLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeWithLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeWithLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Remaining = {_remaining}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("RecoverSignal: Source = {_source}")]
+    public sealed class RecoverSignal<T, TException> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T> where TException : System.Exception
+    {
+        public RecoverSignal(System.IObservable<T> source, System.Func<TException, System.IObservable<T>> handler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceCoordinator: Remaining = {_remaining}, Disposed = {_disposed}")]
     public sealed class RepeatSourceCoordinator<T> : System.IDisposable
     {
         public RepeatSourceCoordinator(System.IObservable<T> source, int? repeatCount, System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.RepeatSourceCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, RepeatCount = {_repeatCount}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceSignal: Source = {_source}, RepeatCount = {_repeatCount}")]
     public sealed class RepeatSourceSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public RepeatSourceSignal(System.IObservable<T> source, int? repeatCount) { }
@@ -971,7 +1020,7 @@ namespace ReactiveUI.Primitives.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Generation = {_generation}, Terminated = {_terminated}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceWitness: Generation = {_generation}, Terminated = {_terminated}")]
     public sealed class RepeatSourceWitness<T> : System.IObserver<T>
     {
         public RepeatSourceWitness(ReactiveUI.Primitives.Advanced.RepeatSourceCoordinator<T> parent, int generation) { }
@@ -979,7 +1028,15 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_value}, Scheduler = {_scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ResumeSignal: Source = {_source}, Fallback = {_fallback}")]
+    public sealed class ResumeSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ResumeSignal(System.IObservable<T> source, System.IObservable<T> fallback) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ReturnSignal: Value = {_value}, Scheduler = {_scheduler}")]
     public sealed class ReturnSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ReturnSignal(T value, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -988,13 +1045,13 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Values = {Values}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledEnumerableSignal: Values = {Values}, Scheduler = {Scheduler}")]
     public sealed class ScheduledEnumerableSignal<T> : System.IObservable<T>
     {
         public ScheduledEnumerableSignal(System.Collections.Generic.IEnumerable<T> values, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyCoordinator<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TResult>> selector) { }
@@ -1008,13 +1065,13 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Advanced.SelectManyCoordinator<TSource, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableSignal: Source = {_source}")]
     public sealed class SelectManyEnumerableSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManyEnumerableSignal(System.IObservable<TSource> source, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SelectManyEnumerableWitness<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyEnumerableWitness(System.IObserver<TResult> observer, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
@@ -1028,7 +1085,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyResultCoordinator<TSource, TCollection, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyResultCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
@@ -1041,20 +1098,20 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Advanced.SelectManyResultCoordinator<TSource, TCollection, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, CollectionSelector = {CollectionSelector}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultSignal: Source = {Source}, CollectionSelector = {CollectionSelector}")]
     public sealed class SelectManyResultSignal<TSource, TCollection, TResult> : System.IObservable<TResult>
     {
         public SelectManyResultSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManySignal: Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
     public sealed class SelectManySignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManySignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public SelectManySignal(System.IObservable<TSource> source, System.IObservable<TResult> inner) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Start = {Start}, Count = {Count}")]
+    [System.Diagnostics.DebuggerDisplay("SequenceSignal: Start = {Start}, Count = {Count}")]
     public sealed class SequenceSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<int>
     {
         public SequenceSignal(int start, int count, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -1065,13 +1122,13 @@ namespace ReactiveUI.Primitives.Advanced
     {
         public static System.IDisposable Subscribe<T>(System.IObserver<T> observer, bool currentThreadRequired, System.Func<System.IObserver<T>, System.IDisposable, System.IDisposable> subscribeCore) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SparkSignal: Source = {Source}")]
     public sealed class SparkSignal<T> : System.IObservable<ReactiveUI.Primitives.Core.Spark<T>>
     {
         public SparkSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.Spark<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SparkWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SparkWitness(System.IObserver<ReactiveUI.Primitives.Core.Spark<T>> observer) { }
@@ -1086,21 +1143,21 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Action = {Action}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Action = {Action}, Scheduler = {Scheduler}")]
     public sealed class StartSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<ReactiveUI.Primitives.RxVoid>
     {
         public StartSignal(System.Action action, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.RxVoid> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Function = {Function}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Function = {Function}, Scheduler = {Scheduler}")]
     public sealed class StartSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public StartSignal(System.Func<T> function, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SubscribeSafeWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SubscribeSafeWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SubscribeSafeWitness(System.IObserver<T> observer) { }
@@ -1114,50 +1171,50 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, SkipNullSources = {_skipNullSources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchMapSignal: Source = {_source}, SkipNullSources = {_skipNullSources}")]
     public sealed class SwitchMapSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SwitchMapSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchSignal: Sources = {Sources}")]
     public sealed class SwitchSignal<T> : System.IObservable<T>
     {
         public SwitchSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Version = {_version}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchWitness: Version = {_version}, IsDone = {IsDone}")]
     public sealed class SwitchWitness<T> : System.IDisposable
     {
         public SwitchWitness(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.SwitchWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class SyncLatestSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public SyncLatestSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
     public sealed class SyncLatestWitness<TLeft, TRight, TResult>
     {
         public SyncLatestWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Gate = {Gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeGateSignal: Source = {Source}, Gate = {Gate}")]
     public sealed class SynchronizeGateSignal<T> : System.IObservable<T>
     {
         public SynchronizeGateSignal(System.IObservable<T> source, System.Threading.Lock gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, Gate = {_gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectSignal: Source = {_source}, Gate = {_gate}")]
     public sealed class SynchronizeObjectSignal<T> : System.IObservable<T>
     {
         public SynchronizeObjectSignal(System.IObservable<T> source, object gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SynchronizeObjectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SynchronizeObjectWitness(System.IObserver<T> observer, object gate) { }
@@ -1169,19 +1226,19 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeSignal: Source = {Source}")]
     public sealed class SynchronizeSignal<T> : System.IObservable<T>
     {
         public SynchronizeSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("TapSignal: Source = {Source}")]
     public sealed class TapSignal<T> : System.IObservable<T>
     {
         public TapSignal(System.IObservable<T> source, System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskAnyWitness: Stopped = {_stopped}, Task = {Task}")]
     public sealed class TaskAnyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskAnyWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1197,7 +1254,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainCoordinator: Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
     public sealed class TaskChainCoordinator<T> : System.IDisposable
     {
         public TaskChainCoordinator(System.IObserver<T> observer) { }
@@ -1205,13 +1262,13 @@ namespace ReactiveUI.Primitives.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.TaskChainCoordinator<T> Run(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainSignal: Sources = {_sources}")]
     public sealed class TaskChainSignal<T> : System.IObservable<T>
     {
         public TaskChainSignal(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskCountWitness: Count = {_count}, Stopped = {_stopped}")]
     public sealed class TaskCountWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskCountWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1227,13 +1284,13 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSignal: Task = {Task}")]
     public sealed class TaskInstanceSignal<T> : System.IObservable<T>
     {
         public TaskInstanceSignal(System.Threading.Tasks.Task<T> task) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSubscription: Stopped = {_stopped}")]
     public sealed class TaskInstanceSubscription : System.IDisposable
     {
         public TaskInstanceSubscription() { }
@@ -1241,13 +1298,22 @@ namespace ReactiveUI.Primitives.Advanced
         public void Dispose() { }
         public bool TryStop() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Sequencer = {Sequencer}")]
+    [System.Diagnostics.DebuggerDisplay("ThrowSignal: Error = {_error}, Scheduler = {_scheduler}")]
+    public sealed class ThrowSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ThrowSignal(System.Exception error, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalSignal: Source = {Source}, Sequencer = {Sequencer}")]
     public sealed class TimeIntervalSignal<T> : System.IObservable<ReactiveUI.Primitives.Core.TimeInterval<T>>
     {
         public TimeIntervalSignal(System.IObservable<T> source, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("First = {_first}, Last = {_last}")]
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalWitness: First = {_first}, Last = {_last}")]
     public sealed class TimeIntervalWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TimeIntervalWitness(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -1265,13 +1331,13 @@ namespace ReactiveUI.Primitives.Advanced
     {
         public static void Arm(ReactiveUI.Primitives.Disposables.SingleReplaceableDisposable slot, ReactiveUI.Primitives.Concurrency.ISequencer sequencer, System.TimeSpan delay, System.Action tick) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkSignal: Source = {Source}")]
     public sealed class UnsparkSignal<T> : System.IObservable<T>
     {
         public UnsparkSignal(System.IObservable<ReactiveUI.Primitives.Core.Spark<T>> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class UnsparkWitness<T> : System.IDisposable, System.IObserver<ReactiveUI.Primitives.Core.Spark<T>>
     {
         public UnsparkWitness(System.IObserver<T> observer) { }
@@ -1866,7 +1932,7 @@ namespace ReactiveUI.Primitives.Extensions.Operators
 }
 namespace ReactiveUI.Primitives.Signals
 {
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
+    [System.Diagnostics.DebuggerDisplay("PrioritySemaphoreSignal: Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
     public sealed class PrioritySemaphoreSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T> where T : System.IComparable<T>
     {
         public PrioritySemaphoreSignal(int maxCount) { }
@@ -1901,7 +1967,7 @@ namespace ReactiveUI.Primitives.Signals
         public void OnNext(T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledSignal: Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
     public class ScheduledSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T>
     {
         public ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }

--- a/src/ReactiveUI.Primitives/PublicAPI/net10.0-tvos/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net10.0-tvos/PublicAPI.txt
@@ -514,7 +514,7 @@ namespace ReactiveUI.Primitives
 }
 namespace ReactiveUI.Primitives.Advanced
 {
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Period = {_period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSignal: DueTime = {_dueTime}, Period = {_period}")]
     public sealed class AfterSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
     {
         public AfterSignal(System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -522,7 +522,7 @@ namespace ReactiveUI.Primitives.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<long> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSubscription: Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
     public sealed class AfterSubscription : System.IDisposable
     {
         public AfterSubscription(System.IObserver<long> observer, ReactiveUI.Primitives.Concurrency.ISequencer scheduler, System.TimeSpan dueTime, System.TimeSpan? period) { }
@@ -530,21 +530,21 @@ namespace ReactiveUI.Primitives.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.AfterSubscription Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("SubscribeAsync = {SubscribeAsync}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncCreateSignal: SubscribeAsync = {SubscribeAsync}")]
     public sealed class AsyncCreateSignal<T> : System.IObservable<T>
     {
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ObservableFactory = {ObservableFactory}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncDeferSignal: ObservableFactory = {ObservableFactory}")]
     public sealed class AsyncDeferSignal<T> : System.IObservable<T>
     {
         public AsyncDeferSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public AsyncDeferSignal(System.Func<System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncSubscriptionLifetime: Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
     public sealed class AsyncSubscriptionLifetime : System.IDisposable
     {
         public AsyncSubscriptionLifetime() { }
@@ -555,33 +555,33 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable? disposable) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connected = {_connected}")]
+    [System.Diagnostics.DebuggerDisplay("AutoConnectSignal: Count = {_count}, Connected = {_connected}")]
     public sealed class AutoConnectSignal<T> : System.IObservable<T>
     {
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount) { }
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount, System.Action<System.IDisposable>? onConnect) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connection = {_connection}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSignal: Count = {_count}, Connection = {_connection}")]
     public sealed class AutoShareSignal<T> : System.IObservable<T>
     {
         public AutoShareSignal(ReactiveUI.Primitives.ConnectableSignal<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Owner = {_owner}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSubscription: Owner = {_owner}, Subscription = {Subscription}")]
     public sealed class AutoShareSubscription<T> : System.IDisposable
     {
         public AutoShareSubscription(ReactiveUI.Primitives.Advanced.AutoShareSignal<T> owner, System.IDisposable subscription) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void Dispose() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("BlendSignal: Sources = {Sources}")]
     public sealed class BlendSignal<T> : System.IObservable<T>
     {
         public BlendSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("BlendWitness: ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
     public sealed class BlendWitness<T> : System.IDisposable
     {
         public BlendWitness(System.IObserver<T> observer) { }
@@ -590,7 +590,7 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.BlendWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.BlendWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("BufferEachWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class BufferEachWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public BufferEachWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -604,20 +604,20 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Window = {Window}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("BufferSignal: Window = {Window}, Source = {Source}")]
     public sealed class BufferSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public BufferSignal(System.IObservable<T> source, System.TimeSpan timeSpan, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("CastSignal: Source = {Source}")]
     public sealed class CastSignal<TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public CastSignal(System.IObservable<object?> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CastWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CastWitness<TResult> : System.IDisposable, System.IObserver<object?>
     {
         public CastWitness(System.IObserver<TResult> observer) { }
@@ -631,7 +631,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
+    [System.Diagnostics.DebuggerDisplay("ChainSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
     public sealed class ChainSignal<T> : System.IObservable<T>
     {
         public ChainSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -639,7 +639,7 @@ namespace ReactiveUI.Primitives.Advanced
         public ChainSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("ChainWitness: IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
     public sealed class ChainWitness<T> : System.IDisposable
     {
         public ChainWitness(System.IObserver<T> observer) { }
@@ -649,13 +649,13 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.ChainWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.ChainWitness<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, TimeSpan = {TimeSpan}")]
+    [System.Diagnostics.DebuggerDisplay("CollectSignal: Source = {Source}, TimeSpan = {TimeSpan}")]
     public sealed class CollectSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public CollectSignal(System.IObservable<T> source, System.TimeSpan timeSpan, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Buffered = {Values.Count}")]
+    [System.Diagnostics.DebuggerDisplay("CollectWitness: Stopped = {_stopped}, Buffered = {Values.Count}")]
     public sealed class CollectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CollectWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -667,7 +667,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateSink: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class CreateSink<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateSink(System.IObserver<T> observer, bool disposeOnNextThrow) { }
@@ -679,7 +679,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CreateWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateWitness(System.IObserver<T> observer) { }
@@ -693,7 +693,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
+    [System.Diagnostics.DebuggerDisplay("DispatchSequencerState: ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
     public record struct DispatchSequencerState : System.IEquatable<ReactiveUI.Primitives.Advanced.DispatchSequencerState>
     {
         public DispatchSequencerState(ReactiveUI.Primitives.Concurrency.ISequencer owner, System.Func<System.Action, bool> post, System.Action drain) { }
@@ -708,13 +708,13 @@ namespace ReactiveUI.Primitives.Advanced
         public static System.TimeSpan DelayUntil(long dueTimestamp) { }
         public static void RunIfActive(ReactiveUI.Primitives.Concurrency.IWorkItem item) { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {DueTime}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietSignal: DueTime = {DueTime}, Source = {Source}")]
     public sealed class EmitIfQuietSignal<T> : System.IObservable<T>
     {
         public EmitIfQuietSignal(System.IObservable<T> source, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietWitness: HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
     public sealed class EmitIfQuietWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public EmitIfQuietWitness(System.IObserver<T> observer, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
@@ -725,7 +725,16 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("EmptySignal: Scheduler = {_scheduler}")]
+    public sealed class EmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public EmptySignal(ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("EnumerableBlendSignal: Sources = {Sources}")]
     public sealed class EnumerableBlendSignal<T> : System.IObservable<T>
     {
         public EnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -735,7 +744,14 @@ namespace ReactiveUI.Primitives.Advanced
     {
         public static System.IDisposable Attach<TEventHandler>(TEventHandler handler, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
+    [System.Diagnostics.DebuggerDisplay("EverySignal: Period = {_period}, Scheduler = {_scheduler}")]
+    public sealed class EverySignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
+    {
+        public EverySignal(System.TimeSpan period, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<long> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ExpireCoordinator: Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
     public sealed class ExpireCoordinator<T> : System.IDisposable, System.IObserver<T>
     {
         public ExpireCoordinator(System.IObservable<T> source, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer, System.IObserver<T> observer) { }
@@ -745,39 +761,48 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnNext(T value) { }
         public ReactiveUI.Primitives.Advanced.ExpireCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("ExpireSignal: DueTime = {_dueTime}, Source = {_source}")]
     public sealed class ExpireSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ExpireSignal(System.IObservable<T> source, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("FinallySignal: Source = {_source}")]
+    public sealed class FinallySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public FinallySignal(System.IObservable<T> source, System.Action finallyAction) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ForkJoinSignal: Left = {Left}, Right = {Right}")]
     public sealed class ForkJoinSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public ForkJoinSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("ForkJoinWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
     public sealed class ForkJoinWitness<TLeft, TRight, TResult>
     {
         public ForkJoinWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("CancellationRequested = {CancellationToken.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncExternalCancellationSignal: CancellationRequested = {CancellationToken.IsCancellationRequested}")]
     public sealed class FromAsyncExternalCancellationSignal<T> : System.IObservable<T>
     {
         public FromAsyncExternalCancellationSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSignal: TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
     public sealed class FromAsyncSignal<T> : System.IObservable<T>
     {
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSubscription: Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
     public sealed class FromAsyncSubscription<T> : System.IDisposable
     {
         public FromAsyncSubscription(System.IObserver<T> observer, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
@@ -790,14 +815,14 @@ namespace ReactiveUI.Primitives.Advanced
         public FromEventConversionSignal(System.Func<TCallback, TEventHandler> conversion, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Func<System.IObserver<TResult>, TCallback> callback, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
+    [System.Diagnostics.DebuggerDisplay("FromEventPatternSignal: AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
     public sealed class FromEventPatternSignal<TEventHandler, TEventArgs> : System.IObservable<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> where TEventHandler : System.Delegate where TEventArgs : System.EventArgs
     {
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler) { }
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Disposed = {_disposed}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("GuardedWitness: Disposed = {_disposed}, Observer = {_observer}")]
     public sealed class GuardedWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public GuardedWitness(System.IObserver<T> observer, System.IDisposable cancel) { }
@@ -807,7 +832,7 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IgnoreValuesSignal: Source = {Source}")]
     public sealed class IgnoreValuesSignal<T> : System.IObservable<T>
     {
         public IgnoreValuesSignal(System.IObservable<T> source) { }
@@ -821,14 +846,14 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.RxVoid> observer) { }
         public System.IDisposable Subscribe(System.Action<ReactiveUI.Primitives.RxVoid> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptySignal: Source = {Source}")]
     public sealed class IsEmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<bool>
     {
         public IsEmptySignal(System.IObservable<T> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<bool> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptyWitness: Stopped = {_stopped}, Subscription = {Subscription}")]
     public sealed class IsEmptyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public IsEmptyWitness(System.IObserver<bool> observer) { }
@@ -841,14 +866,23 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {Value}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("LeadSignal: Value = {Value}, Source = {Source}")]
     public sealed class LeadSignal<T> : ReactiveUI.Primitives.Advanced.IInlineSignal<T>
     {
         public LeadSignal(System.IObservable<T> source, T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
         public System.IDisposable Subscribe(System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("LoopSignal: Value = {Value}")]
+    public sealed class LoopSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public LoopSignal(T value) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("MapIndexedSignal: Source = {_source}")]
     public sealed class MapIndexedSignal<TSource, TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public MapIndexedSignal(System.IObservable<TSource> source, System.Func<TSource, int, TResult> selector) { }
@@ -856,7 +890,7 @@ namespace ReactiveUI.Primitives.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Index = {_index}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("MapIndexedWitness: Index = {_index}, Stopped = {_stopped}")]
     public sealed class MapIndexedWitness<TSource, TResult> : System.IObserver<TSource>
     {
         public MapIndexedWitness(System.IObserver<TResult> observer, System.Func<TSource, int, TResult> selector) { }
@@ -864,20 +898,20 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(TSource value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentBlendCoordinator: Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
     public sealed class MaxConcurrentBlendCoordinator<T> : System.IDisposable
     {
         public MaxConcurrentBlendCoordinator(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.MaxConcurrentBlendCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentEnumerableBlendSignal: Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
     public sealed class MaxConcurrentEnumerableBlendSignal<T> : System.IObservable<T>
     {
         public MaxConcurrentEnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("MergeCoordinator: Active = {Active}, Done = {Done}")]
     public sealed class MergeCoordinator<T> : System.IDisposable
     {
         public MergeCoordinator(System.IObserver<T> observer) { }
@@ -888,7 +922,7 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.MergeCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.MergeCoordinator<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MergeSignal: Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
     public sealed class MergeSignal<T> : System.IObservable<T>
     {
         public MergeSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -896,32 +930,39 @@ namespace ReactiveUI.Primitives.Advanced
         public MergeSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("OnErrorResumeNextSignal: Sources = {_sources}")]
+    public sealed class OnErrorResumeNextSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("PairSignal: Left = {Left}, Right = {Right}")]
     public sealed class PairSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public PairSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
+    [System.Diagnostics.DebuggerDisplay("PairWitness: IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
     public sealed class PairWitness<TLeft, TRight, TResult>
     {
         public PairWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("PublishSelectorSignal: Source = {Source}, Selector = {Selector}")]
     public sealed class PublishSelectorSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public PublishSelectorSignal(System.IObservable<TSource> source, System.Func<System.IObservable<TSource>, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
+    [System.Diagnostics.DebuggerDisplay("RaceSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
     public sealed class RaceSignal<T> : System.IObservable<T>
     {
         public RaceSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public RaceSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Arms = {_arms}")]
+    [System.Diagnostics.DebuggerDisplay("RaceWitness: Arms = {_arms}")]
     public sealed class RaceWitness<T> : System.IDisposable
     {
         public RaceWitness(System.IObserver<T> observer) { }
@@ -930,40 +971,48 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.RaceWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.RaceWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeCombineLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeCombineLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeCombineLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
+    [System.Diagnostics.DebuggerDisplay("RangeForkJoinSignal: Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
     public sealed class RangeForkJoinSignal<TResult> : System.IObservable<TResult>
     {
         public RangeForkJoinSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeSyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeSyncLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeSyncLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeWithLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeWithLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeWithLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Remaining = {_remaining}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("RecoverSignal: Source = {_source}")]
+    public sealed class RecoverSignal<T, TException> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T> where TException : System.Exception
+    {
+        public RecoverSignal(System.IObservable<T> source, System.Func<TException, System.IObservable<T>> handler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceCoordinator: Remaining = {_remaining}, Disposed = {_disposed}")]
     public sealed class RepeatSourceCoordinator<T> : System.IDisposable
     {
         public RepeatSourceCoordinator(System.IObservable<T> source, int? repeatCount, System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.RepeatSourceCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, RepeatCount = {_repeatCount}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceSignal: Source = {_source}, RepeatCount = {_repeatCount}")]
     public sealed class RepeatSourceSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public RepeatSourceSignal(System.IObservable<T> source, int? repeatCount) { }
@@ -971,7 +1020,7 @@ namespace ReactiveUI.Primitives.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Generation = {_generation}, Terminated = {_terminated}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceWitness: Generation = {_generation}, Terminated = {_terminated}")]
     public sealed class RepeatSourceWitness<T> : System.IObserver<T>
     {
         public RepeatSourceWitness(ReactiveUI.Primitives.Advanced.RepeatSourceCoordinator<T> parent, int generation) { }
@@ -979,7 +1028,15 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_value}, Scheduler = {_scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ResumeSignal: Source = {_source}, Fallback = {_fallback}")]
+    public sealed class ResumeSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ResumeSignal(System.IObservable<T> source, System.IObservable<T> fallback) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ReturnSignal: Value = {_value}, Scheduler = {_scheduler}")]
     public sealed class ReturnSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ReturnSignal(T value, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -988,13 +1045,13 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Values = {Values}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledEnumerableSignal: Values = {Values}, Scheduler = {Scheduler}")]
     public sealed class ScheduledEnumerableSignal<T> : System.IObservable<T>
     {
         public ScheduledEnumerableSignal(System.Collections.Generic.IEnumerable<T> values, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyCoordinator<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TResult>> selector) { }
@@ -1008,13 +1065,13 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Advanced.SelectManyCoordinator<TSource, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableSignal: Source = {_source}")]
     public sealed class SelectManyEnumerableSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManyEnumerableSignal(System.IObservable<TSource> source, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SelectManyEnumerableWitness<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyEnumerableWitness(System.IObserver<TResult> observer, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
@@ -1028,7 +1085,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyResultCoordinator<TSource, TCollection, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyResultCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
@@ -1041,20 +1098,20 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Advanced.SelectManyResultCoordinator<TSource, TCollection, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, CollectionSelector = {CollectionSelector}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultSignal: Source = {Source}, CollectionSelector = {CollectionSelector}")]
     public sealed class SelectManyResultSignal<TSource, TCollection, TResult> : System.IObservable<TResult>
     {
         public SelectManyResultSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManySignal: Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
     public sealed class SelectManySignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManySignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public SelectManySignal(System.IObservable<TSource> source, System.IObservable<TResult> inner) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Start = {Start}, Count = {Count}")]
+    [System.Diagnostics.DebuggerDisplay("SequenceSignal: Start = {Start}, Count = {Count}")]
     public sealed class SequenceSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<int>
     {
         public SequenceSignal(int start, int count, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -1065,13 +1122,13 @@ namespace ReactiveUI.Primitives.Advanced
     {
         public static System.IDisposable Subscribe<T>(System.IObserver<T> observer, bool currentThreadRequired, System.Func<System.IObserver<T>, System.IDisposable, System.IDisposable> subscribeCore) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SparkSignal: Source = {Source}")]
     public sealed class SparkSignal<T> : System.IObservable<ReactiveUI.Primitives.Core.Spark<T>>
     {
         public SparkSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.Spark<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SparkWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SparkWitness(System.IObserver<ReactiveUI.Primitives.Core.Spark<T>> observer) { }
@@ -1086,21 +1143,21 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Action = {Action}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Action = {Action}, Scheduler = {Scheduler}")]
     public sealed class StartSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<ReactiveUI.Primitives.RxVoid>
     {
         public StartSignal(System.Action action, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.RxVoid> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Function = {Function}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Function = {Function}, Scheduler = {Scheduler}")]
     public sealed class StartSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public StartSignal(System.Func<T> function, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SubscribeSafeWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SubscribeSafeWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SubscribeSafeWitness(System.IObserver<T> observer) { }
@@ -1114,50 +1171,50 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, SkipNullSources = {_skipNullSources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchMapSignal: Source = {_source}, SkipNullSources = {_skipNullSources}")]
     public sealed class SwitchMapSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SwitchMapSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchSignal: Sources = {Sources}")]
     public sealed class SwitchSignal<T> : System.IObservable<T>
     {
         public SwitchSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Version = {_version}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchWitness: Version = {_version}, IsDone = {IsDone}")]
     public sealed class SwitchWitness<T> : System.IDisposable
     {
         public SwitchWitness(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.SwitchWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class SyncLatestSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public SyncLatestSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
     public sealed class SyncLatestWitness<TLeft, TRight, TResult>
     {
         public SyncLatestWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Gate = {Gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeGateSignal: Source = {Source}, Gate = {Gate}")]
     public sealed class SynchronizeGateSignal<T> : System.IObservable<T>
     {
         public SynchronizeGateSignal(System.IObservable<T> source, System.Threading.Lock gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, Gate = {_gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectSignal: Source = {_source}, Gate = {_gate}")]
     public sealed class SynchronizeObjectSignal<T> : System.IObservable<T>
     {
         public SynchronizeObjectSignal(System.IObservable<T> source, object gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SynchronizeObjectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SynchronizeObjectWitness(System.IObserver<T> observer, object gate) { }
@@ -1169,19 +1226,19 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeSignal: Source = {Source}")]
     public sealed class SynchronizeSignal<T> : System.IObservable<T>
     {
         public SynchronizeSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("TapSignal: Source = {Source}")]
     public sealed class TapSignal<T> : System.IObservable<T>
     {
         public TapSignal(System.IObservable<T> source, System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskAnyWitness: Stopped = {_stopped}, Task = {Task}")]
     public sealed class TaskAnyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskAnyWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1197,7 +1254,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainCoordinator: Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
     public sealed class TaskChainCoordinator<T> : System.IDisposable
     {
         public TaskChainCoordinator(System.IObserver<T> observer) { }
@@ -1205,13 +1262,13 @@ namespace ReactiveUI.Primitives.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.TaskChainCoordinator<T> Run(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainSignal: Sources = {_sources}")]
     public sealed class TaskChainSignal<T> : System.IObservable<T>
     {
         public TaskChainSignal(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskCountWitness: Count = {_count}, Stopped = {_stopped}")]
     public sealed class TaskCountWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskCountWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1227,13 +1284,13 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSignal: Task = {Task}")]
     public sealed class TaskInstanceSignal<T> : System.IObservable<T>
     {
         public TaskInstanceSignal(System.Threading.Tasks.Task<T> task) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSubscription: Stopped = {_stopped}")]
     public sealed class TaskInstanceSubscription : System.IDisposable
     {
         public TaskInstanceSubscription() { }
@@ -1241,13 +1298,22 @@ namespace ReactiveUI.Primitives.Advanced
         public void Dispose() { }
         public bool TryStop() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Sequencer = {Sequencer}")]
+    [System.Diagnostics.DebuggerDisplay("ThrowSignal: Error = {_error}, Scheduler = {_scheduler}")]
+    public sealed class ThrowSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ThrowSignal(System.Exception error, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalSignal: Source = {Source}, Sequencer = {Sequencer}")]
     public sealed class TimeIntervalSignal<T> : System.IObservable<ReactiveUI.Primitives.Core.TimeInterval<T>>
     {
         public TimeIntervalSignal(System.IObservable<T> source, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("First = {_first}, Last = {_last}")]
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalWitness: First = {_first}, Last = {_last}")]
     public sealed class TimeIntervalWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TimeIntervalWitness(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -1265,13 +1331,13 @@ namespace ReactiveUI.Primitives.Advanced
     {
         public static void Arm(ReactiveUI.Primitives.Disposables.SingleReplaceableDisposable slot, ReactiveUI.Primitives.Concurrency.ISequencer sequencer, System.TimeSpan delay, System.Action tick) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkSignal: Source = {Source}")]
     public sealed class UnsparkSignal<T> : System.IObservable<T>
     {
         public UnsparkSignal(System.IObservable<ReactiveUI.Primitives.Core.Spark<T>> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class UnsparkWitness<T> : System.IDisposable, System.IObserver<ReactiveUI.Primitives.Core.Spark<T>>
     {
         public UnsparkWitness(System.IObserver<T> observer) { }
@@ -1866,7 +1932,7 @@ namespace ReactiveUI.Primitives.Extensions.Operators
 }
 namespace ReactiveUI.Primitives.Signals
 {
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
+    [System.Diagnostics.DebuggerDisplay("PrioritySemaphoreSignal: Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
     public sealed class PrioritySemaphoreSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T> where T : System.IComparable<T>
     {
         public PrioritySemaphoreSignal(int maxCount) { }
@@ -1901,7 +1967,7 @@ namespace ReactiveUI.Primitives.Signals
         public void OnNext(T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledSignal: Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
     public class ScheduledSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T>
     {
         public ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }

--- a/src/ReactiveUI.Primitives/PublicAPI/net10.0/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net10.0/PublicAPI.txt
@@ -513,7 +513,7 @@ namespace ReactiveUI.Primitives
 }
 namespace ReactiveUI.Primitives.Advanced
 {
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Period = {_period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSignal: DueTime = {_dueTime}, Period = {_period}")]
     public sealed class AfterSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
     {
         public AfterSignal(System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -521,7 +521,7 @@ namespace ReactiveUI.Primitives.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<long> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSubscription: Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
     public sealed class AfterSubscription : System.IDisposable
     {
         public AfterSubscription(System.IObserver<long> observer, ReactiveUI.Primitives.Concurrency.ISequencer scheduler, System.TimeSpan dueTime, System.TimeSpan? period) { }
@@ -529,21 +529,21 @@ namespace ReactiveUI.Primitives.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.AfterSubscription Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("SubscribeAsync = {SubscribeAsync}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncCreateSignal: SubscribeAsync = {SubscribeAsync}")]
     public sealed class AsyncCreateSignal<T> : System.IObservable<T>
     {
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ObservableFactory = {ObservableFactory}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncDeferSignal: ObservableFactory = {ObservableFactory}")]
     public sealed class AsyncDeferSignal<T> : System.IObservable<T>
     {
         public AsyncDeferSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public AsyncDeferSignal(System.Func<System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncSubscriptionLifetime: Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
     public sealed class AsyncSubscriptionLifetime : System.IDisposable
     {
         public AsyncSubscriptionLifetime() { }
@@ -554,33 +554,33 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable? disposable) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connected = {_connected}")]
+    [System.Diagnostics.DebuggerDisplay("AutoConnectSignal: Count = {_count}, Connected = {_connected}")]
     public sealed class AutoConnectSignal<T> : System.IObservable<T>
     {
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount) { }
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount, System.Action<System.IDisposable>? onConnect) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connection = {_connection}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSignal: Count = {_count}, Connection = {_connection}")]
     public sealed class AutoShareSignal<T> : System.IObservable<T>
     {
         public AutoShareSignal(ReactiveUI.Primitives.ConnectableSignal<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Owner = {_owner}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSubscription: Owner = {_owner}, Subscription = {Subscription}")]
     public sealed class AutoShareSubscription<T> : System.IDisposable
     {
         public AutoShareSubscription(ReactiveUI.Primitives.Advanced.AutoShareSignal<T> owner, System.IDisposable subscription) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void Dispose() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("BlendSignal: Sources = {Sources}")]
     public sealed class BlendSignal<T> : System.IObservable<T>
     {
         public BlendSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("BlendWitness: ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
     public sealed class BlendWitness<T> : System.IDisposable
     {
         public BlendWitness(System.IObserver<T> observer) { }
@@ -589,7 +589,7 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.BlendWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.BlendWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("BufferEachWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class BufferEachWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public BufferEachWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -603,20 +603,20 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Window = {Window}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("BufferSignal: Window = {Window}, Source = {Source}")]
     public sealed class BufferSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public BufferSignal(System.IObservable<T> source, System.TimeSpan timeSpan, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("CastSignal: Source = {Source}")]
     public sealed class CastSignal<TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public CastSignal(System.IObservable<object?> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CastWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CastWitness<TResult> : System.IDisposable, System.IObserver<object?>
     {
         public CastWitness(System.IObserver<TResult> observer) { }
@@ -630,7 +630,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
+    [System.Diagnostics.DebuggerDisplay("ChainSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
     public sealed class ChainSignal<T> : System.IObservable<T>
     {
         public ChainSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -638,7 +638,7 @@ namespace ReactiveUI.Primitives.Advanced
         public ChainSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("ChainWitness: IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
     public sealed class ChainWitness<T> : System.IDisposable
     {
         public ChainWitness(System.IObserver<T> observer) { }
@@ -648,13 +648,13 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.ChainWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.ChainWitness<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, TimeSpan = {TimeSpan}")]
+    [System.Diagnostics.DebuggerDisplay("CollectSignal: Source = {Source}, TimeSpan = {TimeSpan}")]
     public sealed class CollectSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public CollectSignal(System.IObservable<T> source, System.TimeSpan timeSpan, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Buffered = {Values.Count}")]
+    [System.Diagnostics.DebuggerDisplay("CollectWitness: Stopped = {_stopped}, Buffered = {Values.Count}")]
     public sealed class CollectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CollectWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -666,7 +666,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateSink: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class CreateSink<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateSink(System.IObserver<T> observer, bool disposeOnNextThrow) { }
@@ -678,7 +678,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CreateWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateWitness(System.IObserver<T> observer) { }
@@ -692,7 +692,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
+    [System.Diagnostics.DebuggerDisplay("DispatchSequencerState: ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
     public record struct DispatchSequencerState : System.IEquatable<ReactiveUI.Primitives.Advanced.DispatchSequencerState>
     {
         public DispatchSequencerState(ReactiveUI.Primitives.Concurrency.ISequencer owner, System.Func<System.Action, bool> post, System.Action drain) { }
@@ -707,13 +707,13 @@ namespace ReactiveUI.Primitives.Advanced
         public static System.TimeSpan DelayUntil(long dueTimestamp) { }
         public static void RunIfActive(ReactiveUI.Primitives.Concurrency.IWorkItem item) { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {DueTime}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietSignal: DueTime = {DueTime}, Source = {Source}")]
     public sealed class EmitIfQuietSignal<T> : System.IObservable<T>
     {
         public EmitIfQuietSignal(System.IObservable<T> source, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietWitness: HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
     public sealed class EmitIfQuietWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public EmitIfQuietWitness(System.IObserver<T> observer, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
@@ -724,7 +724,16 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("EmptySignal: Scheduler = {_scheduler}")]
+    public sealed class EmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public EmptySignal(ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("EnumerableBlendSignal: Sources = {Sources}")]
     public sealed class EnumerableBlendSignal<T> : System.IObservable<T>
     {
         public EnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -734,7 +743,14 @@ namespace ReactiveUI.Primitives.Advanced
     {
         public static System.IDisposable Attach<TEventHandler>(TEventHandler handler, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
+    [System.Diagnostics.DebuggerDisplay("EverySignal: Period = {_period}, Scheduler = {_scheduler}")]
+    public sealed class EverySignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
+    {
+        public EverySignal(System.TimeSpan period, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<long> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ExpireCoordinator: Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
     public sealed class ExpireCoordinator<T> : System.IDisposable, System.IObserver<T>
     {
         public ExpireCoordinator(System.IObservable<T> source, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer, System.IObserver<T> observer) { }
@@ -744,39 +760,48 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnNext(T value) { }
         public ReactiveUI.Primitives.Advanced.ExpireCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("ExpireSignal: DueTime = {_dueTime}, Source = {_source}")]
     public sealed class ExpireSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ExpireSignal(System.IObservable<T> source, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("FinallySignal: Source = {_source}")]
+    public sealed class FinallySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public FinallySignal(System.IObservable<T> source, System.Action finallyAction) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ForkJoinSignal: Left = {Left}, Right = {Right}")]
     public sealed class ForkJoinSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public ForkJoinSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("ForkJoinWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
     public sealed class ForkJoinWitness<TLeft, TRight, TResult>
     {
         public ForkJoinWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("CancellationRequested = {CancellationToken.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncExternalCancellationSignal: CancellationRequested = {CancellationToken.IsCancellationRequested}")]
     public sealed class FromAsyncExternalCancellationSignal<T> : System.IObservable<T>
     {
         public FromAsyncExternalCancellationSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSignal: TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
     public sealed class FromAsyncSignal<T> : System.IObservable<T>
     {
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSubscription: Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
     public sealed class FromAsyncSubscription<T> : System.IDisposable
     {
         public FromAsyncSubscription(System.IObserver<T> observer, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
@@ -789,14 +814,14 @@ namespace ReactiveUI.Primitives.Advanced
         public FromEventConversionSignal(System.Func<TCallback, TEventHandler> conversion, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Func<System.IObserver<TResult>, TCallback> callback, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
+    [System.Diagnostics.DebuggerDisplay("FromEventPatternSignal: AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
     public sealed class FromEventPatternSignal<TEventHandler, TEventArgs> : System.IObservable<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> where TEventHandler : System.Delegate where TEventArgs : System.EventArgs
     {
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler) { }
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Disposed = {_disposed}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("GuardedWitness: Disposed = {_disposed}, Observer = {_observer}")]
     public sealed class GuardedWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public GuardedWitness(System.IObserver<T> observer, System.IDisposable cancel) { }
@@ -806,7 +831,7 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IgnoreValuesSignal: Source = {Source}")]
     public sealed class IgnoreValuesSignal<T> : System.IObservable<T>
     {
         public IgnoreValuesSignal(System.IObservable<T> source) { }
@@ -820,14 +845,14 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.RxVoid> observer) { }
         public System.IDisposable Subscribe(System.Action<ReactiveUI.Primitives.RxVoid> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptySignal: Source = {Source}")]
     public sealed class IsEmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<bool>
     {
         public IsEmptySignal(System.IObservable<T> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<bool> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptyWitness: Stopped = {_stopped}, Subscription = {Subscription}")]
     public sealed class IsEmptyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public IsEmptyWitness(System.IObserver<bool> observer) { }
@@ -840,14 +865,23 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {Value}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("LeadSignal: Value = {Value}, Source = {Source}")]
     public sealed class LeadSignal<T> : ReactiveUI.Primitives.Advanced.IInlineSignal<T>
     {
         public LeadSignal(System.IObservable<T> source, T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
         public System.IDisposable Subscribe(System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("LoopSignal: Value = {Value}")]
+    public sealed class LoopSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public LoopSignal(T value) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("MapIndexedSignal: Source = {_source}")]
     public sealed class MapIndexedSignal<TSource, TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public MapIndexedSignal(System.IObservable<TSource> source, System.Func<TSource, int, TResult> selector) { }
@@ -855,7 +889,7 @@ namespace ReactiveUI.Primitives.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Index = {_index}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("MapIndexedWitness: Index = {_index}, Stopped = {_stopped}")]
     public sealed class MapIndexedWitness<TSource, TResult> : System.IObserver<TSource>
     {
         public MapIndexedWitness(System.IObserver<TResult> observer, System.Func<TSource, int, TResult> selector) { }
@@ -863,20 +897,20 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(TSource value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentBlendCoordinator: Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
     public sealed class MaxConcurrentBlendCoordinator<T> : System.IDisposable
     {
         public MaxConcurrentBlendCoordinator(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.MaxConcurrentBlendCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentEnumerableBlendSignal: Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
     public sealed class MaxConcurrentEnumerableBlendSignal<T> : System.IObservable<T>
     {
         public MaxConcurrentEnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("MergeCoordinator: Active = {Active}, Done = {Done}")]
     public sealed class MergeCoordinator<T> : System.IDisposable
     {
         public MergeCoordinator(System.IObserver<T> observer) { }
@@ -887,7 +921,7 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.MergeCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.MergeCoordinator<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MergeSignal: Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
     public sealed class MergeSignal<T> : System.IObservable<T>
     {
         public MergeSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -895,32 +929,39 @@ namespace ReactiveUI.Primitives.Advanced
         public MergeSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("OnErrorResumeNextSignal: Sources = {_sources}")]
+    public sealed class OnErrorResumeNextSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("PairSignal: Left = {Left}, Right = {Right}")]
     public sealed class PairSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public PairSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
+    [System.Diagnostics.DebuggerDisplay("PairWitness: IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
     public sealed class PairWitness<TLeft, TRight, TResult>
     {
         public PairWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("PublishSelectorSignal: Source = {Source}, Selector = {Selector}")]
     public sealed class PublishSelectorSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public PublishSelectorSignal(System.IObservable<TSource> source, System.Func<System.IObservable<TSource>, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
+    [System.Diagnostics.DebuggerDisplay("RaceSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
     public sealed class RaceSignal<T> : System.IObservable<T>
     {
         public RaceSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public RaceSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Arms = {_arms}")]
+    [System.Diagnostics.DebuggerDisplay("RaceWitness: Arms = {_arms}")]
     public sealed class RaceWitness<T> : System.IDisposable
     {
         public RaceWitness(System.IObserver<T> observer) { }
@@ -929,40 +970,48 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.RaceWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.RaceWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeCombineLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeCombineLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeCombineLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
+    [System.Diagnostics.DebuggerDisplay("RangeForkJoinSignal: Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
     public sealed class RangeForkJoinSignal<TResult> : System.IObservable<TResult>
     {
         public RangeForkJoinSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeSyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeSyncLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeSyncLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeWithLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeWithLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeWithLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Remaining = {_remaining}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("RecoverSignal: Source = {_source}")]
+    public sealed class RecoverSignal<T, TException> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T> where TException : System.Exception
+    {
+        public RecoverSignal(System.IObservable<T> source, System.Func<TException, System.IObservable<T>> handler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceCoordinator: Remaining = {_remaining}, Disposed = {_disposed}")]
     public sealed class RepeatSourceCoordinator<T> : System.IDisposable
     {
         public RepeatSourceCoordinator(System.IObservable<T> source, int? repeatCount, System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.RepeatSourceCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, RepeatCount = {_repeatCount}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceSignal: Source = {_source}, RepeatCount = {_repeatCount}")]
     public sealed class RepeatSourceSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public RepeatSourceSignal(System.IObservable<T> source, int? repeatCount) { }
@@ -970,7 +1019,7 @@ namespace ReactiveUI.Primitives.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Generation = {_generation}, Terminated = {_terminated}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceWitness: Generation = {_generation}, Terminated = {_terminated}")]
     public sealed class RepeatSourceWitness<T> : System.IObserver<T>
     {
         public RepeatSourceWitness(ReactiveUI.Primitives.Advanced.RepeatSourceCoordinator<T> parent, int generation) { }
@@ -978,7 +1027,15 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_value}, Scheduler = {_scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ResumeSignal: Source = {_source}, Fallback = {_fallback}")]
+    public sealed class ResumeSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ResumeSignal(System.IObservable<T> source, System.IObservable<T> fallback) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ReturnSignal: Value = {_value}, Scheduler = {_scheduler}")]
     public sealed class ReturnSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ReturnSignal(T value, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -987,13 +1044,13 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Values = {Values}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledEnumerableSignal: Values = {Values}, Scheduler = {Scheduler}")]
     public sealed class ScheduledEnumerableSignal<T> : System.IObservable<T>
     {
         public ScheduledEnumerableSignal(System.Collections.Generic.IEnumerable<T> values, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyCoordinator<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TResult>> selector) { }
@@ -1007,13 +1064,13 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Advanced.SelectManyCoordinator<TSource, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableSignal: Source = {_source}")]
     public sealed class SelectManyEnumerableSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManyEnumerableSignal(System.IObservable<TSource> source, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SelectManyEnumerableWitness<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyEnumerableWitness(System.IObserver<TResult> observer, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
@@ -1027,7 +1084,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyResultCoordinator<TSource, TCollection, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyResultCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
@@ -1040,20 +1097,20 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Advanced.SelectManyResultCoordinator<TSource, TCollection, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, CollectionSelector = {CollectionSelector}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultSignal: Source = {Source}, CollectionSelector = {CollectionSelector}")]
     public sealed class SelectManyResultSignal<TSource, TCollection, TResult> : System.IObservable<TResult>
     {
         public SelectManyResultSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManySignal: Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
     public sealed class SelectManySignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManySignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public SelectManySignal(System.IObservable<TSource> source, System.IObservable<TResult> inner) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Start = {Start}, Count = {Count}")]
+    [System.Diagnostics.DebuggerDisplay("SequenceSignal: Start = {Start}, Count = {Count}")]
     public sealed class SequenceSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<int>
     {
         public SequenceSignal(int start, int count, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -1064,13 +1121,13 @@ namespace ReactiveUI.Primitives.Advanced
     {
         public static System.IDisposable Subscribe<T>(System.IObserver<T> observer, bool currentThreadRequired, System.Func<System.IObserver<T>, System.IDisposable, System.IDisposable> subscribeCore) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SparkSignal: Source = {Source}")]
     public sealed class SparkSignal<T> : System.IObservable<ReactiveUI.Primitives.Core.Spark<T>>
     {
         public SparkSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.Spark<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SparkWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SparkWitness(System.IObserver<ReactiveUI.Primitives.Core.Spark<T>> observer) { }
@@ -1085,21 +1142,21 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Action = {Action}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Action = {Action}, Scheduler = {Scheduler}")]
     public sealed class StartSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<ReactiveUI.Primitives.RxVoid>
     {
         public StartSignal(System.Action action, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.RxVoid> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Function = {Function}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Function = {Function}, Scheduler = {Scheduler}")]
     public sealed class StartSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public StartSignal(System.Func<T> function, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SubscribeSafeWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SubscribeSafeWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SubscribeSafeWitness(System.IObserver<T> observer) { }
@@ -1113,50 +1170,50 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, SkipNullSources = {_skipNullSources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchMapSignal: Source = {_source}, SkipNullSources = {_skipNullSources}")]
     public sealed class SwitchMapSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SwitchMapSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchSignal: Sources = {Sources}")]
     public sealed class SwitchSignal<T> : System.IObservable<T>
     {
         public SwitchSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Version = {_version}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchWitness: Version = {_version}, IsDone = {IsDone}")]
     public sealed class SwitchWitness<T> : System.IDisposable
     {
         public SwitchWitness(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.SwitchWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class SyncLatestSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public SyncLatestSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
     public sealed class SyncLatestWitness<TLeft, TRight, TResult>
     {
         public SyncLatestWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Gate = {Gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeGateSignal: Source = {Source}, Gate = {Gate}")]
     public sealed class SynchronizeGateSignal<T> : System.IObservable<T>
     {
         public SynchronizeGateSignal(System.IObservable<T> source, System.Threading.Lock gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, Gate = {_gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectSignal: Source = {_source}, Gate = {_gate}")]
     public sealed class SynchronizeObjectSignal<T> : System.IObservable<T>
     {
         public SynchronizeObjectSignal(System.IObservable<T> source, object gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SynchronizeObjectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SynchronizeObjectWitness(System.IObserver<T> observer, object gate) { }
@@ -1168,19 +1225,19 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeSignal: Source = {Source}")]
     public sealed class SynchronizeSignal<T> : System.IObservable<T>
     {
         public SynchronizeSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("TapSignal: Source = {Source}")]
     public sealed class TapSignal<T> : System.IObservable<T>
     {
         public TapSignal(System.IObservable<T> source, System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskAnyWitness: Stopped = {_stopped}, Task = {Task}")]
     public sealed class TaskAnyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskAnyWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1196,7 +1253,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainCoordinator: Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
     public sealed class TaskChainCoordinator<T> : System.IDisposable
     {
         public TaskChainCoordinator(System.IObserver<T> observer) { }
@@ -1204,13 +1261,13 @@ namespace ReactiveUI.Primitives.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.TaskChainCoordinator<T> Run(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainSignal: Sources = {_sources}")]
     public sealed class TaskChainSignal<T> : System.IObservable<T>
     {
         public TaskChainSignal(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskCountWitness: Count = {_count}, Stopped = {_stopped}")]
     public sealed class TaskCountWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskCountWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1226,13 +1283,13 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSignal: Task = {Task}")]
     public sealed class TaskInstanceSignal<T> : System.IObservable<T>
     {
         public TaskInstanceSignal(System.Threading.Tasks.Task<T> task) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSubscription: Stopped = {_stopped}")]
     public sealed class TaskInstanceSubscription : System.IDisposable
     {
         public TaskInstanceSubscription() { }
@@ -1240,13 +1297,22 @@ namespace ReactiveUI.Primitives.Advanced
         public void Dispose() { }
         public bool TryStop() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Sequencer = {Sequencer}")]
+    [System.Diagnostics.DebuggerDisplay("ThrowSignal: Error = {_error}, Scheduler = {_scheduler}")]
+    public sealed class ThrowSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ThrowSignal(System.Exception error, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalSignal: Source = {Source}, Sequencer = {Sequencer}")]
     public sealed class TimeIntervalSignal<T> : System.IObservable<ReactiveUI.Primitives.Core.TimeInterval<T>>
     {
         public TimeIntervalSignal(System.IObservable<T> source, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("First = {_first}, Last = {_last}")]
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalWitness: First = {_first}, Last = {_last}")]
     public sealed class TimeIntervalWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TimeIntervalWitness(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -1264,13 +1330,13 @@ namespace ReactiveUI.Primitives.Advanced
     {
         public static void Arm(ReactiveUI.Primitives.Disposables.SingleReplaceableDisposable slot, ReactiveUI.Primitives.Concurrency.ISequencer sequencer, System.TimeSpan delay, System.Action tick) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkSignal: Source = {Source}")]
     public sealed class UnsparkSignal<T> : System.IObservable<T>
     {
         public UnsparkSignal(System.IObservable<ReactiveUI.Primitives.Core.Spark<T>> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class UnsparkWitness<T> : System.IDisposable, System.IObserver<ReactiveUI.Primitives.Core.Spark<T>>
     {
         public UnsparkWitness(System.IObserver<T> observer) { }
@@ -1853,7 +1919,7 @@ namespace ReactiveUI.Primitives.Extensions.Operators
 }
 namespace ReactiveUI.Primitives.Signals
 {
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
+    [System.Diagnostics.DebuggerDisplay("PrioritySemaphoreSignal: Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
     public sealed class PrioritySemaphoreSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T> where T : System.IComparable<T>
     {
         public PrioritySemaphoreSignal(int maxCount) { }
@@ -1888,7 +1954,7 @@ namespace ReactiveUI.Primitives.Signals
         public void OnNext(T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledSignal: Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
     public class ScheduledSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T>
     {
         public ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }

--- a/src/ReactiveUI.Primitives/PublicAPI/net11.0-android/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net11.0-android/PublicAPI.txt
@@ -518,7 +518,7 @@ namespace ReactiveUI.Primitives
 }
 namespace ReactiveUI.Primitives.Advanced
 {
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Period = {_period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSignal: DueTime = {_dueTime}, Period = {_period}")]
     public sealed class AfterSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
     {
         public AfterSignal(System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -526,7 +526,7 @@ namespace ReactiveUI.Primitives.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<long> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSubscription: Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
     public sealed class AfterSubscription : System.IDisposable
     {
         public AfterSubscription(System.IObserver<long> observer, ReactiveUI.Primitives.Concurrency.ISequencer scheduler, System.TimeSpan dueTime, System.TimeSpan? period) { }
@@ -534,21 +534,21 @@ namespace ReactiveUI.Primitives.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.AfterSubscription Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("SubscribeAsync = {SubscribeAsync}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncCreateSignal: SubscribeAsync = {SubscribeAsync}")]
     public sealed class AsyncCreateSignal<T> : System.IObservable<T>
     {
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ObservableFactory = {ObservableFactory}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncDeferSignal: ObservableFactory = {ObservableFactory}")]
     public sealed class AsyncDeferSignal<T> : System.IObservable<T>
     {
         public AsyncDeferSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public AsyncDeferSignal(System.Func<System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncSubscriptionLifetime: Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
     public sealed class AsyncSubscriptionLifetime : System.IDisposable
     {
         public AsyncSubscriptionLifetime() { }
@@ -559,33 +559,33 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable? disposable) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connected = {_connected}")]
+    [System.Diagnostics.DebuggerDisplay("AutoConnectSignal: Count = {_count}, Connected = {_connected}")]
     public sealed class AutoConnectSignal<T> : System.IObservable<T>
     {
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount) { }
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount, System.Action<System.IDisposable>? onConnect) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connection = {_connection}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSignal: Count = {_count}, Connection = {_connection}")]
     public sealed class AutoShareSignal<T> : System.IObservable<T>
     {
         public AutoShareSignal(ReactiveUI.Primitives.ConnectableSignal<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Owner = {_owner}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSubscription: Owner = {_owner}, Subscription = {Subscription}")]
     public sealed class AutoShareSubscription<T> : System.IDisposable
     {
         public AutoShareSubscription(ReactiveUI.Primitives.Advanced.AutoShareSignal<T> owner, System.IDisposable subscription) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void Dispose() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("BlendSignal: Sources = {Sources}")]
     public sealed class BlendSignal<T> : System.IObservable<T>
     {
         public BlendSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("BlendWitness: ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
     public sealed class BlendWitness<T> : System.IDisposable
     {
         public BlendWitness(System.IObserver<T> observer) { }
@@ -594,7 +594,7 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.BlendWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.BlendWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("BufferEachWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class BufferEachWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public BufferEachWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -608,20 +608,20 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Window = {Window}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("BufferSignal: Window = {Window}, Source = {Source}")]
     public sealed class BufferSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public BufferSignal(System.IObservable<T> source, System.TimeSpan timeSpan, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("CastSignal: Source = {Source}")]
     public sealed class CastSignal<TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public CastSignal(System.IObservable<object?> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CastWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CastWitness<TResult> : System.IDisposable, System.IObserver<object?>
     {
         public CastWitness(System.IObserver<TResult> observer) { }
@@ -635,7 +635,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
+    [System.Diagnostics.DebuggerDisplay("ChainSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
     public sealed class ChainSignal<T> : System.IObservable<T>
     {
         public ChainSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -643,7 +643,7 @@ namespace ReactiveUI.Primitives.Advanced
         public ChainSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("ChainWitness: IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
     public sealed class ChainWitness<T> : System.IDisposable
     {
         public ChainWitness(System.IObserver<T> observer) { }
@@ -653,13 +653,13 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.ChainWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.ChainWitness<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, TimeSpan = {TimeSpan}")]
+    [System.Diagnostics.DebuggerDisplay("CollectSignal: Source = {Source}, TimeSpan = {TimeSpan}")]
     public sealed class CollectSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public CollectSignal(System.IObservable<T> source, System.TimeSpan timeSpan, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Buffered = {Values.Count}")]
+    [System.Diagnostics.DebuggerDisplay("CollectWitness: Stopped = {_stopped}, Buffered = {Values.Count}")]
     public sealed class CollectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CollectWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -671,7 +671,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateSink: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class CreateSink<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateSink(System.IObserver<T> observer, bool disposeOnNextThrow) { }
@@ -683,7 +683,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CreateWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateWitness(System.IObserver<T> observer) { }
@@ -697,7 +697,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
+    [System.Diagnostics.DebuggerDisplay("DispatchSequencerState: ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
     public record struct DispatchSequencerState : System.IEquatable<ReactiveUI.Primitives.Advanced.DispatchSequencerState>
     {
         public DispatchSequencerState(ReactiveUI.Primitives.Concurrency.ISequencer owner, System.Func<System.Action, bool> post, System.Action drain) { }
@@ -712,13 +712,13 @@ namespace ReactiveUI.Primitives.Advanced
         public static System.TimeSpan DelayUntil(long dueTimestamp) { }
         public static void RunIfActive(ReactiveUI.Primitives.Concurrency.IWorkItem item) { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {DueTime}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietSignal: DueTime = {DueTime}, Source = {Source}")]
     public sealed class EmitIfQuietSignal<T> : System.IObservable<T>
     {
         public EmitIfQuietSignal(System.IObservable<T> source, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietWitness: HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
     public sealed class EmitIfQuietWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public EmitIfQuietWitness(System.IObserver<T> observer, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
@@ -729,7 +729,16 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("EmptySignal: Scheduler = {_scheduler}")]
+    public sealed class EmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public EmptySignal(ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("EnumerableBlendSignal: Sources = {Sources}")]
     public sealed class EnumerableBlendSignal<T> : System.IObservable<T>
     {
         public EnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -739,7 +748,14 @@ namespace ReactiveUI.Primitives.Advanced
     {
         public static System.IDisposable Attach<TEventHandler>(TEventHandler handler, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
+    [System.Diagnostics.DebuggerDisplay("EverySignal: Period = {_period}, Scheduler = {_scheduler}")]
+    public sealed class EverySignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
+    {
+        public EverySignal(System.TimeSpan period, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<long> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ExpireCoordinator: Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
     public sealed class ExpireCoordinator<T> : System.IDisposable, System.IObserver<T>
     {
         public ExpireCoordinator(System.IObservable<T> source, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer, System.IObserver<T> observer) { }
@@ -749,39 +765,48 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnNext(T value) { }
         public ReactiveUI.Primitives.Advanced.ExpireCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("ExpireSignal: DueTime = {_dueTime}, Source = {_source}")]
     public sealed class ExpireSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ExpireSignal(System.IObservable<T> source, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("FinallySignal: Source = {_source}")]
+    public sealed class FinallySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public FinallySignal(System.IObservable<T> source, System.Action finallyAction) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ForkJoinSignal: Left = {Left}, Right = {Right}")]
     public sealed class ForkJoinSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public ForkJoinSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("ForkJoinWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
     public sealed class ForkJoinWitness<TLeft, TRight, TResult>
     {
         public ForkJoinWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("CancellationRequested = {CancellationToken.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncExternalCancellationSignal: CancellationRequested = {CancellationToken.IsCancellationRequested}")]
     public sealed class FromAsyncExternalCancellationSignal<T> : System.IObservable<T>
     {
         public FromAsyncExternalCancellationSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSignal: TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
     public sealed class FromAsyncSignal<T> : System.IObservable<T>
     {
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSubscription: Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
     public sealed class FromAsyncSubscription<T> : System.IDisposable
     {
         public FromAsyncSubscription(System.IObserver<T> observer, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
@@ -794,14 +819,14 @@ namespace ReactiveUI.Primitives.Advanced
         public FromEventConversionSignal(System.Func<TCallback, TEventHandler> conversion, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Func<System.IObserver<TResult>, TCallback> callback, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
+    [System.Diagnostics.DebuggerDisplay("FromEventPatternSignal: AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
     public sealed class FromEventPatternSignal<TEventHandler, TEventArgs> : System.IObservable<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> where TEventHandler : System.Delegate where TEventArgs : System.EventArgs
     {
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler) { }
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Disposed = {_disposed}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("GuardedWitness: Disposed = {_disposed}, Observer = {_observer}")]
     public sealed class GuardedWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public GuardedWitness(System.IObserver<T> observer, System.IDisposable cancel) { }
@@ -811,7 +836,7 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IgnoreValuesSignal: Source = {Source}")]
     public sealed class IgnoreValuesSignal<T> : System.IObservable<T>
     {
         public IgnoreValuesSignal(System.IObservable<T> source) { }
@@ -825,14 +850,14 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.RxVoid> observer) { }
         public System.IDisposable Subscribe(System.Action<ReactiveUI.Primitives.RxVoid> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptySignal: Source = {Source}")]
     public sealed class IsEmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<bool>
     {
         public IsEmptySignal(System.IObservable<T> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<bool> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptyWitness: Stopped = {_stopped}, Subscription = {Subscription}")]
     public sealed class IsEmptyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public IsEmptyWitness(System.IObserver<bool> observer) { }
@@ -845,14 +870,23 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {Value}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("LeadSignal: Value = {Value}, Source = {Source}")]
     public sealed class LeadSignal<T> : ReactiveUI.Primitives.Advanced.IInlineSignal<T>
     {
         public LeadSignal(System.IObservable<T> source, T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
         public System.IDisposable Subscribe(System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("LoopSignal: Value = {Value}")]
+    public sealed class LoopSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public LoopSignal(T value) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("MapIndexedSignal: Source = {_source}")]
     public sealed class MapIndexedSignal<TSource, TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public MapIndexedSignal(System.IObservable<TSource> source, System.Func<TSource, int, TResult> selector) { }
@@ -860,7 +894,7 @@ namespace ReactiveUI.Primitives.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Index = {_index}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("MapIndexedWitness: Index = {_index}, Stopped = {_stopped}")]
     public sealed class MapIndexedWitness<TSource, TResult> : System.IObserver<TSource>
     {
         public MapIndexedWitness(System.IObserver<TResult> observer, System.Func<TSource, int, TResult> selector) { }
@@ -868,20 +902,20 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(TSource value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentBlendCoordinator: Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
     public sealed class MaxConcurrentBlendCoordinator<T> : System.IDisposable
     {
         public MaxConcurrentBlendCoordinator(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.MaxConcurrentBlendCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentEnumerableBlendSignal: Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
     public sealed class MaxConcurrentEnumerableBlendSignal<T> : System.IObservable<T>
     {
         public MaxConcurrentEnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("MergeCoordinator: Active = {Active}, Done = {Done}")]
     public sealed class MergeCoordinator<T> : System.IDisposable
     {
         public MergeCoordinator(System.IObserver<T> observer) { }
@@ -892,7 +926,7 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.MergeCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.MergeCoordinator<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MergeSignal: Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
     public sealed class MergeSignal<T> : System.IObservable<T>
     {
         public MergeSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -900,32 +934,39 @@ namespace ReactiveUI.Primitives.Advanced
         public MergeSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("OnErrorResumeNextSignal: Sources = {_sources}")]
+    public sealed class OnErrorResumeNextSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("PairSignal: Left = {Left}, Right = {Right}")]
     public sealed class PairSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public PairSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
+    [System.Diagnostics.DebuggerDisplay("PairWitness: IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
     public sealed class PairWitness<TLeft, TRight, TResult>
     {
         public PairWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("PublishSelectorSignal: Source = {Source}, Selector = {Selector}")]
     public sealed class PublishSelectorSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public PublishSelectorSignal(System.IObservable<TSource> source, System.Func<System.IObservable<TSource>, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
+    [System.Diagnostics.DebuggerDisplay("RaceSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
     public sealed class RaceSignal<T> : System.IObservable<T>
     {
         public RaceSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public RaceSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Arms = {_arms}")]
+    [System.Diagnostics.DebuggerDisplay("RaceWitness: Arms = {_arms}")]
     public sealed class RaceWitness<T> : System.IDisposable
     {
         public RaceWitness(System.IObserver<T> observer) { }
@@ -934,40 +975,48 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.RaceWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.RaceWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeCombineLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeCombineLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeCombineLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
+    [System.Diagnostics.DebuggerDisplay("RangeForkJoinSignal: Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
     public sealed class RangeForkJoinSignal<TResult> : System.IObservable<TResult>
     {
         public RangeForkJoinSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeSyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeSyncLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeSyncLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeWithLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeWithLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeWithLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Remaining = {_remaining}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("RecoverSignal: Source = {_source}")]
+    public sealed class RecoverSignal<T, TException> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T> where TException : System.Exception
+    {
+        public RecoverSignal(System.IObservable<T> source, System.Func<TException, System.IObservable<T>> handler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceCoordinator: Remaining = {_remaining}, Disposed = {_disposed}")]
     public sealed class RepeatSourceCoordinator<T> : System.IDisposable
     {
         public RepeatSourceCoordinator(System.IObservable<T> source, int? repeatCount, System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.RepeatSourceCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, RepeatCount = {_repeatCount}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceSignal: Source = {_source}, RepeatCount = {_repeatCount}")]
     public sealed class RepeatSourceSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public RepeatSourceSignal(System.IObservable<T> source, int? repeatCount) { }
@@ -975,7 +1024,7 @@ namespace ReactiveUI.Primitives.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Generation = {_generation}, Terminated = {_terminated}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceWitness: Generation = {_generation}, Terminated = {_terminated}")]
     public sealed class RepeatSourceWitness<T> : System.IObserver<T>
     {
         public RepeatSourceWitness(ReactiveUI.Primitives.Advanced.RepeatSourceCoordinator<T> parent, int generation) { }
@@ -983,7 +1032,15 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_value}, Scheduler = {_scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ResumeSignal: Source = {_source}, Fallback = {_fallback}")]
+    public sealed class ResumeSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ResumeSignal(System.IObservable<T> source, System.IObservable<T> fallback) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ReturnSignal: Value = {_value}, Scheduler = {_scheduler}")]
     public sealed class ReturnSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ReturnSignal(T value, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -992,13 +1049,13 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Values = {Values}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledEnumerableSignal: Values = {Values}, Scheduler = {Scheduler}")]
     public sealed class ScheduledEnumerableSignal<T> : System.IObservable<T>
     {
         public ScheduledEnumerableSignal(System.Collections.Generic.IEnumerable<T> values, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyCoordinator<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TResult>> selector) { }
@@ -1012,13 +1069,13 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Advanced.SelectManyCoordinator<TSource, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableSignal: Source = {_source}")]
     public sealed class SelectManyEnumerableSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManyEnumerableSignal(System.IObservable<TSource> source, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SelectManyEnumerableWitness<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyEnumerableWitness(System.IObserver<TResult> observer, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
@@ -1032,7 +1089,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyResultCoordinator<TSource, TCollection, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyResultCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
@@ -1045,20 +1102,20 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Advanced.SelectManyResultCoordinator<TSource, TCollection, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, CollectionSelector = {CollectionSelector}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultSignal: Source = {Source}, CollectionSelector = {CollectionSelector}")]
     public sealed class SelectManyResultSignal<TSource, TCollection, TResult> : System.IObservable<TResult>
     {
         public SelectManyResultSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManySignal: Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
     public sealed class SelectManySignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManySignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public SelectManySignal(System.IObservable<TSource> source, System.IObservable<TResult> inner) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Start = {Start}, Count = {Count}")]
+    [System.Diagnostics.DebuggerDisplay("SequenceSignal: Start = {Start}, Count = {Count}")]
     public sealed class SequenceSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<int>
     {
         public SequenceSignal(int start, int count, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -1069,13 +1126,13 @@ namespace ReactiveUI.Primitives.Advanced
     {
         public static System.IDisposable Subscribe<T>(System.IObserver<T> observer, bool currentThreadRequired, System.Func<System.IObserver<T>, System.IDisposable, System.IDisposable> subscribeCore) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SparkSignal: Source = {Source}")]
     public sealed class SparkSignal<T> : System.IObservable<ReactiveUI.Primitives.Core.Spark<T>>
     {
         public SparkSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.Spark<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SparkWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SparkWitness(System.IObserver<ReactiveUI.Primitives.Core.Spark<T>> observer) { }
@@ -1090,21 +1147,21 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Action = {Action}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Action = {Action}, Scheduler = {Scheduler}")]
     public sealed class StartSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<ReactiveUI.Primitives.RxVoid>
     {
         public StartSignal(System.Action action, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.RxVoid> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Function = {Function}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Function = {Function}, Scheduler = {Scheduler}")]
     public sealed class StartSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public StartSignal(System.Func<T> function, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SubscribeSafeWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SubscribeSafeWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SubscribeSafeWitness(System.IObserver<T> observer) { }
@@ -1118,50 +1175,50 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, SkipNullSources = {_skipNullSources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchMapSignal: Source = {_source}, SkipNullSources = {_skipNullSources}")]
     public sealed class SwitchMapSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SwitchMapSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchSignal: Sources = {Sources}")]
     public sealed class SwitchSignal<T> : System.IObservable<T>
     {
         public SwitchSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Version = {_version}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchWitness: Version = {_version}, IsDone = {IsDone}")]
     public sealed class SwitchWitness<T> : System.IDisposable
     {
         public SwitchWitness(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.SwitchWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class SyncLatestSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public SyncLatestSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
     public sealed class SyncLatestWitness<TLeft, TRight, TResult>
     {
         public SyncLatestWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Gate = {Gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeGateSignal: Source = {Source}, Gate = {Gate}")]
     public sealed class SynchronizeGateSignal<T> : System.IObservable<T>
     {
         public SynchronizeGateSignal(System.IObservable<T> source, System.Threading.Lock gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, Gate = {_gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectSignal: Source = {_source}, Gate = {_gate}")]
     public sealed class SynchronizeObjectSignal<T> : System.IObservable<T>
     {
         public SynchronizeObjectSignal(System.IObservable<T> source, object gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SynchronizeObjectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SynchronizeObjectWitness(System.IObserver<T> observer, object gate) { }
@@ -1173,19 +1230,19 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeSignal: Source = {Source}")]
     public sealed class SynchronizeSignal<T> : System.IObservable<T>
     {
         public SynchronizeSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("TapSignal: Source = {Source}")]
     public sealed class TapSignal<T> : System.IObservable<T>
     {
         public TapSignal(System.IObservable<T> source, System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskAnyWitness: Stopped = {_stopped}, Task = {Task}")]
     public sealed class TaskAnyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskAnyWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1201,7 +1258,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainCoordinator: Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
     public sealed class TaskChainCoordinator<T> : System.IDisposable
     {
         public TaskChainCoordinator(System.IObserver<T> observer) { }
@@ -1209,13 +1266,13 @@ namespace ReactiveUI.Primitives.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.TaskChainCoordinator<T> Run(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainSignal: Sources = {_sources}")]
     public sealed class TaskChainSignal<T> : System.IObservable<T>
     {
         public TaskChainSignal(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskCountWitness: Count = {_count}, Stopped = {_stopped}")]
     public sealed class TaskCountWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskCountWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1231,13 +1288,13 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSignal: Task = {Task}")]
     public sealed class TaskInstanceSignal<T> : System.IObservable<T>
     {
         public TaskInstanceSignal(System.Threading.Tasks.Task<T> task) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSubscription: Stopped = {_stopped}")]
     public sealed class TaskInstanceSubscription : System.IDisposable
     {
         public TaskInstanceSubscription() { }
@@ -1245,13 +1302,22 @@ namespace ReactiveUI.Primitives.Advanced
         public void Dispose() { }
         public bool TryStop() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Sequencer = {Sequencer}")]
+    [System.Diagnostics.DebuggerDisplay("ThrowSignal: Error = {_error}, Scheduler = {_scheduler}")]
+    public sealed class ThrowSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ThrowSignal(System.Exception error, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalSignal: Source = {Source}, Sequencer = {Sequencer}")]
     public sealed class TimeIntervalSignal<T> : System.IObservable<ReactiveUI.Primitives.Core.TimeInterval<T>>
     {
         public TimeIntervalSignal(System.IObservable<T> source, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("First = {_first}, Last = {_last}")]
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalWitness: First = {_first}, Last = {_last}")]
     public sealed class TimeIntervalWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TimeIntervalWitness(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -1269,13 +1335,13 @@ namespace ReactiveUI.Primitives.Advanced
     {
         public static void Arm(ReactiveUI.Primitives.Disposables.SingleReplaceableDisposable slot, ReactiveUI.Primitives.Concurrency.ISequencer sequencer, System.TimeSpan delay, System.Action tick) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkSignal: Source = {Source}")]
     public sealed class UnsparkSignal<T> : System.IObservable<T>
     {
         public UnsparkSignal(System.IObservable<ReactiveUI.Primitives.Core.Spark<T>> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class UnsparkWitness<T> : System.IDisposable, System.IObserver<ReactiveUI.Primitives.Core.Spark<T>>
     {
         public UnsparkWitness(System.IObserver<T> observer) { }
@@ -1872,7 +1938,7 @@ namespace ReactiveUI.Primitives.Extensions.Operators
 }
 namespace ReactiveUI.Primitives.Signals
 {
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
+    [System.Diagnostics.DebuggerDisplay("PrioritySemaphoreSignal: Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
     public sealed class PrioritySemaphoreSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T> where T : System.IComparable<T>
     {
         public PrioritySemaphoreSignal(int maxCount) { }
@@ -1907,7 +1973,7 @@ namespace ReactiveUI.Primitives.Signals
         public void OnNext(T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledSignal: Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
     public class ScheduledSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T>
     {
         public ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }

--- a/src/ReactiveUI.Primitives/PublicAPI/net11.0-ios/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net11.0-ios/PublicAPI.txt
@@ -514,7 +514,7 @@ namespace ReactiveUI.Primitives
 }
 namespace ReactiveUI.Primitives.Advanced
 {
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Period = {_period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSignal: DueTime = {_dueTime}, Period = {_period}")]
     public sealed class AfterSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
     {
         public AfterSignal(System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -522,7 +522,7 @@ namespace ReactiveUI.Primitives.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<long> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSubscription: Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
     public sealed class AfterSubscription : System.IDisposable
     {
         public AfterSubscription(System.IObserver<long> observer, ReactiveUI.Primitives.Concurrency.ISequencer scheduler, System.TimeSpan dueTime, System.TimeSpan? period) { }
@@ -530,21 +530,21 @@ namespace ReactiveUI.Primitives.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.AfterSubscription Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("SubscribeAsync = {SubscribeAsync}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncCreateSignal: SubscribeAsync = {SubscribeAsync}")]
     public sealed class AsyncCreateSignal<T> : System.IObservable<T>
     {
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ObservableFactory = {ObservableFactory}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncDeferSignal: ObservableFactory = {ObservableFactory}")]
     public sealed class AsyncDeferSignal<T> : System.IObservable<T>
     {
         public AsyncDeferSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public AsyncDeferSignal(System.Func<System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncSubscriptionLifetime: Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
     public sealed class AsyncSubscriptionLifetime : System.IDisposable
     {
         public AsyncSubscriptionLifetime() { }
@@ -555,33 +555,33 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable? disposable) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connected = {_connected}")]
+    [System.Diagnostics.DebuggerDisplay("AutoConnectSignal: Count = {_count}, Connected = {_connected}")]
     public sealed class AutoConnectSignal<T> : System.IObservable<T>
     {
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount) { }
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount, System.Action<System.IDisposable>? onConnect) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connection = {_connection}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSignal: Count = {_count}, Connection = {_connection}")]
     public sealed class AutoShareSignal<T> : System.IObservable<T>
     {
         public AutoShareSignal(ReactiveUI.Primitives.ConnectableSignal<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Owner = {_owner}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSubscription: Owner = {_owner}, Subscription = {Subscription}")]
     public sealed class AutoShareSubscription<T> : System.IDisposable
     {
         public AutoShareSubscription(ReactiveUI.Primitives.Advanced.AutoShareSignal<T> owner, System.IDisposable subscription) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void Dispose() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("BlendSignal: Sources = {Sources}")]
     public sealed class BlendSignal<T> : System.IObservable<T>
     {
         public BlendSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("BlendWitness: ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
     public sealed class BlendWitness<T> : System.IDisposable
     {
         public BlendWitness(System.IObserver<T> observer) { }
@@ -590,7 +590,7 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.BlendWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.BlendWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("BufferEachWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class BufferEachWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public BufferEachWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -604,20 +604,20 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Window = {Window}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("BufferSignal: Window = {Window}, Source = {Source}")]
     public sealed class BufferSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public BufferSignal(System.IObservable<T> source, System.TimeSpan timeSpan, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("CastSignal: Source = {Source}")]
     public sealed class CastSignal<TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public CastSignal(System.IObservable<object?> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CastWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CastWitness<TResult> : System.IDisposable, System.IObserver<object?>
     {
         public CastWitness(System.IObserver<TResult> observer) { }
@@ -631,7 +631,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
+    [System.Diagnostics.DebuggerDisplay("ChainSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
     public sealed class ChainSignal<T> : System.IObservable<T>
     {
         public ChainSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -639,7 +639,7 @@ namespace ReactiveUI.Primitives.Advanced
         public ChainSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("ChainWitness: IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
     public sealed class ChainWitness<T> : System.IDisposable
     {
         public ChainWitness(System.IObserver<T> observer) { }
@@ -649,13 +649,13 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.ChainWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.ChainWitness<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, TimeSpan = {TimeSpan}")]
+    [System.Diagnostics.DebuggerDisplay("CollectSignal: Source = {Source}, TimeSpan = {TimeSpan}")]
     public sealed class CollectSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public CollectSignal(System.IObservable<T> source, System.TimeSpan timeSpan, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Buffered = {Values.Count}")]
+    [System.Diagnostics.DebuggerDisplay("CollectWitness: Stopped = {_stopped}, Buffered = {Values.Count}")]
     public sealed class CollectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CollectWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -667,7 +667,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateSink: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class CreateSink<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateSink(System.IObserver<T> observer, bool disposeOnNextThrow) { }
@@ -679,7 +679,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CreateWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateWitness(System.IObserver<T> observer) { }
@@ -693,7 +693,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
+    [System.Diagnostics.DebuggerDisplay("DispatchSequencerState: ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
     public record struct DispatchSequencerState : System.IEquatable<ReactiveUI.Primitives.Advanced.DispatchSequencerState>
     {
         public DispatchSequencerState(ReactiveUI.Primitives.Concurrency.ISequencer owner, System.Func<System.Action, bool> post, System.Action drain) { }
@@ -708,13 +708,13 @@ namespace ReactiveUI.Primitives.Advanced
         public static System.TimeSpan DelayUntil(long dueTimestamp) { }
         public static void RunIfActive(ReactiveUI.Primitives.Concurrency.IWorkItem item) { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {DueTime}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietSignal: DueTime = {DueTime}, Source = {Source}")]
     public sealed class EmitIfQuietSignal<T> : System.IObservable<T>
     {
         public EmitIfQuietSignal(System.IObservable<T> source, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietWitness: HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
     public sealed class EmitIfQuietWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public EmitIfQuietWitness(System.IObserver<T> observer, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
@@ -725,7 +725,16 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("EmptySignal: Scheduler = {_scheduler}")]
+    public sealed class EmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public EmptySignal(ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("EnumerableBlendSignal: Sources = {Sources}")]
     public sealed class EnumerableBlendSignal<T> : System.IObservable<T>
     {
         public EnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -735,7 +744,14 @@ namespace ReactiveUI.Primitives.Advanced
     {
         public static System.IDisposable Attach<TEventHandler>(TEventHandler handler, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
+    [System.Diagnostics.DebuggerDisplay("EverySignal: Period = {_period}, Scheduler = {_scheduler}")]
+    public sealed class EverySignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
+    {
+        public EverySignal(System.TimeSpan period, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<long> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ExpireCoordinator: Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
     public sealed class ExpireCoordinator<T> : System.IDisposable, System.IObserver<T>
     {
         public ExpireCoordinator(System.IObservable<T> source, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer, System.IObserver<T> observer) { }
@@ -745,39 +761,48 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnNext(T value) { }
         public ReactiveUI.Primitives.Advanced.ExpireCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("ExpireSignal: DueTime = {_dueTime}, Source = {_source}")]
     public sealed class ExpireSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ExpireSignal(System.IObservable<T> source, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("FinallySignal: Source = {_source}")]
+    public sealed class FinallySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public FinallySignal(System.IObservable<T> source, System.Action finallyAction) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ForkJoinSignal: Left = {Left}, Right = {Right}")]
     public sealed class ForkJoinSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public ForkJoinSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("ForkJoinWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
     public sealed class ForkJoinWitness<TLeft, TRight, TResult>
     {
         public ForkJoinWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("CancellationRequested = {CancellationToken.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncExternalCancellationSignal: CancellationRequested = {CancellationToken.IsCancellationRequested}")]
     public sealed class FromAsyncExternalCancellationSignal<T> : System.IObservable<T>
     {
         public FromAsyncExternalCancellationSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSignal: TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
     public sealed class FromAsyncSignal<T> : System.IObservable<T>
     {
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSubscription: Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
     public sealed class FromAsyncSubscription<T> : System.IDisposable
     {
         public FromAsyncSubscription(System.IObserver<T> observer, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
@@ -790,14 +815,14 @@ namespace ReactiveUI.Primitives.Advanced
         public FromEventConversionSignal(System.Func<TCallback, TEventHandler> conversion, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Func<System.IObserver<TResult>, TCallback> callback, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
+    [System.Diagnostics.DebuggerDisplay("FromEventPatternSignal: AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
     public sealed class FromEventPatternSignal<TEventHandler, TEventArgs> : System.IObservable<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> where TEventHandler : System.Delegate where TEventArgs : System.EventArgs
     {
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler) { }
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Disposed = {_disposed}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("GuardedWitness: Disposed = {_disposed}, Observer = {_observer}")]
     public sealed class GuardedWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public GuardedWitness(System.IObserver<T> observer, System.IDisposable cancel) { }
@@ -807,7 +832,7 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IgnoreValuesSignal: Source = {Source}")]
     public sealed class IgnoreValuesSignal<T> : System.IObservable<T>
     {
         public IgnoreValuesSignal(System.IObservable<T> source) { }
@@ -821,14 +846,14 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.RxVoid> observer) { }
         public System.IDisposable Subscribe(System.Action<ReactiveUI.Primitives.RxVoid> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptySignal: Source = {Source}")]
     public sealed class IsEmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<bool>
     {
         public IsEmptySignal(System.IObservable<T> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<bool> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptyWitness: Stopped = {_stopped}, Subscription = {Subscription}")]
     public sealed class IsEmptyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public IsEmptyWitness(System.IObserver<bool> observer) { }
@@ -841,14 +866,23 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {Value}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("LeadSignal: Value = {Value}, Source = {Source}")]
     public sealed class LeadSignal<T> : ReactiveUI.Primitives.Advanced.IInlineSignal<T>
     {
         public LeadSignal(System.IObservable<T> source, T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
         public System.IDisposable Subscribe(System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("LoopSignal: Value = {Value}")]
+    public sealed class LoopSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public LoopSignal(T value) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("MapIndexedSignal: Source = {_source}")]
     public sealed class MapIndexedSignal<TSource, TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public MapIndexedSignal(System.IObservable<TSource> source, System.Func<TSource, int, TResult> selector) { }
@@ -856,7 +890,7 @@ namespace ReactiveUI.Primitives.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Index = {_index}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("MapIndexedWitness: Index = {_index}, Stopped = {_stopped}")]
     public sealed class MapIndexedWitness<TSource, TResult> : System.IObserver<TSource>
     {
         public MapIndexedWitness(System.IObserver<TResult> observer, System.Func<TSource, int, TResult> selector) { }
@@ -864,20 +898,20 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(TSource value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentBlendCoordinator: Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
     public sealed class MaxConcurrentBlendCoordinator<T> : System.IDisposable
     {
         public MaxConcurrentBlendCoordinator(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.MaxConcurrentBlendCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentEnumerableBlendSignal: Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
     public sealed class MaxConcurrentEnumerableBlendSignal<T> : System.IObservable<T>
     {
         public MaxConcurrentEnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("MergeCoordinator: Active = {Active}, Done = {Done}")]
     public sealed class MergeCoordinator<T> : System.IDisposable
     {
         public MergeCoordinator(System.IObserver<T> observer) { }
@@ -888,7 +922,7 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.MergeCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.MergeCoordinator<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MergeSignal: Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
     public sealed class MergeSignal<T> : System.IObservable<T>
     {
         public MergeSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -896,32 +930,39 @@ namespace ReactiveUI.Primitives.Advanced
         public MergeSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("OnErrorResumeNextSignal: Sources = {_sources}")]
+    public sealed class OnErrorResumeNextSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("PairSignal: Left = {Left}, Right = {Right}")]
     public sealed class PairSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public PairSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
+    [System.Diagnostics.DebuggerDisplay("PairWitness: IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
     public sealed class PairWitness<TLeft, TRight, TResult>
     {
         public PairWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("PublishSelectorSignal: Source = {Source}, Selector = {Selector}")]
     public sealed class PublishSelectorSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public PublishSelectorSignal(System.IObservable<TSource> source, System.Func<System.IObservable<TSource>, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
+    [System.Diagnostics.DebuggerDisplay("RaceSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
     public sealed class RaceSignal<T> : System.IObservable<T>
     {
         public RaceSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public RaceSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Arms = {_arms}")]
+    [System.Diagnostics.DebuggerDisplay("RaceWitness: Arms = {_arms}")]
     public sealed class RaceWitness<T> : System.IDisposable
     {
         public RaceWitness(System.IObserver<T> observer) { }
@@ -930,40 +971,48 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.RaceWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.RaceWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeCombineLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeCombineLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeCombineLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
+    [System.Diagnostics.DebuggerDisplay("RangeForkJoinSignal: Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
     public sealed class RangeForkJoinSignal<TResult> : System.IObservable<TResult>
     {
         public RangeForkJoinSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeSyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeSyncLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeSyncLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeWithLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeWithLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeWithLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Remaining = {_remaining}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("RecoverSignal: Source = {_source}")]
+    public sealed class RecoverSignal<T, TException> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T> where TException : System.Exception
+    {
+        public RecoverSignal(System.IObservable<T> source, System.Func<TException, System.IObservable<T>> handler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceCoordinator: Remaining = {_remaining}, Disposed = {_disposed}")]
     public sealed class RepeatSourceCoordinator<T> : System.IDisposable
     {
         public RepeatSourceCoordinator(System.IObservable<T> source, int? repeatCount, System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.RepeatSourceCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, RepeatCount = {_repeatCount}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceSignal: Source = {_source}, RepeatCount = {_repeatCount}")]
     public sealed class RepeatSourceSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public RepeatSourceSignal(System.IObservable<T> source, int? repeatCount) { }
@@ -971,7 +1020,7 @@ namespace ReactiveUI.Primitives.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Generation = {_generation}, Terminated = {_terminated}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceWitness: Generation = {_generation}, Terminated = {_terminated}")]
     public sealed class RepeatSourceWitness<T> : System.IObserver<T>
     {
         public RepeatSourceWitness(ReactiveUI.Primitives.Advanced.RepeatSourceCoordinator<T> parent, int generation) { }
@@ -979,7 +1028,15 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_value}, Scheduler = {_scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ResumeSignal: Source = {_source}, Fallback = {_fallback}")]
+    public sealed class ResumeSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ResumeSignal(System.IObservable<T> source, System.IObservable<T> fallback) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ReturnSignal: Value = {_value}, Scheduler = {_scheduler}")]
     public sealed class ReturnSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ReturnSignal(T value, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -988,13 +1045,13 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Values = {Values}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledEnumerableSignal: Values = {Values}, Scheduler = {Scheduler}")]
     public sealed class ScheduledEnumerableSignal<T> : System.IObservable<T>
     {
         public ScheduledEnumerableSignal(System.Collections.Generic.IEnumerable<T> values, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyCoordinator<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TResult>> selector) { }
@@ -1008,13 +1065,13 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Advanced.SelectManyCoordinator<TSource, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableSignal: Source = {_source}")]
     public sealed class SelectManyEnumerableSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManyEnumerableSignal(System.IObservable<TSource> source, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SelectManyEnumerableWitness<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyEnumerableWitness(System.IObserver<TResult> observer, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
@@ -1028,7 +1085,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyResultCoordinator<TSource, TCollection, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyResultCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
@@ -1041,20 +1098,20 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Advanced.SelectManyResultCoordinator<TSource, TCollection, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, CollectionSelector = {CollectionSelector}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultSignal: Source = {Source}, CollectionSelector = {CollectionSelector}")]
     public sealed class SelectManyResultSignal<TSource, TCollection, TResult> : System.IObservable<TResult>
     {
         public SelectManyResultSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManySignal: Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
     public sealed class SelectManySignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManySignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public SelectManySignal(System.IObservable<TSource> source, System.IObservable<TResult> inner) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Start = {Start}, Count = {Count}")]
+    [System.Diagnostics.DebuggerDisplay("SequenceSignal: Start = {Start}, Count = {Count}")]
     public sealed class SequenceSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<int>
     {
         public SequenceSignal(int start, int count, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -1065,13 +1122,13 @@ namespace ReactiveUI.Primitives.Advanced
     {
         public static System.IDisposable Subscribe<T>(System.IObserver<T> observer, bool currentThreadRequired, System.Func<System.IObserver<T>, System.IDisposable, System.IDisposable> subscribeCore) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SparkSignal: Source = {Source}")]
     public sealed class SparkSignal<T> : System.IObservable<ReactiveUI.Primitives.Core.Spark<T>>
     {
         public SparkSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.Spark<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SparkWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SparkWitness(System.IObserver<ReactiveUI.Primitives.Core.Spark<T>> observer) { }
@@ -1086,21 +1143,21 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Action = {Action}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Action = {Action}, Scheduler = {Scheduler}")]
     public sealed class StartSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<ReactiveUI.Primitives.RxVoid>
     {
         public StartSignal(System.Action action, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.RxVoid> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Function = {Function}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Function = {Function}, Scheduler = {Scheduler}")]
     public sealed class StartSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public StartSignal(System.Func<T> function, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SubscribeSafeWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SubscribeSafeWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SubscribeSafeWitness(System.IObserver<T> observer) { }
@@ -1114,50 +1171,50 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, SkipNullSources = {_skipNullSources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchMapSignal: Source = {_source}, SkipNullSources = {_skipNullSources}")]
     public sealed class SwitchMapSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SwitchMapSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchSignal: Sources = {Sources}")]
     public sealed class SwitchSignal<T> : System.IObservable<T>
     {
         public SwitchSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Version = {_version}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchWitness: Version = {_version}, IsDone = {IsDone}")]
     public sealed class SwitchWitness<T> : System.IDisposable
     {
         public SwitchWitness(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.SwitchWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class SyncLatestSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public SyncLatestSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
     public sealed class SyncLatestWitness<TLeft, TRight, TResult>
     {
         public SyncLatestWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Gate = {Gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeGateSignal: Source = {Source}, Gate = {Gate}")]
     public sealed class SynchronizeGateSignal<T> : System.IObservable<T>
     {
         public SynchronizeGateSignal(System.IObservable<T> source, System.Threading.Lock gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, Gate = {_gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectSignal: Source = {_source}, Gate = {_gate}")]
     public sealed class SynchronizeObjectSignal<T> : System.IObservable<T>
     {
         public SynchronizeObjectSignal(System.IObservable<T> source, object gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SynchronizeObjectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SynchronizeObjectWitness(System.IObserver<T> observer, object gate) { }
@@ -1169,19 +1226,19 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeSignal: Source = {Source}")]
     public sealed class SynchronizeSignal<T> : System.IObservable<T>
     {
         public SynchronizeSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("TapSignal: Source = {Source}")]
     public sealed class TapSignal<T> : System.IObservable<T>
     {
         public TapSignal(System.IObservable<T> source, System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskAnyWitness: Stopped = {_stopped}, Task = {Task}")]
     public sealed class TaskAnyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskAnyWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1197,7 +1254,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainCoordinator: Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
     public sealed class TaskChainCoordinator<T> : System.IDisposable
     {
         public TaskChainCoordinator(System.IObserver<T> observer) { }
@@ -1205,13 +1262,13 @@ namespace ReactiveUI.Primitives.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.TaskChainCoordinator<T> Run(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainSignal: Sources = {_sources}")]
     public sealed class TaskChainSignal<T> : System.IObservable<T>
     {
         public TaskChainSignal(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskCountWitness: Count = {_count}, Stopped = {_stopped}")]
     public sealed class TaskCountWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskCountWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1227,13 +1284,13 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSignal: Task = {Task}")]
     public sealed class TaskInstanceSignal<T> : System.IObservable<T>
     {
         public TaskInstanceSignal(System.Threading.Tasks.Task<T> task) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSubscription: Stopped = {_stopped}")]
     public sealed class TaskInstanceSubscription : System.IDisposable
     {
         public TaskInstanceSubscription() { }
@@ -1241,13 +1298,22 @@ namespace ReactiveUI.Primitives.Advanced
         public void Dispose() { }
         public bool TryStop() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Sequencer = {Sequencer}")]
+    [System.Diagnostics.DebuggerDisplay("ThrowSignal: Error = {_error}, Scheduler = {_scheduler}")]
+    public sealed class ThrowSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ThrowSignal(System.Exception error, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalSignal: Source = {Source}, Sequencer = {Sequencer}")]
     public sealed class TimeIntervalSignal<T> : System.IObservable<ReactiveUI.Primitives.Core.TimeInterval<T>>
     {
         public TimeIntervalSignal(System.IObservable<T> source, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("First = {_first}, Last = {_last}")]
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalWitness: First = {_first}, Last = {_last}")]
     public sealed class TimeIntervalWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TimeIntervalWitness(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -1265,13 +1331,13 @@ namespace ReactiveUI.Primitives.Advanced
     {
         public static void Arm(ReactiveUI.Primitives.Disposables.SingleReplaceableDisposable slot, ReactiveUI.Primitives.Concurrency.ISequencer sequencer, System.TimeSpan delay, System.Action tick) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkSignal: Source = {Source}")]
     public sealed class UnsparkSignal<T> : System.IObservable<T>
     {
         public UnsparkSignal(System.IObservable<ReactiveUI.Primitives.Core.Spark<T>> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class UnsparkWitness<T> : System.IDisposable, System.IObserver<ReactiveUI.Primitives.Core.Spark<T>>
     {
         public UnsparkWitness(System.IObserver<T> observer) { }
@@ -1866,7 +1932,7 @@ namespace ReactiveUI.Primitives.Extensions.Operators
 }
 namespace ReactiveUI.Primitives.Signals
 {
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
+    [System.Diagnostics.DebuggerDisplay("PrioritySemaphoreSignal: Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
     public sealed class PrioritySemaphoreSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T> where T : System.IComparable<T>
     {
         public PrioritySemaphoreSignal(int maxCount) { }
@@ -1901,7 +1967,7 @@ namespace ReactiveUI.Primitives.Signals
         public void OnNext(T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledSignal: Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
     public class ScheduledSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T>
     {
         public ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }

--- a/src/ReactiveUI.Primitives/PublicAPI/net11.0-maccatalyst/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net11.0-maccatalyst/PublicAPI.txt
@@ -514,7 +514,7 @@ namespace ReactiveUI.Primitives
 }
 namespace ReactiveUI.Primitives.Advanced
 {
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Period = {_period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSignal: DueTime = {_dueTime}, Period = {_period}")]
     public sealed class AfterSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
     {
         public AfterSignal(System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -522,7 +522,7 @@ namespace ReactiveUI.Primitives.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<long> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSubscription: Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
     public sealed class AfterSubscription : System.IDisposable
     {
         public AfterSubscription(System.IObserver<long> observer, ReactiveUI.Primitives.Concurrency.ISequencer scheduler, System.TimeSpan dueTime, System.TimeSpan? period) { }
@@ -530,21 +530,21 @@ namespace ReactiveUI.Primitives.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.AfterSubscription Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("SubscribeAsync = {SubscribeAsync}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncCreateSignal: SubscribeAsync = {SubscribeAsync}")]
     public sealed class AsyncCreateSignal<T> : System.IObservable<T>
     {
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ObservableFactory = {ObservableFactory}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncDeferSignal: ObservableFactory = {ObservableFactory}")]
     public sealed class AsyncDeferSignal<T> : System.IObservable<T>
     {
         public AsyncDeferSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public AsyncDeferSignal(System.Func<System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncSubscriptionLifetime: Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
     public sealed class AsyncSubscriptionLifetime : System.IDisposable
     {
         public AsyncSubscriptionLifetime() { }
@@ -555,33 +555,33 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable? disposable) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connected = {_connected}")]
+    [System.Diagnostics.DebuggerDisplay("AutoConnectSignal: Count = {_count}, Connected = {_connected}")]
     public sealed class AutoConnectSignal<T> : System.IObservable<T>
     {
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount) { }
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount, System.Action<System.IDisposable>? onConnect) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connection = {_connection}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSignal: Count = {_count}, Connection = {_connection}")]
     public sealed class AutoShareSignal<T> : System.IObservable<T>
     {
         public AutoShareSignal(ReactiveUI.Primitives.ConnectableSignal<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Owner = {_owner}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSubscription: Owner = {_owner}, Subscription = {Subscription}")]
     public sealed class AutoShareSubscription<T> : System.IDisposable
     {
         public AutoShareSubscription(ReactiveUI.Primitives.Advanced.AutoShareSignal<T> owner, System.IDisposable subscription) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void Dispose() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("BlendSignal: Sources = {Sources}")]
     public sealed class BlendSignal<T> : System.IObservable<T>
     {
         public BlendSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("BlendWitness: ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
     public sealed class BlendWitness<T> : System.IDisposable
     {
         public BlendWitness(System.IObserver<T> observer) { }
@@ -590,7 +590,7 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.BlendWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.BlendWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("BufferEachWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class BufferEachWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public BufferEachWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -604,20 +604,20 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Window = {Window}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("BufferSignal: Window = {Window}, Source = {Source}")]
     public sealed class BufferSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public BufferSignal(System.IObservable<T> source, System.TimeSpan timeSpan, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("CastSignal: Source = {Source}")]
     public sealed class CastSignal<TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public CastSignal(System.IObservable<object?> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CastWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CastWitness<TResult> : System.IDisposable, System.IObserver<object?>
     {
         public CastWitness(System.IObserver<TResult> observer) { }
@@ -631,7 +631,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
+    [System.Diagnostics.DebuggerDisplay("ChainSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
     public sealed class ChainSignal<T> : System.IObservable<T>
     {
         public ChainSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -639,7 +639,7 @@ namespace ReactiveUI.Primitives.Advanced
         public ChainSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("ChainWitness: IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
     public sealed class ChainWitness<T> : System.IDisposable
     {
         public ChainWitness(System.IObserver<T> observer) { }
@@ -649,13 +649,13 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.ChainWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.ChainWitness<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, TimeSpan = {TimeSpan}")]
+    [System.Diagnostics.DebuggerDisplay("CollectSignal: Source = {Source}, TimeSpan = {TimeSpan}")]
     public sealed class CollectSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public CollectSignal(System.IObservable<T> source, System.TimeSpan timeSpan, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Buffered = {Values.Count}")]
+    [System.Diagnostics.DebuggerDisplay("CollectWitness: Stopped = {_stopped}, Buffered = {Values.Count}")]
     public sealed class CollectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CollectWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -667,7 +667,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateSink: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class CreateSink<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateSink(System.IObserver<T> observer, bool disposeOnNextThrow) { }
@@ -679,7 +679,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CreateWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateWitness(System.IObserver<T> observer) { }
@@ -693,7 +693,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
+    [System.Diagnostics.DebuggerDisplay("DispatchSequencerState: ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
     public record struct DispatchSequencerState : System.IEquatable<ReactiveUI.Primitives.Advanced.DispatchSequencerState>
     {
         public DispatchSequencerState(ReactiveUI.Primitives.Concurrency.ISequencer owner, System.Func<System.Action, bool> post, System.Action drain) { }
@@ -708,13 +708,13 @@ namespace ReactiveUI.Primitives.Advanced
         public static System.TimeSpan DelayUntil(long dueTimestamp) { }
         public static void RunIfActive(ReactiveUI.Primitives.Concurrency.IWorkItem item) { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {DueTime}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietSignal: DueTime = {DueTime}, Source = {Source}")]
     public sealed class EmitIfQuietSignal<T> : System.IObservable<T>
     {
         public EmitIfQuietSignal(System.IObservable<T> source, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietWitness: HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
     public sealed class EmitIfQuietWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public EmitIfQuietWitness(System.IObserver<T> observer, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
@@ -725,7 +725,16 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("EmptySignal: Scheduler = {_scheduler}")]
+    public sealed class EmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public EmptySignal(ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("EnumerableBlendSignal: Sources = {Sources}")]
     public sealed class EnumerableBlendSignal<T> : System.IObservable<T>
     {
         public EnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -735,7 +744,14 @@ namespace ReactiveUI.Primitives.Advanced
     {
         public static System.IDisposable Attach<TEventHandler>(TEventHandler handler, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
+    [System.Diagnostics.DebuggerDisplay("EverySignal: Period = {_period}, Scheduler = {_scheduler}")]
+    public sealed class EverySignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
+    {
+        public EverySignal(System.TimeSpan period, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<long> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ExpireCoordinator: Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
     public sealed class ExpireCoordinator<T> : System.IDisposable, System.IObserver<T>
     {
         public ExpireCoordinator(System.IObservable<T> source, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer, System.IObserver<T> observer) { }
@@ -745,39 +761,48 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnNext(T value) { }
         public ReactiveUI.Primitives.Advanced.ExpireCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("ExpireSignal: DueTime = {_dueTime}, Source = {_source}")]
     public sealed class ExpireSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ExpireSignal(System.IObservable<T> source, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("FinallySignal: Source = {_source}")]
+    public sealed class FinallySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public FinallySignal(System.IObservable<T> source, System.Action finallyAction) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ForkJoinSignal: Left = {Left}, Right = {Right}")]
     public sealed class ForkJoinSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public ForkJoinSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("ForkJoinWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
     public sealed class ForkJoinWitness<TLeft, TRight, TResult>
     {
         public ForkJoinWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("CancellationRequested = {CancellationToken.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncExternalCancellationSignal: CancellationRequested = {CancellationToken.IsCancellationRequested}")]
     public sealed class FromAsyncExternalCancellationSignal<T> : System.IObservable<T>
     {
         public FromAsyncExternalCancellationSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSignal: TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
     public sealed class FromAsyncSignal<T> : System.IObservable<T>
     {
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSubscription: Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
     public sealed class FromAsyncSubscription<T> : System.IDisposable
     {
         public FromAsyncSubscription(System.IObserver<T> observer, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
@@ -790,14 +815,14 @@ namespace ReactiveUI.Primitives.Advanced
         public FromEventConversionSignal(System.Func<TCallback, TEventHandler> conversion, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Func<System.IObserver<TResult>, TCallback> callback, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
+    [System.Diagnostics.DebuggerDisplay("FromEventPatternSignal: AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
     public sealed class FromEventPatternSignal<TEventHandler, TEventArgs> : System.IObservable<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> where TEventHandler : System.Delegate where TEventArgs : System.EventArgs
     {
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler) { }
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Disposed = {_disposed}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("GuardedWitness: Disposed = {_disposed}, Observer = {_observer}")]
     public sealed class GuardedWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public GuardedWitness(System.IObserver<T> observer, System.IDisposable cancel) { }
@@ -807,7 +832,7 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IgnoreValuesSignal: Source = {Source}")]
     public sealed class IgnoreValuesSignal<T> : System.IObservable<T>
     {
         public IgnoreValuesSignal(System.IObservable<T> source) { }
@@ -821,14 +846,14 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.RxVoid> observer) { }
         public System.IDisposable Subscribe(System.Action<ReactiveUI.Primitives.RxVoid> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptySignal: Source = {Source}")]
     public sealed class IsEmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<bool>
     {
         public IsEmptySignal(System.IObservable<T> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<bool> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptyWitness: Stopped = {_stopped}, Subscription = {Subscription}")]
     public sealed class IsEmptyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public IsEmptyWitness(System.IObserver<bool> observer) { }
@@ -841,14 +866,23 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {Value}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("LeadSignal: Value = {Value}, Source = {Source}")]
     public sealed class LeadSignal<T> : ReactiveUI.Primitives.Advanced.IInlineSignal<T>
     {
         public LeadSignal(System.IObservable<T> source, T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
         public System.IDisposable Subscribe(System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("LoopSignal: Value = {Value}")]
+    public sealed class LoopSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public LoopSignal(T value) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("MapIndexedSignal: Source = {_source}")]
     public sealed class MapIndexedSignal<TSource, TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public MapIndexedSignal(System.IObservable<TSource> source, System.Func<TSource, int, TResult> selector) { }
@@ -856,7 +890,7 @@ namespace ReactiveUI.Primitives.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Index = {_index}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("MapIndexedWitness: Index = {_index}, Stopped = {_stopped}")]
     public sealed class MapIndexedWitness<TSource, TResult> : System.IObserver<TSource>
     {
         public MapIndexedWitness(System.IObserver<TResult> observer, System.Func<TSource, int, TResult> selector) { }
@@ -864,20 +898,20 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(TSource value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentBlendCoordinator: Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
     public sealed class MaxConcurrentBlendCoordinator<T> : System.IDisposable
     {
         public MaxConcurrentBlendCoordinator(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.MaxConcurrentBlendCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentEnumerableBlendSignal: Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
     public sealed class MaxConcurrentEnumerableBlendSignal<T> : System.IObservable<T>
     {
         public MaxConcurrentEnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("MergeCoordinator: Active = {Active}, Done = {Done}")]
     public sealed class MergeCoordinator<T> : System.IDisposable
     {
         public MergeCoordinator(System.IObserver<T> observer) { }
@@ -888,7 +922,7 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.MergeCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.MergeCoordinator<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MergeSignal: Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
     public sealed class MergeSignal<T> : System.IObservable<T>
     {
         public MergeSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -896,32 +930,39 @@ namespace ReactiveUI.Primitives.Advanced
         public MergeSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("OnErrorResumeNextSignal: Sources = {_sources}")]
+    public sealed class OnErrorResumeNextSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("PairSignal: Left = {Left}, Right = {Right}")]
     public sealed class PairSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public PairSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
+    [System.Diagnostics.DebuggerDisplay("PairWitness: IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
     public sealed class PairWitness<TLeft, TRight, TResult>
     {
         public PairWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("PublishSelectorSignal: Source = {Source}, Selector = {Selector}")]
     public sealed class PublishSelectorSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public PublishSelectorSignal(System.IObservable<TSource> source, System.Func<System.IObservable<TSource>, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
+    [System.Diagnostics.DebuggerDisplay("RaceSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
     public sealed class RaceSignal<T> : System.IObservable<T>
     {
         public RaceSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public RaceSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Arms = {_arms}")]
+    [System.Diagnostics.DebuggerDisplay("RaceWitness: Arms = {_arms}")]
     public sealed class RaceWitness<T> : System.IDisposable
     {
         public RaceWitness(System.IObserver<T> observer) { }
@@ -930,40 +971,48 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.RaceWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.RaceWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeCombineLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeCombineLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeCombineLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
+    [System.Diagnostics.DebuggerDisplay("RangeForkJoinSignal: Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
     public sealed class RangeForkJoinSignal<TResult> : System.IObservable<TResult>
     {
         public RangeForkJoinSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeSyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeSyncLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeSyncLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeWithLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeWithLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeWithLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Remaining = {_remaining}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("RecoverSignal: Source = {_source}")]
+    public sealed class RecoverSignal<T, TException> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T> where TException : System.Exception
+    {
+        public RecoverSignal(System.IObservable<T> source, System.Func<TException, System.IObservable<T>> handler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceCoordinator: Remaining = {_remaining}, Disposed = {_disposed}")]
     public sealed class RepeatSourceCoordinator<T> : System.IDisposable
     {
         public RepeatSourceCoordinator(System.IObservable<T> source, int? repeatCount, System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.RepeatSourceCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, RepeatCount = {_repeatCount}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceSignal: Source = {_source}, RepeatCount = {_repeatCount}")]
     public sealed class RepeatSourceSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public RepeatSourceSignal(System.IObservable<T> source, int? repeatCount) { }
@@ -971,7 +1020,7 @@ namespace ReactiveUI.Primitives.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Generation = {_generation}, Terminated = {_terminated}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceWitness: Generation = {_generation}, Terminated = {_terminated}")]
     public sealed class RepeatSourceWitness<T> : System.IObserver<T>
     {
         public RepeatSourceWitness(ReactiveUI.Primitives.Advanced.RepeatSourceCoordinator<T> parent, int generation) { }
@@ -979,7 +1028,15 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_value}, Scheduler = {_scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ResumeSignal: Source = {_source}, Fallback = {_fallback}")]
+    public sealed class ResumeSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ResumeSignal(System.IObservable<T> source, System.IObservable<T> fallback) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ReturnSignal: Value = {_value}, Scheduler = {_scheduler}")]
     public sealed class ReturnSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ReturnSignal(T value, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -988,13 +1045,13 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Values = {Values}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledEnumerableSignal: Values = {Values}, Scheduler = {Scheduler}")]
     public sealed class ScheduledEnumerableSignal<T> : System.IObservable<T>
     {
         public ScheduledEnumerableSignal(System.Collections.Generic.IEnumerable<T> values, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyCoordinator<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TResult>> selector) { }
@@ -1008,13 +1065,13 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Advanced.SelectManyCoordinator<TSource, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableSignal: Source = {_source}")]
     public sealed class SelectManyEnumerableSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManyEnumerableSignal(System.IObservable<TSource> source, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SelectManyEnumerableWitness<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyEnumerableWitness(System.IObserver<TResult> observer, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
@@ -1028,7 +1085,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyResultCoordinator<TSource, TCollection, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyResultCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
@@ -1041,20 +1098,20 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Advanced.SelectManyResultCoordinator<TSource, TCollection, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, CollectionSelector = {CollectionSelector}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultSignal: Source = {Source}, CollectionSelector = {CollectionSelector}")]
     public sealed class SelectManyResultSignal<TSource, TCollection, TResult> : System.IObservable<TResult>
     {
         public SelectManyResultSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManySignal: Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
     public sealed class SelectManySignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManySignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public SelectManySignal(System.IObservable<TSource> source, System.IObservable<TResult> inner) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Start = {Start}, Count = {Count}")]
+    [System.Diagnostics.DebuggerDisplay("SequenceSignal: Start = {Start}, Count = {Count}")]
     public sealed class SequenceSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<int>
     {
         public SequenceSignal(int start, int count, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -1065,13 +1122,13 @@ namespace ReactiveUI.Primitives.Advanced
     {
         public static System.IDisposable Subscribe<T>(System.IObserver<T> observer, bool currentThreadRequired, System.Func<System.IObserver<T>, System.IDisposable, System.IDisposable> subscribeCore) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SparkSignal: Source = {Source}")]
     public sealed class SparkSignal<T> : System.IObservable<ReactiveUI.Primitives.Core.Spark<T>>
     {
         public SparkSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.Spark<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SparkWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SparkWitness(System.IObserver<ReactiveUI.Primitives.Core.Spark<T>> observer) { }
@@ -1086,21 +1143,21 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Action = {Action}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Action = {Action}, Scheduler = {Scheduler}")]
     public sealed class StartSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<ReactiveUI.Primitives.RxVoid>
     {
         public StartSignal(System.Action action, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.RxVoid> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Function = {Function}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Function = {Function}, Scheduler = {Scheduler}")]
     public sealed class StartSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public StartSignal(System.Func<T> function, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SubscribeSafeWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SubscribeSafeWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SubscribeSafeWitness(System.IObserver<T> observer) { }
@@ -1114,50 +1171,50 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, SkipNullSources = {_skipNullSources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchMapSignal: Source = {_source}, SkipNullSources = {_skipNullSources}")]
     public sealed class SwitchMapSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SwitchMapSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchSignal: Sources = {Sources}")]
     public sealed class SwitchSignal<T> : System.IObservable<T>
     {
         public SwitchSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Version = {_version}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchWitness: Version = {_version}, IsDone = {IsDone}")]
     public sealed class SwitchWitness<T> : System.IDisposable
     {
         public SwitchWitness(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.SwitchWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class SyncLatestSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public SyncLatestSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
     public sealed class SyncLatestWitness<TLeft, TRight, TResult>
     {
         public SyncLatestWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Gate = {Gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeGateSignal: Source = {Source}, Gate = {Gate}")]
     public sealed class SynchronizeGateSignal<T> : System.IObservable<T>
     {
         public SynchronizeGateSignal(System.IObservable<T> source, System.Threading.Lock gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, Gate = {_gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectSignal: Source = {_source}, Gate = {_gate}")]
     public sealed class SynchronizeObjectSignal<T> : System.IObservable<T>
     {
         public SynchronizeObjectSignal(System.IObservable<T> source, object gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SynchronizeObjectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SynchronizeObjectWitness(System.IObserver<T> observer, object gate) { }
@@ -1169,19 +1226,19 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeSignal: Source = {Source}")]
     public sealed class SynchronizeSignal<T> : System.IObservable<T>
     {
         public SynchronizeSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("TapSignal: Source = {Source}")]
     public sealed class TapSignal<T> : System.IObservable<T>
     {
         public TapSignal(System.IObservable<T> source, System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskAnyWitness: Stopped = {_stopped}, Task = {Task}")]
     public sealed class TaskAnyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskAnyWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1197,7 +1254,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainCoordinator: Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
     public sealed class TaskChainCoordinator<T> : System.IDisposable
     {
         public TaskChainCoordinator(System.IObserver<T> observer) { }
@@ -1205,13 +1262,13 @@ namespace ReactiveUI.Primitives.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.TaskChainCoordinator<T> Run(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainSignal: Sources = {_sources}")]
     public sealed class TaskChainSignal<T> : System.IObservable<T>
     {
         public TaskChainSignal(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskCountWitness: Count = {_count}, Stopped = {_stopped}")]
     public sealed class TaskCountWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskCountWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1227,13 +1284,13 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSignal: Task = {Task}")]
     public sealed class TaskInstanceSignal<T> : System.IObservable<T>
     {
         public TaskInstanceSignal(System.Threading.Tasks.Task<T> task) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSubscription: Stopped = {_stopped}")]
     public sealed class TaskInstanceSubscription : System.IDisposable
     {
         public TaskInstanceSubscription() { }
@@ -1241,13 +1298,22 @@ namespace ReactiveUI.Primitives.Advanced
         public void Dispose() { }
         public bool TryStop() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Sequencer = {Sequencer}")]
+    [System.Diagnostics.DebuggerDisplay("ThrowSignal: Error = {_error}, Scheduler = {_scheduler}")]
+    public sealed class ThrowSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ThrowSignal(System.Exception error, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalSignal: Source = {Source}, Sequencer = {Sequencer}")]
     public sealed class TimeIntervalSignal<T> : System.IObservable<ReactiveUI.Primitives.Core.TimeInterval<T>>
     {
         public TimeIntervalSignal(System.IObservable<T> source, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("First = {_first}, Last = {_last}")]
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalWitness: First = {_first}, Last = {_last}")]
     public sealed class TimeIntervalWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TimeIntervalWitness(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -1265,13 +1331,13 @@ namespace ReactiveUI.Primitives.Advanced
     {
         public static void Arm(ReactiveUI.Primitives.Disposables.SingleReplaceableDisposable slot, ReactiveUI.Primitives.Concurrency.ISequencer sequencer, System.TimeSpan delay, System.Action tick) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkSignal: Source = {Source}")]
     public sealed class UnsparkSignal<T> : System.IObservable<T>
     {
         public UnsparkSignal(System.IObservable<ReactiveUI.Primitives.Core.Spark<T>> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class UnsparkWitness<T> : System.IDisposable, System.IObserver<ReactiveUI.Primitives.Core.Spark<T>>
     {
         public UnsparkWitness(System.IObserver<T> observer) { }
@@ -1866,7 +1932,7 @@ namespace ReactiveUI.Primitives.Extensions.Operators
 }
 namespace ReactiveUI.Primitives.Signals
 {
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
+    [System.Diagnostics.DebuggerDisplay("PrioritySemaphoreSignal: Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
     public sealed class PrioritySemaphoreSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T> where T : System.IComparable<T>
     {
         public PrioritySemaphoreSignal(int maxCount) { }
@@ -1901,7 +1967,7 @@ namespace ReactiveUI.Primitives.Signals
         public void OnNext(T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledSignal: Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
     public class ScheduledSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T>
     {
         public ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }

--- a/src/ReactiveUI.Primitives/PublicAPI/net11.0-macos/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net11.0-macos/PublicAPI.txt
@@ -514,7 +514,7 @@ namespace ReactiveUI.Primitives
 }
 namespace ReactiveUI.Primitives.Advanced
 {
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Period = {_period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSignal: DueTime = {_dueTime}, Period = {_period}")]
     public sealed class AfterSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
     {
         public AfterSignal(System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -522,7 +522,7 @@ namespace ReactiveUI.Primitives.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<long> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSubscription: Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
     public sealed class AfterSubscription : System.IDisposable
     {
         public AfterSubscription(System.IObserver<long> observer, ReactiveUI.Primitives.Concurrency.ISequencer scheduler, System.TimeSpan dueTime, System.TimeSpan? period) { }
@@ -530,21 +530,21 @@ namespace ReactiveUI.Primitives.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.AfterSubscription Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("SubscribeAsync = {SubscribeAsync}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncCreateSignal: SubscribeAsync = {SubscribeAsync}")]
     public sealed class AsyncCreateSignal<T> : System.IObservable<T>
     {
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ObservableFactory = {ObservableFactory}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncDeferSignal: ObservableFactory = {ObservableFactory}")]
     public sealed class AsyncDeferSignal<T> : System.IObservable<T>
     {
         public AsyncDeferSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public AsyncDeferSignal(System.Func<System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncSubscriptionLifetime: Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
     public sealed class AsyncSubscriptionLifetime : System.IDisposable
     {
         public AsyncSubscriptionLifetime() { }
@@ -555,33 +555,33 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable? disposable) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connected = {_connected}")]
+    [System.Diagnostics.DebuggerDisplay("AutoConnectSignal: Count = {_count}, Connected = {_connected}")]
     public sealed class AutoConnectSignal<T> : System.IObservable<T>
     {
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount) { }
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount, System.Action<System.IDisposable>? onConnect) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connection = {_connection}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSignal: Count = {_count}, Connection = {_connection}")]
     public sealed class AutoShareSignal<T> : System.IObservable<T>
     {
         public AutoShareSignal(ReactiveUI.Primitives.ConnectableSignal<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Owner = {_owner}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSubscription: Owner = {_owner}, Subscription = {Subscription}")]
     public sealed class AutoShareSubscription<T> : System.IDisposable
     {
         public AutoShareSubscription(ReactiveUI.Primitives.Advanced.AutoShareSignal<T> owner, System.IDisposable subscription) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void Dispose() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("BlendSignal: Sources = {Sources}")]
     public sealed class BlendSignal<T> : System.IObservable<T>
     {
         public BlendSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("BlendWitness: ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
     public sealed class BlendWitness<T> : System.IDisposable
     {
         public BlendWitness(System.IObserver<T> observer) { }
@@ -590,7 +590,7 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.BlendWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.BlendWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("BufferEachWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class BufferEachWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public BufferEachWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -604,20 +604,20 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Window = {Window}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("BufferSignal: Window = {Window}, Source = {Source}")]
     public sealed class BufferSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public BufferSignal(System.IObservable<T> source, System.TimeSpan timeSpan, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("CastSignal: Source = {Source}")]
     public sealed class CastSignal<TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public CastSignal(System.IObservable<object?> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CastWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CastWitness<TResult> : System.IDisposable, System.IObserver<object?>
     {
         public CastWitness(System.IObserver<TResult> observer) { }
@@ -631,7 +631,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
+    [System.Diagnostics.DebuggerDisplay("ChainSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
     public sealed class ChainSignal<T> : System.IObservable<T>
     {
         public ChainSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -639,7 +639,7 @@ namespace ReactiveUI.Primitives.Advanced
         public ChainSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("ChainWitness: IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
     public sealed class ChainWitness<T> : System.IDisposable
     {
         public ChainWitness(System.IObserver<T> observer) { }
@@ -649,13 +649,13 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.ChainWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.ChainWitness<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, TimeSpan = {TimeSpan}")]
+    [System.Diagnostics.DebuggerDisplay("CollectSignal: Source = {Source}, TimeSpan = {TimeSpan}")]
     public sealed class CollectSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public CollectSignal(System.IObservable<T> source, System.TimeSpan timeSpan, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Buffered = {Values.Count}")]
+    [System.Diagnostics.DebuggerDisplay("CollectWitness: Stopped = {_stopped}, Buffered = {Values.Count}")]
     public sealed class CollectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CollectWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -667,7 +667,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateSink: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class CreateSink<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateSink(System.IObserver<T> observer, bool disposeOnNextThrow) { }
@@ -679,7 +679,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CreateWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateWitness(System.IObserver<T> observer) { }
@@ -693,7 +693,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
+    [System.Diagnostics.DebuggerDisplay("DispatchSequencerState: ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
     public record struct DispatchSequencerState : System.IEquatable<ReactiveUI.Primitives.Advanced.DispatchSequencerState>
     {
         public DispatchSequencerState(ReactiveUI.Primitives.Concurrency.ISequencer owner, System.Func<System.Action, bool> post, System.Action drain) { }
@@ -708,13 +708,13 @@ namespace ReactiveUI.Primitives.Advanced
         public static System.TimeSpan DelayUntil(long dueTimestamp) { }
         public static void RunIfActive(ReactiveUI.Primitives.Concurrency.IWorkItem item) { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {DueTime}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietSignal: DueTime = {DueTime}, Source = {Source}")]
     public sealed class EmitIfQuietSignal<T> : System.IObservable<T>
     {
         public EmitIfQuietSignal(System.IObservable<T> source, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietWitness: HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
     public sealed class EmitIfQuietWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public EmitIfQuietWitness(System.IObserver<T> observer, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
@@ -725,7 +725,16 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("EmptySignal: Scheduler = {_scheduler}")]
+    public sealed class EmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public EmptySignal(ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("EnumerableBlendSignal: Sources = {Sources}")]
     public sealed class EnumerableBlendSignal<T> : System.IObservable<T>
     {
         public EnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -735,7 +744,14 @@ namespace ReactiveUI.Primitives.Advanced
     {
         public static System.IDisposable Attach<TEventHandler>(TEventHandler handler, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
+    [System.Diagnostics.DebuggerDisplay("EverySignal: Period = {_period}, Scheduler = {_scheduler}")]
+    public sealed class EverySignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
+    {
+        public EverySignal(System.TimeSpan period, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<long> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ExpireCoordinator: Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
     public sealed class ExpireCoordinator<T> : System.IDisposable, System.IObserver<T>
     {
         public ExpireCoordinator(System.IObservable<T> source, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer, System.IObserver<T> observer) { }
@@ -745,39 +761,48 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnNext(T value) { }
         public ReactiveUI.Primitives.Advanced.ExpireCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("ExpireSignal: DueTime = {_dueTime}, Source = {_source}")]
     public sealed class ExpireSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ExpireSignal(System.IObservable<T> source, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("FinallySignal: Source = {_source}")]
+    public sealed class FinallySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public FinallySignal(System.IObservable<T> source, System.Action finallyAction) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ForkJoinSignal: Left = {Left}, Right = {Right}")]
     public sealed class ForkJoinSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public ForkJoinSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("ForkJoinWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
     public sealed class ForkJoinWitness<TLeft, TRight, TResult>
     {
         public ForkJoinWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("CancellationRequested = {CancellationToken.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncExternalCancellationSignal: CancellationRequested = {CancellationToken.IsCancellationRequested}")]
     public sealed class FromAsyncExternalCancellationSignal<T> : System.IObservable<T>
     {
         public FromAsyncExternalCancellationSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSignal: TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
     public sealed class FromAsyncSignal<T> : System.IObservable<T>
     {
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSubscription: Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
     public sealed class FromAsyncSubscription<T> : System.IDisposable
     {
         public FromAsyncSubscription(System.IObserver<T> observer, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
@@ -790,14 +815,14 @@ namespace ReactiveUI.Primitives.Advanced
         public FromEventConversionSignal(System.Func<TCallback, TEventHandler> conversion, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Func<System.IObserver<TResult>, TCallback> callback, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
+    [System.Diagnostics.DebuggerDisplay("FromEventPatternSignal: AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
     public sealed class FromEventPatternSignal<TEventHandler, TEventArgs> : System.IObservable<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> where TEventHandler : System.Delegate where TEventArgs : System.EventArgs
     {
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler) { }
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Disposed = {_disposed}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("GuardedWitness: Disposed = {_disposed}, Observer = {_observer}")]
     public sealed class GuardedWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public GuardedWitness(System.IObserver<T> observer, System.IDisposable cancel) { }
@@ -807,7 +832,7 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IgnoreValuesSignal: Source = {Source}")]
     public sealed class IgnoreValuesSignal<T> : System.IObservable<T>
     {
         public IgnoreValuesSignal(System.IObservable<T> source) { }
@@ -821,14 +846,14 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.RxVoid> observer) { }
         public System.IDisposable Subscribe(System.Action<ReactiveUI.Primitives.RxVoid> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptySignal: Source = {Source}")]
     public sealed class IsEmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<bool>
     {
         public IsEmptySignal(System.IObservable<T> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<bool> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptyWitness: Stopped = {_stopped}, Subscription = {Subscription}")]
     public sealed class IsEmptyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public IsEmptyWitness(System.IObserver<bool> observer) { }
@@ -841,14 +866,23 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {Value}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("LeadSignal: Value = {Value}, Source = {Source}")]
     public sealed class LeadSignal<T> : ReactiveUI.Primitives.Advanced.IInlineSignal<T>
     {
         public LeadSignal(System.IObservable<T> source, T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
         public System.IDisposable Subscribe(System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("LoopSignal: Value = {Value}")]
+    public sealed class LoopSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public LoopSignal(T value) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("MapIndexedSignal: Source = {_source}")]
     public sealed class MapIndexedSignal<TSource, TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public MapIndexedSignal(System.IObservable<TSource> source, System.Func<TSource, int, TResult> selector) { }
@@ -856,7 +890,7 @@ namespace ReactiveUI.Primitives.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Index = {_index}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("MapIndexedWitness: Index = {_index}, Stopped = {_stopped}")]
     public sealed class MapIndexedWitness<TSource, TResult> : System.IObserver<TSource>
     {
         public MapIndexedWitness(System.IObserver<TResult> observer, System.Func<TSource, int, TResult> selector) { }
@@ -864,20 +898,20 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(TSource value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentBlendCoordinator: Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
     public sealed class MaxConcurrentBlendCoordinator<T> : System.IDisposable
     {
         public MaxConcurrentBlendCoordinator(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.MaxConcurrentBlendCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentEnumerableBlendSignal: Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
     public sealed class MaxConcurrentEnumerableBlendSignal<T> : System.IObservable<T>
     {
         public MaxConcurrentEnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("MergeCoordinator: Active = {Active}, Done = {Done}")]
     public sealed class MergeCoordinator<T> : System.IDisposable
     {
         public MergeCoordinator(System.IObserver<T> observer) { }
@@ -888,7 +922,7 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.MergeCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.MergeCoordinator<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MergeSignal: Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
     public sealed class MergeSignal<T> : System.IObservable<T>
     {
         public MergeSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -896,32 +930,39 @@ namespace ReactiveUI.Primitives.Advanced
         public MergeSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("OnErrorResumeNextSignal: Sources = {_sources}")]
+    public sealed class OnErrorResumeNextSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("PairSignal: Left = {Left}, Right = {Right}")]
     public sealed class PairSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public PairSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
+    [System.Diagnostics.DebuggerDisplay("PairWitness: IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
     public sealed class PairWitness<TLeft, TRight, TResult>
     {
         public PairWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("PublishSelectorSignal: Source = {Source}, Selector = {Selector}")]
     public sealed class PublishSelectorSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public PublishSelectorSignal(System.IObservable<TSource> source, System.Func<System.IObservable<TSource>, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
+    [System.Diagnostics.DebuggerDisplay("RaceSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
     public sealed class RaceSignal<T> : System.IObservable<T>
     {
         public RaceSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public RaceSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Arms = {_arms}")]
+    [System.Diagnostics.DebuggerDisplay("RaceWitness: Arms = {_arms}")]
     public sealed class RaceWitness<T> : System.IDisposable
     {
         public RaceWitness(System.IObserver<T> observer) { }
@@ -930,40 +971,48 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.RaceWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.RaceWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeCombineLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeCombineLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeCombineLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
+    [System.Diagnostics.DebuggerDisplay("RangeForkJoinSignal: Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
     public sealed class RangeForkJoinSignal<TResult> : System.IObservable<TResult>
     {
         public RangeForkJoinSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeSyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeSyncLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeSyncLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeWithLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeWithLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeWithLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Remaining = {_remaining}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("RecoverSignal: Source = {_source}")]
+    public sealed class RecoverSignal<T, TException> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T> where TException : System.Exception
+    {
+        public RecoverSignal(System.IObservable<T> source, System.Func<TException, System.IObservable<T>> handler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceCoordinator: Remaining = {_remaining}, Disposed = {_disposed}")]
     public sealed class RepeatSourceCoordinator<T> : System.IDisposable
     {
         public RepeatSourceCoordinator(System.IObservable<T> source, int? repeatCount, System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.RepeatSourceCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, RepeatCount = {_repeatCount}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceSignal: Source = {_source}, RepeatCount = {_repeatCount}")]
     public sealed class RepeatSourceSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public RepeatSourceSignal(System.IObservable<T> source, int? repeatCount) { }
@@ -971,7 +1020,7 @@ namespace ReactiveUI.Primitives.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Generation = {_generation}, Terminated = {_terminated}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceWitness: Generation = {_generation}, Terminated = {_terminated}")]
     public sealed class RepeatSourceWitness<T> : System.IObserver<T>
     {
         public RepeatSourceWitness(ReactiveUI.Primitives.Advanced.RepeatSourceCoordinator<T> parent, int generation) { }
@@ -979,7 +1028,15 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_value}, Scheduler = {_scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ResumeSignal: Source = {_source}, Fallback = {_fallback}")]
+    public sealed class ResumeSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ResumeSignal(System.IObservable<T> source, System.IObservable<T> fallback) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ReturnSignal: Value = {_value}, Scheduler = {_scheduler}")]
     public sealed class ReturnSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ReturnSignal(T value, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -988,13 +1045,13 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Values = {Values}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledEnumerableSignal: Values = {Values}, Scheduler = {Scheduler}")]
     public sealed class ScheduledEnumerableSignal<T> : System.IObservable<T>
     {
         public ScheduledEnumerableSignal(System.Collections.Generic.IEnumerable<T> values, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyCoordinator<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TResult>> selector) { }
@@ -1008,13 +1065,13 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Advanced.SelectManyCoordinator<TSource, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableSignal: Source = {_source}")]
     public sealed class SelectManyEnumerableSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManyEnumerableSignal(System.IObservable<TSource> source, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SelectManyEnumerableWitness<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyEnumerableWitness(System.IObserver<TResult> observer, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
@@ -1028,7 +1085,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyResultCoordinator<TSource, TCollection, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyResultCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
@@ -1041,20 +1098,20 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Advanced.SelectManyResultCoordinator<TSource, TCollection, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, CollectionSelector = {CollectionSelector}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultSignal: Source = {Source}, CollectionSelector = {CollectionSelector}")]
     public sealed class SelectManyResultSignal<TSource, TCollection, TResult> : System.IObservable<TResult>
     {
         public SelectManyResultSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManySignal: Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
     public sealed class SelectManySignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManySignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public SelectManySignal(System.IObservable<TSource> source, System.IObservable<TResult> inner) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Start = {Start}, Count = {Count}")]
+    [System.Diagnostics.DebuggerDisplay("SequenceSignal: Start = {Start}, Count = {Count}")]
     public sealed class SequenceSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<int>
     {
         public SequenceSignal(int start, int count, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -1065,13 +1122,13 @@ namespace ReactiveUI.Primitives.Advanced
     {
         public static System.IDisposable Subscribe<T>(System.IObserver<T> observer, bool currentThreadRequired, System.Func<System.IObserver<T>, System.IDisposable, System.IDisposable> subscribeCore) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SparkSignal: Source = {Source}")]
     public sealed class SparkSignal<T> : System.IObservable<ReactiveUI.Primitives.Core.Spark<T>>
     {
         public SparkSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.Spark<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SparkWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SparkWitness(System.IObserver<ReactiveUI.Primitives.Core.Spark<T>> observer) { }
@@ -1086,21 +1143,21 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Action = {Action}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Action = {Action}, Scheduler = {Scheduler}")]
     public sealed class StartSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<ReactiveUI.Primitives.RxVoid>
     {
         public StartSignal(System.Action action, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.RxVoid> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Function = {Function}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Function = {Function}, Scheduler = {Scheduler}")]
     public sealed class StartSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public StartSignal(System.Func<T> function, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SubscribeSafeWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SubscribeSafeWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SubscribeSafeWitness(System.IObserver<T> observer) { }
@@ -1114,50 +1171,50 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, SkipNullSources = {_skipNullSources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchMapSignal: Source = {_source}, SkipNullSources = {_skipNullSources}")]
     public sealed class SwitchMapSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SwitchMapSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchSignal: Sources = {Sources}")]
     public sealed class SwitchSignal<T> : System.IObservable<T>
     {
         public SwitchSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Version = {_version}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchWitness: Version = {_version}, IsDone = {IsDone}")]
     public sealed class SwitchWitness<T> : System.IDisposable
     {
         public SwitchWitness(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.SwitchWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class SyncLatestSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public SyncLatestSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
     public sealed class SyncLatestWitness<TLeft, TRight, TResult>
     {
         public SyncLatestWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Gate = {Gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeGateSignal: Source = {Source}, Gate = {Gate}")]
     public sealed class SynchronizeGateSignal<T> : System.IObservable<T>
     {
         public SynchronizeGateSignal(System.IObservable<T> source, System.Threading.Lock gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, Gate = {_gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectSignal: Source = {_source}, Gate = {_gate}")]
     public sealed class SynchronizeObjectSignal<T> : System.IObservable<T>
     {
         public SynchronizeObjectSignal(System.IObservable<T> source, object gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SynchronizeObjectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SynchronizeObjectWitness(System.IObserver<T> observer, object gate) { }
@@ -1169,19 +1226,19 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeSignal: Source = {Source}")]
     public sealed class SynchronizeSignal<T> : System.IObservable<T>
     {
         public SynchronizeSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("TapSignal: Source = {Source}")]
     public sealed class TapSignal<T> : System.IObservable<T>
     {
         public TapSignal(System.IObservable<T> source, System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskAnyWitness: Stopped = {_stopped}, Task = {Task}")]
     public sealed class TaskAnyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskAnyWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1197,7 +1254,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainCoordinator: Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
     public sealed class TaskChainCoordinator<T> : System.IDisposable
     {
         public TaskChainCoordinator(System.IObserver<T> observer) { }
@@ -1205,13 +1262,13 @@ namespace ReactiveUI.Primitives.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.TaskChainCoordinator<T> Run(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainSignal: Sources = {_sources}")]
     public sealed class TaskChainSignal<T> : System.IObservable<T>
     {
         public TaskChainSignal(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskCountWitness: Count = {_count}, Stopped = {_stopped}")]
     public sealed class TaskCountWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskCountWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1227,13 +1284,13 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSignal: Task = {Task}")]
     public sealed class TaskInstanceSignal<T> : System.IObservable<T>
     {
         public TaskInstanceSignal(System.Threading.Tasks.Task<T> task) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSubscription: Stopped = {_stopped}")]
     public sealed class TaskInstanceSubscription : System.IDisposable
     {
         public TaskInstanceSubscription() { }
@@ -1241,13 +1298,22 @@ namespace ReactiveUI.Primitives.Advanced
         public void Dispose() { }
         public bool TryStop() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Sequencer = {Sequencer}")]
+    [System.Diagnostics.DebuggerDisplay("ThrowSignal: Error = {_error}, Scheduler = {_scheduler}")]
+    public sealed class ThrowSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ThrowSignal(System.Exception error, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalSignal: Source = {Source}, Sequencer = {Sequencer}")]
     public sealed class TimeIntervalSignal<T> : System.IObservable<ReactiveUI.Primitives.Core.TimeInterval<T>>
     {
         public TimeIntervalSignal(System.IObservable<T> source, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("First = {_first}, Last = {_last}")]
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalWitness: First = {_first}, Last = {_last}")]
     public sealed class TimeIntervalWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TimeIntervalWitness(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -1265,13 +1331,13 @@ namespace ReactiveUI.Primitives.Advanced
     {
         public static void Arm(ReactiveUI.Primitives.Disposables.SingleReplaceableDisposable slot, ReactiveUI.Primitives.Concurrency.ISequencer sequencer, System.TimeSpan delay, System.Action tick) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkSignal: Source = {Source}")]
     public sealed class UnsparkSignal<T> : System.IObservable<T>
     {
         public UnsparkSignal(System.IObservable<ReactiveUI.Primitives.Core.Spark<T>> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class UnsparkWitness<T> : System.IDisposable, System.IObserver<ReactiveUI.Primitives.Core.Spark<T>>
     {
         public UnsparkWitness(System.IObserver<T> observer) { }
@@ -1866,7 +1932,7 @@ namespace ReactiveUI.Primitives.Extensions.Operators
 }
 namespace ReactiveUI.Primitives.Signals
 {
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
+    [System.Diagnostics.DebuggerDisplay("PrioritySemaphoreSignal: Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
     public sealed class PrioritySemaphoreSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T> where T : System.IComparable<T>
     {
         public PrioritySemaphoreSignal(int maxCount) { }
@@ -1901,7 +1967,7 @@ namespace ReactiveUI.Primitives.Signals
         public void OnNext(T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledSignal: Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
     public class ScheduledSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T>
     {
         public ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }

--- a/src/ReactiveUI.Primitives/PublicAPI/net11.0-tvos/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net11.0-tvos/PublicAPI.txt
@@ -514,7 +514,7 @@ namespace ReactiveUI.Primitives
 }
 namespace ReactiveUI.Primitives.Advanced
 {
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Period = {_period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSignal: DueTime = {_dueTime}, Period = {_period}")]
     public sealed class AfterSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
     {
         public AfterSignal(System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -522,7 +522,7 @@ namespace ReactiveUI.Primitives.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<long> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSubscription: Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
     public sealed class AfterSubscription : System.IDisposable
     {
         public AfterSubscription(System.IObserver<long> observer, ReactiveUI.Primitives.Concurrency.ISequencer scheduler, System.TimeSpan dueTime, System.TimeSpan? period) { }
@@ -530,21 +530,21 @@ namespace ReactiveUI.Primitives.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.AfterSubscription Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("SubscribeAsync = {SubscribeAsync}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncCreateSignal: SubscribeAsync = {SubscribeAsync}")]
     public sealed class AsyncCreateSignal<T> : System.IObservable<T>
     {
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ObservableFactory = {ObservableFactory}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncDeferSignal: ObservableFactory = {ObservableFactory}")]
     public sealed class AsyncDeferSignal<T> : System.IObservable<T>
     {
         public AsyncDeferSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public AsyncDeferSignal(System.Func<System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncSubscriptionLifetime: Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
     public sealed class AsyncSubscriptionLifetime : System.IDisposable
     {
         public AsyncSubscriptionLifetime() { }
@@ -555,33 +555,33 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable? disposable) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connected = {_connected}")]
+    [System.Diagnostics.DebuggerDisplay("AutoConnectSignal: Count = {_count}, Connected = {_connected}")]
     public sealed class AutoConnectSignal<T> : System.IObservable<T>
     {
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount) { }
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount, System.Action<System.IDisposable>? onConnect) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connection = {_connection}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSignal: Count = {_count}, Connection = {_connection}")]
     public sealed class AutoShareSignal<T> : System.IObservable<T>
     {
         public AutoShareSignal(ReactiveUI.Primitives.ConnectableSignal<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Owner = {_owner}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSubscription: Owner = {_owner}, Subscription = {Subscription}")]
     public sealed class AutoShareSubscription<T> : System.IDisposable
     {
         public AutoShareSubscription(ReactiveUI.Primitives.Advanced.AutoShareSignal<T> owner, System.IDisposable subscription) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void Dispose() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("BlendSignal: Sources = {Sources}")]
     public sealed class BlendSignal<T> : System.IObservable<T>
     {
         public BlendSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("BlendWitness: ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
     public sealed class BlendWitness<T> : System.IDisposable
     {
         public BlendWitness(System.IObserver<T> observer) { }
@@ -590,7 +590,7 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.BlendWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.BlendWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("BufferEachWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class BufferEachWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public BufferEachWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -604,20 +604,20 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Window = {Window}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("BufferSignal: Window = {Window}, Source = {Source}")]
     public sealed class BufferSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public BufferSignal(System.IObservable<T> source, System.TimeSpan timeSpan, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("CastSignal: Source = {Source}")]
     public sealed class CastSignal<TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public CastSignal(System.IObservable<object?> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CastWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CastWitness<TResult> : System.IDisposable, System.IObserver<object?>
     {
         public CastWitness(System.IObserver<TResult> observer) { }
@@ -631,7 +631,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
+    [System.Diagnostics.DebuggerDisplay("ChainSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
     public sealed class ChainSignal<T> : System.IObservable<T>
     {
         public ChainSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -639,7 +639,7 @@ namespace ReactiveUI.Primitives.Advanced
         public ChainSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("ChainWitness: IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
     public sealed class ChainWitness<T> : System.IDisposable
     {
         public ChainWitness(System.IObserver<T> observer) { }
@@ -649,13 +649,13 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.ChainWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.ChainWitness<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, TimeSpan = {TimeSpan}")]
+    [System.Diagnostics.DebuggerDisplay("CollectSignal: Source = {Source}, TimeSpan = {TimeSpan}")]
     public sealed class CollectSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public CollectSignal(System.IObservable<T> source, System.TimeSpan timeSpan, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Buffered = {Values.Count}")]
+    [System.Diagnostics.DebuggerDisplay("CollectWitness: Stopped = {_stopped}, Buffered = {Values.Count}")]
     public sealed class CollectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CollectWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -667,7 +667,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateSink: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class CreateSink<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateSink(System.IObserver<T> observer, bool disposeOnNextThrow) { }
@@ -679,7 +679,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CreateWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateWitness(System.IObserver<T> observer) { }
@@ -693,7 +693,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
+    [System.Diagnostics.DebuggerDisplay("DispatchSequencerState: ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
     public record struct DispatchSequencerState : System.IEquatable<ReactiveUI.Primitives.Advanced.DispatchSequencerState>
     {
         public DispatchSequencerState(ReactiveUI.Primitives.Concurrency.ISequencer owner, System.Func<System.Action, bool> post, System.Action drain) { }
@@ -708,13 +708,13 @@ namespace ReactiveUI.Primitives.Advanced
         public static System.TimeSpan DelayUntil(long dueTimestamp) { }
         public static void RunIfActive(ReactiveUI.Primitives.Concurrency.IWorkItem item) { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {DueTime}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietSignal: DueTime = {DueTime}, Source = {Source}")]
     public sealed class EmitIfQuietSignal<T> : System.IObservable<T>
     {
         public EmitIfQuietSignal(System.IObservable<T> source, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietWitness: HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
     public sealed class EmitIfQuietWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public EmitIfQuietWitness(System.IObserver<T> observer, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
@@ -725,7 +725,16 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("EmptySignal: Scheduler = {_scheduler}")]
+    public sealed class EmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public EmptySignal(ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("EnumerableBlendSignal: Sources = {Sources}")]
     public sealed class EnumerableBlendSignal<T> : System.IObservable<T>
     {
         public EnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -735,7 +744,14 @@ namespace ReactiveUI.Primitives.Advanced
     {
         public static System.IDisposable Attach<TEventHandler>(TEventHandler handler, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
+    [System.Diagnostics.DebuggerDisplay("EverySignal: Period = {_period}, Scheduler = {_scheduler}")]
+    public sealed class EverySignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
+    {
+        public EverySignal(System.TimeSpan period, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<long> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ExpireCoordinator: Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
     public sealed class ExpireCoordinator<T> : System.IDisposable, System.IObserver<T>
     {
         public ExpireCoordinator(System.IObservable<T> source, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer, System.IObserver<T> observer) { }
@@ -745,39 +761,48 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnNext(T value) { }
         public ReactiveUI.Primitives.Advanced.ExpireCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("ExpireSignal: DueTime = {_dueTime}, Source = {_source}")]
     public sealed class ExpireSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ExpireSignal(System.IObservable<T> source, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("FinallySignal: Source = {_source}")]
+    public sealed class FinallySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public FinallySignal(System.IObservable<T> source, System.Action finallyAction) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ForkJoinSignal: Left = {Left}, Right = {Right}")]
     public sealed class ForkJoinSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public ForkJoinSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("ForkJoinWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
     public sealed class ForkJoinWitness<TLeft, TRight, TResult>
     {
         public ForkJoinWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("CancellationRequested = {CancellationToken.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncExternalCancellationSignal: CancellationRequested = {CancellationToken.IsCancellationRequested}")]
     public sealed class FromAsyncExternalCancellationSignal<T> : System.IObservable<T>
     {
         public FromAsyncExternalCancellationSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSignal: TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
     public sealed class FromAsyncSignal<T> : System.IObservable<T>
     {
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSubscription: Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
     public sealed class FromAsyncSubscription<T> : System.IDisposable
     {
         public FromAsyncSubscription(System.IObserver<T> observer, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
@@ -790,14 +815,14 @@ namespace ReactiveUI.Primitives.Advanced
         public FromEventConversionSignal(System.Func<TCallback, TEventHandler> conversion, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Func<System.IObserver<TResult>, TCallback> callback, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
+    [System.Diagnostics.DebuggerDisplay("FromEventPatternSignal: AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
     public sealed class FromEventPatternSignal<TEventHandler, TEventArgs> : System.IObservable<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> where TEventHandler : System.Delegate where TEventArgs : System.EventArgs
     {
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler) { }
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Disposed = {_disposed}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("GuardedWitness: Disposed = {_disposed}, Observer = {_observer}")]
     public sealed class GuardedWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public GuardedWitness(System.IObserver<T> observer, System.IDisposable cancel) { }
@@ -807,7 +832,7 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IgnoreValuesSignal: Source = {Source}")]
     public sealed class IgnoreValuesSignal<T> : System.IObservable<T>
     {
         public IgnoreValuesSignal(System.IObservable<T> source) { }
@@ -821,14 +846,14 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.RxVoid> observer) { }
         public System.IDisposable Subscribe(System.Action<ReactiveUI.Primitives.RxVoid> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptySignal: Source = {Source}")]
     public sealed class IsEmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<bool>
     {
         public IsEmptySignal(System.IObservable<T> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<bool> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptyWitness: Stopped = {_stopped}, Subscription = {Subscription}")]
     public sealed class IsEmptyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public IsEmptyWitness(System.IObserver<bool> observer) { }
@@ -841,14 +866,23 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {Value}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("LeadSignal: Value = {Value}, Source = {Source}")]
     public sealed class LeadSignal<T> : ReactiveUI.Primitives.Advanced.IInlineSignal<T>
     {
         public LeadSignal(System.IObservable<T> source, T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
         public System.IDisposable Subscribe(System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("LoopSignal: Value = {Value}")]
+    public sealed class LoopSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public LoopSignal(T value) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("MapIndexedSignal: Source = {_source}")]
     public sealed class MapIndexedSignal<TSource, TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public MapIndexedSignal(System.IObservable<TSource> source, System.Func<TSource, int, TResult> selector) { }
@@ -856,7 +890,7 @@ namespace ReactiveUI.Primitives.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Index = {_index}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("MapIndexedWitness: Index = {_index}, Stopped = {_stopped}")]
     public sealed class MapIndexedWitness<TSource, TResult> : System.IObserver<TSource>
     {
         public MapIndexedWitness(System.IObserver<TResult> observer, System.Func<TSource, int, TResult> selector) { }
@@ -864,20 +898,20 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(TSource value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentBlendCoordinator: Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
     public sealed class MaxConcurrentBlendCoordinator<T> : System.IDisposable
     {
         public MaxConcurrentBlendCoordinator(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.MaxConcurrentBlendCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentEnumerableBlendSignal: Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
     public sealed class MaxConcurrentEnumerableBlendSignal<T> : System.IObservable<T>
     {
         public MaxConcurrentEnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("MergeCoordinator: Active = {Active}, Done = {Done}")]
     public sealed class MergeCoordinator<T> : System.IDisposable
     {
         public MergeCoordinator(System.IObserver<T> observer) { }
@@ -888,7 +922,7 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.MergeCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.MergeCoordinator<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MergeSignal: Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
     public sealed class MergeSignal<T> : System.IObservable<T>
     {
         public MergeSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -896,32 +930,39 @@ namespace ReactiveUI.Primitives.Advanced
         public MergeSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("OnErrorResumeNextSignal: Sources = {_sources}")]
+    public sealed class OnErrorResumeNextSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("PairSignal: Left = {Left}, Right = {Right}")]
     public sealed class PairSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public PairSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
+    [System.Diagnostics.DebuggerDisplay("PairWitness: IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
     public sealed class PairWitness<TLeft, TRight, TResult>
     {
         public PairWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("PublishSelectorSignal: Source = {Source}, Selector = {Selector}")]
     public sealed class PublishSelectorSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public PublishSelectorSignal(System.IObservable<TSource> source, System.Func<System.IObservable<TSource>, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
+    [System.Diagnostics.DebuggerDisplay("RaceSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
     public sealed class RaceSignal<T> : System.IObservable<T>
     {
         public RaceSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public RaceSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Arms = {_arms}")]
+    [System.Diagnostics.DebuggerDisplay("RaceWitness: Arms = {_arms}")]
     public sealed class RaceWitness<T> : System.IDisposable
     {
         public RaceWitness(System.IObserver<T> observer) { }
@@ -930,40 +971,48 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.RaceWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.RaceWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeCombineLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeCombineLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeCombineLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
+    [System.Diagnostics.DebuggerDisplay("RangeForkJoinSignal: Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
     public sealed class RangeForkJoinSignal<TResult> : System.IObservable<TResult>
     {
         public RangeForkJoinSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeSyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeSyncLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeSyncLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeWithLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeWithLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeWithLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Remaining = {_remaining}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("RecoverSignal: Source = {_source}")]
+    public sealed class RecoverSignal<T, TException> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T> where TException : System.Exception
+    {
+        public RecoverSignal(System.IObservable<T> source, System.Func<TException, System.IObservable<T>> handler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceCoordinator: Remaining = {_remaining}, Disposed = {_disposed}")]
     public sealed class RepeatSourceCoordinator<T> : System.IDisposable
     {
         public RepeatSourceCoordinator(System.IObservable<T> source, int? repeatCount, System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.RepeatSourceCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, RepeatCount = {_repeatCount}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceSignal: Source = {_source}, RepeatCount = {_repeatCount}")]
     public sealed class RepeatSourceSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public RepeatSourceSignal(System.IObservable<T> source, int? repeatCount) { }
@@ -971,7 +1020,7 @@ namespace ReactiveUI.Primitives.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Generation = {_generation}, Terminated = {_terminated}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceWitness: Generation = {_generation}, Terminated = {_terminated}")]
     public sealed class RepeatSourceWitness<T> : System.IObserver<T>
     {
         public RepeatSourceWitness(ReactiveUI.Primitives.Advanced.RepeatSourceCoordinator<T> parent, int generation) { }
@@ -979,7 +1028,15 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_value}, Scheduler = {_scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ResumeSignal: Source = {_source}, Fallback = {_fallback}")]
+    public sealed class ResumeSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ResumeSignal(System.IObservable<T> source, System.IObservable<T> fallback) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ReturnSignal: Value = {_value}, Scheduler = {_scheduler}")]
     public sealed class ReturnSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ReturnSignal(T value, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -988,13 +1045,13 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Values = {Values}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledEnumerableSignal: Values = {Values}, Scheduler = {Scheduler}")]
     public sealed class ScheduledEnumerableSignal<T> : System.IObservable<T>
     {
         public ScheduledEnumerableSignal(System.Collections.Generic.IEnumerable<T> values, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyCoordinator<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TResult>> selector) { }
@@ -1008,13 +1065,13 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Advanced.SelectManyCoordinator<TSource, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableSignal: Source = {_source}")]
     public sealed class SelectManyEnumerableSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManyEnumerableSignal(System.IObservable<TSource> source, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SelectManyEnumerableWitness<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyEnumerableWitness(System.IObserver<TResult> observer, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
@@ -1028,7 +1085,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyResultCoordinator<TSource, TCollection, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyResultCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
@@ -1041,20 +1098,20 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Advanced.SelectManyResultCoordinator<TSource, TCollection, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, CollectionSelector = {CollectionSelector}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultSignal: Source = {Source}, CollectionSelector = {CollectionSelector}")]
     public sealed class SelectManyResultSignal<TSource, TCollection, TResult> : System.IObservable<TResult>
     {
         public SelectManyResultSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManySignal: Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
     public sealed class SelectManySignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManySignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public SelectManySignal(System.IObservable<TSource> source, System.IObservable<TResult> inner) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Start = {Start}, Count = {Count}")]
+    [System.Diagnostics.DebuggerDisplay("SequenceSignal: Start = {Start}, Count = {Count}")]
     public sealed class SequenceSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<int>
     {
         public SequenceSignal(int start, int count, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -1065,13 +1122,13 @@ namespace ReactiveUI.Primitives.Advanced
     {
         public static System.IDisposable Subscribe<T>(System.IObserver<T> observer, bool currentThreadRequired, System.Func<System.IObserver<T>, System.IDisposable, System.IDisposable> subscribeCore) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SparkSignal: Source = {Source}")]
     public sealed class SparkSignal<T> : System.IObservable<ReactiveUI.Primitives.Core.Spark<T>>
     {
         public SparkSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.Spark<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SparkWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SparkWitness(System.IObserver<ReactiveUI.Primitives.Core.Spark<T>> observer) { }
@@ -1086,21 +1143,21 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Action = {Action}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Action = {Action}, Scheduler = {Scheduler}")]
     public sealed class StartSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<ReactiveUI.Primitives.RxVoid>
     {
         public StartSignal(System.Action action, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.RxVoid> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Function = {Function}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Function = {Function}, Scheduler = {Scheduler}")]
     public sealed class StartSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public StartSignal(System.Func<T> function, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SubscribeSafeWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SubscribeSafeWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SubscribeSafeWitness(System.IObserver<T> observer) { }
@@ -1114,50 +1171,50 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, SkipNullSources = {_skipNullSources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchMapSignal: Source = {_source}, SkipNullSources = {_skipNullSources}")]
     public sealed class SwitchMapSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SwitchMapSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchSignal: Sources = {Sources}")]
     public sealed class SwitchSignal<T> : System.IObservable<T>
     {
         public SwitchSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Version = {_version}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchWitness: Version = {_version}, IsDone = {IsDone}")]
     public sealed class SwitchWitness<T> : System.IDisposable
     {
         public SwitchWitness(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.SwitchWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class SyncLatestSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public SyncLatestSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
     public sealed class SyncLatestWitness<TLeft, TRight, TResult>
     {
         public SyncLatestWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Gate = {Gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeGateSignal: Source = {Source}, Gate = {Gate}")]
     public sealed class SynchronizeGateSignal<T> : System.IObservable<T>
     {
         public SynchronizeGateSignal(System.IObservable<T> source, System.Threading.Lock gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, Gate = {_gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectSignal: Source = {_source}, Gate = {_gate}")]
     public sealed class SynchronizeObjectSignal<T> : System.IObservable<T>
     {
         public SynchronizeObjectSignal(System.IObservable<T> source, object gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SynchronizeObjectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SynchronizeObjectWitness(System.IObserver<T> observer, object gate) { }
@@ -1169,19 +1226,19 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeSignal: Source = {Source}")]
     public sealed class SynchronizeSignal<T> : System.IObservable<T>
     {
         public SynchronizeSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("TapSignal: Source = {Source}")]
     public sealed class TapSignal<T> : System.IObservable<T>
     {
         public TapSignal(System.IObservable<T> source, System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskAnyWitness: Stopped = {_stopped}, Task = {Task}")]
     public sealed class TaskAnyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskAnyWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1197,7 +1254,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainCoordinator: Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
     public sealed class TaskChainCoordinator<T> : System.IDisposable
     {
         public TaskChainCoordinator(System.IObserver<T> observer) { }
@@ -1205,13 +1262,13 @@ namespace ReactiveUI.Primitives.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.TaskChainCoordinator<T> Run(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainSignal: Sources = {_sources}")]
     public sealed class TaskChainSignal<T> : System.IObservable<T>
     {
         public TaskChainSignal(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskCountWitness: Count = {_count}, Stopped = {_stopped}")]
     public sealed class TaskCountWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskCountWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1227,13 +1284,13 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSignal: Task = {Task}")]
     public sealed class TaskInstanceSignal<T> : System.IObservable<T>
     {
         public TaskInstanceSignal(System.Threading.Tasks.Task<T> task) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSubscription: Stopped = {_stopped}")]
     public sealed class TaskInstanceSubscription : System.IDisposable
     {
         public TaskInstanceSubscription() { }
@@ -1241,13 +1298,22 @@ namespace ReactiveUI.Primitives.Advanced
         public void Dispose() { }
         public bool TryStop() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Sequencer = {Sequencer}")]
+    [System.Diagnostics.DebuggerDisplay("ThrowSignal: Error = {_error}, Scheduler = {_scheduler}")]
+    public sealed class ThrowSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ThrowSignal(System.Exception error, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalSignal: Source = {Source}, Sequencer = {Sequencer}")]
     public sealed class TimeIntervalSignal<T> : System.IObservable<ReactiveUI.Primitives.Core.TimeInterval<T>>
     {
         public TimeIntervalSignal(System.IObservable<T> source, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("First = {_first}, Last = {_last}")]
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalWitness: First = {_first}, Last = {_last}")]
     public sealed class TimeIntervalWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TimeIntervalWitness(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -1265,13 +1331,13 @@ namespace ReactiveUI.Primitives.Advanced
     {
         public static void Arm(ReactiveUI.Primitives.Disposables.SingleReplaceableDisposable slot, ReactiveUI.Primitives.Concurrency.ISequencer sequencer, System.TimeSpan delay, System.Action tick) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkSignal: Source = {Source}")]
     public sealed class UnsparkSignal<T> : System.IObservable<T>
     {
         public UnsparkSignal(System.IObservable<ReactiveUI.Primitives.Core.Spark<T>> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class UnsparkWitness<T> : System.IDisposable, System.IObserver<ReactiveUI.Primitives.Core.Spark<T>>
     {
         public UnsparkWitness(System.IObserver<T> observer) { }
@@ -1866,7 +1932,7 @@ namespace ReactiveUI.Primitives.Extensions.Operators
 }
 namespace ReactiveUI.Primitives.Signals
 {
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
+    [System.Diagnostics.DebuggerDisplay("PrioritySemaphoreSignal: Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
     public sealed class PrioritySemaphoreSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T> where T : System.IComparable<T>
     {
         public PrioritySemaphoreSignal(int maxCount) { }
@@ -1901,7 +1967,7 @@ namespace ReactiveUI.Primitives.Signals
         public void OnNext(T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledSignal: Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
     public class ScheduledSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T>
     {
         public ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }

--- a/src/ReactiveUI.Primitives/PublicAPI/net11.0/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net11.0/PublicAPI.txt
@@ -513,7 +513,7 @@ namespace ReactiveUI.Primitives
 }
 namespace ReactiveUI.Primitives.Advanced
 {
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Period = {_period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSignal: DueTime = {_dueTime}, Period = {_period}")]
     public sealed class AfterSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
     {
         public AfterSignal(System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -521,7 +521,7 @@ namespace ReactiveUI.Primitives.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<long> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSubscription: Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
     public sealed class AfterSubscription : System.IDisposable
     {
         public AfterSubscription(System.IObserver<long> observer, ReactiveUI.Primitives.Concurrency.ISequencer scheduler, System.TimeSpan dueTime, System.TimeSpan? period) { }
@@ -529,21 +529,21 @@ namespace ReactiveUI.Primitives.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.AfterSubscription Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("SubscribeAsync = {SubscribeAsync}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncCreateSignal: SubscribeAsync = {SubscribeAsync}")]
     public sealed class AsyncCreateSignal<T> : System.IObservable<T>
     {
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ObservableFactory = {ObservableFactory}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncDeferSignal: ObservableFactory = {ObservableFactory}")]
     public sealed class AsyncDeferSignal<T> : System.IObservable<T>
     {
         public AsyncDeferSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public AsyncDeferSignal(System.Func<System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncSubscriptionLifetime: Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
     public sealed class AsyncSubscriptionLifetime : System.IDisposable
     {
         public AsyncSubscriptionLifetime() { }
@@ -554,33 +554,33 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable? disposable) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connected = {_connected}")]
+    [System.Diagnostics.DebuggerDisplay("AutoConnectSignal: Count = {_count}, Connected = {_connected}")]
     public sealed class AutoConnectSignal<T> : System.IObservable<T>
     {
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount) { }
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount, System.Action<System.IDisposable>? onConnect) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connection = {_connection}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSignal: Count = {_count}, Connection = {_connection}")]
     public sealed class AutoShareSignal<T> : System.IObservable<T>
     {
         public AutoShareSignal(ReactiveUI.Primitives.ConnectableSignal<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Owner = {_owner}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSubscription: Owner = {_owner}, Subscription = {Subscription}")]
     public sealed class AutoShareSubscription<T> : System.IDisposable
     {
         public AutoShareSubscription(ReactiveUI.Primitives.Advanced.AutoShareSignal<T> owner, System.IDisposable subscription) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void Dispose() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("BlendSignal: Sources = {Sources}")]
     public sealed class BlendSignal<T> : System.IObservable<T>
     {
         public BlendSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("BlendWitness: ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
     public sealed class BlendWitness<T> : System.IDisposable
     {
         public BlendWitness(System.IObserver<T> observer) { }
@@ -589,7 +589,7 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.BlendWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.BlendWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("BufferEachWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class BufferEachWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public BufferEachWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -603,20 +603,20 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Window = {Window}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("BufferSignal: Window = {Window}, Source = {Source}")]
     public sealed class BufferSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public BufferSignal(System.IObservable<T> source, System.TimeSpan timeSpan, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("CastSignal: Source = {Source}")]
     public sealed class CastSignal<TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public CastSignal(System.IObservable<object?> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CastWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CastWitness<TResult> : System.IDisposable, System.IObserver<object?>
     {
         public CastWitness(System.IObserver<TResult> observer) { }
@@ -630,7 +630,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
+    [System.Diagnostics.DebuggerDisplay("ChainSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
     public sealed class ChainSignal<T> : System.IObservable<T>
     {
         public ChainSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -638,7 +638,7 @@ namespace ReactiveUI.Primitives.Advanced
         public ChainSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("ChainWitness: IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
     public sealed class ChainWitness<T> : System.IDisposable
     {
         public ChainWitness(System.IObserver<T> observer) { }
@@ -648,13 +648,13 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.ChainWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.ChainWitness<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, TimeSpan = {TimeSpan}")]
+    [System.Diagnostics.DebuggerDisplay("CollectSignal: Source = {Source}, TimeSpan = {TimeSpan}")]
     public sealed class CollectSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public CollectSignal(System.IObservable<T> source, System.TimeSpan timeSpan, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Buffered = {Values.Count}")]
+    [System.Diagnostics.DebuggerDisplay("CollectWitness: Stopped = {_stopped}, Buffered = {Values.Count}")]
     public sealed class CollectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CollectWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -666,7 +666,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateSink: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class CreateSink<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateSink(System.IObserver<T> observer, bool disposeOnNextThrow) { }
@@ -678,7 +678,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CreateWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateWitness(System.IObserver<T> observer) { }
@@ -692,7 +692,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
+    [System.Diagnostics.DebuggerDisplay("DispatchSequencerState: ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
     public record struct DispatchSequencerState : System.IEquatable<ReactiveUI.Primitives.Advanced.DispatchSequencerState>
     {
         public DispatchSequencerState(ReactiveUI.Primitives.Concurrency.ISequencer owner, System.Func<System.Action, bool> post, System.Action drain) { }
@@ -707,13 +707,13 @@ namespace ReactiveUI.Primitives.Advanced
         public static System.TimeSpan DelayUntil(long dueTimestamp) { }
         public static void RunIfActive(ReactiveUI.Primitives.Concurrency.IWorkItem item) { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {DueTime}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietSignal: DueTime = {DueTime}, Source = {Source}")]
     public sealed class EmitIfQuietSignal<T> : System.IObservable<T>
     {
         public EmitIfQuietSignal(System.IObservable<T> source, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietWitness: HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
     public sealed class EmitIfQuietWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public EmitIfQuietWitness(System.IObserver<T> observer, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
@@ -724,7 +724,16 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("EmptySignal: Scheduler = {_scheduler}")]
+    public sealed class EmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public EmptySignal(ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("EnumerableBlendSignal: Sources = {Sources}")]
     public sealed class EnumerableBlendSignal<T> : System.IObservable<T>
     {
         public EnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -734,7 +743,14 @@ namespace ReactiveUI.Primitives.Advanced
     {
         public static System.IDisposable Attach<TEventHandler>(TEventHandler handler, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
+    [System.Diagnostics.DebuggerDisplay("EverySignal: Period = {_period}, Scheduler = {_scheduler}")]
+    public sealed class EverySignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
+    {
+        public EverySignal(System.TimeSpan period, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<long> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ExpireCoordinator: Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
     public sealed class ExpireCoordinator<T> : System.IDisposable, System.IObserver<T>
     {
         public ExpireCoordinator(System.IObservable<T> source, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer, System.IObserver<T> observer) { }
@@ -744,39 +760,48 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnNext(T value) { }
         public ReactiveUI.Primitives.Advanced.ExpireCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("ExpireSignal: DueTime = {_dueTime}, Source = {_source}")]
     public sealed class ExpireSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ExpireSignal(System.IObservable<T> source, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("FinallySignal: Source = {_source}")]
+    public sealed class FinallySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public FinallySignal(System.IObservable<T> source, System.Action finallyAction) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ForkJoinSignal: Left = {Left}, Right = {Right}")]
     public sealed class ForkJoinSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public ForkJoinSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("ForkJoinWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
     public sealed class ForkJoinWitness<TLeft, TRight, TResult>
     {
         public ForkJoinWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("CancellationRequested = {CancellationToken.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncExternalCancellationSignal: CancellationRequested = {CancellationToken.IsCancellationRequested}")]
     public sealed class FromAsyncExternalCancellationSignal<T> : System.IObservable<T>
     {
         public FromAsyncExternalCancellationSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSignal: TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
     public sealed class FromAsyncSignal<T> : System.IObservable<T>
     {
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSubscription: Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
     public sealed class FromAsyncSubscription<T> : System.IDisposable
     {
         public FromAsyncSubscription(System.IObserver<T> observer, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
@@ -789,14 +814,14 @@ namespace ReactiveUI.Primitives.Advanced
         public FromEventConversionSignal(System.Func<TCallback, TEventHandler> conversion, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Func<System.IObserver<TResult>, TCallback> callback, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
+    [System.Diagnostics.DebuggerDisplay("FromEventPatternSignal: AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
     public sealed class FromEventPatternSignal<TEventHandler, TEventArgs> : System.IObservable<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> where TEventHandler : System.Delegate where TEventArgs : System.EventArgs
     {
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler) { }
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Disposed = {_disposed}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("GuardedWitness: Disposed = {_disposed}, Observer = {_observer}")]
     public sealed class GuardedWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public GuardedWitness(System.IObserver<T> observer, System.IDisposable cancel) { }
@@ -806,7 +831,7 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IgnoreValuesSignal: Source = {Source}")]
     public sealed class IgnoreValuesSignal<T> : System.IObservable<T>
     {
         public IgnoreValuesSignal(System.IObservable<T> source) { }
@@ -820,14 +845,14 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.RxVoid> observer) { }
         public System.IDisposable Subscribe(System.Action<ReactiveUI.Primitives.RxVoid> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptySignal: Source = {Source}")]
     public sealed class IsEmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<bool>
     {
         public IsEmptySignal(System.IObservable<T> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<bool> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptyWitness: Stopped = {_stopped}, Subscription = {Subscription}")]
     public sealed class IsEmptyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public IsEmptyWitness(System.IObserver<bool> observer) { }
@@ -840,14 +865,23 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {Value}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("LeadSignal: Value = {Value}, Source = {Source}")]
     public sealed class LeadSignal<T> : ReactiveUI.Primitives.Advanced.IInlineSignal<T>
     {
         public LeadSignal(System.IObservable<T> source, T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
         public System.IDisposable Subscribe(System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("LoopSignal: Value = {Value}")]
+    public sealed class LoopSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public LoopSignal(T value) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("MapIndexedSignal: Source = {_source}")]
     public sealed class MapIndexedSignal<TSource, TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public MapIndexedSignal(System.IObservable<TSource> source, System.Func<TSource, int, TResult> selector) { }
@@ -855,7 +889,7 @@ namespace ReactiveUI.Primitives.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Index = {_index}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("MapIndexedWitness: Index = {_index}, Stopped = {_stopped}")]
     public sealed class MapIndexedWitness<TSource, TResult> : System.IObserver<TSource>
     {
         public MapIndexedWitness(System.IObserver<TResult> observer, System.Func<TSource, int, TResult> selector) { }
@@ -863,20 +897,20 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(TSource value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentBlendCoordinator: Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
     public sealed class MaxConcurrentBlendCoordinator<T> : System.IDisposable
     {
         public MaxConcurrentBlendCoordinator(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.MaxConcurrentBlendCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentEnumerableBlendSignal: Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
     public sealed class MaxConcurrentEnumerableBlendSignal<T> : System.IObservable<T>
     {
         public MaxConcurrentEnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("MergeCoordinator: Active = {Active}, Done = {Done}")]
     public sealed class MergeCoordinator<T> : System.IDisposable
     {
         public MergeCoordinator(System.IObserver<T> observer) { }
@@ -887,7 +921,7 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.MergeCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.MergeCoordinator<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MergeSignal: Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
     public sealed class MergeSignal<T> : System.IObservable<T>
     {
         public MergeSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -895,32 +929,39 @@ namespace ReactiveUI.Primitives.Advanced
         public MergeSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("OnErrorResumeNextSignal: Sources = {_sources}")]
+    public sealed class OnErrorResumeNextSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("PairSignal: Left = {Left}, Right = {Right}")]
     public sealed class PairSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public PairSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
+    [System.Diagnostics.DebuggerDisplay("PairWitness: IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
     public sealed class PairWitness<TLeft, TRight, TResult>
     {
         public PairWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("PublishSelectorSignal: Source = {Source}, Selector = {Selector}")]
     public sealed class PublishSelectorSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public PublishSelectorSignal(System.IObservable<TSource> source, System.Func<System.IObservable<TSource>, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
+    [System.Diagnostics.DebuggerDisplay("RaceSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
     public sealed class RaceSignal<T> : System.IObservable<T>
     {
         public RaceSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public RaceSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Arms = {_arms}")]
+    [System.Diagnostics.DebuggerDisplay("RaceWitness: Arms = {_arms}")]
     public sealed class RaceWitness<T> : System.IDisposable
     {
         public RaceWitness(System.IObserver<T> observer) { }
@@ -929,40 +970,48 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.RaceWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.RaceWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeCombineLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeCombineLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeCombineLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
+    [System.Diagnostics.DebuggerDisplay("RangeForkJoinSignal: Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
     public sealed class RangeForkJoinSignal<TResult> : System.IObservable<TResult>
     {
         public RangeForkJoinSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeSyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeSyncLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeSyncLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeWithLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeWithLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeWithLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Remaining = {_remaining}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("RecoverSignal: Source = {_source}")]
+    public sealed class RecoverSignal<T, TException> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T> where TException : System.Exception
+    {
+        public RecoverSignal(System.IObservable<T> source, System.Func<TException, System.IObservable<T>> handler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceCoordinator: Remaining = {_remaining}, Disposed = {_disposed}")]
     public sealed class RepeatSourceCoordinator<T> : System.IDisposable
     {
         public RepeatSourceCoordinator(System.IObservable<T> source, int? repeatCount, System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.RepeatSourceCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, RepeatCount = {_repeatCount}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceSignal: Source = {_source}, RepeatCount = {_repeatCount}")]
     public sealed class RepeatSourceSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public RepeatSourceSignal(System.IObservable<T> source, int? repeatCount) { }
@@ -970,7 +1019,7 @@ namespace ReactiveUI.Primitives.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Generation = {_generation}, Terminated = {_terminated}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceWitness: Generation = {_generation}, Terminated = {_terminated}")]
     public sealed class RepeatSourceWitness<T> : System.IObserver<T>
     {
         public RepeatSourceWitness(ReactiveUI.Primitives.Advanced.RepeatSourceCoordinator<T> parent, int generation) { }
@@ -978,7 +1027,15 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_value}, Scheduler = {_scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ResumeSignal: Source = {_source}, Fallback = {_fallback}")]
+    public sealed class ResumeSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ResumeSignal(System.IObservable<T> source, System.IObservable<T> fallback) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ReturnSignal: Value = {_value}, Scheduler = {_scheduler}")]
     public sealed class ReturnSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ReturnSignal(T value, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -987,13 +1044,13 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Values = {Values}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledEnumerableSignal: Values = {Values}, Scheduler = {Scheduler}")]
     public sealed class ScheduledEnumerableSignal<T> : System.IObservable<T>
     {
         public ScheduledEnumerableSignal(System.Collections.Generic.IEnumerable<T> values, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyCoordinator<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TResult>> selector) { }
@@ -1007,13 +1064,13 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Advanced.SelectManyCoordinator<TSource, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableSignal: Source = {_source}")]
     public sealed class SelectManyEnumerableSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManyEnumerableSignal(System.IObservable<TSource> source, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SelectManyEnumerableWitness<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyEnumerableWitness(System.IObserver<TResult> observer, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
@@ -1027,7 +1084,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyResultCoordinator<TSource, TCollection, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyResultCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
@@ -1040,20 +1097,20 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Advanced.SelectManyResultCoordinator<TSource, TCollection, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, CollectionSelector = {CollectionSelector}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultSignal: Source = {Source}, CollectionSelector = {CollectionSelector}")]
     public sealed class SelectManyResultSignal<TSource, TCollection, TResult> : System.IObservable<TResult>
     {
         public SelectManyResultSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManySignal: Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
     public sealed class SelectManySignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManySignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public SelectManySignal(System.IObservable<TSource> source, System.IObservable<TResult> inner) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Start = {Start}, Count = {Count}")]
+    [System.Diagnostics.DebuggerDisplay("SequenceSignal: Start = {Start}, Count = {Count}")]
     public sealed class SequenceSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<int>
     {
         public SequenceSignal(int start, int count, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -1064,13 +1121,13 @@ namespace ReactiveUI.Primitives.Advanced
     {
         public static System.IDisposable Subscribe<T>(System.IObserver<T> observer, bool currentThreadRequired, System.Func<System.IObserver<T>, System.IDisposable, System.IDisposable> subscribeCore) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SparkSignal: Source = {Source}")]
     public sealed class SparkSignal<T> : System.IObservable<ReactiveUI.Primitives.Core.Spark<T>>
     {
         public SparkSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.Spark<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SparkWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SparkWitness(System.IObserver<ReactiveUI.Primitives.Core.Spark<T>> observer) { }
@@ -1085,21 +1142,21 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Action = {Action}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Action = {Action}, Scheduler = {Scheduler}")]
     public sealed class StartSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<ReactiveUI.Primitives.RxVoid>
     {
         public StartSignal(System.Action action, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.RxVoid> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Function = {Function}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Function = {Function}, Scheduler = {Scheduler}")]
     public sealed class StartSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public StartSignal(System.Func<T> function, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SubscribeSafeWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SubscribeSafeWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SubscribeSafeWitness(System.IObserver<T> observer) { }
@@ -1113,50 +1170,50 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, SkipNullSources = {_skipNullSources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchMapSignal: Source = {_source}, SkipNullSources = {_skipNullSources}")]
     public sealed class SwitchMapSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SwitchMapSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchSignal: Sources = {Sources}")]
     public sealed class SwitchSignal<T> : System.IObservable<T>
     {
         public SwitchSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Version = {_version}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchWitness: Version = {_version}, IsDone = {IsDone}")]
     public sealed class SwitchWitness<T> : System.IDisposable
     {
         public SwitchWitness(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.SwitchWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class SyncLatestSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public SyncLatestSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
     public sealed class SyncLatestWitness<TLeft, TRight, TResult>
     {
         public SyncLatestWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Gate = {Gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeGateSignal: Source = {Source}, Gate = {Gate}")]
     public sealed class SynchronizeGateSignal<T> : System.IObservable<T>
     {
         public SynchronizeGateSignal(System.IObservable<T> source, System.Threading.Lock gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, Gate = {_gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectSignal: Source = {_source}, Gate = {_gate}")]
     public sealed class SynchronizeObjectSignal<T> : System.IObservable<T>
     {
         public SynchronizeObjectSignal(System.IObservable<T> source, object gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SynchronizeObjectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SynchronizeObjectWitness(System.IObserver<T> observer, object gate) { }
@@ -1168,19 +1225,19 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeSignal: Source = {Source}")]
     public sealed class SynchronizeSignal<T> : System.IObservable<T>
     {
         public SynchronizeSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("TapSignal: Source = {Source}")]
     public sealed class TapSignal<T> : System.IObservable<T>
     {
         public TapSignal(System.IObservable<T> source, System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskAnyWitness: Stopped = {_stopped}, Task = {Task}")]
     public sealed class TaskAnyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskAnyWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1196,7 +1253,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainCoordinator: Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
     public sealed class TaskChainCoordinator<T> : System.IDisposable
     {
         public TaskChainCoordinator(System.IObserver<T> observer) { }
@@ -1204,13 +1261,13 @@ namespace ReactiveUI.Primitives.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.TaskChainCoordinator<T> Run(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainSignal: Sources = {_sources}")]
     public sealed class TaskChainSignal<T> : System.IObservable<T>
     {
         public TaskChainSignal(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskCountWitness: Count = {_count}, Stopped = {_stopped}")]
     public sealed class TaskCountWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskCountWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1226,13 +1283,13 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSignal: Task = {Task}")]
     public sealed class TaskInstanceSignal<T> : System.IObservable<T>
     {
         public TaskInstanceSignal(System.Threading.Tasks.Task<T> task) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSubscription: Stopped = {_stopped}")]
     public sealed class TaskInstanceSubscription : System.IDisposable
     {
         public TaskInstanceSubscription() { }
@@ -1240,13 +1297,22 @@ namespace ReactiveUI.Primitives.Advanced
         public void Dispose() { }
         public bool TryStop() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Sequencer = {Sequencer}")]
+    [System.Diagnostics.DebuggerDisplay("ThrowSignal: Error = {_error}, Scheduler = {_scheduler}")]
+    public sealed class ThrowSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ThrowSignal(System.Exception error, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalSignal: Source = {Source}, Sequencer = {Sequencer}")]
     public sealed class TimeIntervalSignal<T> : System.IObservable<ReactiveUI.Primitives.Core.TimeInterval<T>>
     {
         public TimeIntervalSignal(System.IObservable<T> source, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("First = {_first}, Last = {_last}")]
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalWitness: First = {_first}, Last = {_last}")]
     public sealed class TimeIntervalWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TimeIntervalWitness(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -1264,13 +1330,13 @@ namespace ReactiveUI.Primitives.Advanced
     {
         public static void Arm(ReactiveUI.Primitives.Disposables.SingleReplaceableDisposable slot, ReactiveUI.Primitives.Concurrency.ISequencer sequencer, System.TimeSpan delay, System.Action tick) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkSignal: Source = {Source}")]
     public sealed class UnsparkSignal<T> : System.IObservable<T>
     {
         public UnsparkSignal(System.IObservable<ReactiveUI.Primitives.Core.Spark<T>> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class UnsparkWitness<T> : System.IDisposable, System.IObserver<ReactiveUI.Primitives.Core.Spark<T>>
     {
         public UnsparkWitness(System.IObserver<T> observer) { }
@@ -1853,7 +1919,7 @@ namespace ReactiveUI.Primitives.Extensions.Operators
 }
 namespace ReactiveUI.Primitives.Signals
 {
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
+    [System.Diagnostics.DebuggerDisplay("PrioritySemaphoreSignal: Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
     public sealed class PrioritySemaphoreSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T> where T : System.IComparable<T>
     {
         public PrioritySemaphoreSignal(int maxCount) { }
@@ -1888,7 +1954,7 @@ namespace ReactiveUI.Primitives.Signals
         public void OnNext(T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledSignal: Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
     public class ScheduledSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T>
     {
         public ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }

--- a/src/ReactiveUI.Primitives/PublicAPI/net462/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net462/PublicAPI.txt
@@ -479,7 +479,7 @@ namespace ReactiveUI.Primitives
 }
 namespace ReactiveUI.Primitives.Advanced
 {
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Period = {_period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSignal: DueTime = {_dueTime}, Period = {_period}")]
     public sealed class AfterSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
     {
         public AfterSignal(System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -487,7 +487,7 @@ namespace ReactiveUI.Primitives.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<long> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSubscription: Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
     public sealed class AfterSubscription : System.IDisposable
     {
         public AfterSubscription(System.IObserver<long> observer, ReactiveUI.Primitives.Concurrency.ISequencer scheduler, System.TimeSpan dueTime, System.TimeSpan? period) { }
@@ -495,21 +495,21 @@ namespace ReactiveUI.Primitives.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.AfterSubscription Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("SubscribeAsync = {SubscribeAsync}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncCreateSignal: SubscribeAsync = {SubscribeAsync}")]
     public sealed class AsyncCreateSignal<T> : System.IObservable<T>
     {
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ObservableFactory = {ObservableFactory}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncDeferSignal: ObservableFactory = {ObservableFactory}")]
     public sealed class AsyncDeferSignal<T> : System.IObservable<T>
     {
         public AsyncDeferSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public AsyncDeferSignal(System.Func<System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncSubscriptionLifetime: Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
     public sealed class AsyncSubscriptionLifetime : System.IDisposable
     {
         public AsyncSubscriptionLifetime() { }
@@ -520,33 +520,33 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable? disposable) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connected = {_connected}")]
+    [System.Diagnostics.DebuggerDisplay("AutoConnectSignal: Count = {_count}, Connected = {_connected}")]
     public sealed class AutoConnectSignal<T> : System.IObservable<T>
     {
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount) { }
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount, System.Action<System.IDisposable>? onConnect) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connection = {_connection}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSignal: Count = {_count}, Connection = {_connection}")]
     public sealed class AutoShareSignal<T> : System.IObservable<T>
     {
         public AutoShareSignal(ReactiveUI.Primitives.ConnectableSignal<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Owner = {_owner}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSubscription: Owner = {_owner}, Subscription = {Subscription}")]
     public sealed class AutoShareSubscription<T> : System.IDisposable
     {
         public AutoShareSubscription(ReactiveUI.Primitives.Advanced.AutoShareSignal<T> owner, System.IDisposable subscription) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void Dispose() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("BlendSignal: Sources = {Sources}")]
     public sealed class BlendSignal<T> : System.IObservable<T>
     {
         public BlendSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("BlendWitness: ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
     public sealed class BlendWitness<T> : System.IDisposable
     {
         public BlendWitness(System.IObserver<T> observer) { }
@@ -555,7 +555,7 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.BlendWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.BlendWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("BufferEachWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class BufferEachWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public BufferEachWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -569,20 +569,20 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Window = {Window}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("BufferSignal: Window = {Window}, Source = {Source}")]
     public sealed class BufferSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public BufferSignal(System.IObservable<T> source, System.TimeSpan timeSpan, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("CastSignal: Source = {Source}")]
     public sealed class CastSignal<TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public CastSignal(System.IObservable<object?> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CastWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CastWitness<TResult> : System.IDisposable, System.IObserver<object?>
     {
         public CastWitness(System.IObserver<TResult> observer) { }
@@ -596,7 +596,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
+    [System.Diagnostics.DebuggerDisplay("ChainSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
     public sealed class ChainSignal<T> : System.IObservable<T>
     {
         public ChainSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -604,7 +604,7 @@ namespace ReactiveUI.Primitives.Advanced
         public ChainSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("ChainWitness: IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
     public sealed class ChainWitness<T> : System.IDisposable
     {
         public ChainWitness(System.IObserver<T> observer) { }
@@ -614,13 +614,13 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.ChainWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.ChainWitness<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, TimeSpan = {TimeSpan}")]
+    [System.Diagnostics.DebuggerDisplay("CollectSignal: Source = {Source}, TimeSpan = {TimeSpan}")]
     public sealed class CollectSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public CollectSignal(System.IObservable<T> source, System.TimeSpan timeSpan, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Buffered = {Values.Count}")]
+    [System.Diagnostics.DebuggerDisplay("CollectWitness: Stopped = {_stopped}, Buffered = {Values.Count}")]
     public sealed class CollectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CollectWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -632,7 +632,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateSink: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class CreateSink<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateSink(System.IObserver<T> observer, bool disposeOnNextThrow) { }
@@ -644,7 +644,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CreateWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateWitness(System.IObserver<T> observer) { }
@@ -658,7 +658,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
+    [System.Diagnostics.DebuggerDisplay("DispatchSequencerState: ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
     public record struct DispatchSequencerState : System.IEquatable<ReactiveUI.Primitives.Advanced.DispatchSequencerState>
     {
         public DispatchSequencerState(ReactiveUI.Primitives.Concurrency.ISequencer owner, System.Func<System.Action, bool> post, System.Action drain) { }
@@ -673,13 +673,13 @@ namespace ReactiveUI.Primitives.Advanced
         public static System.TimeSpan DelayUntil(long dueTimestamp) { }
         public static void RunIfActive(ReactiveUI.Primitives.Concurrency.IWorkItem item) { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {DueTime}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietSignal: DueTime = {DueTime}, Source = {Source}")]
     public sealed class EmitIfQuietSignal<T> : System.IObservable<T>
     {
         public EmitIfQuietSignal(System.IObservable<T> source, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietWitness: HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
     public sealed class EmitIfQuietWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public EmitIfQuietWitness(System.IObserver<T> observer, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
@@ -690,7 +690,16 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("EmptySignal: Scheduler = {_scheduler}")]
+    public sealed class EmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public EmptySignal(ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("EnumerableBlendSignal: Sources = {Sources}")]
     public sealed class EnumerableBlendSignal<T> : System.IObservable<T>
     {
         public EnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -700,7 +709,14 @@ namespace ReactiveUI.Primitives.Advanced
     {
         public static System.IDisposable Attach<TEventHandler>(TEventHandler handler, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
+    [System.Diagnostics.DebuggerDisplay("EverySignal: Period = {_period}, Scheduler = {_scheduler}")]
+    public sealed class EverySignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
+    {
+        public EverySignal(System.TimeSpan period, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<long> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ExpireCoordinator: Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
     public sealed class ExpireCoordinator<T> : System.IDisposable, System.IObserver<T>
     {
         public ExpireCoordinator(System.IObservable<T> source, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer, System.IObserver<T> observer) { }
@@ -710,39 +726,48 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnNext(T value) { }
         public ReactiveUI.Primitives.Advanced.ExpireCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("ExpireSignal: DueTime = {_dueTime}, Source = {_source}")]
     public sealed class ExpireSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ExpireSignal(System.IObservable<T> source, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("FinallySignal: Source = {_source}")]
+    public sealed class FinallySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public FinallySignal(System.IObservable<T> source, System.Action finallyAction) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ForkJoinSignal: Left = {Left}, Right = {Right}")]
     public sealed class ForkJoinSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public ForkJoinSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("ForkJoinWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
     public sealed class ForkJoinWitness<TLeft, TRight, TResult>
     {
         public ForkJoinWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("CancellationRequested = {CancellationToken.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncExternalCancellationSignal: CancellationRequested = {CancellationToken.IsCancellationRequested}")]
     public sealed class FromAsyncExternalCancellationSignal<T> : System.IObservable<T>
     {
         public FromAsyncExternalCancellationSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSignal: TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
     public sealed class FromAsyncSignal<T> : System.IObservable<T>
     {
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSubscription: Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
     public sealed class FromAsyncSubscription<T> : System.IDisposable
     {
         public FromAsyncSubscription(System.IObserver<T> observer, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
@@ -755,14 +780,14 @@ namespace ReactiveUI.Primitives.Advanced
         public FromEventConversionSignal(System.Func<TCallback, TEventHandler> conversion, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Func<System.IObserver<TResult>, TCallback> callback, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
+    [System.Diagnostics.DebuggerDisplay("FromEventPatternSignal: AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
     public sealed class FromEventPatternSignal<TEventHandler, TEventArgs> : System.IObservable<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> where TEventHandler : System.Delegate where TEventArgs : System.EventArgs
     {
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler) { }
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Disposed = {_disposed}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("GuardedWitness: Disposed = {_disposed}, Observer = {_observer}")]
     public sealed class GuardedWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public GuardedWitness(System.IObserver<T> observer, System.IDisposable cancel) { }
@@ -772,7 +797,7 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IgnoreValuesSignal: Source = {Source}")]
     public sealed class IgnoreValuesSignal<T> : System.IObservable<T>
     {
         public IgnoreValuesSignal(System.IObservable<T> source) { }
@@ -786,14 +811,14 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.RxVoid> observer) { }
         public System.IDisposable Subscribe(System.Action<ReactiveUI.Primitives.RxVoid> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptySignal: Source = {Source}")]
     public sealed class IsEmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<bool>
     {
         public IsEmptySignal(System.IObservable<T> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<bool> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptyWitness: Stopped = {_stopped}, Subscription = {Subscription}")]
     public sealed class IsEmptyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public IsEmptyWitness(System.IObserver<bool> observer) { }
@@ -806,14 +831,23 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {Value}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("LeadSignal: Value = {Value}, Source = {Source}")]
     public sealed class LeadSignal<T> : ReactiveUI.Primitives.Advanced.IInlineSignal<T>
     {
         public LeadSignal(System.IObservable<T> source, T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
         public System.IDisposable Subscribe(System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("LoopSignal: Value = {Value}")]
+    public sealed class LoopSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public LoopSignal(T value) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("MapIndexedSignal: Source = {_source}")]
     public sealed class MapIndexedSignal<TSource, TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public MapIndexedSignal(System.IObservable<TSource> source, System.Func<TSource, int, TResult> selector) { }
@@ -821,7 +855,7 @@ namespace ReactiveUI.Primitives.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Index = {_index}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("MapIndexedWitness: Index = {_index}, Stopped = {_stopped}")]
     public sealed class MapIndexedWitness<TSource, TResult> : System.IObserver<TSource>
     {
         public MapIndexedWitness(System.IObserver<TResult> observer, System.Func<TSource, int, TResult> selector) { }
@@ -829,20 +863,20 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(TSource value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentBlendCoordinator: Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
     public sealed class MaxConcurrentBlendCoordinator<T> : System.IDisposable
     {
         public MaxConcurrentBlendCoordinator(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.MaxConcurrentBlendCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentEnumerableBlendSignal: Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
     public sealed class MaxConcurrentEnumerableBlendSignal<T> : System.IObservable<T>
     {
         public MaxConcurrentEnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("MergeCoordinator: Active = {Active}, Done = {Done}")]
     public sealed class MergeCoordinator<T> : System.IDisposable
     {
         public MergeCoordinator(System.IObserver<T> observer) { }
@@ -853,7 +887,7 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.MergeCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.MergeCoordinator<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MergeSignal: Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
     public sealed class MergeSignal<T> : System.IObservable<T>
     {
         public MergeSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -861,32 +895,39 @@ namespace ReactiveUI.Primitives.Advanced
         public MergeSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("OnErrorResumeNextSignal: Sources = {_sources}")]
+    public sealed class OnErrorResumeNextSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("PairSignal: Left = {Left}, Right = {Right}")]
     public sealed class PairSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public PairSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
+    [System.Diagnostics.DebuggerDisplay("PairWitness: IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
     public sealed class PairWitness<TLeft, TRight, TResult>
     {
         public PairWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("PublishSelectorSignal: Source = {Source}, Selector = {Selector}")]
     public sealed class PublishSelectorSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public PublishSelectorSignal(System.IObservable<TSource> source, System.Func<System.IObservable<TSource>, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
+    [System.Diagnostics.DebuggerDisplay("RaceSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
     public sealed class RaceSignal<T> : System.IObservable<T>
     {
         public RaceSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public RaceSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Arms = {_arms}")]
+    [System.Diagnostics.DebuggerDisplay("RaceWitness: Arms = {_arms}")]
     public sealed class RaceWitness<T> : System.IDisposable
     {
         public RaceWitness(System.IObserver<T> observer) { }
@@ -895,40 +936,48 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.RaceWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.RaceWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeCombineLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeCombineLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeCombineLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
+    [System.Diagnostics.DebuggerDisplay("RangeForkJoinSignal: Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
     public sealed class RangeForkJoinSignal<TResult> : System.IObservable<TResult>
     {
         public RangeForkJoinSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeSyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeSyncLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeSyncLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeWithLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeWithLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeWithLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Remaining = {_remaining}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("RecoverSignal: Source = {_source}")]
+    public sealed class RecoverSignal<T, TException> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T> where TException : System.Exception
+    {
+        public RecoverSignal(System.IObservable<T> source, System.Func<TException, System.IObservable<T>> handler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceCoordinator: Remaining = {_remaining}, Disposed = {_disposed}")]
     public sealed class RepeatSourceCoordinator<T> : System.IDisposable
     {
         public RepeatSourceCoordinator(System.IObservable<T> source, int? repeatCount, System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.RepeatSourceCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, RepeatCount = {_repeatCount}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceSignal: Source = {_source}, RepeatCount = {_repeatCount}")]
     public sealed class RepeatSourceSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public RepeatSourceSignal(System.IObservable<T> source, int? repeatCount) { }
@@ -936,7 +985,7 @@ namespace ReactiveUI.Primitives.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Generation = {_generation}, Terminated = {_terminated}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceWitness: Generation = {_generation}, Terminated = {_terminated}")]
     public sealed class RepeatSourceWitness<T> : System.IObserver<T>
     {
         public RepeatSourceWitness(ReactiveUI.Primitives.Advanced.RepeatSourceCoordinator<T> parent, int generation) { }
@@ -944,7 +993,15 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_value}, Scheduler = {_scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ResumeSignal: Source = {_source}, Fallback = {_fallback}")]
+    public sealed class ResumeSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ResumeSignal(System.IObservable<T> source, System.IObservable<T> fallback) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ReturnSignal: Value = {_value}, Scheduler = {_scheduler}")]
     public sealed class ReturnSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ReturnSignal(T value, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -953,13 +1010,13 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Values = {Values}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledEnumerableSignal: Values = {Values}, Scheduler = {Scheduler}")]
     public sealed class ScheduledEnumerableSignal<T> : System.IObservable<T>
     {
         public ScheduledEnumerableSignal(System.Collections.Generic.IEnumerable<T> values, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyCoordinator<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TResult>> selector) { }
@@ -973,13 +1030,13 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Advanced.SelectManyCoordinator<TSource, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableSignal: Source = {_source}")]
     public sealed class SelectManyEnumerableSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManyEnumerableSignal(System.IObservable<TSource> source, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SelectManyEnumerableWitness<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyEnumerableWitness(System.IObserver<TResult> observer, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
@@ -993,7 +1050,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyResultCoordinator<TSource, TCollection, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyResultCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
@@ -1006,20 +1063,20 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Advanced.SelectManyResultCoordinator<TSource, TCollection, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, CollectionSelector = {CollectionSelector}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultSignal: Source = {Source}, CollectionSelector = {CollectionSelector}")]
     public sealed class SelectManyResultSignal<TSource, TCollection, TResult> : System.IObservable<TResult>
     {
         public SelectManyResultSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManySignal: Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
     public sealed class SelectManySignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManySignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public SelectManySignal(System.IObservable<TSource> source, System.IObservable<TResult> inner) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Start = {Start}, Count = {Count}")]
+    [System.Diagnostics.DebuggerDisplay("SequenceSignal: Start = {Start}, Count = {Count}")]
     public sealed class SequenceSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<int>
     {
         public SequenceSignal(int start, int count, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -1030,13 +1087,13 @@ namespace ReactiveUI.Primitives.Advanced
     {
         public static System.IDisposable Subscribe<T>(System.IObserver<T> observer, bool currentThreadRequired, System.Func<System.IObserver<T>, System.IDisposable, System.IDisposable> subscribeCore) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SparkSignal: Source = {Source}")]
     public sealed class SparkSignal<T> : System.IObservable<ReactiveUI.Primitives.Core.Spark<T>>
     {
         public SparkSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.Spark<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SparkWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SparkWitness(System.IObserver<ReactiveUI.Primitives.Core.Spark<T>> observer) { }
@@ -1051,21 +1108,21 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Action = {Action}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Action = {Action}, Scheduler = {Scheduler}")]
     public sealed class StartSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<ReactiveUI.Primitives.RxVoid>
     {
         public StartSignal(System.Action action, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.RxVoid> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Function = {Function}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Function = {Function}, Scheduler = {Scheduler}")]
     public sealed class StartSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public StartSignal(System.Func<T> function, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SubscribeSafeWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SubscribeSafeWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SubscribeSafeWitness(System.IObserver<T> observer) { }
@@ -1079,50 +1136,50 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, SkipNullSources = {_skipNullSources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchMapSignal: Source = {_source}, SkipNullSources = {_skipNullSources}")]
     public sealed class SwitchMapSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SwitchMapSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchSignal: Sources = {Sources}")]
     public sealed class SwitchSignal<T> : System.IObservable<T>
     {
         public SwitchSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Version = {_version}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchWitness: Version = {_version}, IsDone = {IsDone}")]
     public sealed class SwitchWitness<T> : System.IDisposable
     {
         public SwitchWitness(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.SwitchWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class SyncLatestSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public SyncLatestSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
     public sealed class SyncLatestWitness<TLeft, TRight, TResult>
     {
         public SyncLatestWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Gate = {Gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeGateSignal: Source = {Source}, Gate = {Gate}")]
     public sealed class SynchronizeGateSignal<T> : System.IObservable<T>
     {
         public SynchronizeGateSignal(System.IObservable<T> source, object gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, Gate = {_gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectSignal: Source = {_source}, Gate = {_gate}")]
     public sealed class SynchronizeObjectSignal<T> : System.IObservable<T>
     {
         public SynchronizeObjectSignal(System.IObservable<T> source, object gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SynchronizeObjectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SynchronizeObjectWitness(System.IObserver<T> observer, object gate) { }
@@ -1134,19 +1191,19 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeSignal: Source = {Source}")]
     public sealed class SynchronizeSignal<T> : System.IObservable<T>
     {
         public SynchronizeSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("TapSignal: Source = {Source}")]
     public sealed class TapSignal<T> : System.IObservable<T>
     {
         public TapSignal(System.IObservable<T> source, System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskAnyWitness: Stopped = {_stopped}, Task = {Task}")]
     public sealed class TaskAnyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskAnyWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1162,7 +1219,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainCoordinator: Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
     public sealed class TaskChainCoordinator<T> : System.IDisposable
     {
         public TaskChainCoordinator(System.IObserver<T> observer) { }
@@ -1170,13 +1227,13 @@ namespace ReactiveUI.Primitives.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.TaskChainCoordinator<T> Run(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainSignal: Sources = {_sources}")]
     public sealed class TaskChainSignal<T> : System.IObservable<T>
     {
         public TaskChainSignal(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskCountWitness: Count = {_count}, Stopped = {_stopped}")]
     public sealed class TaskCountWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskCountWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1192,13 +1249,13 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSignal: Task = {Task}")]
     public sealed class TaskInstanceSignal<T> : System.IObservable<T>
     {
         public TaskInstanceSignal(System.Threading.Tasks.Task<T> task) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSubscription: Stopped = {_stopped}")]
     public sealed class TaskInstanceSubscription : System.IDisposable
     {
         public TaskInstanceSubscription() { }
@@ -1206,13 +1263,22 @@ namespace ReactiveUI.Primitives.Advanced
         public void Dispose() { }
         public bool TryStop() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Sequencer = {Sequencer}")]
+    [System.Diagnostics.DebuggerDisplay("ThrowSignal: Error = {_error}, Scheduler = {_scheduler}")]
+    public sealed class ThrowSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ThrowSignal(System.Exception error, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalSignal: Source = {Source}, Sequencer = {Sequencer}")]
     public sealed class TimeIntervalSignal<T> : System.IObservable<ReactiveUI.Primitives.Core.TimeInterval<T>>
     {
         public TimeIntervalSignal(System.IObservable<T> source, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("First = {_first}, Last = {_last}")]
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalWitness: First = {_first}, Last = {_last}")]
     public sealed class TimeIntervalWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TimeIntervalWitness(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -1230,13 +1296,13 @@ namespace ReactiveUI.Primitives.Advanced
     {
         public static void Arm(ReactiveUI.Primitives.Disposables.SingleReplaceableDisposable slot, ReactiveUI.Primitives.Concurrency.ISequencer sequencer, System.TimeSpan delay, System.Action tick) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkSignal: Source = {Source}")]
     public sealed class UnsparkSignal<T> : System.IObservable<T>
     {
         public UnsparkSignal(System.IObservable<ReactiveUI.Primitives.Core.Spark<T>> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class UnsparkWitness<T> : System.IDisposable, System.IObserver<ReactiveUI.Primitives.Core.Spark<T>>
     {
         public UnsparkWitness(System.IObserver<T> observer) { }
@@ -1819,7 +1885,7 @@ namespace ReactiveUI.Primitives.Extensions.Operators
 }
 namespace ReactiveUI.Primitives.Signals
 {
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
+    [System.Diagnostics.DebuggerDisplay("PrioritySemaphoreSignal: Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
     public sealed class PrioritySemaphoreSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T> where T : System.IComparable<T>
     {
         public PrioritySemaphoreSignal(int maxCount) { }
@@ -1854,7 +1920,7 @@ namespace ReactiveUI.Primitives.Signals
         public void OnNext(T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledSignal: Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
     public class ScheduledSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T>
     {
         public ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }

--- a/src/ReactiveUI.Primitives/PublicAPI/net472/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net472/PublicAPI.txt
@@ -479,7 +479,7 @@ namespace ReactiveUI.Primitives
 }
 namespace ReactiveUI.Primitives.Advanced
 {
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Period = {_period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSignal: DueTime = {_dueTime}, Period = {_period}")]
     public sealed class AfterSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
     {
         public AfterSignal(System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -487,7 +487,7 @@ namespace ReactiveUI.Primitives.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<long> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSubscription: Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
     public sealed class AfterSubscription : System.IDisposable
     {
         public AfterSubscription(System.IObserver<long> observer, ReactiveUI.Primitives.Concurrency.ISequencer scheduler, System.TimeSpan dueTime, System.TimeSpan? period) { }
@@ -495,21 +495,21 @@ namespace ReactiveUI.Primitives.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.AfterSubscription Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("SubscribeAsync = {SubscribeAsync}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncCreateSignal: SubscribeAsync = {SubscribeAsync}")]
     public sealed class AsyncCreateSignal<T> : System.IObservable<T>
     {
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ObservableFactory = {ObservableFactory}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncDeferSignal: ObservableFactory = {ObservableFactory}")]
     public sealed class AsyncDeferSignal<T> : System.IObservable<T>
     {
         public AsyncDeferSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public AsyncDeferSignal(System.Func<System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncSubscriptionLifetime: Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
     public sealed class AsyncSubscriptionLifetime : System.IDisposable
     {
         public AsyncSubscriptionLifetime() { }
@@ -520,33 +520,33 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable? disposable) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connected = {_connected}")]
+    [System.Diagnostics.DebuggerDisplay("AutoConnectSignal: Count = {_count}, Connected = {_connected}")]
     public sealed class AutoConnectSignal<T> : System.IObservable<T>
     {
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount) { }
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount, System.Action<System.IDisposable>? onConnect) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connection = {_connection}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSignal: Count = {_count}, Connection = {_connection}")]
     public sealed class AutoShareSignal<T> : System.IObservable<T>
     {
         public AutoShareSignal(ReactiveUI.Primitives.ConnectableSignal<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Owner = {_owner}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSubscription: Owner = {_owner}, Subscription = {Subscription}")]
     public sealed class AutoShareSubscription<T> : System.IDisposable
     {
         public AutoShareSubscription(ReactiveUI.Primitives.Advanced.AutoShareSignal<T> owner, System.IDisposable subscription) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void Dispose() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("BlendSignal: Sources = {Sources}")]
     public sealed class BlendSignal<T> : System.IObservable<T>
     {
         public BlendSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("BlendWitness: ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
     public sealed class BlendWitness<T> : System.IDisposable
     {
         public BlendWitness(System.IObserver<T> observer) { }
@@ -555,7 +555,7 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.BlendWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.BlendWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("BufferEachWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class BufferEachWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public BufferEachWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -569,20 +569,20 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Window = {Window}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("BufferSignal: Window = {Window}, Source = {Source}")]
     public sealed class BufferSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public BufferSignal(System.IObservable<T> source, System.TimeSpan timeSpan, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("CastSignal: Source = {Source}")]
     public sealed class CastSignal<TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public CastSignal(System.IObservable<object?> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CastWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CastWitness<TResult> : System.IDisposable, System.IObserver<object?>
     {
         public CastWitness(System.IObserver<TResult> observer) { }
@@ -596,7 +596,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
+    [System.Diagnostics.DebuggerDisplay("ChainSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
     public sealed class ChainSignal<T> : System.IObservable<T>
     {
         public ChainSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -604,7 +604,7 @@ namespace ReactiveUI.Primitives.Advanced
         public ChainSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("ChainWitness: IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
     public sealed class ChainWitness<T> : System.IDisposable
     {
         public ChainWitness(System.IObserver<T> observer) { }
@@ -614,13 +614,13 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.ChainWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.ChainWitness<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, TimeSpan = {TimeSpan}")]
+    [System.Diagnostics.DebuggerDisplay("CollectSignal: Source = {Source}, TimeSpan = {TimeSpan}")]
     public sealed class CollectSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public CollectSignal(System.IObservable<T> source, System.TimeSpan timeSpan, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Buffered = {Values.Count}")]
+    [System.Diagnostics.DebuggerDisplay("CollectWitness: Stopped = {_stopped}, Buffered = {Values.Count}")]
     public sealed class CollectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CollectWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -632,7 +632,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateSink: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class CreateSink<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateSink(System.IObserver<T> observer, bool disposeOnNextThrow) { }
@@ -644,7 +644,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CreateWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateWitness(System.IObserver<T> observer) { }
@@ -658,7 +658,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
+    [System.Diagnostics.DebuggerDisplay("DispatchSequencerState: ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
     public record struct DispatchSequencerState : System.IEquatable<ReactiveUI.Primitives.Advanced.DispatchSequencerState>
     {
         public DispatchSequencerState(ReactiveUI.Primitives.Concurrency.ISequencer owner, System.Func<System.Action, bool> post, System.Action drain) { }
@@ -673,13 +673,13 @@ namespace ReactiveUI.Primitives.Advanced
         public static System.TimeSpan DelayUntil(long dueTimestamp) { }
         public static void RunIfActive(ReactiveUI.Primitives.Concurrency.IWorkItem item) { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {DueTime}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietSignal: DueTime = {DueTime}, Source = {Source}")]
     public sealed class EmitIfQuietSignal<T> : System.IObservable<T>
     {
         public EmitIfQuietSignal(System.IObservable<T> source, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietWitness: HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
     public sealed class EmitIfQuietWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public EmitIfQuietWitness(System.IObserver<T> observer, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
@@ -690,7 +690,16 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("EmptySignal: Scheduler = {_scheduler}")]
+    public sealed class EmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public EmptySignal(ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("EnumerableBlendSignal: Sources = {Sources}")]
     public sealed class EnumerableBlendSignal<T> : System.IObservable<T>
     {
         public EnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -700,7 +709,14 @@ namespace ReactiveUI.Primitives.Advanced
     {
         public static System.IDisposable Attach<TEventHandler>(TEventHandler handler, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
+    [System.Diagnostics.DebuggerDisplay("EverySignal: Period = {_period}, Scheduler = {_scheduler}")]
+    public sealed class EverySignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
+    {
+        public EverySignal(System.TimeSpan period, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<long> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ExpireCoordinator: Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
     public sealed class ExpireCoordinator<T> : System.IDisposable, System.IObserver<T>
     {
         public ExpireCoordinator(System.IObservable<T> source, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer, System.IObserver<T> observer) { }
@@ -710,39 +726,48 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnNext(T value) { }
         public ReactiveUI.Primitives.Advanced.ExpireCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("ExpireSignal: DueTime = {_dueTime}, Source = {_source}")]
     public sealed class ExpireSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ExpireSignal(System.IObservable<T> source, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("FinallySignal: Source = {_source}")]
+    public sealed class FinallySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public FinallySignal(System.IObservable<T> source, System.Action finallyAction) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ForkJoinSignal: Left = {Left}, Right = {Right}")]
     public sealed class ForkJoinSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public ForkJoinSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("ForkJoinWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
     public sealed class ForkJoinWitness<TLeft, TRight, TResult>
     {
         public ForkJoinWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("CancellationRequested = {CancellationToken.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncExternalCancellationSignal: CancellationRequested = {CancellationToken.IsCancellationRequested}")]
     public sealed class FromAsyncExternalCancellationSignal<T> : System.IObservable<T>
     {
         public FromAsyncExternalCancellationSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSignal: TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
     public sealed class FromAsyncSignal<T> : System.IObservable<T>
     {
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSubscription: Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
     public sealed class FromAsyncSubscription<T> : System.IDisposable
     {
         public FromAsyncSubscription(System.IObserver<T> observer, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
@@ -755,14 +780,14 @@ namespace ReactiveUI.Primitives.Advanced
         public FromEventConversionSignal(System.Func<TCallback, TEventHandler> conversion, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Func<System.IObserver<TResult>, TCallback> callback, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
+    [System.Diagnostics.DebuggerDisplay("FromEventPatternSignal: AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
     public sealed class FromEventPatternSignal<TEventHandler, TEventArgs> : System.IObservable<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> where TEventHandler : System.Delegate where TEventArgs : System.EventArgs
     {
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler) { }
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Disposed = {_disposed}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("GuardedWitness: Disposed = {_disposed}, Observer = {_observer}")]
     public sealed class GuardedWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public GuardedWitness(System.IObserver<T> observer, System.IDisposable cancel) { }
@@ -772,7 +797,7 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IgnoreValuesSignal: Source = {Source}")]
     public sealed class IgnoreValuesSignal<T> : System.IObservable<T>
     {
         public IgnoreValuesSignal(System.IObservable<T> source) { }
@@ -786,14 +811,14 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.RxVoid> observer) { }
         public System.IDisposable Subscribe(System.Action<ReactiveUI.Primitives.RxVoid> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptySignal: Source = {Source}")]
     public sealed class IsEmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<bool>
     {
         public IsEmptySignal(System.IObservable<T> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<bool> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptyWitness: Stopped = {_stopped}, Subscription = {Subscription}")]
     public sealed class IsEmptyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public IsEmptyWitness(System.IObserver<bool> observer) { }
@@ -806,14 +831,23 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {Value}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("LeadSignal: Value = {Value}, Source = {Source}")]
     public sealed class LeadSignal<T> : ReactiveUI.Primitives.Advanced.IInlineSignal<T>
     {
         public LeadSignal(System.IObservable<T> source, T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
         public System.IDisposable Subscribe(System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("LoopSignal: Value = {Value}")]
+    public sealed class LoopSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public LoopSignal(T value) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("MapIndexedSignal: Source = {_source}")]
     public sealed class MapIndexedSignal<TSource, TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public MapIndexedSignal(System.IObservable<TSource> source, System.Func<TSource, int, TResult> selector) { }
@@ -821,7 +855,7 @@ namespace ReactiveUI.Primitives.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Index = {_index}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("MapIndexedWitness: Index = {_index}, Stopped = {_stopped}")]
     public sealed class MapIndexedWitness<TSource, TResult> : System.IObserver<TSource>
     {
         public MapIndexedWitness(System.IObserver<TResult> observer, System.Func<TSource, int, TResult> selector) { }
@@ -829,20 +863,20 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(TSource value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentBlendCoordinator: Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
     public sealed class MaxConcurrentBlendCoordinator<T> : System.IDisposable
     {
         public MaxConcurrentBlendCoordinator(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.MaxConcurrentBlendCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentEnumerableBlendSignal: Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
     public sealed class MaxConcurrentEnumerableBlendSignal<T> : System.IObservable<T>
     {
         public MaxConcurrentEnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("MergeCoordinator: Active = {Active}, Done = {Done}")]
     public sealed class MergeCoordinator<T> : System.IDisposable
     {
         public MergeCoordinator(System.IObserver<T> observer) { }
@@ -853,7 +887,7 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.MergeCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.MergeCoordinator<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MergeSignal: Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
     public sealed class MergeSignal<T> : System.IObservable<T>
     {
         public MergeSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -861,32 +895,39 @@ namespace ReactiveUI.Primitives.Advanced
         public MergeSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("OnErrorResumeNextSignal: Sources = {_sources}")]
+    public sealed class OnErrorResumeNextSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("PairSignal: Left = {Left}, Right = {Right}")]
     public sealed class PairSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public PairSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
+    [System.Diagnostics.DebuggerDisplay("PairWitness: IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
     public sealed class PairWitness<TLeft, TRight, TResult>
     {
         public PairWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("PublishSelectorSignal: Source = {Source}, Selector = {Selector}")]
     public sealed class PublishSelectorSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public PublishSelectorSignal(System.IObservable<TSource> source, System.Func<System.IObservable<TSource>, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
+    [System.Diagnostics.DebuggerDisplay("RaceSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
     public sealed class RaceSignal<T> : System.IObservable<T>
     {
         public RaceSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public RaceSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Arms = {_arms}")]
+    [System.Diagnostics.DebuggerDisplay("RaceWitness: Arms = {_arms}")]
     public sealed class RaceWitness<T> : System.IDisposable
     {
         public RaceWitness(System.IObserver<T> observer) { }
@@ -895,40 +936,48 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.RaceWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.RaceWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeCombineLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeCombineLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeCombineLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
+    [System.Diagnostics.DebuggerDisplay("RangeForkJoinSignal: Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
     public sealed class RangeForkJoinSignal<TResult> : System.IObservable<TResult>
     {
         public RangeForkJoinSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeSyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeSyncLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeSyncLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeWithLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeWithLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeWithLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Remaining = {_remaining}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("RecoverSignal: Source = {_source}")]
+    public sealed class RecoverSignal<T, TException> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T> where TException : System.Exception
+    {
+        public RecoverSignal(System.IObservable<T> source, System.Func<TException, System.IObservable<T>> handler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceCoordinator: Remaining = {_remaining}, Disposed = {_disposed}")]
     public sealed class RepeatSourceCoordinator<T> : System.IDisposable
     {
         public RepeatSourceCoordinator(System.IObservable<T> source, int? repeatCount, System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.RepeatSourceCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, RepeatCount = {_repeatCount}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceSignal: Source = {_source}, RepeatCount = {_repeatCount}")]
     public sealed class RepeatSourceSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public RepeatSourceSignal(System.IObservable<T> source, int? repeatCount) { }
@@ -936,7 +985,7 @@ namespace ReactiveUI.Primitives.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Generation = {_generation}, Terminated = {_terminated}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceWitness: Generation = {_generation}, Terminated = {_terminated}")]
     public sealed class RepeatSourceWitness<T> : System.IObserver<T>
     {
         public RepeatSourceWitness(ReactiveUI.Primitives.Advanced.RepeatSourceCoordinator<T> parent, int generation) { }
@@ -944,7 +993,15 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_value}, Scheduler = {_scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ResumeSignal: Source = {_source}, Fallback = {_fallback}")]
+    public sealed class ResumeSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ResumeSignal(System.IObservable<T> source, System.IObservable<T> fallback) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ReturnSignal: Value = {_value}, Scheduler = {_scheduler}")]
     public sealed class ReturnSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ReturnSignal(T value, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -953,13 +1010,13 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Values = {Values}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledEnumerableSignal: Values = {Values}, Scheduler = {Scheduler}")]
     public sealed class ScheduledEnumerableSignal<T> : System.IObservable<T>
     {
         public ScheduledEnumerableSignal(System.Collections.Generic.IEnumerable<T> values, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyCoordinator<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TResult>> selector) { }
@@ -973,13 +1030,13 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Advanced.SelectManyCoordinator<TSource, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableSignal: Source = {_source}")]
     public sealed class SelectManyEnumerableSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManyEnumerableSignal(System.IObservable<TSource> source, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SelectManyEnumerableWitness<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyEnumerableWitness(System.IObserver<TResult> observer, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
@@ -993,7 +1050,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyResultCoordinator<TSource, TCollection, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyResultCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
@@ -1006,20 +1063,20 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Advanced.SelectManyResultCoordinator<TSource, TCollection, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, CollectionSelector = {CollectionSelector}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultSignal: Source = {Source}, CollectionSelector = {CollectionSelector}")]
     public sealed class SelectManyResultSignal<TSource, TCollection, TResult> : System.IObservable<TResult>
     {
         public SelectManyResultSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManySignal: Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
     public sealed class SelectManySignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManySignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public SelectManySignal(System.IObservable<TSource> source, System.IObservable<TResult> inner) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Start = {Start}, Count = {Count}")]
+    [System.Diagnostics.DebuggerDisplay("SequenceSignal: Start = {Start}, Count = {Count}")]
     public sealed class SequenceSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<int>
     {
         public SequenceSignal(int start, int count, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -1030,13 +1087,13 @@ namespace ReactiveUI.Primitives.Advanced
     {
         public static System.IDisposable Subscribe<T>(System.IObserver<T> observer, bool currentThreadRequired, System.Func<System.IObserver<T>, System.IDisposable, System.IDisposable> subscribeCore) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SparkSignal: Source = {Source}")]
     public sealed class SparkSignal<T> : System.IObservable<ReactiveUI.Primitives.Core.Spark<T>>
     {
         public SparkSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.Spark<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SparkWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SparkWitness(System.IObserver<ReactiveUI.Primitives.Core.Spark<T>> observer) { }
@@ -1051,21 +1108,21 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Action = {Action}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Action = {Action}, Scheduler = {Scheduler}")]
     public sealed class StartSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<ReactiveUI.Primitives.RxVoid>
     {
         public StartSignal(System.Action action, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.RxVoid> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Function = {Function}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Function = {Function}, Scheduler = {Scheduler}")]
     public sealed class StartSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public StartSignal(System.Func<T> function, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SubscribeSafeWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SubscribeSafeWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SubscribeSafeWitness(System.IObserver<T> observer) { }
@@ -1079,50 +1136,50 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, SkipNullSources = {_skipNullSources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchMapSignal: Source = {_source}, SkipNullSources = {_skipNullSources}")]
     public sealed class SwitchMapSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SwitchMapSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchSignal: Sources = {Sources}")]
     public sealed class SwitchSignal<T> : System.IObservable<T>
     {
         public SwitchSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Version = {_version}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchWitness: Version = {_version}, IsDone = {IsDone}")]
     public sealed class SwitchWitness<T> : System.IDisposable
     {
         public SwitchWitness(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.SwitchWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class SyncLatestSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public SyncLatestSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
     public sealed class SyncLatestWitness<TLeft, TRight, TResult>
     {
         public SyncLatestWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Gate = {Gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeGateSignal: Source = {Source}, Gate = {Gate}")]
     public sealed class SynchronizeGateSignal<T> : System.IObservable<T>
     {
         public SynchronizeGateSignal(System.IObservable<T> source, object gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, Gate = {_gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectSignal: Source = {_source}, Gate = {_gate}")]
     public sealed class SynchronizeObjectSignal<T> : System.IObservable<T>
     {
         public SynchronizeObjectSignal(System.IObservable<T> source, object gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SynchronizeObjectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SynchronizeObjectWitness(System.IObserver<T> observer, object gate) { }
@@ -1134,19 +1191,19 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeSignal: Source = {Source}")]
     public sealed class SynchronizeSignal<T> : System.IObservable<T>
     {
         public SynchronizeSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("TapSignal: Source = {Source}")]
     public sealed class TapSignal<T> : System.IObservable<T>
     {
         public TapSignal(System.IObservable<T> source, System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskAnyWitness: Stopped = {_stopped}, Task = {Task}")]
     public sealed class TaskAnyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskAnyWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1162,7 +1219,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainCoordinator: Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
     public sealed class TaskChainCoordinator<T> : System.IDisposable
     {
         public TaskChainCoordinator(System.IObserver<T> observer) { }
@@ -1170,13 +1227,13 @@ namespace ReactiveUI.Primitives.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.TaskChainCoordinator<T> Run(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainSignal: Sources = {_sources}")]
     public sealed class TaskChainSignal<T> : System.IObservable<T>
     {
         public TaskChainSignal(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskCountWitness: Count = {_count}, Stopped = {_stopped}")]
     public sealed class TaskCountWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskCountWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1192,13 +1249,13 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSignal: Task = {Task}")]
     public sealed class TaskInstanceSignal<T> : System.IObservable<T>
     {
         public TaskInstanceSignal(System.Threading.Tasks.Task<T> task) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSubscription: Stopped = {_stopped}")]
     public sealed class TaskInstanceSubscription : System.IDisposable
     {
         public TaskInstanceSubscription() { }
@@ -1206,13 +1263,22 @@ namespace ReactiveUI.Primitives.Advanced
         public void Dispose() { }
         public bool TryStop() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Sequencer = {Sequencer}")]
+    [System.Diagnostics.DebuggerDisplay("ThrowSignal: Error = {_error}, Scheduler = {_scheduler}")]
+    public sealed class ThrowSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ThrowSignal(System.Exception error, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalSignal: Source = {Source}, Sequencer = {Sequencer}")]
     public sealed class TimeIntervalSignal<T> : System.IObservable<ReactiveUI.Primitives.Core.TimeInterval<T>>
     {
         public TimeIntervalSignal(System.IObservable<T> source, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("First = {_first}, Last = {_last}")]
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalWitness: First = {_first}, Last = {_last}")]
     public sealed class TimeIntervalWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TimeIntervalWitness(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -1230,13 +1296,13 @@ namespace ReactiveUI.Primitives.Advanced
     {
         public static void Arm(ReactiveUI.Primitives.Disposables.SingleReplaceableDisposable slot, ReactiveUI.Primitives.Concurrency.ISequencer sequencer, System.TimeSpan delay, System.Action tick) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkSignal: Source = {Source}")]
     public sealed class UnsparkSignal<T> : System.IObservable<T>
     {
         public UnsparkSignal(System.IObservable<ReactiveUI.Primitives.Core.Spark<T>> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class UnsparkWitness<T> : System.IDisposable, System.IObserver<ReactiveUI.Primitives.Core.Spark<T>>
     {
         public UnsparkWitness(System.IObserver<T> observer) { }
@@ -1819,7 +1885,7 @@ namespace ReactiveUI.Primitives.Extensions.Operators
 }
 namespace ReactiveUI.Primitives.Signals
 {
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
+    [System.Diagnostics.DebuggerDisplay("PrioritySemaphoreSignal: Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
     public sealed class PrioritySemaphoreSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T> where T : System.IComparable<T>
     {
         public PrioritySemaphoreSignal(int maxCount) { }
@@ -1854,7 +1920,7 @@ namespace ReactiveUI.Primitives.Signals
         public void OnNext(T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledSignal: Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
     public class ScheduledSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T>
     {
         public ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }

--- a/src/ReactiveUI.Primitives/PublicAPI/net48/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net48/PublicAPI.txt
@@ -479,7 +479,7 @@ namespace ReactiveUI.Primitives
 }
 namespace ReactiveUI.Primitives.Advanced
 {
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Period = {_period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSignal: DueTime = {_dueTime}, Period = {_period}")]
     public sealed class AfterSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
     {
         public AfterSignal(System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -487,7 +487,7 @@ namespace ReactiveUI.Primitives.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<long> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSubscription: Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
     public sealed class AfterSubscription : System.IDisposable
     {
         public AfterSubscription(System.IObserver<long> observer, ReactiveUI.Primitives.Concurrency.ISequencer scheduler, System.TimeSpan dueTime, System.TimeSpan? period) { }
@@ -495,21 +495,21 @@ namespace ReactiveUI.Primitives.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.AfterSubscription Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("SubscribeAsync = {SubscribeAsync}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncCreateSignal: SubscribeAsync = {SubscribeAsync}")]
     public sealed class AsyncCreateSignal<T> : System.IObservable<T>
     {
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ObservableFactory = {ObservableFactory}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncDeferSignal: ObservableFactory = {ObservableFactory}")]
     public sealed class AsyncDeferSignal<T> : System.IObservable<T>
     {
         public AsyncDeferSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public AsyncDeferSignal(System.Func<System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncSubscriptionLifetime: Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
     public sealed class AsyncSubscriptionLifetime : System.IDisposable
     {
         public AsyncSubscriptionLifetime() { }
@@ -520,33 +520,33 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable? disposable) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connected = {_connected}")]
+    [System.Diagnostics.DebuggerDisplay("AutoConnectSignal: Count = {_count}, Connected = {_connected}")]
     public sealed class AutoConnectSignal<T> : System.IObservable<T>
     {
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount) { }
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount, System.Action<System.IDisposable>? onConnect) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connection = {_connection}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSignal: Count = {_count}, Connection = {_connection}")]
     public sealed class AutoShareSignal<T> : System.IObservable<T>
     {
         public AutoShareSignal(ReactiveUI.Primitives.ConnectableSignal<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Owner = {_owner}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSubscription: Owner = {_owner}, Subscription = {Subscription}")]
     public sealed class AutoShareSubscription<T> : System.IDisposable
     {
         public AutoShareSubscription(ReactiveUI.Primitives.Advanced.AutoShareSignal<T> owner, System.IDisposable subscription) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void Dispose() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("BlendSignal: Sources = {Sources}")]
     public sealed class BlendSignal<T> : System.IObservable<T>
     {
         public BlendSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("BlendWitness: ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
     public sealed class BlendWitness<T> : System.IDisposable
     {
         public BlendWitness(System.IObserver<T> observer) { }
@@ -555,7 +555,7 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.BlendWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.BlendWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("BufferEachWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class BufferEachWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public BufferEachWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -569,20 +569,20 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Window = {Window}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("BufferSignal: Window = {Window}, Source = {Source}")]
     public sealed class BufferSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public BufferSignal(System.IObservable<T> source, System.TimeSpan timeSpan, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("CastSignal: Source = {Source}")]
     public sealed class CastSignal<TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public CastSignal(System.IObservable<object?> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CastWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CastWitness<TResult> : System.IDisposable, System.IObserver<object?>
     {
         public CastWitness(System.IObserver<TResult> observer) { }
@@ -596,7 +596,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
+    [System.Diagnostics.DebuggerDisplay("ChainSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
     public sealed class ChainSignal<T> : System.IObservable<T>
     {
         public ChainSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -604,7 +604,7 @@ namespace ReactiveUI.Primitives.Advanced
         public ChainSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("ChainWitness: IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
     public sealed class ChainWitness<T> : System.IDisposable
     {
         public ChainWitness(System.IObserver<T> observer) { }
@@ -614,13 +614,13 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.ChainWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.ChainWitness<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, TimeSpan = {TimeSpan}")]
+    [System.Diagnostics.DebuggerDisplay("CollectSignal: Source = {Source}, TimeSpan = {TimeSpan}")]
     public sealed class CollectSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public CollectSignal(System.IObservable<T> source, System.TimeSpan timeSpan, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Buffered = {Values.Count}")]
+    [System.Diagnostics.DebuggerDisplay("CollectWitness: Stopped = {_stopped}, Buffered = {Values.Count}")]
     public sealed class CollectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CollectWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -632,7 +632,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateSink: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class CreateSink<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateSink(System.IObserver<T> observer, bool disposeOnNextThrow) { }
@@ -644,7 +644,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CreateWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateWitness(System.IObserver<T> observer) { }
@@ -658,7 +658,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
+    [System.Diagnostics.DebuggerDisplay("DispatchSequencerState: ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
     public record struct DispatchSequencerState : System.IEquatable<ReactiveUI.Primitives.Advanced.DispatchSequencerState>
     {
         public DispatchSequencerState(ReactiveUI.Primitives.Concurrency.ISequencer owner, System.Func<System.Action, bool> post, System.Action drain) { }
@@ -673,13 +673,13 @@ namespace ReactiveUI.Primitives.Advanced
         public static System.TimeSpan DelayUntil(long dueTimestamp) { }
         public static void RunIfActive(ReactiveUI.Primitives.Concurrency.IWorkItem item) { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {DueTime}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietSignal: DueTime = {DueTime}, Source = {Source}")]
     public sealed class EmitIfQuietSignal<T> : System.IObservable<T>
     {
         public EmitIfQuietSignal(System.IObservable<T> source, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietWitness: HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
     public sealed class EmitIfQuietWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public EmitIfQuietWitness(System.IObserver<T> observer, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
@@ -690,7 +690,16 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("EmptySignal: Scheduler = {_scheduler}")]
+    public sealed class EmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public EmptySignal(ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("EnumerableBlendSignal: Sources = {Sources}")]
     public sealed class EnumerableBlendSignal<T> : System.IObservable<T>
     {
         public EnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -700,7 +709,14 @@ namespace ReactiveUI.Primitives.Advanced
     {
         public static System.IDisposable Attach<TEventHandler>(TEventHandler handler, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
+    [System.Diagnostics.DebuggerDisplay("EverySignal: Period = {_period}, Scheduler = {_scheduler}")]
+    public sealed class EverySignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
+    {
+        public EverySignal(System.TimeSpan period, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<long> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ExpireCoordinator: Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
     public sealed class ExpireCoordinator<T> : System.IDisposable, System.IObserver<T>
     {
         public ExpireCoordinator(System.IObservable<T> source, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer, System.IObserver<T> observer) { }
@@ -710,39 +726,48 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnNext(T value) { }
         public ReactiveUI.Primitives.Advanced.ExpireCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("ExpireSignal: DueTime = {_dueTime}, Source = {_source}")]
     public sealed class ExpireSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ExpireSignal(System.IObservable<T> source, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("FinallySignal: Source = {_source}")]
+    public sealed class FinallySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public FinallySignal(System.IObservable<T> source, System.Action finallyAction) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ForkJoinSignal: Left = {Left}, Right = {Right}")]
     public sealed class ForkJoinSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public ForkJoinSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("ForkJoinWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
     public sealed class ForkJoinWitness<TLeft, TRight, TResult>
     {
         public ForkJoinWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("CancellationRequested = {CancellationToken.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncExternalCancellationSignal: CancellationRequested = {CancellationToken.IsCancellationRequested}")]
     public sealed class FromAsyncExternalCancellationSignal<T> : System.IObservable<T>
     {
         public FromAsyncExternalCancellationSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSignal: TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
     public sealed class FromAsyncSignal<T> : System.IObservable<T>
     {
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSubscription: Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
     public sealed class FromAsyncSubscription<T> : System.IDisposable
     {
         public FromAsyncSubscription(System.IObserver<T> observer, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
@@ -755,14 +780,14 @@ namespace ReactiveUI.Primitives.Advanced
         public FromEventConversionSignal(System.Func<TCallback, TEventHandler> conversion, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Func<System.IObserver<TResult>, TCallback> callback, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
+    [System.Diagnostics.DebuggerDisplay("FromEventPatternSignal: AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
     public sealed class FromEventPatternSignal<TEventHandler, TEventArgs> : System.IObservable<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> where TEventHandler : System.Delegate where TEventArgs : System.EventArgs
     {
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler) { }
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Disposed = {_disposed}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("GuardedWitness: Disposed = {_disposed}, Observer = {_observer}")]
     public sealed class GuardedWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public GuardedWitness(System.IObserver<T> observer, System.IDisposable cancel) { }
@@ -772,7 +797,7 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IgnoreValuesSignal: Source = {Source}")]
     public sealed class IgnoreValuesSignal<T> : System.IObservable<T>
     {
         public IgnoreValuesSignal(System.IObservable<T> source) { }
@@ -786,14 +811,14 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.RxVoid> observer) { }
         public System.IDisposable Subscribe(System.Action<ReactiveUI.Primitives.RxVoid> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptySignal: Source = {Source}")]
     public sealed class IsEmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<bool>
     {
         public IsEmptySignal(System.IObservable<T> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<bool> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptyWitness: Stopped = {_stopped}, Subscription = {Subscription}")]
     public sealed class IsEmptyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public IsEmptyWitness(System.IObserver<bool> observer) { }
@@ -806,14 +831,23 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {Value}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("LeadSignal: Value = {Value}, Source = {Source}")]
     public sealed class LeadSignal<T> : ReactiveUI.Primitives.Advanced.IInlineSignal<T>
     {
         public LeadSignal(System.IObservable<T> source, T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
         public System.IDisposable Subscribe(System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("LoopSignal: Value = {Value}")]
+    public sealed class LoopSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public LoopSignal(T value) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("MapIndexedSignal: Source = {_source}")]
     public sealed class MapIndexedSignal<TSource, TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public MapIndexedSignal(System.IObservable<TSource> source, System.Func<TSource, int, TResult> selector) { }
@@ -821,7 +855,7 @@ namespace ReactiveUI.Primitives.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Index = {_index}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("MapIndexedWitness: Index = {_index}, Stopped = {_stopped}")]
     public sealed class MapIndexedWitness<TSource, TResult> : System.IObserver<TSource>
     {
         public MapIndexedWitness(System.IObserver<TResult> observer, System.Func<TSource, int, TResult> selector) { }
@@ -829,20 +863,20 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(TSource value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentBlendCoordinator: Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
     public sealed class MaxConcurrentBlendCoordinator<T> : System.IDisposable
     {
         public MaxConcurrentBlendCoordinator(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.MaxConcurrentBlendCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentEnumerableBlendSignal: Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
     public sealed class MaxConcurrentEnumerableBlendSignal<T> : System.IObservable<T>
     {
         public MaxConcurrentEnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("MergeCoordinator: Active = {Active}, Done = {Done}")]
     public sealed class MergeCoordinator<T> : System.IDisposable
     {
         public MergeCoordinator(System.IObserver<T> observer) { }
@@ -853,7 +887,7 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.MergeCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.MergeCoordinator<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MergeSignal: Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
     public sealed class MergeSignal<T> : System.IObservable<T>
     {
         public MergeSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -861,32 +895,39 @@ namespace ReactiveUI.Primitives.Advanced
         public MergeSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("OnErrorResumeNextSignal: Sources = {_sources}")]
+    public sealed class OnErrorResumeNextSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("PairSignal: Left = {Left}, Right = {Right}")]
     public sealed class PairSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public PairSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
+    [System.Diagnostics.DebuggerDisplay("PairWitness: IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
     public sealed class PairWitness<TLeft, TRight, TResult>
     {
         public PairWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("PublishSelectorSignal: Source = {Source}, Selector = {Selector}")]
     public sealed class PublishSelectorSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public PublishSelectorSignal(System.IObservable<TSource> source, System.Func<System.IObservable<TSource>, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
+    [System.Diagnostics.DebuggerDisplay("RaceSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
     public sealed class RaceSignal<T> : System.IObservable<T>
     {
         public RaceSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public RaceSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Arms = {_arms}")]
+    [System.Diagnostics.DebuggerDisplay("RaceWitness: Arms = {_arms}")]
     public sealed class RaceWitness<T> : System.IDisposable
     {
         public RaceWitness(System.IObserver<T> observer) { }
@@ -895,40 +936,48 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.RaceWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.RaceWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeCombineLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeCombineLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeCombineLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
+    [System.Diagnostics.DebuggerDisplay("RangeForkJoinSignal: Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
     public sealed class RangeForkJoinSignal<TResult> : System.IObservable<TResult>
     {
         public RangeForkJoinSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeSyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeSyncLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeSyncLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeWithLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeWithLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeWithLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Remaining = {_remaining}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("RecoverSignal: Source = {_source}")]
+    public sealed class RecoverSignal<T, TException> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T> where TException : System.Exception
+    {
+        public RecoverSignal(System.IObservable<T> source, System.Func<TException, System.IObservable<T>> handler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceCoordinator: Remaining = {_remaining}, Disposed = {_disposed}")]
     public sealed class RepeatSourceCoordinator<T> : System.IDisposable
     {
         public RepeatSourceCoordinator(System.IObservable<T> source, int? repeatCount, System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.RepeatSourceCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, RepeatCount = {_repeatCount}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceSignal: Source = {_source}, RepeatCount = {_repeatCount}")]
     public sealed class RepeatSourceSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public RepeatSourceSignal(System.IObservable<T> source, int? repeatCount) { }
@@ -936,7 +985,7 @@ namespace ReactiveUI.Primitives.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Generation = {_generation}, Terminated = {_terminated}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceWitness: Generation = {_generation}, Terminated = {_terminated}")]
     public sealed class RepeatSourceWitness<T> : System.IObserver<T>
     {
         public RepeatSourceWitness(ReactiveUI.Primitives.Advanced.RepeatSourceCoordinator<T> parent, int generation) { }
@@ -944,7 +993,15 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_value}, Scheduler = {_scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ResumeSignal: Source = {_source}, Fallback = {_fallback}")]
+    public sealed class ResumeSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ResumeSignal(System.IObservable<T> source, System.IObservable<T> fallback) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ReturnSignal: Value = {_value}, Scheduler = {_scheduler}")]
     public sealed class ReturnSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ReturnSignal(T value, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -953,13 +1010,13 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Values = {Values}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledEnumerableSignal: Values = {Values}, Scheduler = {Scheduler}")]
     public sealed class ScheduledEnumerableSignal<T> : System.IObservable<T>
     {
         public ScheduledEnumerableSignal(System.Collections.Generic.IEnumerable<T> values, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyCoordinator<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TResult>> selector) { }
@@ -973,13 +1030,13 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Advanced.SelectManyCoordinator<TSource, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableSignal: Source = {_source}")]
     public sealed class SelectManyEnumerableSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManyEnumerableSignal(System.IObservable<TSource> source, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SelectManyEnumerableWitness<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyEnumerableWitness(System.IObserver<TResult> observer, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
@@ -993,7 +1050,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyResultCoordinator<TSource, TCollection, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyResultCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
@@ -1006,20 +1063,20 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Advanced.SelectManyResultCoordinator<TSource, TCollection, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, CollectionSelector = {CollectionSelector}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultSignal: Source = {Source}, CollectionSelector = {CollectionSelector}")]
     public sealed class SelectManyResultSignal<TSource, TCollection, TResult> : System.IObservable<TResult>
     {
         public SelectManyResultSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManySignal: Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
     public sealed class SelectManySignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManySignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public SelectManySignal(System.IObservable<TSource> source, System.IObservable<TResult> inner) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Start = {Start}, Count = {Count}")]
+    [System.Diagnostics.DebuggerDisplay("SequenceSignal: Start = {Start}, Count = {Count}")]
     public sealed class SequenceSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<int>
     {
         public SequenceSignal(int start, int count, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -1030,13 +1087,13 @@ namespace ReactiveUI.Primitives.Advanced
     {
         public static System.IDisposable Subscribe<T>(System.IObserver<T> observer, bool currentThreadRequired, System.Func<System.IObserver<T>, System.IDisposable, System.IDisposable> subscribeCore) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SparkSignal: Source = {Source}")]
     public sealed class SparkSignal<T> : System.IObservable<ReactiveUI.Primitives.Core.Spark<T>>
     {
         public SparkSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.Spark<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SparkWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SparkWitness(System.IObserver<ReactiveUI.Primitives.Core.Spark<T>> observer) { }
@@ -1051,21 +1108,21 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Action = {Action}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Action = {Action}, Scheduler = {Scheduler}")]
     public sealed class StartSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<ReactiveUI.Primitives.RxVoid>
     {
         public StartSignal(System.Action action, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.RxVoid> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Function = {Function}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Function = {Function}, Scheduler = {Scheduler}")]
     public sealed class StartSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public StartSignal(System.Func<T> function, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SubscribeSafeWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SubscribeSafeWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SubscribeSafeWitness(System.IObserver<T> observer) { }
@@ -1079,50 +1136,50 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, SkipNullSources = {_skipNullSources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchMapSignal: Source = {_source}, SkipNullSources = {_skipNullSources}")]
     public sealed class SwitchMapSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SwitchMapSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchSignal: Sources = {Sources}")]
     public sealed class SwitchSignal<T> : System.IObservable<T>
     {
         public SwitchSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Version = {_version}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchWitness: Version = {_version}, IsDone = {IsDone}")]
     public sealed class SwitchWitness<T> : System.IDisposable
     {
         public SwitchWitness(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.SwitchWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class SyncLatestSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public SyncLatestSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
     public sealed class SyncLatestWitness<TLeft, TRight, TResult>
     {
         public SyncLatestWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Gate = {Gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeGateSignal: Source = {Source}, Gate = {Gate}")]
     public sealed class SynchronizeGateSignal<T> : System.IObservable<T>
     {
         public SynchronizeGateSignal(System.IObservable<T> source, object gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, Gate = {_gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectSignal: Source = {_source}, Gate = {_gate}")]
     public sealed class SynchronizeObjectSignal<T> : System.IObservable<T>
     {
         public SynchronizeObjectSignal(System.IObservable<T> source, object gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SynchronizeObjectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SynchronizeObjectWitness(System.IObserver<T> observer, object gate) { }
@@ -1134,19 +1191,19 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeSignal: Source = {Source}")]
     public sealed class SynchronizeSignal<T> : System.IObservable<T>
     {
         public SynchronizeSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("TapSignal: Source = {Source}")]
     public sealed class TapSignal<T> : System.IObservable<T>
     {
         public TapSignal(System.IObservable<T> source, System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskAnyWitness: Stopped = {_stopped}, Task = {Task}")]
     public sealed class TaskAnyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskAnyWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1162,7 +1219,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainCoordinator: Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
     public sealed class TaskChainCoordinator<T> : System.IDisposable
     {
         public TaskChainCoordinator(System.IObserver<T> observer) { }
@@ -1170,13 +1227,13 @@ namespace ReactiveUI.Primitives.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.TaskChainCoordinator<T> Run(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainSignal: Sources = {_sources}")]
     public sealed class TaskChainSignal<T> : System.IObservable<T>
     {
         public TaskChainSignal(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskCountWitness: Count = {_count}, Stopped = {_stopped}")]
     public sealed class TaskCountWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskCountWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1192,13 +1249,13 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSignal: Task = {Task}")]
     public sealed class TaskInstanceSignal<T> : System.IObservable<T>
     {
         public TaskInstanceSignal(System.Threading.Tasks.Task<T> task) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSubscription: Stopped = {_stopped}")]
     public sealed class TaskInstanceSubscription : System.IDisposable
     {
         public TaskInstanceSubscription() { }
@@ -1206,13 +1263,22 @@ namespace ReactiveUI.Primitives.Advanced
         public void Dispose() { }
         public bool TryStop() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Sequencer = {Sequencer}")]
+    [System.Diagnostics.DebuggerDisplay("ThrowSignal: Error = {_error}, Scheduler = {_scheduler}")]
+    public sealed class ThrowSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ThrowSignal(System.Exception error, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalSignal: Source = {Source}, Sequencer = {Sequencer}")]
     public sealed class TimeIntervalSignal<T> : System.IObservable<ReactiveUI.Primitives.Core.TimeInterval<T>>
     {
         public TimeIntervalSignal(System.IObservable<T> source, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("First = {_first}, Last = {_last}")]
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalWitness: First = {_first}, Last = {_last}")]
     public sealed class TimeIntervalWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TimeIntervalWitness(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -1230,13 +1296,13 @@ namespace ReactiveUI.Primitives.Advanced
     {
         public static void Arm(ReactiveUI.Primitives.Disposables.SingleReplaceableDisposable slot, ReactiveUI.Primitives.Concurrency.ISequencer sequencer, System.TimeSpan delay, System.Action tick) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkSignal: Source = {Source}")]
     public sealed class UnsparkSignal<T> : System.IObservable<T>
     {
         public UnsparkSignal(System.IObservable<ReactiveUI.Primitives.Core.Spark<T>> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class UnsparkWitness<T> : System.IDisposable, System.IObserver<ReactiveUI.Primitives.Core.Spark<T>>
     {
         public UnsparkWitness(System.IObserver<T> observer) { }
@@ -1819,7 +1885,7 @@ namespace ReactiveUI.Primitives.Extensions.Operators
 }
 namespace ReactiveUI.Primitives.Signals
 {
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
+    [System.Diagnostics.DebuggerDisplay("PrioritySemaphoreSignal: Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
     public sealed class PrioritySemaphoreSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T> where T : System.IComparable<T>
     {
         public PrioritySemaphoreSignal(int maxCount) { }
@@ -1854,7 +1920,7 @@ namespace ReactiveUI.Primitives.Signals
         public void OnNext(T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledSignal: Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
     public class ScheduledSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T>
     {
         public ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }

--- a/src/ReactiveUI.Primitives/PublicAPI/net481/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net481/PublicAPI.txt
@@ -479,7 +479,7 @@ namespace ReactiveUI.Primitives
 }
 namespace ReactiveUI.Primitives.Advanced
 {
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Period = {_period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSignal: DueTime = {_dueTime}, Period = {_period}")]
     public sealed class AfterSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
     {
         public AfterSignal(System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -487,7 +487,7 @@ namespace ReactiveUI.Primitives.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<long> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSubscription: Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
     public sealed class AfterSubscription : System.IDisposable
     {
         public AfterSubscription(System.IObserver<long> observer, ReactiveUI.Primitives.Concurrency.ISequencer scheduler, System.TimeSpan dueTime, System.TimeSpan? period) { }
@@ -495,21 +495,21 @@ namespace ReactiveUI.Primitives.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.AfterSubscription Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("SubscribeAsync = {SubscribeAsync}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncCreateSignal: SubscribeAsync = {SubscribeAsync}")]
     public sealed class AsyncCreateSignal<T> : System.IObservable<T>
     {
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ObservableFactory = {ObservableFactory}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncDeferSignal: ObservableFactory = {ObservableFactory}")]
     public sealed class AsyncDeferSignal<T> : System.IObservable<T>
     {
         public AsyncDeferSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public AsyncDeferSignal(System.Func<System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncSubscriptionLifetime: Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
     public sealed class AsyncSubscriptionLifetime : System.IDisposable
     {
         public AsyncSubscriptionLifetime() { }
@@ -520,33 +520,33 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable? disposable) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connected = {_connected}")]
+    [System.Diagnostics.DebuggerDisplay("AutoConnectSignal: Count = {_count}, Connected = {_connected}")]
     public sealed class AutoConnectSignal<T> : System.IObservable<T>
     {
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount) { }
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount, System.Action<System.IDisposable>? onConnect) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connection = {_connection}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSignal: Count = {_count}, Connection = {_connection}")]
     public sealed class AutoShareSignal<T> : System.IObservable<T>
     {
         public AutoShareSignal(ReactiveUI.Primitives.ConnectableSignal<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Owner = {_owner}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSubscription: Owner = {_owner}, Subscription = {Subscription}")]
     public sealed class AutoShareSubscription<T> : System.IDisposable
     {
         public AutoShareSubscription(ReactiveUI.Primitives.Advanced.AutoShareSignal<T> owner, System.IDisposable subscription) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void Dispose() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("BlendSignal: Sources = {Sources}")]
     public sealed class BlendSignal<T> : System.IObservable<T>
     {
         public BlendSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("BlendWitness: ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
     public sealed class BlendWitness<T> : System.IDisposable
     {
         public BlendWitness(System.IObserver<T> observer) { }
@@ -555,7 +555,7 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.BlendWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.BlendWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("BufferEachWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class BufferEachWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public BufferEachWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -569,20 +569,20 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Window = {Window}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("BufferSignal: Window = {Window}, Source = {Source}")]
     public sealed class BufferSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public BufferSignal(System.IObservable<T> source, System.TimeSpan timeSpan, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("CastSignal: Source = {Source}")]
     public sealed class CastSignal<TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public CastSignal(System.IObservable<object?> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CastWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CastWitness<TResult> : System.IDisposable, System.IObserver<object?>
     {
         public CastWitness(System.IObserver<TResult> observer) { }
@@ -596,7 +596,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
+    [System.Diagnostics.DebuggerDisplay("ChainSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
     public sealed class ChainSignal<T> : System.IObservable<T>
     {
         public ChainSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -604,7 +604,7 @@ namespace ReactiveUI.Primitives.Advanced
         public ChainSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("ChainWitness: IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
     public sealed class ChainWitness<T> : System.IDisposable
     {
         public ChainWitness(System.IObserver<T> observer) { }
@@ -614,13 +614,13 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.ChainWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.ChainWitness<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, TimeSpan = {TimeSpan}")]
+    [System.Diagnostics.DebuggerDisplay("CollectSignal: Source = {Source}, TimeSpan = {TimeSpan}")]
     public sealed class CollectSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public CollectSignal(System.IObservable<T> source, System.TimeSpan timeSpan, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Buffered = {Values.Count}")]
+    [System.Diagnostics.DebuggerDisplay("CollectWitness: Stopped = {_stopped}, Buffered = {Values.Count}")]
     public sealed class CollectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CollectWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -632,7 +632,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateSink: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class CreateSink<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateSink(System.IObserver<T> observer, bool disposeOnNextThrow) { }
@@ -644,7 +644,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CreateWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateWitness(System.IObserver<T> observer) { }
@@ -658,7 +658,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
+    [System.Diagnostics.DebuggerDisplay("DispatchSequencerState: ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
     public record struct DispatchSequencerState : System.IEquatable<ReactiveUI.Primitives.Advanced.DispatchSequencerState>
     {
         public DispatchSequencerState(ReactiveUI.Primitives.Concurrency.ISequencer owner, System.Func<System.Action, bool> post, System.Action drain) { }
@@ -673,13 +673,13 @@ namespace ReactiveUI.Primitives.Advanced
         public static System.TimeSpan DelayUntil(long dueTimestamp) { }
         public static void RunIfActive(ReactiveUI.Primitives.Concurrency.IWorkItem item) { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {DueTime}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietSignal: DueTime = {DueTime}, Source = {Source}")]
     public sealed class EmitIfQuietSignal<T> : System.IObservable<T>
     {
         public EmitIfQuietSignal(System.IObservable<T> source, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietWitness: HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
     public sealed class EmitIfQuietWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public EmitIfQuietWitness(System.IObserver<T> observer, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
@@ -690,7 +690,16 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("EmptySignal: Scheduler = {_scheduler}")]
+    public sealed class EmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public EmptySignal(ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("EnumerableBlendSignal: Sources = {Sources}")]
     public sealed class EnumerableBlendSignal<T> : System.IObservable<T>
     {
         public EnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -700,7 +709,14 @@ namespace ReactiveUI.Primitives.Advanced
     {
         public static System.IDisposable Attach<TEventHandler>(TEventHandler handler, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
+    [System.Diagnostics.DebuggerDisplay("EverySignal: Period = {_period}, Scheduler = {_scheduler}")]
+    public sealed class EverySignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
+    {
+        public EverySignal(System.TimeSpan period, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<long> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ExpireCoordinator: Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
     public sealed class ExpireCoordinator<T> : System.IDisposable, System.IObserver<T>
     {
         public ExpireCoordinator(System.IObservable<T> source, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer, System.IObserver<T> observer) { }
@@ -710,39 +726,48 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnNext(T value) { }
         public ReactiveUI.Primitives.Advanced.ExpireCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("ExpireSignal: DueTime = {_dueTime}, Source = {_source}")]
     public sealed class ExpireSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ExpireSignal(System.IObservable<T> source, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("FinallySignal: Source = {_source}")]
+    public sealed class FinallySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public FinallySignal(System.IObservable<T> source, System.Action finallyAction) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ForkJoinSignal: Left = {Left}, Right = {Right}")]
     public sealed class ForkJoinSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public ForkJoinSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("ForkJoinWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
     public sealed class ForkJoinWitness<TLeft, TRight, TResult>
     {
         public ForkJoinWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("CancellationRequested = {CancellationToken.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncExternalCancellationSignal: CancellationRequested = {CancellationToken.IsCancellationRequested}")]
     public sealed class FromAsyncExternalCancellationSignal<T> : System.IObservable<T>
     {
         public FromAsyncExternalCancellationSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSignal: TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
     public sealed class FromAsyncSignal<T> : System.IObservable<T>
     {
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSubscription: Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
     public sealed class FromAsyncSubscription<T> : System.IDisposable
     {
         public FromAsyncSubscription(System.IObserver<T> observer, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
@@ -755,14 +780,14 @@ namespace ReactiveUI.Primitives.Advanced
         public FromEventConversionSignal(System.Func<TCallback, TEventHandler> conversion, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Func<System.IObserver<TResult>, TCallback> callback, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
+    [System.Diagnostics.DebuggerDisplay("FromEventPatternSignal: AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
     public sealed class FromEventPatternSignal<TEventHandler, TEventArgs> : System.IObservable<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> where TEventHandler : System.Delegate where TEventArgs : System.EventArgs
     {
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler) { }
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Disposed = {_disposed}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("GuardedWitness: Disposed = {_disposed}, Observer = {_observer}")]
     public sealed class GuardedWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public GuardedWitness(System.IObserver<T> observer, System.IDisposable cancel) { }
@@ -772,7 +797,7 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IgnoreValuesSignal: Source = {Source}")]
     public sealed class IgnoreValuesSignal<T> : System.IObservable<T>
     {
         public IgnoreValuesSignal(System.IObservable<T> source) { }
@@ -786,14 +811,14 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.RxVoid> observer) { }
         public System.IDisposable Subscribe(System.Action<ReactiveUI.Primitives.RxVoid> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptySignal: Source = {Source}")]
     public sealed class IsEmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<bool>
     {
         public IsEmptySignal(System.IObservable<T> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<bool> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptyWitness: Stopped = {_stopped}, Subscription = {Subscription}")]
     public sealed class IsEmptyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public IsEmptyWitness(System.IObserver<bool> observer) { }
@@ -806,14 +831,23 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {Value}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("LeadSignal: Value = {Value}, Source = {Source}")]
     public sealed class LeadSignal<T> : ReactiveUI.Primitives.Advanced.IInlineSignal<T>
     {
         public LeadSignal(System.IObservable<T> source, T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
         public System.IDisposable Subscribe(System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("LoopSignal: Value = {Value}")]
+    public sealed class LoopSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public LoopSignal(T value) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("MapIndexedSignal: Source = {_source}")]
     public sealed class MapIndexedSignal<TSource, TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public MapIndexedSignal(System.IObservable<TSource> source, System.Func<TSource, int, TResult> selector) { }
@@ -821,7 +855,7 @@ namespace ReactiveUI.Primitives.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Index = {_index}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("MapIndexedWitness: Index = {_index}, Stopped = {_stopped}")]
     public sealed class MapIndexedWitness<TSource, TResult> : System.IObserver<TSource>
     {
         public MapIndexedWitness(System.IObserver<TResult> observer, System.Func<TSource, int, TResult> selector) { }
@@ -829,20 +863,20 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(TSource value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentBlendCoordinator: Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
     public sealed class MaxConcurrentBlendCoordinator<T> : System.IDisposable
     {
         public MaxConcurrentBlendCoordinator(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.MaxConcurrentBlendCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentEnumerableBlendSignal: Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
     public sealed class MaxConcurrentEnumerableBlendSignal<T> : System.IObservable<T>
     {
         public MaxConcurrentEnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("MergeCoordinator: Active = {Active}, Done = {Done}")]
     public sealed class MergeCoordinator<T> : System.IDisposable
     {
         public MergeCoordinator(System.IObserver<T> observer) { }
@@ -853,7 +887,7 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.MergeCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.MergeCoordinator<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MergeSignal: Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
     public sealed class MergeSignal<T> : System.IObservable<T>
     {
         public MergeSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -861,32 +895,39 @@ namespace ReactiveUI.Primitives.Advanced
         public MergeSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("OnErrorResumeNextSignal: Sources = {_sources}")]
+    public sealed class OnErrorResumeNextSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("PairSignal: Left = {Left}, Right = {Right}")]
     public sealed class PairSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public PairSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
+    [System.Diagnostics.DebuggerDisplay("PairWitness: IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
     public sealed class PairWitness<TLeft, TRight, TResult>
     {
         public PairWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("PublishSelectorSignal: Source = {Source}, Selector = {Selector}")]
     public sealed class PublishSelectorSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public PublishSelectorSignal(System.IObservable<TSource> source, System.Func<System.IObservable<TSource>, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
+    [System.Diagnostics.DebuggerDisplay("RaceSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
     public sealed class RaceSignal<T> : System.IObservable<T>
     {
         public RaceSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public RaceSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Arms = {_arms}")]
+    [System.Diagnostics.DebuggerDisplay("RaceWitness: Arms = {_arms}")]
     public sealed class RaceWitness<T> : System.IDisposable
     {
         public RaceWitness(System.IObserver<T> observer) { }
@@ -895,40 +936,48 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.RaceWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.RaceWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeCombineLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeCombineLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeCombineLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
+    [System.Diagnostics.DebuggerDisplay("RangeForkJoinSignal: Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
     public sealed class RangeForkJoinSignal<TResult> : System.IObservable<TResult>
     {
         public RangeForkJoinSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeSyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeSyncLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeSyncLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeWithLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeWithLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeWithLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Remaining = {_remaining}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("RecoverSignal: Source = {_source}")]
+    public sealed class RecoverSignal<T, TException> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T> where TException : System.Exception
+    {
+        public RecoverSignal(System.IObservable<T> source, System.Func<TException, System.IObservable<T>> handler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceCoordinator: Remaining = {_remaining}, Disposed = {_disposed}")]
     public sealed class RepeatSourceCoordinator<T> : System.IDisposable
     {
         public RepeatSourceCoordinator(System.IObservable<T> source, int? repeatCount, System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.RepeatSourceCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, RepeatCount = {_repeatCount}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceSignal: Source = {_source}, RepeatCount = {_repeatCount}")]
     public sealed class RepeatSourceSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public RepeatSourceSignal(System.IObservable<T> source, int? repeatCount) { }
@@ -936,7 +985,7 @@ namespace ReactiveUI.Primitives.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Generation = {_generation}, Terminated = {_terminated}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceWitness: Generation = {_generation}, Terminated = {_terminated}")]
     public sealed class RepeatSourceWitness<T> : System.IObserver<T>
     {
         public RepeatSourceWitness(ReactiveUI.Primitives.Advanced.RepeatSourceCoordinator<T> parent, int generation) { }
@@ -944,7 +993,15 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_value}, Scheduler = {_scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ResumeSignal: Source = {_source}, Fallback = {_fallback}")]
+    public sealed class ResumeSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ResumeSignal(System.IObservable<T> source, System.IObservable<T> fallback) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ReturnSignal: Value = {_value}, Scheduler = {_scheduler}")]
     public sealed class ReturnSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ReturnSignal(T value, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -953,13 +1010,13 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Values = {Values}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledEnumerableSignal: Values = {Values}, Scheduler = {Scheduler}")]
     public sealed class ScheduledEnumerableSignal<T> : System.IObservable<T>
     {
         public ScheduledEnumerableSignal(System.Collections.Generic.IEnumerable<T> values, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyCoordinator<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TResult>> selector) { }
@@ -973,13 +1030,13 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Advanced.SelectManyCoordinator<TSource, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableSignal: Source = {_source}")]
     public sealed class SelectManyEnumerableSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManyEnumerableSignal(System.IObservable<TSource> source, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SelectManyEnumerableWitness<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyEnumerableWitness(System.IObserver<TResult> observer, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
@@ -993,7 +1050,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyResultCoordinator<TSource, TCollection, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyResultCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
@@ -1006,20 +1063,20 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Advanced.SelectManyResultCoordinator<TSource, TCollection, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, CollectionSelector = {CollectionSelector}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultSignal: Source = {Source}, CollectionSelector = {CollectionSelector}")]
     public sealed class SelectManyResultSignal<TSource, TCollection, TResult> : System.IObservable<TResult>
     {
         public SelectManyResultSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManySignal: Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
     public sealed class SelectManySignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManySignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public SelectManySignal(System.IObservable<TSource> source, System.IObservable<TResult> inner) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Start = {Start}, Count = {Count}")]
+    [System.Diagnostics.DebuggerDisplay("SequenceSignal: Start = {Start}, Count = {Count}")]
     public sealed class SequenceSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<int>
     {
         public SequenceSignal(int start, int count, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -1030,13 +1087,13 @@ namespace ReactiveUI.Primitives.Advanced
     {
         public static System.IDisposable Subscribe<T>(System.IObserver<T> observer, bool currentThreadRequired, System.Func<System.IObserver<T>, System.IDisposable, System.IDisposable> subscribeCore) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SparkSignal: Source = {Source}")]
     public sealed class SparkSignal<T> : System.IObservable<ReactiveUI.Primitives.Core.Spark<T>>
     {
         public SparkSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.Spark<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SparkWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SparkWitness(System.IObserver<ReactiveUI.Primitives.Core.Spark<T>> observer) { }
@@ -1051,21 +1108,21 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Action = {Action}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Action = {Action}, Scheduler = {Scheduler}")]
     public sealed class StartSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<ReactiveUI.Primitives.RxVoid>
     {
         public StartSignal(System.Action action, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.RxVoid> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Function = {Function}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Function = {Function}, Scheduler = {Scheduler}")]
     public sealed class StartSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public StartSignal(System.Func<T> function, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SubscribeSafeWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SubscribeSafeWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SubscribeSafeWitness(System.IObserver<T> observer) { }
@@ -1079,50 +1136,50 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, SkipNullSources = {_skipNullSources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchMapSignal: Source = {_source}, SkipNullSources = {_skipNullSources}")]
     public sealed class SwitchMapSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SwitchMapSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchSignal: Sources = {Sources}")]
     public sealed class SwitchSignal<T> : System.IObservable<T>
     {
         public SwitchSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Version = {_version}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchWitness: Version = {_version}, IsDone = {IsDone}")]
     public sealed class SwitchWitness<T> : System.IDisposable
     {
         public SwitchWitness(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.SwitchWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class SyncLatestSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public SyncLatestSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
     public sealed class SyncLatestWitness<TLeft, TRight, TResult>
     {
         public SyncLatestWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Gate = {Gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeGateSignal: Source = {Source}, Gate = {Gate}")]
     public sealed class SynchronizeGateSignal<T> : System.IObservable<T>
     {
         public SynchronizeGateSignal(System.IObservable<T> source, object gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, Gate = {_gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectSignal: Source = {_source}, Gate = {_gate}")]
     public sealed class SynchronizeObjectSignal<T> : System.IObservable<T>
     {
         public SynchronizeObjectSignal(System.IObservable<T> source, object gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SynchronizeObjectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SynchronizeObjectWitness(System.IObserver<T> observer, object gate) { }
@@ -1134,19 +1191,19 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeSignal: Source = {Source}")]
     public sealed class SynchronizeSignal<T> : System.IObservable<T>
     {
         public SynchronizeSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("TapSignal: Source = {Source}")]
     public sealed class TapSignal<T> : System.IObservable<T>
     {
         public TapSignal(System.IObservable<T> source, System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskAnyWitness: Stopped = {_stopped}, Task = {Task}")]
     public sealed class TaskAnyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskAnyWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1162,7 +1219,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainCoordinator: Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
     public sealed class TaskChainCoordinator<T> : System.IDisposable
     {
         public TaskChainCoordinator(System.IObserver<T> observer) { }
@@ -1170,13 +1227,13 @@ namespace ReactiveUI.Primitives.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.TaskChainCoordinator<T> Run(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainSignal: Sources = {_sources}")]
     public sealed class TaskChainSignal<T> : System.IObservable<T>
     {
         public TaskChainSignal(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskCountWitness: Count = {_count}, Stopped = {_stopped}")]
     public sealed class TaskCountWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskCountWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1192,13 +1249,13 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSignal: Task = {Task}")]
     public sealed class TaskInstanceSignal<T> : System.IObservable<T>
     {
         public TaskInstanceSignal(System.Threading.Tasks.Task<T> task) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSubscription: Stopped = {_stopped}")]
     public sealed class TaskInstanceSubscription : System.IDisposable
     {
         public TaskInstanceSubscription() { }
@@ -1206,13 +1263,22 @@ namespace ReactiveUI.Primitives.Advanced
         public void Dispose() { }
         public bool TryStop() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Sequencer = {Sequencer}")]
+    [System.Diagnostics.DebuggerDisplay("ThrowSignal: Error = {_error}, Scheduler = {_scheduler}")]
+    public sealed class ThrowSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ThrowSignal(System.Exception error, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalSignal: Source = {Source}, Sequencer = {Sequencer}")]
     public sealed class TimeIntervalSignal<T> : System.IObservable<ReactiveUI.Primitives.Core.TimeInterval<T>>
     {
         public TimeIntervalSignal(System.IObservable<T> source, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("First = {_first}, Last = {_last}")]
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalWitness: First = {_first}, Last = {_last}")]
     public sealed class TimeIntervalWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TimeIntervalWitness(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -1230,13 +1296,13 @@ namespace ReactiveUI.Primitives.Advanced
     {
         public static void Arm(ReactiveUI.Primitives.Disposables.SingleReplaceableDisposable slot, ReactiveUI.Primitives.Concurrency.ISequencer sequencer, System.TimeSpan delay, System.Action tick) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkSignal: Source = {Source}")]
     public sealed class UnsparkSignal<T> : System.IObservable<T>
     {
         public UnsparkSignal(System.IObservable<ReactiveUI.Primitives.Core.Spark<T>> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class UnsparkWitness<T> : System.IDisposable, System.IObserver<ReactiveUI.Primitives.Core.Spark<T>>
     {
         public UnsparkWitness(System.IObserver<T> observer) { }
@@ -1819,7 +1885,7 @@ namespace ReactiveUI.Primitives.Extensions.Operators
 }
 namespace ReactiveUI.Primitives.Signals
 {
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
+    [System.Diagnostics.DebuggerDisplay("PrioritySemaphoreSignal: Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
     public sealed class PrioritySemaphoreSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T> where T : System.IComparable<T>
     {
         public PrioritySemaphoreSignal(int maxCount) { }
@@ -1854,7 +1920,7 @@ namespace ReactiveUI.Primitives.Signals
         public void OnNext(T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledSignal: Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
     public class ScheduledSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T>
     {
         public ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }

--- a/src/ReactiveUI.Primitives/PublicAPI/net8.0/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net8.0/PublicAPI.txt
@@ -479,7 +479,7 @@ namespace ReactiveUI.Primitives
 }
 namespace ReactiveUI.Primitives.Advanced
 {
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Period = {_period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSignal: DueTime = {_dueTime}, Period = {_period}")]
     public sealed class AfterSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
     {
         public AfterSignal(System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -487,7 +487,7 @@ namespace ReactiveUI.Primitives.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<long> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSubscription: Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
     public sealed class AfterSubscription : System.IDisposable
     {
         public AfterSubscription(System.IObserver<long> observer, ReactiveUI.Primitives.Concurrency.ISequencer scheduler, System.TimeSpan dueTime, System.TimeSpan? period) { }
@@ -495,21 +495,21 @@ namespace ReactiveUI.Primitives.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.AfterSubscription Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("SubscribeAsync = {SubscribeAsync}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncCreateSignal: SubscribeAsync = {SubscribeAsync}")]
     public sealed class AsyncCreateSignal<T> : System.IObservable<T>
     {
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ObservableFactory = {ObservableFactory}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncDeferSignal: ObservableFactory = {ObservableFactory}")]
     public sealed class AsyncDeferSignal<T> : System.IObservable<T>
     {
         public AsyncDeferSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public AsyncDeferSignal(System.Func<System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncSubscriptionLifetime: Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
     public sealed class AsyncSubscriptionLifetime : System.IDisposable
     {
         public AsyncSubscriptionLifetime() { }
@@ -520,33 +520,33 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable? disposable) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connected = {_connected}")]
+    [System.Diagnostics.DebuggerDisplay("AutoConnectSignal: Count = {_count}, Connected = {_connected}")]
     public sealed class AutoConnectSignal<T> : System.IObservable<T>
     {
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount) { }
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount, System.Action<System.IDisposable>? onConnect) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connection = {_connection}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSignal: Count = {_count}, Connection = {_connection}")]
     public sealed class AutoShareSignal<T> : System.IObservable<T>
     {
         public AutoShareSignal(ReactiveUI.Primitives.ConnectableSignal<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Owner = {_owner}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSubscription: Owner = {_owner}, Subscription = {Subscription}")]
     public sealed class AutoShareSubscription<T> : System.IDisposable
     {
         public AutoShareSubscription(ReactiveUI.Primitives.Advanced.AutoShareSignal<T> owner, System.IDisposable subscription) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void Dispose() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("BlendSignal: Sources = {Sources}")]
     public sealed class BlendSignal<T> : System.IObservable<T>
     {
         public BlendSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("BlendWitness: ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
     public sealed class BlendWitness<T> : System.IDisposable
     {
         public BlendWitness(System.IObserver<T> observer) { }
@@ -555,7 +555,7 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.BlendWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.BlendWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("BufferEachWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class BufferEachWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public BufferEachWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -569,20 +569,20 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Window = {Window}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("BufferSignal: Window = {Window}, Source = {Source}")]
     public sealed class BufferSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public BufferSignal(System.IObservable<T> source, System.TimeSpan timeSpan, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("CastSignal: Source = {Source}")]
     public sealed class CastSignal<TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public CastSignal(System.IObservable<object?> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CastWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CastWitness<TResult> : System.IDisposable, System.IObserver<object?>
     {
         public CastWitness(System.IObserver<TResult> observer) { }
@@ -596,7 +596,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
+    [System.Diagnostics.DebuggerDisplay("ChainSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
     public sealed class ChainSignal<T> : System.IObservable<T>
     {
         public ChainSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -604,7 +604,7 @@ namespace ReactiveUI.Primitives.Advanced
         public ChainSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("ChainWitness: IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
     public sealed class ChainWitness<T> : System.IDisposable
     {
         public ChainWitness(System.IObserver<T> observer) { }
@@ -614,13 +614,13 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.ChainWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.ChainWitness<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, TimeSpan = {TimeSpan}")]
+    [System.Diagnostics.DebuggerDisplay("CollectSignal: Source = {Source}, TimeSpan = {TimeSpan}")]
     public sealed class CollectSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public CollectSignal(System.IObservable<T> source, System.TimeSpan timeSpan, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Buffered = {Values.Count}")]
+    [System.Diagnostics.DebuggerDisplay("CollectWitness: Stopped = {_stopped}, Buffered = {Values.Count}")]
     public sealed class CollectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CollectWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -632,7 +632,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateSink: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class CreateSink<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateSink(System.IObserver<T> observer, bool disposeOnNextThrow) { }
@@ -644,7 +644,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CreateWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateWitness(System.IObserver<T> observer) { }
@@ -658,7 +658,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
+    [System.Diagnostics.DebuggerDisplay("DispatchSequencerState: ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
     public record struct DispatchSequencerState : System.IEquatable<ReactiveUI.Primitives.Advanced.DispatchSequencerState>
     {
         public DispatchSequencerState(ReactiveUI.Primitives.Concurrency.ISequencer owner, System.Func<System.Action, bool> post, System.Action drain) { }
@@ -673,13 +673,13 @@ namespace ReactiveUI.Primitives.Advanced
         public static System.TimeSpan DelayUntil(long dueTimestamp) { }
         public static void RunIfActive(ReactiveUI.Primitives.Concurrency.IWorkItem item) { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {DueTime}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietSignal: DueTime = {DueTime}, Source = {Source}")]
     public sealed class EmitIfQuietSignal<T> : System.IObservable<T>
     {
         public EmitIfQuietSignal(System.IObservable<T> source, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietWitness: HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
     public sealed class EmitIfQuietWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public EmitIfQuietWitness(System.IObserver<T> observer, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
@@ -690,7 +690,16 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("EmptySignal: Scheduler = {_scheduler}")]
+    public sealed class EmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public EmptySignal(ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("EnumerableBlendSignal: Sources = {Sources}")]
     public sealed class EnumerableBlendSignal<T> : System.IObservable<T>
     {
         public EnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -700,7 +709,14 @@ namespace ReactiveUI.Primitives.Advanced
     {
         public static System.IDisposable Attach<TEventHandler>(TEventHandler handler, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
+    [System.Diagnostics.DebuggerDisplay("EverySignal: Period = {_period}, Scheduler = {_scheduler}")]
+    public sealed class EverySignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
+    {
+        public EverySignal(System.TimeSpan period, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<long> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ExpireCoordinator: Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
     public sealed class ExpireCoordinator<T> : System.IDisposable, System.IObserver<T>
     {
         public ExpireCoordinator(System.IObservable<T> source, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer, System.IObserver<T> observer) { }
@@ -710,39 +726,48 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnNext(T value) { }
         public ReactiveUI.Primitives.Advanced.ExpireCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("ExpireSignal: DueTime = {_dueTime}, Source = {_source}")]
     public sealed class ExpireSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ExpireSignal(System.IObservable<T> source, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("FinallySignal: Source = {_source}")]
+    public sealed class FinallySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public FinallySignal(System.IObservable<T> source, System.Action finallyAction) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ForkJoinSignal: Left = {Left}, Right = {Right}")]
     public sealed class ForkJoinSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public ForkJoinSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("ForkJoinWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
     public sealed class ForkJoinWitness<TLeft, TRight, TResult>
     {
         public ForkJoinWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("CancellationRequested = {CancellationToken.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncExternalCancellationSignal: CancellationRequested = {CancellationToken.IsCancellationRequested}")]
     public sealed class FromAsyncExternalCancellationSignal<T> : System.IObservable<T>
     {
         public FromAsyncExternalCancellationSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSignal: TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
     public sealed class FromAsyncSignal<T> : System.IObservable<T>
     {
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSubscription: Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
     public sealed class FromAsyncSubscription<T> : System.IDisposable
     {
         public FromAsyncSubscription(System.IObserver<T> observer, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
@@ -755,14 +780,14 @@ namespace ReactiveUI.Primitives.Advanced
         public FromEventConversionSignal(System.Func<TCallback, TEventHandler> conversion, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Func<System.IObserver<TResult>, TCallback> callback, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
+    [System.Diagnostics.DebuggerDisplay("FromEventPatternSignal: AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
     public sealed class FromEventPatternSignal<TEventHandler, TEventArgs> : System.IObservable<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> where TEventHandler : System.Delegate where TEventArgs : System.EventArgs
     {
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler) { }
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Disposed = {_disposed}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("GuardedWitness: Disposed = {_disposed}, Observer = {_observer}")]
     public sealed class GuardedWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public GuardedWitness(System.IObserver<T> observer, System.IDisposable cancel) { }
@@ -772,7 +797,7 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IgnoreValuesSignal: Source = {Source}")]
     public sealed class IgnoreValuesSignal<T> : System.IObservable<T>
     {
         public IgnoreValuesSignal(System.IObservable<T> source) { }
@@ -786,14 +811,14 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.RxVoid> observer) { }
         public System.IDisposable Subscribe(System.Action<ReactiveUI.Primitives.RxVoid> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptySignal: Source = {Source}")]
     public sealed class IsEmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<bool>
     {
         public IsEmptySignal(System.IObservable<T> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<bool> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptyWitness: Stopped = {_stopped}, Subscription = {Subscription}")]
     public sealed class IsEmptyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public IsEmptyWitness(System.IObserver<bool> observer) { }
@@ -806,14 +831,23 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {Value}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("LeadSignal: Value = {Value}, Source = {Source}")]
     public sealed class LeadSignal<T> : ReactiveUI.Primitives.Advanced.IInlineSignal<T>
     {
         public LeadSignal(System.IObservable<T> source, T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
         public System.IDisposable Subscribe(System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("LoopSignal: Value = {Value}")]
+    public sealed class LoopSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public LoopSignal(T value) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("MapIndexedSignal: Source = {_source}")]
     public sealed class MapIndexedSignal<TSource, TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public MapIndexedSignal(System.IObservable<TSource> source, System.Func<TSource, int, TResult> selector) { }
@@ -821,7 +855,7 @@ namespace ReactiveUI.Primitives.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Index = {_index}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("MapIndexedWitness: Index = {_index}, Stopped = {_stopped}")]
     public sealed class MapIndexedWitness<TSource, TResult> : System.IObserver<TSource>
     {
         public MapIndexedWitness(System.IObserver<TResult> observer, System.Func<TSource, int, TResult> selector) { }
@@ -829,20 +863,20 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(TSource value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentBlendCoordinator: Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
     public sealed class MaxConcurrentBlendCoordinator<T> : System.IDisposable
     {
         public MaxConcurrentBlendCoordinator(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.MaxConcurrentBlendCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentEnumerableBlendSignal: Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
     public sealed class MaxConcurrentEnumerableBlendSignal<T> : System.IObservable<T>
     {
         public MaxConcurrentEnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("MergeCoordinator: Active = {Active}, Done = {Done}")]
     public sealed class MergeCoordinator<T> : System.IDisposable
     {
         public MergeCoordinator(System.IObserver<T> observer) { }
@@ -853,7 +887,7 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.MergeCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.MergeCoordinator<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MergeSignal: Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
     public sealed class MergeSignal<T> : System.IObservable<T>
     {
         public MergeSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -861,32 +895,39 @@ namespace ReactiveUI.Primitives.Advanced
         public MergeSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("OnErrorResumeNextSignal: Sources = {_sources}")]
+    public sealed class OnErrorResumeNextSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("PairSignal: Left = {Left}, Right = {Right}")]
     public sealed class PairSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public PairSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
+    [System.Diagnostics.DebuggerDisplay("PairWitness: IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
     public sealed class PairWitness<TLeft, TRight, TResult>
     {
         public PairWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("PublishSelectorSignal: Source = {Source}, Selector = {Selector}")]
     public sealed class PublishSelectorSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public PublishSelectorSignal(System.IObservable<TSource> source, System.Func<System.IObservable<TSource>, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
+    [System.Diagnostics.DebuggerDisplay("RaceSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
     public sealed class RaceSignal<T> : System.IObservable<T>
     {
         public RaceSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public RaceSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Arms = {_arms}")]
+    [System.Diagnostics.DebuggerDisplay("RaceWitness: Arms = {_arms}")]
     public sealed class RaceWitness<T> : System.IDisposable
     {
         public RaceWitness(System.IObserver<T> observer) { }
@@ -895,40 +936,48 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.RaceWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.RaceWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeCombineLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeCombineLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeCombineLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
+    [System.Diagnostics.DebuggerDisplay("RangeForkJoinSignal: Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
     public sealed class RangeForkJoinSignal<TResult> : System.IObservable<TResult>
     {
         public RangeForkJoinSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeSyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeSyncLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeSyncLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeWithLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeWithLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeWithLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Remaining = {_remaining}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("RecoverSignal: Source = {_source}")]
+    public sealed class RecoverSignal<T, TException> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T> where TException : System.Exception
+    {
+        public RecoverSignal(System.IObservable<T> source, System.Func<TException, System.IObservable<T>> handler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceCoordinator: Remaining = {_remaining}, Disposed = {_disposed}")]
     public sealed class RepeatSourceCoordinator<T> : System.IDisposable
     {
         public RepeatSourceCoordinator(System.IObservable<T> source, int? repeatCount, System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.RepeatSourceCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, RepeatCount = {_repeatCount}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceSignal: Source = {_source}, RepeatCount = {_repeatCount}")]
     public sealed class RepeatSourceSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public RepeatSourceSignal(System.IObservable<T> source, int? repeatCount) { }
@@ -936,7 +985,7 @@ namespace ReactiveUI.Primitives.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Generation = {_generation}, Terminated = {_terminated}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceWitness: Generation = {_generation}, Terminated = {_terminated}")]
     public sealed class RepeatSourceWitness<T> : System.IObserver<T>
     {
         public RepeatSourceWitness(ReactiveUI.Primitives.Advanced.RepeatSourceCoordinator<T> parent, int generation) { }
@@ -944,7 +993,15 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_value}, Scheduler = {_scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ResumeSignal: Source = {_source}, Fallback = {_fallback}")]
+    public sealed class ResumeSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ResumeSignal(System.IObservable<T> source, System.IObservable<T> fallback) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ReturnSignal: Value = {_value}, Scheduler = {_scheduler}")]
     public sealed class ReturnSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ReturnSignal(T value, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -953,13 +1010,13 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Values = {Values}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledEnumerableSignal: Values = {Values}, Scheduler = {Scheduler}")]
     public sealed class ScheduledEnumerableSignal<T> : System.IObservable<T>
     {
         public ScheduledEnumerableSignal(System.Collections.Generic.IEnumerable<T> values, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyCoordinator<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TResult>> selector) { }
@@ -973,13 +1030,13 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Advanced.SelectManyCoordinator<TSource, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableSignal: Source = {_source}")]
     public sealed class SelectManyEnumerableSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManyEnumerableSignal(System.IObservable<TSource> source, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SelectManyEnumerableWitness<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyEnumerableWitness(System.IObserver<TResult> observer, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
@@ -993,7 +1050,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyResultCoordinator<TSource, TCollection, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyResultCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
@@ -1006,20 +1063,20 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Advanced.SelectManyResultCoordinator<TSource, TCollection, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, CollectionSelector = {CollectionSelector}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultSignal: Source = {Source}, CollectionSelector = {CollectionSelector}")]
     public sealed class SelectManyResultSignal<TSource, TCollection, TResult> : System.IObservable<TResult>
     {
         public SelectManyResultSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManySignal: Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
     public sealed class SelectManySignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManySignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public SelectManySignal(System.IObservable<TSource> source, System.IObservable<TResult> inner) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Start = {Start}, Count = {Count}")]
+    [System.Diagnostics.DebuggerDisplay("SequenceSignal: Start = {Start}, Count = {Count}")]
     public sealed class SequenceSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<int>
     {
         public SequenceSignal(int start, int count, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -1030,13 +1087,13 @@ namespace ReactiveUI.Primitives.Advanced
     {
         public static System.IDisposable Subscribe<T>(System.IObserver<T> observer, bool currentThreadRequired, System.Func<System.IObserver<T>, System.IDisposable, System.IDisposable> subscribeCore) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SparkSignal: Source = {Source}")]
     public sealed class SparkSignal<T> : System.IObservable<ReactiveUI.Primitives.Core.Spark<T>>
     {
         public SparkSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.Spark<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SparkWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SparkWitness(System.IObserver<ReactiveUI.Primitives.Core.Spark<T>> observer) { }
@@ -1051,21 +1108,21 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Action = {Action}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Action = {Action}, Scheduler = {Scheduler}")]
     public sealed class StartSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<ReactiveUI.Primitives.RxVoid>
     {
         public StartSignal(System.Action action, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.RxVoid> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Function = {Function}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Function = {Function}, Scheduler = {Scheduler}")]
     public sealed class StartSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public StartSignal(System.Func<T> function, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SubscribeSafeWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SubscribeSafeWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SubscribeSafeWitness(System.IObserver<T> observer) { }
@@ -1079,50 +1136,50 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, SkipNullSources = {_skipNullSources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchMapSignal: Source = {_source}, SkipNullSources = {_skipNullSources}")]
     public sealed class SwitchMapSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SwitchMapSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchSignal: Sources = {Sources}")]
     public sealed class SwitchSignal<T> : System.IObservable<T>
     {
         public SwitchSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Version = {_version}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchWitness: Version = {_version}, IsDone = {IsDone}")]
     public sealed class SwitchWitness<T> : System.IDisposable
     {
         public SwitchWitness(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.SwitchWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class SyncLatestSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public SyncLatestSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
     public sealed class SyncLatestWitness<TLeft, TRight, TResult>
     {
         public SyncLatestWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Gate = {Gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeGateSignal: Source = {Source}, Gate = {Gate}")]
     public sealed class SynchronizeGateSignal<T> : System.IObservable<T>
     {
         public SynchronizeGateSignal(System.IObservable<T> source, object gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, Gate = {_gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectSignal: Source = {_source}, Gate = {_gate}")]
     public sealed class SynchronizeObjectSignal<T> : System.IObservable<T>
     {
         public SynchronizeObjectSignal(System.IObservable<T> source, object gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SynchronizeObjectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SynchronizeObjectWitness(System.IObserver<T> observer, object gate) { }
@@ -1134,19 +1191,19 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeSignal: Source = {Source}")]
     public sealed class SynchronizeSignal<T> : System.IObservable<T>
     {
         public SynchronizeSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("TapSignal: Source = {Source}")]
     public sealed class TapSignal<T> : System.IObservable<T>
     {
         public TapSignal(System.IObservable<T> source, System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskAnyWitness: Stopped = {_stopped}, Task = {Task}")]
     public sealed class TaskAnyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskAnyWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1162,7 +1219,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainCoordinator: Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
     public sealed class TaskChainCoordinator<T> : System.IDisposable
     {
         public TaskChainCoordinator(System.IObserver<T> observer) { }
@@ -1170,13 +1227,13 @@ namespace ReactiveUI.Primitives.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.TaskChainCoordinator<T> Run(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainSignal: Sources = {_sources}")]
     public sealed class TaskChainSignal<T> : System.IObservable<T>
     {
         public TaskChainSignal(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskCountWitness: Count = {_count}, Stopped = {_stopped}")]
     public sealed class TaskCountWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskCountWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1192,13 +1249,13 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSignal: Task = {Task}")]
     public sealed class TaskInstanceSignal<T> : System.IObservable<T>
     {
         public TaskInstanceSignal(System.Threading.Tasks.Task<T> task) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSubscription: Stopped = {_stopped}")]
     public sealed class TaskInstanceSubscription : System.IDisposable
     {
         public TaskInstanceSubscription() { }
@@ -1206,13 +1263,22 @@ namespace ReactiveUI.Primitives.Advanced
         public void Dispose() { }
         public bool TryStop() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Sequencer = {Sequencer}")]
+    [System.Diagnostics.DebuggerDisplay("ThrowSignal: Error = {_error}, Scheduler = {_scheduler}")]
+    public sealed class ThrowSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ThrowSignal(System.Exception error, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalSignal: Source = {Source}, Sequencer = {Sequencer}")]
     public sealed class TimeIntervalSignal<T> : System.IObservable<ReactiveUI.Primitives.Core.TimeInterval<T>>
     {
         public TimeIntervalSignal(System.IObservable<T> source, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("First = {_first}, Last = {_last}")]
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalWitness: First = {_first}, Last = {_last}")]
     public sealed class TimeIntervalWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TimeIntervalWitness(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -1230,13 +1296,13 @@ namespace ReactiveUI.Primitives.Advanced
     {
         public static void Arm(ReactiveUI.Primitives.Disposables.SingleReplaceableDisposable slot, ReactiveUI.Primitives.Concurrency.ISequencer sequencer, System.TimeSpan delay, System.Action tick) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkSignal: Source = {Source}")]
     public sealed class UnsparkSignal<T> : System.IObservable<T>
     {
         public UnsparkSignal(System.IObservable<ReactiveUI.Primitives.Core.Spark<T>> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class UnsparkWitness<T> : System.IDisposable, System.IObserver<ReactiveUI.Primitives.Core.Spark<T>>
     {
         public UnsparkWitness(System.IObserver<T> observer) { }
@@ -1819,7 +1885,7 @@ namespace ReactiveUI.Primitives.Extensions.Operators
 }
 namespace ReactiveUI.Primitives.Signals
 {
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
+    [System.Diagnostics.DebuggerDisplay("PrioritySemaphoreSignal: Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
     public sealed class PrioritySemaphoreSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T> where T : System.IComparable<T>
     {
         public PrioritySemaphoreSignal(int maxCount) { }
@@ -1854,7 +1920,7 @@ namespace ReactiveUI.Primitives.Signals
         public void OnNext(T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledSignal: Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
     public class ScheduledSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T>
     {
         public ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }

--- a/src/ReactiveUI.Primitives/PublicAPI/net9.0/PublicAPI.txt
+++ b/src/ReactiveUI.Primitives/PublicAPI/net9.0/PublicAPI.txt
@@ -513,7 +513,7 @@ namespace ReactiveUI.Primitives
 }
 namespace ReactiveUI.Primitives.Advanced
 {
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Period = {_period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSignal: DueTime = {_dueTime}, Period = {_period}")]
     public sealed class AfterSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
     {
         public AfterSignal(System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -521,7 +521,7 @@ namespace ReactiveUI.Primitives.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<long> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
+    [System.Diagnostics.DebuggerDisplay("AfterSubscription: Current = {Current}, DueTime = {DueTime}, Period = {Period}")]
     public sealed class AfterSubscription : System.IDisposable
     {
         public AfterSubscription(System.IObserver<long> observer, ReactiveUI.Primitives.Concurrency.ISequencer scheduler, System.TimeSpan dueTime, System.TimeSpan? period) { }
@@ -529,21 +529,21 @@ namespace ReactiveUI.Primitives.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.AfterSubscription Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("SubscribeAsync = {SubscribeAsync}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncCreateSignal: SubscribeAsync = {SubscribeAsync}")]
     public sealed class AsyncCreateSignal<T> : System.IObservable<T>
     {
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public AsyncCreateSignal(System.Func<System.IObserver<T>, System.Threading.Tasks.Task<System.IDisposable>> subscribe) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ObservableFactory = {ObservableFactory}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncDeferSignal: ObservableFactory = {ObservableFactory}")]
     public sealed class AsyncDeferSignal<T> : System.IObservable<T>
     {
         public AsyncDeferSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public AsyncDeferSignal(System.Func<System.Threading.Tasks.Task<System.IObservable<T>>> observableFactory) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("AsyncSubscriptionLifetime: Completed = {_completed}, Canceled = {_canceled}, Disposed = {_disposed}")]
     public sealed class AsyncSubscriptionLifetime : System.IDisposable
     {
         public AsyncSubscriptionLifetime() { }
@@ -554,33 +554,33 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable? disposable) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connected = {_connected}")]
+    [System.Diagnostics.DebuggerDisplay("AutoConnectSignal: Count = {_count}, Connected = {_connected}")]
     public sealed class AutoConnectSignal<T> : System.IObservable<T>
     {
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount) { }
         public AutoConnectSignal(ReactiveUI.Primitives.ConnectableSignal<T> source, int subscriberCount, System.Action<System.IDisposable>? onConnect) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Connection = {_connection}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSignal: Count = {_count}, Connection = {_connection}")]
     public sealed class AutoShareSignal<T> : System.IObservable<T>
     {
         public AutoShareSignal(ReactiveUI.Primitives.ConnectableSignal<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Owner = {_owner}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("AutoShareSubscription: Owner = {_owner}, Subscription = {Subscription}")]
     public sealed class AutoShareSubscription<T> : System.IDisposable
     {
         public AutoShareSubscription(ReactiveUI.Primitives.Advanced.AutoShareSignal<T> owner, System.IDisposable subscription) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void Dispose() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("BlendSignal: Sources = {Sources}")]
     public sealed class BlendSignal<T> : System.IObservable<T>
     {
         public BlendSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("BlendWitness: ActiveCount = {ActiveCount}, IsOuterCompleted = {IsOuterCompleted}, IsDone = {IsDone}")]
     public sealed class BlendWitness<T> : System.IDisposable
     {
         public BlendWitness(System.IObserver<T> observer) { }
@@ -589,7 +589,7 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.BlendWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.BlendWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("BufferEachWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class BufferEachWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public BufferEachWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -603,20 +603,20 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Window = {Window}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("BufferSignal: Window = {Window}, Source = {Source}")]
     public sealed class BufferSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public BufferSignal(System.IObservable<T> source, System.TimeSpan timeSpan, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("CastSignal: Source = {Source}")]
     public sealed class CastSignal<TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public CastSignal(System.IObservable<object?> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CastWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CastWitness<TResult> : System.IDisposable, System.IObserver<object?>
     {
         public CastWitness(System.IObserver<TResult> observer) { }
@@ -630,7 +630,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
+    [System.Diagnostics.DebuggerDisplay("ChainSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}, First = {First}, Second = {Second}")]
     public sealed class ChainSignal<T> : System.IObservable<T>
     {
         public ChainSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -638,7 +638,7 @@ namespace ReactiveUI.Primitives.Advanced
         public ChainSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("ChainWitness: IsActive = {IsActive}, IsOuterCompleted = {IsOuterCompleted}")]
     public sealed class ChainWitness<T> : System.IDisposable
     {
         public ChainWitness(System.IObserver<T> observer) { }
@@ -648,13 +648,13 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.ChainWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.ChainWitness<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, TimeSpan = {TimeSpan}")]
+    [System.Diagnostics.DebuggerDisplay("CollectSignal: Source = {Source}, TimeSpan = {TimeSpan}")]
     public sealed class CollectSignal<T> : System.IObservable<System.Collections.Generic.IList<T>>
     {
         public CollectSignal(System.IObservable<T> source, System.TimeSpan timeSpan, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Buffered = {Values.Count}")]
+    [System.Diagnostics.DebuggerDisplay("CollectWitness: Stopped = {_stopped}, Buffered = {Values.Count}")]
     public sealed class CollectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CollectWitness(System.IObserver<System.Collections.Generic.IList<T>> observer) { }
@@ -666,7 +666,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateSink: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class CreateSink<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateSink(System.IObserver<T> observer, bool disposeOnNextThrow) { }
@@ -678,7 +678,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {Observer}")]
+    [System.Diagnostics.DebuggerDisplay("CreateWitness: Stopped = {_stopped}, Observer = {Observer}")]
     public sealed class CreateWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public CreateWitness(System.IObserver<T> observer) { }
@@ -692,7 +692,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetCancel(System.IDisposable cancel) { }
     }
-    [System.Diagnostics.DebuggerDisplay("ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
+    [System.Diagnostics.DebuggerDisplay("DispatchSequencerState: ReadyCount = {_readyCount}, DrainPosted = {_drainPosted}")]
     public record struct DispatchSequencerState : System.IEquatable<ReactiveUI.Primitives.Advanced.DispatchSequencerState>
     {
         public DispatchSequencerState(ReactiveUI.Primitives.Concurrency.ISequencer owner, System.Func<System.Action, bool> post, System.Action drain) { }
@@ -707,13 +707,13 @@ namespace ReactiveUI.Primitives.Advanced
         public static System.TimeSpan DelayUntil(long dueTimestamp) { }
         public static void RunIfActive(ReactiveUI.Primitives.Concurrency.IWorkItem item) { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {DueTime}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietSignal: DueTime = {DueTime}, Source = {Source}")]
     public sealed class EmitIfQuietSignal<T> : System.IObservable<T>
     {
         public EmitIfQuietSignal(System.IObservable<T> source, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
+    [System.Diagnostics.DebuggerDisplay("EmitIfQuietWitness: HasValue = {_hasValue}, Stopped = {_stopped}, Version = {_version}")]
     public sealed class EmitIfQuietWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public EmitIfQuietWitness(System.IObserver<T> observer, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
@@ -724,7 +724,16 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("EmptySignal: Scheduler = {_scheduler}")]
+    public sealed class EmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public EmptySignal(ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("EnumerableBlendSignal: Sources = {Sources}")]
     public sealed class EnumerableBlendSignal<T> : System.IObservable<T>
     {
         public EnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -734,7 +743,14 @@ namespace ReactiveUI.Primitives.Advanced
     {
         public static System.IDisposable Attach<TEventHandler>(TEventHandler handler, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
+    [System.Diagnostics.DebuggerDisplay("EverySignal: Period = {_period}, Scheduler = {_scheduler}")]
+    public sealed class EverySignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<long>
+    {
+        public EverySignal(System.TimeSpan period, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<long> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ExpireCoordinator: Done = {_done}, DueTime = {_dueTime}, Deadline = {_deadline}")]
     public sealed class ExpireCoordinator<T> : System.IDisposable, System.IObserver<T>
     {
         public ExpireCoordinator(System.IObservable<T> source, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer, System.IObserver<T> observer) { }
@@ -744,39 +760,48 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnNext(T value) { }
         public ReactiveUI.Primitives.Advanced.ExpireCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("DueTime = {_dueTime}, Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("ExpireSignal: DueTime = {_dueTime}, Source = {_source}")]
     public sealed class ExpireSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ExpireSignal(System.IObservable<T> source, System.TimeSpan dueTime, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("FinallySignal: Source = {_source}")]
+    public sealed class FinallySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public FinallySignal(System.IObservable<T> source, System.Action finallyAction) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ForkJoinSignal: Left = {Left}, Right = {Right}")]
     public sealed class ForkJoinSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public ForkJoinSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("ForkJoinWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsDone = {IsDone}")]
     public sealed class ForkJoinWitness<TLeft, TRight, TResult>
     {
         public ForkJoinWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("CancellationRequested = {CancellationToken.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncExternalCancellationSignal: CancellationRequested = {CancellationToken.IsCancellationRequested}")]
     public sealed class FromAsyncExternalCancellationSignal<T> : System.IObservable<T>
     {
         public FromAsyncExternalCancellationSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSignal: TaskFactory = {TaskFactory}, CanBeCanceled = {CancellationToken.CanBeCanceled}")]
     public sealed class FromAsyncSignal<T> : System.IObservable<T>
     {
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
         public FromAsyncSignal(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory, System.Threading.CancellationToken cancellationToken) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
+    [System.Diagnostics.DebuggerDisplay("FromAsyncSubscription: Completed = {Lifetime.IsCompleted}, CancellationRequested = {Lifetime.IsCancellationRequested}")]
     public sealed class FromAsyncSubscription<T> : System.IDisposable
     {
         public FromAsyncSubscription(System.IObserver<T> observer, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> taskFactory) { }
@@ -789,14 +814,14 @@ namespace ReactiveUI.Primitives.Advanced
         public FromEventConversionSignal(System.Func<TCallback, TEventHandler> conversion, System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, System.Func<System.IObserver<TResult>, TCallback> callback, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
+    [System.Diagnostics.DebuggerDisplay("FromEventPatternSignal: AddHandler = {AddHandler}, RemoveHandler = {RemoveHandler}")]
     public sealed class FromEventPatternSignal<TEventHandler, TEventArgs> : System.IObservable<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> where TEventHandler : System.Delegate where TEventArgs : System.EventArgs
     {
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler) { }
         public FromEventPatternSignal(System.Action<TEventHandler> addHandler, System.Action<TEventHandler> removeHandler, ReactiveUI.Primitives.Concurrency.ISequencer? scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.EventPattern<TEventArgs>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Disposed = {_disposed}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("GuardedWitness: Disposed = {_disposed}, Observer = {_observer}")]
     public sealed class GuardedWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public GuardedWitness(System.IObserver<T> observer, System.IDisposable cancel) { }
@@ -806,7 +831,7 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IgnoreValuesSignal: Source = {Source}")]
     public sealed class IgnoreValuesSignal<T> : System.IObservable<T>
     {
         public IgnoreValuesSignal(System.IObservable<T> source) { }
@@ -820,14 +845,14 @@ namespace ReactiveUI.Primitives.Advanced
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.RxVoid> observer) { }
         public System.IDisposable Subscribe(System.Action<ReactiveUI.Primitives.RxVoid> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptySignal: Source = {Source}")]
     public sealed class IsEmptySignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<bool>
     {
         public IsEmptySignal(System.IObservable<T> source) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<bool> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Subscription = {Subscription}")]
+    [System.Diagnostics.DebuggerDisplay("IsEmptyWitness: Stopped = {_stopped}, Subscription = {Subscription}")]
     public sealed class IsEmptyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public IsEmptyWitness(System.IObserver<bool> observer) { }
@@ -840,14 +865,23 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {Value}, Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("LeadSignal: Value = {Value}, Source = {Source}")]
     public sealed class LeadSignal<T> : ReactiveUI.Primitives.Advanced.IInlineSignal<T>
     {
         public LeadSignal(System.IObservable<T> source, T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
         public System.IDisposable Subscribe(System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("LoopSignal: Value = {Value}")]
+    public sealed class LoopSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public LoopSignal(T value) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("MapIndexedSignal: Source = {_source}")]
     public sealed class MapIndexedSignal<TSource, TResult> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<TResult>
     {
         public MapIndexedSignal(System.IObservable<TSource> source, System.Func<TSource, int, TResult> selector) { }
@@ -855,7 +889,7 @@ namespace ReactiveUI.Primitives.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Index = {_index}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("MapIndexedWitness: Index = {_index}, Stopped = {_stopped}")]
     public sealed class MapIndexedWitness<TSource, TResult> : System.IObserver<TSource>
     {
         public MapIndexedWitness(System.IObserver<TResult> observer, System.Func<TSource, int, TResult> selector) { }
@@ -863,20 +897,20 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(TSource value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentBlendCoordinator: Active = {_active}, EnumerationCompleted = {_enumerationCompleted}, Done = {_done}")]
     public sealed class MaxConcurrentBlendCoordinator<T> : System.IDisposable
     {
         public MaxConcurrentBlendCoordinator(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.MaxConcurrentBlendCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MaxConcurrentEnumerableBlendSignal: Sources = {_sources}, MaxConcurrent = {_maxConcurrent}")]
     public sealed class MaxConcurrentEnumerableBlendSignal<T> : System.IObservable<T>
     {
         public MaxConcurrentEnumerableBlendSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources, int maxConcurrent) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("MergeCoordinator: Active = {Active}, Done = {Done}")]
     public sealed class MergeCoordinator<T> : System.IDisposable
     {
         public MergeCoordinator(System.IObserver<T> observer) { }
@@ -887,7 +921,7 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.MergeCoordinator<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.MergeCoordinator<T> Run(System.IObservable<T> first, System.IObservable<T> second) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
+    [System.Diagnostics.DebuggerDisplay("MergeSignal: Sources = {Sources}, MaxConcurrent = {MaxConcurrent}")]
     public sealed class MergeSignal<T> : System.IObservable<T>
     {
         public MergeSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
@@ -895,32 +929,39 @@ namespace ReactiveUI.Primitives.Advanced
         public MergeSignal(System.IObservable<T> first, System.IObservable<T> second) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("OnErrorResumeNextSignal: Sources = {_sources}")]
+    public sealed class OnErrorResumeNextSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("PairSignal: Left = {Left}, Right = {Right}")]
     public sealed class PairSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public PairSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
+    [System.Diagnostics.DebuggerDisplay("PairWitness: IsCompleted = {IsCompleted}, LeftQueue = {LeftQueue.Count}, RightQueue = {RightQueue.Count}")]
     public sealed class PairWitness<TLeft, TRight, TResult>
     {
         public PairWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}")]
+    [System.Diagnostics.DebuggerDisplay("PublishSelectorSignal: Source = {Source}, Selector = {Selector}")]
     public sealed class PublishSelectorSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public PublishSelectorSignal(System.IObservable<TSource> source, System.Func<System.IObservable<TSource>, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
+    [System.Diagnostics.DebuggerDisplay("RaceSignal: Sources = {Sources}, EnumerableSources = {EnumerableSources}")]
     public sealed class RaceSignal<T> : System.IObservable<T>
     {
         public RaceSignal(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public RaceSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Arms = {_arms}")]
+    [System.Diagnostics.DebuggerDisplay("RaceWitness: Arms = {_arms}")]
     public sealed class RaceWitness<T> : System.IDisposable
     {
         public RaceWitness(System.IObserver<T> observer) { }
@@ -929,40 +970,48 @@ namespace ReactiveUI.Primitives.Advanced
         public ReactiveUI.Primitives.Advanced.RaceWitness<T> Run(System.Collections.Generic.IEnumerable<System.IObservable<T>> sources) { }
         public ReactiveUI.Primitives.Advanced.RaceWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeCombineLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeCombineLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeCombineLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
+    [System.Diagnostics.DebuggerDisplay("RangeForkJoinSignal: Left = {Left.Start}+{Left.Count}, Right = {Right.Start}+{Right.Count}")]
     public sealed class RangeForkJoinSignal<TResult> : System.IObservable<TResult>
     {
         public RangeForkJoinSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeSyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeSyncLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeSyncLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("RangeWithLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class RangeWithLatestSignal<TResult> : System.IObservable<TResult>
     {
         public RangeWithLatestSignal(ReactiveUI.Primitives.Advanced.RangeSignal left, ReactiveUI.Primitives.Advanced.RangeSignal right, System.Func<int, int, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Remaining = {_remaining}, Disposed = {_disposed}")]
+    [System.Diagnostics.DebuggerDisplay("RecoverSignal: Source = {_source}")]
+    public sealed class RecoverSignal<T, TException> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T> where TException : System.Exception
+    {
+        public RecoverSignal(System.IObservable<T> source, System.Func<TException, System.IObservable<T>> handler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceCoordinator: Remaining = {_remaining}, Disposed = {_disposed}")]
     public sealed class RepeatSourceCoordinator<T> : System.IDisposable
     {
         public RepeatSourceCoordinator(System.IObservable<T> source, int? repeatCount, System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.RepeatSourceCoordinator<T> Run() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, RepeatCount = {_repeatCount}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceSignal: Source = {_source}, RepeatCount = {_repeatCount}")]
     public sealed class RepeatSourceSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public RepeatSourceSignal(System.IObservable<T> source, int? repeatCount) { }
@@ -970,7 +1019,7 @@ namespace ReactiveUI.Primitives.Advanced
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Generation = {_generation}, Terminated = {_terminated}")]
+    [System.Diagnostics.DebuggerDisplay("RepeatSourceWitness: Generation = {_generation}, Terminated = {_terminated}")]
     public sealed class RepeatSourceWitness<T> : System.IObserver<T>
     {
         public RepeatSourceWitness(ReactiveUI.Primitives.Advanced.RepeatSourceCoordinator<T> parent, int generation) { }
@@ -978,7 +1027,15 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Value = {_value}, Scheduler = {_scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ResumeSignal: Source = {_source}, Fallback = {_fallback}")]
+    public sealed class ResumeSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ResumeSignal(System.IObservable<T> source, System.IObservable<T> fallback) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("ReturnSignal: Value = {_value}, Scheduler = {_scheduler}")]
     public sealed class ReturnSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public ReturnSignal(T value, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -987,13 +1044,13 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Values = {Values}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledEnumerableSignal: Values = {Values}, Scheduler = {Scheduler}")]
     public sealed class ScheduledEnumerableSignal<T> : System.IObservable<T>
     {
         public ScheduledEnumerableSignal(System.Collections.Generic.IEnumerable<T> values, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyCoordinator<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TResult>> selector) { }
@@ -1007,13 +1064,13 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Advanced.SelectManyCoordinator<TSource, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableSignal: Source = {_source}")]
     public sealed class SelectManyEnumerableSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManyEnumerableSignal(System.IObservable<TSource> source, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyEnumerableWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SelectManyEnumerableWitness<TSource, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyEnumerableWitness(System.IObserver<TResult> observer, System.Func<TSource, System.Collections.Generic.IEnumerable<TResult>> selector) { }
@@ -1027,7 +1084,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultCoordinator: Active = {Active}, OuterCompleted = {OuterCompleted}, Done = {Done}")]
     public sealed class SelectManyResultCoordinator<TSource, TCollection, TResult> : System.IDisposable, System.IObserver<TSource>
     {
         public SelectManyResultCoordinator(System.IObserver<TResult> observer, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
@@ -1040,20 +1097,20 @@ namespace ReactiveUI.Primitives.Advanced
         public void OnNext(TSource value) { }
         public ReactiveUI.Primitives.Advanced.SelectManyResultCoordinator<TSource, TCollection, TResult> Run(System.IObservable<TSource> source) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, CollectionSelector = {CollectionSelector}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManyResultSignal: Source = {Source}, CollectionSelector = {CollectionSelector}")]
     public sealed class SelectManyResultSignal<TSource, TCollection, TResult> : System.IObservable<TResult>
     {
         public SelectManyResultSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
+    [System.Diagnostics.DebuggerDisplay("SelectManySignal: Source = {Source}, Selector = {Selector}, Inner = {Inner}")]
     public sealed class SelectManySignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SelectManySignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public SelectManySignal(System.IObservable<TSource> source, System.IObservable<TResult> inner) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Start = {Start}, Count = {Count}")]
+    [System.Diagnostics.DebuggerDisplay("SequenceSignal: Start = {Start}, Count = {Count}")]
     public sealed class SequenceSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<int>
     {
         public SequenceSignal(int start, int count, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -1064,13 +1121,13 @@ namespace ReactiveUI.Primitives.Advanced
     {
         public static System.IDisposable Subscribe<T>(System.IObserver<T> observer, bool currentThreadRequired, System.Func<System.IObserver<T>, System.IDisposable, System.IDisposable> subscribeCore) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SparkSignal: Source = {Source}")]
     public sealed class SparkSignal<T> : System.IObservable<ReactiveUI.Primitives.Core.Spark<T>>
     {
         public SparkSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.Spark<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SparkWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SparkWitness(System.IObserver<ReactiveUI.Primitives.Core.Spark<T>> observer) { }
@@ -1085,21 +1142,21 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Action = {Action}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Action = {Action}, Scheduler = {Scheduler}")]
     public sealed class StartSignal : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<ReactiveUI.Primitives.RxVoid>
     {
         public StartSignal(System.Action action, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.RxVoid> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Function = {Function}, Scheduler = {Scheduler}")]
+    [System.Diagnostics.DebuggerDisplay("StartSignal: Function = {Function}, Scheduler = {Scheduler}")]
     public sealed class StartSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
     {
         public StartSignal(System.Func<T> function, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
         public bool IsRequiredSubscribeOnCurrentThread() { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Observer = {_observer}")]
+    [System.Diagnostics.DebuggerDisplay("SubscribeSafeWitness: Stopped = {_stopped}, Observer = {_observer}")]
     public sealed class SubscribeSafeWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SubscribeSafeWitness(System.IObserver<T> observer) { }
@@ -1113,50 +1170,50 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, SkipNullSources = {_skipNullSources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchMapSignal: Source = {_source}, SkipNullSources = {_skipNullSources}")]
     public sealed class SwitchMapSignal<TSource, TResult> : System.IObservable<TResult>
     {
         public SwitchMapSignal(System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {Sources}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchSignal: Sources = {Sources}")]
     public sealed class SwitchSignal<T> : System.IObservable<T>
     {
         public SwitchSignal(System.IObservable<System.IObservable<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Version = {_version}, IsDone = {IsDone}")]
+    [System.Diagnostics.DebuggerDisplay("SwitchWitness: Version = {_version}, IsDone = {IsDone}")]
     public sealed class SwitchWitness<T> : System.IDisposable
     {
         public SwitchWitness(System.IObserver<T> observer) { }
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.SwitchWitness<T> Run(System.IObservable<System.IObservable<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Left = {Left}, Right = {Right}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestSignal: Left = {Left}, Right = {Right}")]
     public sealed class SyncLatestSignal<TLeft, TRight, TResult> : System.IObservable<TResult>
     {
         public SyncLatestSignal(System.IObservable<TLeft> left, System.IObservable<TRight> right, System.Func<TLeft, TRight, TResult> selector) { }
         public System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
+    [System.Diagnostics.DebuggerDisplay("SyncLatestWitness: HasLeft = {HasLeft}, HasRight = {HasRight}, IsCompleted = {IsCompleted}")]
     public sealed class SyncLatestWitness<TLeft, TRight, TResult>
     {
         public SyncLatestWitness(System.IObserver<TResult> observer, System.Func<TLeft, TRight, TResult> selector) { }
         public ReactiveUI.Primitives.Disposables.MultipleDisposable Run(System.IObservable<TLeft> left, System.IObservable<TRight> right) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Gate = {Gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeGateSignal: Source = {Source}, Gate = {Gate}")]
     public sealed class SynchronizeGateSignal<T> : System.IObservable<T>
     {
         public SynchronizeGateSignal(System.IObservable<T> source, System.Threading.Lock gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {_source}, Gate = {_gate}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectSignal: Source = {_source}, Gate = {_gate}")]
     public sealed class SynchronizeObjectSignal<T> : System.IObservable<T>
     {
         public SynchronizeObjectSignal(System.IObservable<T> source, object gate) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeObjectWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class SynchronizeObjectWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public SynchronizeObjectWitness(System.IObserver<T> observer, object gate) { }
@@ -1168,19 +1225,19 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("SynchronizeSignal: Source = {Source}")]
     public sealed class SynchronizeSignal<T> : System.IObservable<T>
     {
         public SynchronizeSignal(System.IObservable<T> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("TapSignal: Source = {Source}")]
     public sealed class TapSignal<T> : System.IObservable<T>
     {
         public TapSignal(System.IObservable<T> source, System.Action<T> onNext, System.Action<System.Exception> onError, System.Action onCompleted) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}, Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskAnyWitness: Stopped = {_stopped}, Task = {Task}")]
     public sealed class TaskAnyWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskAnyWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1196,7 +1253,7 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainCoordinator: Queued = {_queue.Count}, Active = {_active}, Done = {_done}")]
     public sealed class TaskChainCoordinator<T> : System.IDisposable
     {
         public TaskChainCoordinator(System.IObserver<T> observer) { }
@@ -1204,13 +1261,13 @@ namespace ReactiveUI.Primitives.Advanced
         public void Dispose() { }
         public ReactiveUI.Primitives.Advanced.TaskChainCoordinator<T> Run(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Sources = {_sources}")]
+    [System.Diagnostics.DebuggerDisplay("TaskChainSignal: Sources = {_sources}")]
     public sealed class TaskChainSignal<T> : System.IObservable<T>
     {
         public TaskChainSignal(System.IObservable<System.Threading.Tasks.Task<T>> sources) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskCountWitness: Count = {_count}, Stopped = {_stopped}")]
     public sealed class TaskCountWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TaskCountWitness(System.Threading.CancellationToken cancellationToken) { }
@@ -1226,13 +1283,13 @@ namespace ReactiveUI.Primitives.Advanced
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void SetSubscription(System.IDisposable subscription) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Task = {Task}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSignal: Task = {Task}")]
     public sealed class TaskInstanceSignal<T> : System.IObservable<T>
     {
         public TaskInstanceSignal(System.Threading.Tasks.Task<T> task) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Stopped = {_stopped}")]
+    [System.Diagnostics.DebuggerDisplay("TaskInstanceSubscription: Stopped = {_stopped}")]
     public sealed class TaskInstanceSubscription : System.IDisposable
     {
         public TaskInstanceSubscription() { }
@@ -1240,13 +1297,22 @@ namespace ReactiveUI.Primitives.Advanced
         public void Dispose() { }
         public bool TryStop() { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}, Sequencer = {Sequencer}")]
+    [System.Diagnostics.DebuggerDisplay("ThrowSignal: Error = {_error}, Scheduler = {_scheduler}")]
+    public sealed class ThrowSignal<T> : ReactiveUI.Primitives.Advanced.IRequireCurrentThread<T>
+    {
+        public ThrowSignal(System.Exception error, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public bool IsRequiredSubscribeOnCurrentThread() { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalSignal: Source = {Source}, Sequencer = {Sequencer}")]
     public sealed class TimeIntervalSignal<T> : System.IObservable<ReactiveUI.Primitives.Core.TimeInterval<T>>
     {
         public TimeIntervalSignal(System.IObservable<T> source, ReactiveUI.Primitives.Concurrency.ISequencer sequencer) { }
         public System.IDisposable Subscribe(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("First = {_first}, Last = {_last}")]
+    [System.Diagnostics.DebuggerDisplay("TimeIntervalWitness: First = {_first}, Last = {_last}")]
     public sealed class TimeIntervalWitness<T> : System.IDisposable, System.IObserver<T>
     {
         public TimeIntervalWitness(System.IObserver<ReactiveUI.Primitives.Core.TimeInterval<T>> observer, ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }
@@ -1264,13 +1330,13 @@ namespace ReactiveUI.Primitives.Advanced
     {
         public static void Arm(ReactiveUI.Primitives.Disposables.SingleReplaceableDisposable slot, ReactiveUI.Primitives.Concurrency.ISequencer sequencer, System.TimeSpan delay, System.Action tick) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Source = {Source}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkSignal: Source = {Source}")]
     public sealed class UnsparkSignal<T> : System.IObservable<T>
     {
         public UnsparkSignal(System.IObservable<ReactiveUI.Primitives.Core.Spark<T>> source) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observer = {_observer}, Subscription = {_subscription}")]
+    [System.Diagnostics.DebuggerDisplay("UnsparkWitness: Observer = {_observer}, Subscription = {_subscription}")]
     public sealed class UnsparkWitness<T> : System.IDisposable, System.IObserver<ReactiveUI.Primitives.Core.Spark<T>>
     {
         public UnsparkWitness(System.IObserver<T> observer) { }
@@ -1853,7 +1919,7 @@ namespace ReactiveUI.Primitives.Extensions.Operators
 }
 namespace ReactiveUI.Primitives.Signals
 {
-    [System.Diagnostics.DebuggerDisplay("Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
+    [System.Diagnostics.DebuggerDisplay("PrioritySemaphoreSignal: Count = {_count}, MaximumCount = {_maximumCount}, IsDraining = {_isDraining}")]
     public sealed class PrioritySemaphoreSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T> where T : System.IComparable<T>
     {
         public PrioritySemaphoreSignal(int maxCount) { }
@@ -1888,7 +1954,7 @@ namespace ReactiveUI.Primitives.Signals
         public void OnNext(T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
     }
-    [System.Diagnostics.DebuggerDisplay("Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
+    [System.Diagnostics.DebuggerDisplay("ScheduledSignal: Observers = {_observerRefCount}, Disposed = {_isDisposed}")]
     public class ScheduledSignal<T> : ReactiveUI.Primitives.Signals.ISignal<T>
     {
         public ScheduledSignal(ReactiveUI.Primitives.Concurrency.ISequencer scheduler) { }

--- a/src/benchmarks/ReactiveUI.Primitives.Benchmarks/ConnectableGcProfileBenchmarks.cs
+++ b/src/benchmarks/ReactiveUI.Primitives.Benchmarks/ConnectableGcProfileBenchmarks.cs
@@ -16,7 +16,7 @@ namespace ReactiveUI.Primitives.Benchmarks;
 [ShortRunJob]
 [MemoryDiagnoser]
 [EventPipeProfiler(EventPipeProfile.GcVerbose)]
-[System.Diagnostics.DebuggerDisplay("Delegate = {_b}")]
+[System.Diagnostics.DebuggerDisplay("ConnectableGcProfileBenchmarks: Delegate = {_b}")]
 public class ConnectableGcProfileBenchmarks
 {
     /// <summary>The delegate benchmark instance that performs the measured work.</summary>

--- a/src/benchmarks/ReactiveUI.Primitives.Benchmarks/FactoryGcProfileBenchmarks.cs
+++ b/src/benchmarks/ReactiveUI.Primitives.Benchmarks/FactoryGcProfileBenchmarks.cs
@@ -16,7 +16,7 @@ namespace ReactiveUI.Primitives.Benchmarks;
 [ShortRunJob]
 [MemoryDiagnoser]
 [EventPipeProfiler(EventPipeProfile.GcVerbose)]
-[System.Diagnostics.DebuggerDisplay("{nameof(FactoryGcProfileBenchmarks),nq}")]
+[System.Diagnostics.DebuggerDisplay("FactoryGcProfileBenchmarks: {nameof(FactoryGcProfileBenchmarks),nq}")]
 public class FactoryGcProfileBenchmarks
 {
     /// <summary>The scalar factory benchmark scenarios delegated to by this profile.</summary>

--- a/src/benchmarks/ReactiveUI.Primitives.Benchmarks/FactoryStateTimerBenchmarks.cs
+++ b/src/benchmarks/ReactiveUI.Primitives.Benchmarks/FactoryStateTimerBenchmarks.cs
@@ -21,7 +21,7 @@ namespace ReactiveUI.Primitives.Benchmarks;
 /// factories under virtual time, and the <c>FromEventPattern</c> event bridge.
 /// </summary>
 [MemoryDiagnoser]
-[System.Diagnostics.DebuggerDisplay("Limit = {_limit}")]
+[System.Diagnostics.DebuggerDisplay("FactoryStateTimerBenchmarks: Limit = {_limit}")]
 public class FactoryStateTimerBenchmarks
 {
     /// <summary>The number of values generated or events raised per benchmark iteration.</summary>

--- a/src/benchmarks/ReactiveUI.Primitives.Benchmarks/OperatorCoreGcProfileBenchmarks.cs
+++ b/src/benchmarks/ReactiveUI.Primitives.Benchmarks/OperatorCoreGcProfileBenchmarks.cs
@@ -16,7 +16,7 @@ namespace ReactiveUI.Primitives.Benchmarks;
 [ShortRunJob]
 [MemoryDiagnoser]
 [EventPipeProfiler(EventPipeProfile.GcVerbose)]
-[System.Diagnostics.DebuggerDisplay("{nameof(OperatorCoreGcProfileBenchmarks),nq}")]
+[System.Diagnostics.DebuggerDisplay("OperatorCoreGcProfileBenchmarks: {nameof(OperatorCoreGcProfileBenchmarks),nq}")]
 public class OperatorCoreGcProfileBenchmarks
 {
     /// <summary>The delegate target for the map/keep and aggregate scenarios.</summary>

--- a/src/benchmarks/ReactiveUI.Primitives.Benchmarks/OperatorHigherOrderGcProfileBenchmarks.cs
+++ b/src/benchmarks/ReactiveUI.Primitives.Benchmarks/OperatorHigherOrderGcProfileBenchmarks.cs
@@ -16,7 +16,7 @@ namespace ReactiveUI.Primitives.Benchmarks;
 [ShortRunJob]
 [MemoryDiagnoser]
 [EventPipeProfiler(EventPipeProfile.GcVerbose)]
-[System.Diagnostics.DebuggerDisplay("Delegate = {_b}")]
+[System.Diagnostics.DebuggerDisplay("OperatorHigherOrderGcProfileBenchmarks: Delegate = {_b}")]
 public class OperatorHigherOrderGcProfileBenchmarks
 {
     /// <summary>The delegate benchmark instance that performs the measured work.</summary>

--- a/src/benchmarks/ReactiveUI.Primitives.Benchmarks/OperatorStatefulVariantBenchmarks.cs
+++ b/src/benchmarks/ReactiveUI.Primitives.Benchmarks/OperatorStatefulVariantBenchmarks.cs
@@ -16,7 +16,7 @@ namespace ReactiveUI.Primitives.Benchmarks;
 /// the comparison frameworks must capture the same runtime value in a closure.
 /// </summary>
 [MemoryDiagnoser]
-[System.Diagnostics.DebuggerDisplay("Factor = {_factor}, Threshold = {_threshold}")]
+[System.Diagnostics.DebuggerDisplay("OperatorStatefulVariantBenchmarks: Factor = {_factor}, Threshold = {_threshold}")]
 public class OperatorStatefulVariantBenchmarks
 {
     /// <summary>The number of values produced by each benchmarked sequence.</summary>

--- a/src/benchmarks/ReactiveUI.Primitives.Benchmarks/ReactiveExtensionsComparisonBenchmarks.Helpers.cs
+++ b/src/benchmarks/ReactiveUI.Primitives.Benchmarks/ReactiveExtensionsComparisonBenchmarks.Helpers.cs
@@ -245,7 +245,7 @@ public partial class ReactiveExtensionsComparisonBenchmarks
     /// <summary>Provides a named benchmark scenario.</summary>
     /// <param name="name">The scenario name.</param>
     /// <param name="run">The delegate that runs the scenario.</param>
-    [System.Diagnostics.DebuggerDisplay("Name = {_name}")]
+    [System.Diagnostics.DebuggerDisplay("ExtensionScenario: Name = {_name}")]
     public sealed class ExtensionScenario(string name, Func<int> run)
     {
         /// <summary>Stores the scenario name.</summary>

--- a/src/benchmarks/ReactiveUI.Primitives.Benchmarks/SubjectGcProfileBenchmarks.cs
+++ b/src/benchmarks/ReactiveUI.Primitives.Benchmarks/SubjectGcProfileBenchmarks.cs
@@ -16,7 +16,7 @@ namespace ReactiveUI.Primitives.Benchmarks;
 [ShortRunJob]
 [MemoryDiagnoser]
 [EventPipeProfiler(EventPipeProfile.GcVerbose)]
-[System.Diagnostics.DebuggerDisplay("{nameof(SubjectGcProfileBenchmarks),nq}")]
+[System.Diagnostics.DebuggerDisplay("SubjectGcProfileBenchmarks: {nameof(SubjectGcProfileBenchmarks),nq}")]
 public class SubjectGcProfileBenchmarks
 {
     /// <summary>The delegate target for the subject throughput scenarios.</summary>

--- a/src/benchmarks/ReactiveUI.Primitives.Benchmarks/TerminalCancellationBenchmarks.cs
+++ b/src/benchmarks/ReactiveUI.Primitives.Benchmarks/TerminalCancellationBenchmarks.cs
@@ -17,7 +17,7 @@ namespace ReactiveUI.Primitives.Benchmarks;
 /// covering the live-token pass-through cost, the task-shim wrapper, and the cancel path.
 /// </summary>
 [MemoryDiagnoser]
-[System.Diagnostics.DebuggerDisplay("Canceled = {_liveSource.IsCancellationRequested}")]
+[System.Diagnostics.DebuggerDisplay("TerminalCancellationBenchmarks: Canceled = {_liveSource.IsCancellationRequested}")]
 public class TerminalCancellationBenchmarks : IDisposable
 {
     /// <summary>The inclusive start value of the range used by each benchmark.</summary>

--- a/src/benchmarks/ReactiveUI.Primitives.Benchmarks/TerminalCollectionGcProfileBenchmarks.cs
+++ b/src/benchmarks/ReactiveUI.Primitives.Benchmarks/TerminalCollectionGcProfileBenchmarks.cs
@@ -16,7 +16,7 @@ namespace ReactiveUI.Primitives.Benchmarks;
 [ShortRunJob]
 [MemoryDiagnoser]
 [EventPipeProfiler(EventPipeProfile.GcVerbose)]
-[System.Diagnostics.DebuggerDisplay("Delegate = {_b}")]
+[System.Diagnostics.DebuggerDisplay("TerminalCollectionGcProfileBenchmarks: Delegate = {_b}")]
 public class TerminalCollectionGcProfileBenchmarks
 {
     /// <summary>The delegate benchmark instance that performs the measured work.</summary>

--- a/src/benchmarks/ReactiveUI.Primitives.ObservableEvents.Benchmarks/EventGeneratorDriverBenchmarks.cs
+++ b/src/benchmarks/ReactiveUI.Primitives.ObservableEvents.Benchmarks/EventGeneratorDriverBenchmarks.cs
@@ -38,7 +38,7 @@ namespace ReactiveUI.Primitives.ObservableEvents.Benchmarks;
 /// the frames, which is the only way to tell the generator's cost from the compiler's.
 /// </para>
 /// </remarks>
-[System.Diagnostics.DebuggerDisplay("{Size}")]
+[System.Diagnostics.DebuggerDisplay("EventGeneratorDriverBenchmarks: {Size}")]
 [SimpleJob(warmupCount: 5, iterationCount: 15)]
 [EventPipeProfiler(EventPipeProfile.CpuSampling)]
 public class EventGeneratorDriverBenchmarks

--- a/src/benchmarks/ReactiveUI.Primitives.ObservableEvents.Benchmarks/EventGeneratorGcProfileBenchmarks.cs
+++ b/src/benchmarks/ReactiveUI.Primitives.ObservableEvents.Benchmarks/EventGeneratorGcProfileBenchmarks.cs
@@ -27,7 +27,7 @@ namespace ReactiveUI.Primitives.ObservableEvents.Benchmarks;
 /// </remarks>
 [ShortRunJob]
 [EventPipeProfiler(EventPipeProfile.GcVerbose)]
-[System.Diagnostics.DebuggerDisplay("{nameof(EventGeneratorGcProfileBenchmarks),nq}")]
+[System.Diagnostics.DebuggerDisplay("EventGeneratorGcProfileBenchmarks: {nameof(EventGeneratorGcProfileBenchmarks),nq}")]
 public class EventGeneratorGcProfileBenchmarks
 {
     /// <summary>The corpus size profiled here.</summary>

--- a/src/tests/ReactiveUI.Primitives.Async.Tests/CombiningOperatorTests.Blend.cs
+++ b/src/tests/ReactiveUI.Primitives.Async.Tests/CombiningOperatorTests.Blend.cs
@@ -9,7 +9,7 @@ using ReactiveUI.Primitives.Async.Signals;
 namespace ReactiveUI.Primitives.Async.Tests;
 
 /// <summary>Tests for the Merge operator.</summary>
-[System.Diagnostics.DebuggerDisplay("{nameof(CombiningOperatorTests),nq}")]
+[System.Diagnostics.DebuggerDisplay("CombiningOperatorTests: {nameof(CombiningOperatorTests),nq}")]
 public partial class CombiningOperatorTests
 {
     /// <summary>Tests Merge two sequences emits from both.</summary>

--- a/src/tests/ReactiveUI.Primitives.Async.Tests/SignalTests.BehaviorAndReplay.cs
+++ b/src/tests/ReactiveUI.Primitives.Async.Tests/SignalTests.BehaviorAndReplay.cs
@@ -7,7 +7,7 @@ using ReactiveUI.Primitives.Async.Signals;
 namespace ReactiveUI.Primitives.Async.Tests;
 
 /// <summary>BehaviorSignal and ReplayLatest tests for <see cref="SignalTests"/>.</summary>
-[System.Diagnostics.DebuggerDisplay("WaitTimeout = {WaitTimeout}")]
+[System.Diagnostics.DebuggerDisplay("SignalTests: WaitTimeout = {WaitTimeout}")]
 public partial class SignalTests
 {
     /// <summary>Tests behavior Signal with start value emits latest first to new subscriber.</summary>

--- a/src/tests/ReactiveUI.Primitives.Async.Tests/TakeUntilOperatorTests.CompletionDelegate.cs
+++ b/src/tests/ReactiveUI.Primitives.Async.Tests/TakeUntilOperatorTests.CompletionDelegate.cs
@@ -8,7 +8,7 @@ using ReactiveUI.Primitives.Async.Signals;
 namespace ReactiveUI.Primitives.Async.Tests;
 
 /// <summary>TakeUntil operator tests — CompletionSignalDelegate overload and option behavior.</summary>
-[System.Diagnostics.DebuggerDisplay("WaitTimeout = {WaitTimeout}")]
+[System.Diagnostics.DebuggerDisplay("TakeUntilOperatorTests: WaitTimeout = {WaitTimeout}")]
 public partial class TakeUntilOperatorTests
 {
     /// <summary>String literal "subscribe failed" used by multiple tests.</summary>

--- a/src/tests/ReactiveUI.Primitives.Extensions.Tests/Operators/ScanWithInitialTests.cs
+++ b/src/tests/ReactiveUI.Primitives.Extensions.Tests/Operators/ScanWithInitialTests.cs
@@ -7,7 +7,7 @@ using System.Reactive.Subjects;
 namespace ReactiveUI.Primitives.Extensions.Tests.Operators;
 
 /// <summary>Tests for the <see cref = "ScanWithInitialObservable{TSource, TAccumulate}"/> class.</summary>
-[System.Diagnostics.DebuggerDisplay("{nameof(ScanWithInitialTests),nq}")]
+[System.Diagnostics.DebuggerDisplay("ScanWithInitialTests: {nameof(ScanWithInitialTests),nq}")]
 public partial class ScanWithInitialTests
 {
     /// <summary>Spin iterations used to widen the interleaving window in contention tests.</summary>

--- a/src/tests/ReactiveUI.Primitives.Extensions.Tests/ReactiveExtensionsTests.Buffer.cs
+++ b/src/tests/ReactiveUI.Primitives.Extensions.Tests/ReactiveExtensionsTests.Buffer.cs
@@ -8,7 +8,7 @@ using ReactiveUI.Primitives.Concurrency;
 namespace ReactiveUI.Primitives.Extensions.Tests;
 
 /// <summary>Tests for ReactiveExtensionsTests.</summary>
-[System.Diagnostics.DebuggerDisplay("{nameof(ReactiveExtensionsTests),nq}")]
+[System.Diagnostics.DebuggerDisplay("ReactiveExtensionsTests: {nameof(ReactiveExtensionsTests),nq}")]
 public partial class ReactiveExtensionsTests
 {
     /// <summary>Tests BufferUntil with character delimiters.</summary>

--- a/src/tests/ReactiveUI.Primitives.Tests/RxNamesTests.Helpers.cs
+++ b/src/tests/ReactiveUI.Primitives.Tests/RxNamesTests.Helpers.cs
@@ -674,7 +674,7 @@ public partial class RxNamesTests
     /// <param name = "Rx">The Rx/LINQ-named builder.</param>
     /// <param name = "Input">The source values.</param>
     /// <param name = "Expected">The expected forwarded values.</param>
-    [System.Diagnostics.DebuggerDisplay("Name = {Name}, Expected = {Expected}")]
+    [System.Diagnostics.DebuggerDisplay("UnaryCase: Name = {Name}, Expected = {Expected}")]
     public sealed record UnaryCase(
         string Name,
         Func<IObservable<int>, IObservable<int>> Deviant,
@@ -692,7 +692,7 @@ public partial class RxNamesTests
     /// <param name = "Rx">The Rx/LINQ-named builder.</param>
     /// <param name = "Inners">The inner source values.</param>
     /// <param name = "Expected">The expected forwarded values.</param>
-    [System.Diagnostics.DebuggerDisplay("Name = {Name}, Expected = {Expected}")]
+    [System.Diagnostics.DebuggerDisplay("HigherOrderCase: Name = {Name}, Expected = {Expected}")]
     public sealed record HigherOrderCase(
         string Name,
         Func<IObservable<IObservable<int>>, IObservable<int>> Deviant,
@@ -710,7 +710,7 @@ public partial class RxNamesTests
     /// <param name = "Rx">The Rx/LINQ-named builder.</param>
     /// <param name = "Drive">The script that pushes values into the left and right subjects.</param>
     /// <param name = "Expected">The expected forwarded values.</param>
-    [System.Diagnostics.DebuggerDisplay("Name = {Name}, Expected = {Expected}")]
+    [System.Diagnostics.DebuggerDisplay("BinaryCase: Name = {Name}, Expected = {Expected}")]
     public sealed record BinaryCase(
         string Name,
         Func<IObservable<int>, IObservable<int>, IObservable<int>> Deviant,
@@ -729,7 +729,7 @@ public partial class RxNamesTests
     /// <param name = "Source">The source factory.</param>
     /// <param name = "Expected">The expected forwarded values.</param>
     /// <param name = "ExpectsTimeout">Whether a <see cref = "TimeoutException"/> is expected.</param>
-    [System.Diagnostics.DebuggerDisplay("Name = {Name}, ExpectsTimeout = {ExpectsTimeout}")]
+    [System.Diagnostics.DebuggerDisplay("TimeCase: Name = {Name}, ExpectsTimeout = {ExpectsTimeout}")]
     public sealed record TimeCase(
         string Name,
         Func<IObservable<int>, ISequencer, IObservable<int>> Deviant,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature (public API surface).

## What is the new behavior?

**Every concrete operator signal under `ReactiveUI.Primitives.Advanced` is public, so callers can name the type they build instead of only the factory that returns it.**

- **Eight signals become public:** `EmptySignal<T>`, `FinallySignal<T>`, `LoopSignal<T>`, `OnErrorResumeNextSignal<T>`, `RecoverSignal<T, TException>`, `ResumeSignal<T>`, `ThrowSignal<T>` and `EverySignal`.
  - They stay in `ReactiveUI.Primitives.Advanced`, alongside `LeadSignal`, `MergeSignal`, `ReturnSignal` and `TapSignal`, which were already public.
  - Types that are genuine plumbing stay internal: the async state machines, the observer leases, `RaceArms<T>` and the helper statics.

**`DebuggerDisplay` now names its own class, so a debugger row says what the object is and not only what it holds.**

- `"LeadSignal: Value = {Value}, Source = {Source}"` rather than `"Value = {Value}, Source = {Source}"`.
- Follows the four attributes that already did this.
- The attributes that delegate to a `DebuggerDisplay` member are untouched, because that member builds the whole string itself.

## What is the current behavior?

- The eight signals are `internal`, so half the operator surface is reachable as a concrete type and half is not. A caller wanting `Empty` on a scheduler has a factory and no type.
- `DebuggerDisplay` strings name their fields but not their class, so two different signals holding a source render identically.

## What might this PR break?

None. The eight types have never shipped public, so no consumer can be depending on them, and they gain visibility in the namespace they already occupied rather than moving.

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [ ] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information

Most of the diff is mechanical and generated. The hand-written parts are the eight signal files under `src/Primitives.Shared/Advanced/`, which carry the visibility change and their new `DebuggerDisplay`. Everything else is the class-name prefix applied across the existing attributes, plus the regenerated `PublicAPI` baselines.

The baseline records attributes, so the visibility change and the prefix cannot land as separate commits without an intermediate state that does not build. The Apple target-framework baselines were regenerated on a Windows host, which is the only one carrying those workloads.
